### PR TITLE
Feature/vector output

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -13,6 +13,7 @@ from .bench_vars import (
     ParametrizedSweep,
     ResultVar,
     ResultVec,
+    ResultList,
     OptDir,
     hash_cust,
 )

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -16,5 +16,5 @@ from .bench_vars import (
     ResultList,
     ResultSeries,
     OptDir,
-    hash_cust,
+    hash_sha1,
 )

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -14,7 +14,7 @@ from .bench_vars import (
     ResultVar,
     ResultVec,
     ResultList,
-    ResSer,
+    ResultSeries,
     OptDir,
     hash_cust,
 )

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -14,6 +14,7 @@ from .bench_vars import (
     ResultVar,
     ResultVec,
     ResultList,
+    ResSer,
     OptDir,
     hash_cust,
 )

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -341,10 +341,10 @@ class BenchCfg(BenchRunCfg):
         doc="Use tags to group different benchmarks together. By default benchmarks are considered distinct from eachother and are identified by the hash of their name and inputs, constants and results and tag, but you can optionally change the hash value to only depend on the tag.  This way you can have multiple unrelated benchmarks share values with eachother based only on the tag value.",
     )
 
-    hash_value:str = param.String(
+    hash_value: str = param.String(
         "",
         doc="store the hash value of the config to avoid having to hash multiple times",
-    )  
+    )
 
     ds = []
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -341,7 +341,10 @@ class BenchCfg(BenchRunCfg):
         doc="Use tags to group different benchmarks together. By default benchmarks are considered distinct from eachother and are identified by the hash of their name and inputs, constants and results and tag, but you can optionally change the hash value to only depend on the tag.  This way you can have multiple unrelated benchmarks share values with eachother based only on the tag value.",
     )
 
-    hash_value = None  # store the hash value of the config to avoid having to hash multiple times
+    hash_value:str = param.String(
+        "",
+        doc="store the hash value of the config to avoid having to hash multiple times",
+    )  
 
     ds = []
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -353,7 +353,7 @@ class BenchCfg(BenchRunCfg):
 
     ds = []
 
-    def hash_custom(self, include_repeats):
+    def hash_persistent(self, include_repeats) -> str:
         """override the default hash function becuase the default hash function does not return the same value for the same inputs.  It references internal variables that are unique per instance of BenchCfg
 
         Args:
@@ -378,10 +378,10 @@ class BenchCfg(BenchRunCfg):
         )
         all_vars = self.input_vars + self.result_vars
         for v in all_vars:
-            hash_val = hash_cust((hash_val, v.hash_custom()))
+            hash_val = hash_cust((hash_val, v.hash_persistent()))
 
         for v in self.const_vars:
-            hash_val = hash_cust((v[0].hash_custom(), hash_cust(v[1])))
+            hash_val = hash_cust((v[0].hash_persistent(), hash_cust(v[1])))
 
         return hash_val
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -341,6 +341,8 @@ class BenchCfg(BenchRunCfg):
         doc="Use tags to group different benchmarks together. By default benchmarks are considered distinct from eachother and are identified by the hash of their name and inputs, constants and results and tag, but you can optionally change the hash value to only depend on the tag.  This way you can have multiple unrelated benchmarks share values with eachother based only on the tag value.",
     )
 
+    hash_value =None #store the hash value of the config to avoid having to hash multiple times
+
     ds = []
 
     def hash_custom(self, include_repeats):

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -10,7 +10,7 @@ from str2bool import str2bool
 import xarray as xr
 from typing import List, Callable, Tuple, Any
 
-from bencher.bench_vars import TimeSnapshot, TimeEvent, describe_variable, OptDir, hash_cust
+from bencher.bench_vars import TimeSnapshot, TimeEvent, describe_variable, OptDir, hash_sha1
 from pandas import DataFrame
 
 
@@ -362,26 +362,26 @@ class BenchCfg(BenchRunCfg):
 
         if include_repeats:
             # needed so that the historical xarray arrays are the same size
-            repeats_hash = hash_cust(self.repeats)
+            repeats_hash = hash_sha1(self.repeats)
         else:
             repeats_hash = 0
 
-        hash_val = hash_cust(
+        hash_val = hash_sha1(
             (
-                hash_cust(str(self.bench_name)),
-                hash_cust(str(self.title)),
-                hash_cust(self.over_time),
+                hash_sha1(str(self.bench_name)),
+                hash_sha1(str(self.title)),
+                hash_sha1(self.over_time),
                 repeats_hash,
-                hash_cust(self.debug),
-                hash_cust(self.tag),
+                hash_sha1(self.debug),
+                hash_sha1(self.tag),
             )
         )
         all_vars = self.input_vars + self.result_vars
         for v in all_vars:
-            hash_val = hash_cust((hash_val, v.hash_persistent()))
+            hash_val = hash_sha1((hash_val, v.hash_persistent()))
 
         for v in self.const_vars:
-            hash_val = hash_cust((v[0].hash_persistent(), hash_cust(v[1])))
+            hash_val = hash_sha1((v[0].hash_persistent(), hash_sha1(v[1])))
 
         return hash_val
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -341,7 +341,7 @@ class BenchCfg(BenchRunCfg):
         doc="Use tags to group different benchmarks together. By default benchmarks are considered distinct from eachother and are identified by the hash of their name and inputs, constants and results and tag, but you can optionally change the hash value to only depend on the tag.  This way you can have multiple unrelated benchmarks share values with eachother based only on the tag value.",
     )
 
-    hash_value =None #store the hash value of the config to avoid having to hash multiple times
+    hash_value = None  # store the hash value of the config to avoid having to hash multiple times
 
     ds = []
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -353,7 +353,6 @@ class BenchCfg(BenchRunCfg):
 
     ds = xr.Dataset()
 
-
     def hash_persistent(self, include_repeats) -> str:
         """override the default hash function becuase the default hash function does not return the same value for the same inputs.  It references internal variables that are unique per instance of BenchCfg
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -13,6 +13,7 @@ from typing import List, Callable, Tuple, Any
 from bencher.bench_vars import TimeSnapshot, TimeEvent, describe_variable, OptDir, hash_cust
 from pandas import DataFrame
 
+
 def to_filename(
     param_cfg: param.Parameterized, param_list: list[str] = None, exclude_params: list[str] = None
 ) -> str:
@@ -476,10 +477,8 @@ class BenchCfg(BenchRunCfg):
         Returns:
             pd.DataFrame: The xarray results array as a pandas dataframe
         """
-        
-        
+
         return self.ds.to_dataframe.reset_index()
-        
 
 
 def describe_benchmark(bench_cfg: BenchCfg) -> str:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -351,7 +351,7 @@ class BenchCfg(BenchRunCfg):
         doc="store the hash value of the config to avoid having to hash multiple times",
     )
 
-    ds = []
+    ds = xr.Dataset()
 
 
     def hash_persistent(self, include_repeats) -> str:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -11,7 +11,7 @@ import xarray as xr
 from typing import List, Callable, Tuple, Any
 
 from bencher.bench_vars import TimeSnapshot, TimeEvent, describe_variable, OptDir, hash_cust
-
+from pandas import DataFrame
 
 def to_filename(
     param_cfg: param.Parameterized, param_list: list[str] = None, exclude_params: list[str] = None
@@ -469,6 +469,17 @@ class BenchCfg(BenchRunCfg):
                 output.append(max(da.coords[iv.name].values[()]))
             logging.info(f"Maximum value of {iv.name}: {output[-1]}")
         return output
+
+    def get_dataframe(self) -> DataFrame:
+        """Get the xarray results as a pandas dataframe
+
+        Returns:
+            pd.DataFrame: The xarray results array as a pandas dataframe
+        """
+        
+        
+        return self.ds.to_dataframe.reset_index()
+        
 
 
 def describe_benchmark(bench_cfg: BenchCfg) -> str:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -353,6 +353,7 @@ class BenchCfg(BenchRunCfg):
 
     ds = []
 
+
     def hash_persistent(self, include_repeats) -> str:
         """override the default hash function becuase the default hash function does not return the same value for the same inputs.  It references internal variables that are unique per instance of BenchCfg
 
@@ -478,7 +479,7 @@ class BenchCfg(BenchRunCfg):
             pd.DataFrame: The xarray results array as a pandas dataframe
         """
 
-        return self.ds.to_dataframe.reset_index()
+        return self.ds.to_dataframe().reset_index()
 
 
 def describe_benchmark(bench_cfg: BenchCfg) -> str:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -150,6 +150,10 @@ class BenchRunCfg(BenchPlotSrvCfg):
         True, doc="Print the inputs to the benchmark function every time it is called"
     )
 
+    print_bench_results: bool = param.Boolean(
+        True, doc="Print the results of the benchmark function every time it is called"
+    )
+
     clear_history: bool = param.Boolean(False, doc="Clear historical results")
 
     print_pandas: bool = param.Boolean(

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -73,7 +73,7 @@ def param_hash(param_type: Parameterized, hash_value: bool = True, hash_meta: bo
 class ParametrizedSweep(Parameterized):
     """Parent class for all Sweep types that need a custom hash"""
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
@@ -81,7 +81,7 @@ class ParametrizedSweep(Parameterized):
 class ParametrizedOutput(Parameterized):
     """Parent class for all Output types that need a custom hash"""
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
@@ -161,7 +161,7 @@ class BoolSweep(Boolean):
         """Generate a string representation of the sampling procedure"""
         return f"sampling {self.name} from: [True,False]"
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -184,7 +184,7 @@ class TimeBase(Selector):
         """
         return f"sampling from [The Past to {self.objects[0]}]"
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -281,7 +281,7 @@ class StringSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -325,7 +325,7 @@ class EnumSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -396,7 +396,7 @@ class IntSweep(Integer):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -444,7 +444,7 @@ class FloatSweep(Number):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -466,7 +466,7 @@ class ResultVar(Number):
         self.default = 0  # json is terrible and does not support nan values
         self.direction = direction
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
@@ -483,7 +483,7 @@ class ResultVec(param.List):
         self.direction = direction
         self.size = size
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
@@ -577,7 +577,7 @@ class ResultList(param.Parameter):
         self.indices = indices
         # self.index = indices
 
-    def hash_custom(self) -> str:
+    def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))
 

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -466,7 +466,7 @@ class ResultVar(Number):
 
 
 class ResultVec(param.List):
-    """A class to represent vector result variable"""
+    """A class to represent fixed size vector result variable"""
 
     __slots__ = ["units", "direction", "size"]
 
@@ -504,3 +504,18 @@ class ResultVec(param.List):
             list[str]: column names
         """
         return [self.index_name(i) for i in range(self.size)]
+
+class ResultList(param.List):
+    """A class to unknown size vector result variable"""
+
+    __slots__ = ["units","dim_name","dim_units"]
+
+    def __init__(self,dim_name,dim_units, units="ul", **params):
+        param.List.__init__(self, **params)
+        self.dim_name= dim_name
+        self.dim_units= dim_units
+
+        self.units = units
+
+    def hash_custom(self) -> int:
+        return hash_cust(self.units)

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -513,20 +513,37 @@ class ResultVec(param.List):
         return [self.index_name(i) for i in range(self.size)]
 
 
-class ResSer:
+class ResultSeries:
+    """A class to represent a vector of results, it also includes an index similar to pandas.series"""
+
     def __init__(self, values=None, index=None) -> None:
         self.values = []
         self.index = []
         self.set_index_and_values(values, index)
 
-    def append(self, value, index=None) -> None:
+    def append(self, value: float | int, index: float | int | str = None) -> None:
+        """Add a value and index to the result series
+
+        Args:
+            value (float | int): result value of the series
+            index (float | int | str, optional): index value of series, the same as a pandas.series index  If no value is passed an integer index is automatically created. Defaults to None.
+        """
+
         if index is None:
             self.index.append(len(self.values))
         else:
             self.index.append(index)
         self.values.append(value)
 
-    def set_index_and_values(self, values, index=None) -> None:
+    def set_index_and_values(
+        self, values: List[float | int], index: List[float | int | str] = None
+    ) -> None:
+        """Add values and indices to the result series
+
+        Args:
+            value (List[float | int]): result value of the series
+            index (List[float | int | str], optional): index value of series, the same as a pandas.series index  If no value is passed an integer index is automatically created. Defaults to None.
+        """
         if values is not None:
             if index is None:
                 self.index = list(range(len(values)))
@@ -544,7 +561,7 @@ class ResultList(param.Parameter):
         self,
         index_name: str,
         index_units: str,
-        default=ResSer(),
+        default=ResultSeries(),
         units="ul",
         indices: List[float] = None,
         instantiate=True,

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -14,7 +14,7 @@ from sys import byteorder
 
 def hash_cust(var: any) -> str:
     """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-    return hashlib.sha1(str(var).encode("ASCII")).hexdigest()    
+    return hashlib.sha1(str(var).encode("ASCII")).hexdigest()
 
 
 def capitalise_words(message: str):
@@ -524,6 +524,6 @@ class ResultList(param.List):
         self.dim_units = dim_units
         self.units = units
 
-     def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -516,14 +516,29 @@ class ResultVec(param.List):
 class ResultList(param.List):
     """A class to unknown size vector result variable"""
 
-    __slots__ = ["units", "dim_name", "dim_units"]
+    __slots__ = ["units", "dim_name", "dim_units", "indices"]
 
-    def __init__(self, dim_name, dim_units, units="ul", **params):
+    def __init__(
+        self,
+        index_name: str,
+        index_units: str,
+        units="ul",
+        indices: List[float] = None,
+        **params,
+    ):
+
         param.List.__init__(self, **params)
-        self.dim_name = dim_name
-        self.dim_units = dim_units
         self.units = units
+        self.dim_name = index_name
+        self.dim_units = index_units
+        self.indices = indices
 
     def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))
+
+    def validate_indices(self, result_vec) -> None:
+        if self.indices is None:
+            self.indices = list(range(len(result_vec)))
+        else:
+            assert len(self.indices) == len(result_vec)

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -12,7 +12,7 @@ import hashlib
 from sys import byteorder
 
 
-def hash_cust(var: any) -> str:
+def hash_sha1(var: any) -> str:
     """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
     return hashlib.sha1(str(var).encode("ASCII")).hexdigest()
 
@@ -59,14 +59,14 @@ def param_hash(param_type: Parameterized, hash_value: bool = True, hash_meta: bo
     if hash_value:
         for k, v in param_type.param.values().items():
             if k != "name":
-                curhash = hash_cust((curhash, hash_cust(v)))
+                curhash = hash_sha1((curhash, hash_sha1(v)))
 
     if hash_meta:
         for k, v in param_type.param.params().items():
             if k != "name":
-                print(f"key:{k}, hash:{hash_cust(k)}")
-                print(f"value:{v}, hash:{hash_cust(v)}")
-                curhash = hash_cust((curhash, hash_cust(k), hash_cust(v)))
+                print(f"key:{k}, hash:{hash_sha1(k)}")
+                print(f"value:{v}, hash:{hash_sha1(v)}")
+                curhash = hash_sha1((curhash, hash_sha1(k), hash_sha1(v)))
     return curhash
 
 
@@ -99,8 +99,8 @@ def sweep_hash(parameter: Parameterized) -> int:
     """
     curhash = 0
     for v in parameter.values():
-        print(f"value:{v}, hash:{hash_cust(v)}")
-        curhash = hash_cust((curhash, hash_cust(v)))
+        print(f"value:{v}, hash:{hash_sha1(v)}")
+        curhash = hash_sha1((curhash, hash_sha1(v)))
     return curhash
 
 
@@ -113,7 +113,7 @@ def hash_extra_vars(parameter: Parameterized) -> int:
     Returns:
         int: hash
     """
-    return hash_cust((parameter.units, parameter.samples, parameter.samples_debug))
+    return hash_sha1((parameter.units, parameter.samples, parameter.samples_debug))
 
 
 def describe_variable(v: Parameterized, debug: bool, include_samples: bool) -> List[str]:
@@ -468,7 +468,7 @@ class ResultVar(Number):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_cust((self.units, self.direction))
+        return hash_sha1((self.units, self.direction))
 
 
 class ResultVec(param.List):
@@ -485,7 +485,7 @@ class ResultVec(param.List):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_cust((self.units, self.direction))
+        return hash_sha1((self.units, self.direction))
 
     def index_name(self, idx: int) -> str:
         """given the index of the vector, return the column name that
@@ -579,7 +579,7 @@ class ResultList(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_cust((self.units, self.dim_name, self.dim_units))
+        return hash_sha1((self.units, self.dim_name, self.dim_units))
 
     # def gen_indices(self, result_vec) -> None:
     #     # if self.indices is None:

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -12,12 +12,9 @@ import hashlib
 from sys import byteorder
 
 
-def hash_cust(var: any):
-    return hashlib.sha1(str(var).encode("ASCII")).hexdigest()
-    # hash_val = 0
-    # for ch in text:
-    # hash_val = (hash_val * 281 ^ ord(ch) * 997) & 0xFFFFFFFF
-    # return hash_val
+def hash_cust(var: any) -> str:
+    """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
+    return hashlib.sha1(str(var).encode("ASCII")).hexdigest()    
 
 
 def capitalise_words(message: str):
@@ -76,14 +73,16 @@ def param_hash(param_type: Parameterized, hash_value: bool = True, hash_meta: bo
 class ParametrizedSweep(Parameterized):
     """Parent class for all Sweep types that need a custom hash"""
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
 
 class ParametrizedOutput(Parameterized):
     """Parent class for all Output types that need a custom hash"""
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
 
@@ -162,7 +161,8 @@ class BoolSweep(Boolean):
         """Generate a string representation of the sampling procedure"""
         return f"sampling {self.name} from: [True,False]"
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -184,7 +184,8 @@ class TimeBase(Selector):
         """
         return f"sampling from [The Past to {self.objects[0]}]"
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -280,7 +281,8 @@ class StringSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -323,7 +325,8 @@ class EnumSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -393,7 +396,8 @@ class IntSweep(Integer):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -440,7 +444,8 @@ class FloatSweep(Number):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
 
@@ -461,7 +466,8 @@ class ResultVar(Number):
         self.default = 0  # json is terrible and does not support nan values
         self.direction = direction
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
 
@@ -477,7 +483,8 @@ class ResultVec(param.List):
         self.direction = direction
         self.size = size
 
-    def hash_custom(self) -> int:
+   def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
     def index_name(self, idx: int) -> str:
@@ -515,8 +522,8 @@ class ResultList(param.List):
         param.List.__init__(self, **params)
         self.dim_name = dim_name
         self.dim_units = dim_units
-
         self.units = units
 
-    def hash_custom(self) -> int:
+    def hash_custom(self) -> str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -513,7 +513,29 @@ class ResultVec(param.List):
         return [self.index_name(i) for i in range(self.size)]
 
 
-class ResultList(param.List):
+class ResSer:
+    def __init__(self, values=None, index=None) -> None:
+        self.values = []
+        self.index = []
+        self.set_index_and_values(values, index)
+
+    def append(self, value, index=None) -> None:
+        if index is None:
+            self.index.append(len(self.values))
+        else:
+            self.index.append(index)
+        self.values.append(value)
+
+    def set_index_and_values(self, values, index=None) -> None:
+        if values is not None:
+            if index is None:
+                self.index = list(range(len(values)))
+            else:
+                self.index = index
+            self.values = values
+
+
+class ResultList(param.Parameter):
     """A class to unknown size vector result variable"""
 
     __slots__ = ["units", "dim_name", "dim_units", "indices"]
@@ -522,23 +544,30 @@ class ResultList(param.List):
         self,
         index_name: str,
         index_units: str,
+        default=ResSer(),
         units="ul",
         indices: List[float] = None,
+        instantiate=True,
         **params,
     ):
-
-        param.List.__init__(self, **params)
+        param.Parameter.__init__(self, default=default, instantiate=instantiate, **params)
+        # self.
+        # self.value_units = units
+        # self.index_units = index_units
         self.units = units
         self.dim_name = index_name
         self.dim_units = index_units
         self.indices = indices
+        # self.index = indices
 
     def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))
 
-    def validate_indices(self, result_vec) -> None:
-        if self.indices is None:
-            self.indices = list(range(len(result_vec)))
-        else:
-            assert len(self.indices) == len(result_vec)
+    # def gen_indices(self, result_vec) -> None:
+    #     # if self.indices is None:
+    #     return list(range(len(result_vec)))
+    # return self.indices
+
+    # def append(self,val):
+    # self.it

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -73,7 +73,7 @@ def param_hash(param_type: Parameterized, hash_value: bool = True, hash_meta: bo
 class ParametrizedSweep(Parameterized):
     """Parent class for all Sweep types that need a custom hash"""
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
@@ -81,7 +81,7 @@ class ParametrizedSweep(Parameterized):
 class ParametrizedOutput(Parameterized):
     """Parent class for all Output types that need a custom hash"""
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return param_hash(self, True, False)
 
@@ -161,7 +161,7 @@ class BoolSweep(Boolean):
         """Generate a string representation of the sampling procedure"""
         return f"sampling {self.name} from: [True,False]"
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -184,7 +184,7 @@ class TimeBase(Selector):
         """
         return f"sampling from [The Past to {self.objects[0]}]"
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -281,7 +281,7 @@ class StringSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -325,7 +325,7 @@ class EnumSweep(Selector):
         object_str = ",".join([i for i in self.objects])
         return f"sampling {self.name} from: [{object_str}]"
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -396,7 +396,7 @@ class IntSweep(Integer):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -444,7 +444,7 @@ class FloatSweep(Number):
         """
         return int_float_sampling_str(self.name, self.values(debug))
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_extra_vars(self)
 
@@ -466,7 +466,7 @@ class ResultVar(Number):
         self.default = 0  # json is terrible and does not support nan values
         self.direction = direction
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
@@ -483,7 +483,7 @@ class ResultVec(param.List):
         self.direction = direction
         self.size = size
 
-   def hash_custom(self) -> str:
+    def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.direction))
 
@@ -524,6 +524,6 @@ class ResultList(param.List):
         self.dim_units = dim_units
         self.units = units
 
-    def hash_custom(self) -> str:
+     def hash_custom(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_cust((self.units, self.dim_name, self.dim_units))

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -505,17 +505,18 @@ class ResultVec(param.List):
         """
         return [self.index_name(i) for i in range(self.size)]
 
+
 class ResultList(param.List):
     """A class to unknown size vector result variable"""
 
-    __slots__ = ["units","dim_name","dim_units"]
+    __slots__ = ["units", "dim_name", "dim_units"]
 
-    def __init__(self,dim_name,dim_units, units="ul", **params):
+    def __init__(self, dim_name, dim_units, units="ul", **params):
         param.List.__init__(self, **params)
-        self.dim_name= dim_name
-        self.dim_units= dim_units
+        self.dim_name = dim_name
+        self.dim_units = dim_units
 
         self.units = units
 
     def hash_custom(self) -> int:
-        return hash_cust(self.units)
+        return hash_cust((self.units, self.dim_name, self.dim_units))

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -576,5 +576,3 @@ class ResultList(param.Parameter):
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_sha1((self.units, self.dim_name, self.dim_units))
-
- 

--- a/bencher/bench_vars.py
+++ b/bencher/bench_vars.py
@@ -568,23 +568,13 @@ class ResultList(param.Parameter):
         **params,
     ):
         param.Parameter.__init__(self, default=default, instantiate=instantiate, **params)
-        # self.
-        # self.value_units = units
-        # self.index_units = index_units
         self.units = units
         self.dim_name = index_name
         self.dim_units = index_units
         self.indices = indices
-        # self.index = indices
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
         return hash_sha1((self.units, self.dim_name, self.dim_units))
 
-    # def gen_indices(self, result_vec) -> None:
-    #     # if self.indices is None:
-    #     return list(range(len(result_vec)))
-    # return self.indices
-
-    # def append(self,val):
-    # self.it
+ 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -551,18 +551,23 @@ class Bench(BenchPlotServer):
                 dimname = bench_cfg.input_vars[0].name
                 input_value = function_input[dimname]
                 # manually create dimension indices to help concat the data later
-                dim_indices = list(range(len(result_value)))
+
+                rv.validate_indices(result_value)
+                # if rv.indicies is None:
+                #     dim_indices = list(range(len(result_value)))
+                # else:
+                #     dim_indices = rv.indices
 
                 print(result_value)
                 print(dimname)
                 print(dimname, input_value)
                 print(rv.dim_name)
-                print(dim_indices)
+                print(rv.indices)
 
                 new_dataarray = xr.DataArray(
                     [result_value],
                     name=rv.name,
-                    coords={dimname: [input_value], rv.dim_name: dim_indices},
+                    coords={dimname: [input_value], rv.dim_name: rv.indices},
                 )
 
                 dataset_key = (bench_cfg.hash_value, rv.name)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -389,8 +389,7 @@ class Bench(BenchPlotServer):
                 data_vars[rv.name] = (dims_cfg.dims_name, result_data)
             elif type(rv) == ResultVec:
                 for i in range(rv.size):
-                    result_data = np.empty(dims_cfg.dims_size)
-                    result_data.fill(np.nan)
+                    result_data.full(dims_cfg.dims_size,np.nan)
                     data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
 
         bench_cfg.ds = xr.Dataset(data_vars=data_vars, coords=dims_cfg.coords)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -551,13 +551,59 @@ class Bench(BenchPlotServer):
                             )
             elif type(rv) == ResultList:
                 dimname =bench_cfg.input_vars[0].name
+                vec_dimname = "time"
+                input_value = function_input[dimname]
+                name = rv.name
+                times_values =list(range(len(result_value)))
+
                 # ,coords={dimname:function_input[dimname]}
-                new= xr.DataArray(result_value,name=rv.name,dims=[dimname])
+                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname],coords={dimname:[function_input[dimname]]*len(result_value)})
+
+                # import pandas as pd
+
+                # data = {dimname:[function_input[dimname]]*len(result_value),rv.name:result_value,vec_dimname:list(range(len(result_value)))}
+
+                # df = pd.DataFrame(data)
+                # print("df")
+                # print(df)
+
+                # new = xr.DataArray(df,name=input_value)
+
+                new= xr.DataArray([result_value],name=name,coords={dimname:[input_value], vec_dimname:times_values})
+
+                # rv1 = np.array(result_value)
+                # rv2 = rv1+1
+
+                # dat = [rv1,rv2]
+                # print(dat)
+                # new= xr.DataArray(dat,name=name,coords={dimname:[0.,2.],vec_dimname:times_values})
+
+
+                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname])
+
+                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname,vec_dimname],coords={dimname:[function_input[dimname]]*len(result_value),vec_dimname:list(range(len(result_value)))})
+
+                print("new")
                 print(new)
-                if rv.name in self.ds_dynamic:                    
-                    self.ds_dynamic[rv.name] = xr.concat([self.ds_dynamic[rv.name],new],dim=dimname)    
+                print(new.to_dataframe().reset_index())
+                if rv.name in self.ds_dynamic:    
+                    self.ds_dynamic[rv.name] = xr.concat([self.ds_dynamic[rv.name],new],dimname)    
+
+                    # self.ds_dynamic[rv.name] = xr.concat([self.ds_dynamic[rv.name],new],"dim2",combine_attrs="drop")    
+                    # self.ds_dynamic[rv.name] = xr.merge([self.ds_dynamic[rv.name],new])    
+                    # self.ds_dynamic[rv.name] = xr.combine_nested([self.ds_dynamic[rv.name],new],dimname)    
+                    # self.ds_dynamic[rv.name] = xr.combine_by_coords([self.ds_dynamic[rv.name],new],dimname)    
+
+
+                    print("concat")
+                    print(self.ds_dynamic[rv.name])
+                    print(self.ds_dynamic[rv.name].to_dataframe())
+                    print(self.ds_dynamic[rv.name].to_dataframe().reset_index())
+
                 else:
                     self.ds_dynamic[rv.name]=new
+               
+
             else:
                 raise RuntimeError("Unsupported result type")
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -207,11 +207,11 @@ class Bench(BenchPlotServer):
         )
         bench_cfg.param.update(run_cfg.param.values())
 
-        bench_cfg_hash = bench_cfg.hash_custom(True)
+        bench_cfg_hash = bench_cfg.hash_persistent(True)
         bench_cfg.hash_value = bench_cfg_hash
 
         # does not include repeats in hash as sample_hash already includes repeat as part of the per sample hash
-        bench_cfg_sample_hash = bench_cfg.hash_custom(False)
+        bench_cfg_sample_hash = bench_cfg.hash_persistent(False)
 
         if bench_cfg.use_sample_cache:
             self.sample_cache = Cache("cachedir/sample_cache", tag_index=True)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -534,13 +534,13 @@ class Bench(BenchPlotServer):
             else:
                 result_value = result.param.values()[rv.name]
 
+            if bench_run_cfg.print_bench_results:
+                logging.info(f"{rv.name}: {result_value}")
+
             if type(rv) == ResultVar:
-                if bench_run_cfg.print_bench_results:
-                    logging.info(rv.name, result_value)
+
                 set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
             elif type(rv) == ResultVec:
-                if bench_run_cfg.print_bench_results:
-                    logging.info(rv.name, result_value)
                 if isinstance(result_value, (list, np.ndarray)):
                     if len(result_value) == rv.size:
                         for i in range(rv.size):
@@ -551,11 +551,6 @@ class Bench(BenchPlotServer):
                 # TODO generalise this for arbirary dimensions, only works for 1 input dim so far.
                 dimname = bench_cfg.input_vars[0].name
                 input_value = function_input[dimname]
-                # print(result_value)
-                # print(dimname)
-                # print(dimname, input_value)
-                # print(rv.dim_name)
-                # print(rv.indices)
 
                 new_dataarray = xr.DataArray(
                     [result_value.values],

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -538,7 +538,6 @@ class Bench(BenchPlotServer):
                 logging.info(f"{rv.name}: {result_value}")
 
             if type(rv) == ResultVar:
-
                 set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
             elif type(rv) == ResultVec:
                 if isinstance(result_value, (list, np.ndarray)):

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -534,12 +534,13 @@ class Bench(BenchPlotServer):
             else:
                 result_value = result.param.values()[rv.name]
 
-            if bench_run_cfg.print_bench_results:
-                logging.info(rv.name, result_value)
-
             if type(rv) == ResultVar:
+                if bench_run_cfg.print_bench_results:
+                    logging.info(rv.name, result_value)
                 set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
             elif type(rv) == ResultVec:
+                if bench_run_cfg.print_bench_results:
+                    logging.info(rv.name, result_value)
                 if isinstance(result_value, (list, np.ndarray)):
                     if len(result_value) == rv.size:
                         for i in range(rv.size):
@@ -550,24 +551,16 @@ class Bench(BenchPlotServer):
                 # TODO generalise this for arbirary dimensions, only works for 1 input dim so far.
                 dimname = bench_cfg.input_vars[0].name
                 input_value = function_input[dimname]
-                # manually create dimension indices to help concat the data later
-
-                rv.validate_indices(result_value)
-                # if rv.indicies is None:
-                #     dim_indices = list(range(len(result_value)))
-                # else:
-                #     dim_indices = rv.indices
-
-                print(result_value)
-                print(dimname)
-                print(dimname, input_value)
-                print(rv.dim_name)
-                print(rv.indices)
+                # print(result_value)
+                # print(dimname)
+                # print(dimname, input_value)
+                # print(rv.dim_name)
+                # print(rv.indices)
 
                 new_dataarray = xr.DataArray(
-                    [result_value],
+                    [result_value.values],
                     name=rv.name,
-                    coords={dimname: [input_value], rv.dim_name: rv.indices},
+                    coords={dimname: [input_value], rv.dim_name: result_value.index},
                 )
 
                 dataset_key = (bench_cfg.hash_value, rv.name)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -389,7 +389,7 @@ class Bench(BenchPlotServer):
                 data_vars[rv.name] = (dims_cfg.dims_name, result_data)
             elif type(rv) == ResultVec:
                 for i in range(rv.size):
-                    result_data.full(dims_cfg.dims_size,np.nan)
+                    result_data.full(dims_cfg.dims_size, np.nan)
                     data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
 
         bench_cfg.ds = xr.Dataset(data_vars=data_vars, coords=dims_cfg.coords)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -43,7 +43,8 @@ def set_xarray_multidim(data_array: xr.DataArray, index_tuple, value: float) -> 
         case 3:
             data_array[index_tuple[0], index_tuple[1], index_tuple[2]] = value
         case 4:
-            data_array[index_tuple[0], index_tuple[1], index_tuple[2], index_tuple[3]] = value
+            data_array[index_tuple[0], index_tuple[1],
+                       index_tuple[2], index_tuple[3]] = value
         case 5:
             data_array[
                 index_tuple[0], index_tuple[1], index_tuple[2], index_tuple[3], index_tuple[4]
@@ -112,7 +113,8 @@ class Bench(BenchPlotServer):
         self.worker_input_cfg = None
         self.set_worker(worker, worker_input_cfg)
 
-        self.plots_instance = pn.Tabs(tabs_location="left", name=self.bench_name)
+        self.plots_instance = pn.Tabs(
+            tabs_location="left", name=self.bench_name)
         # The number of times the wrapped worker was called
         self.worker_wrapper_call_count = 0
         self.worker_fn_call_count = 0  # The number of times the raw worker was called
@@ -121,7 +123,7 @@ class Bench(BenchPlotServer):
         self.bench_cfg_hashes = []  # a list of hashes that point to benchmark results
         self.last_run_cfg = None  # cached run_cfg used to pass to the plotting function
         self.sample_cache = None  # store the results of each benchmark function call in a cache
-        self.ds_dynamic=None
+        self.ds_dynamic = None
 
     def set_worker(self, worker: Callable, worker_input_cfg: ParametrizedSweep = None) -> None:
         """Set the benchmark worker function and optionally the type the worker expects
@@ -208,6 +210,7 @@ class Bench(BenchPlotServer):
         bench_cfg.param.update(run_cfg.param.values())
 
         bench_cfg_hash = bench_cfg.hash_custom(True)
+        bench_cfg.hash_value = bench_cfg_hash
 
         # does not include repeats in hash as sample_hash already includes repeat as part of the per sample hash
         bench_cfg_sample_hash = bench_cfg.hash_custom(False)
@@ -227,14 +230,16 @@ class Bench(BenchPlotServer):
                     f"checking for previously calculated results with key: {bench_cfg_hash}"
                 )
                 if bench_cfg_hash in c:
-                    logging.info(f"loading cached results from key: {bench_cfg_hash}")
+                    logging.info(
+                        f"loading cached results from key: {bench_cfg_hash}")
                     bench_cfg = c[bench_cfg_hash]
                     # if not over_time:  # if over time we always want to calculate results
                     calculate_results = False
                 else:
                     logging.info("did not detect results in cache")
                     if run_cfg.only_plot:
-                        raise FileNotFoundError("Was not able to load the results to plot!")
+                        raise FileNotFoundError(
+                            "Was not able to load the results to plot!")
 
         if calculate_results:
             if run_cfg.time_event is not None:
@@ -251,7 +256,8 @@ class Bench(BenchPlotServer):
                     bench_cfg.ds, bench_cfg_hash, run_cfg.clear_history
                 )
 
-            self.report_results(bench_cfg, run_cfg.print_xarray, run_cfg.print_pandas)
+            self.report_results(
+                bench_cfg, run_cfg.print_xarray, run_cfg.print_pandas)
             self.cache_results(bench_cfg, bench_cfg_hash)
 
         self.plots_instance = BenchPlotter.plot(bench_cfg, self.plots_instance)
@@ -292,11 +298,13 @@ class Bench(BenchPlotServer):
         Returns:
             bench_cfg (BenchCfg): description of the benchmark parameters
         """
-        bench_cfg, func_inputs, dims_name = self.setup_dataset(bench_cfg, time_src)
+        bench_cfg, func_inputs, dims_name = self.setup_dataset(
+            bench_cfg, time_src)
         constant_inputs = self.define_const_inputs(bench_cfg.const_vars)
         callcount = 1
         for idx_tuple, function_input_vars in func_inputs:
-            logging.info(f"{bench_cfg.title}:call {callcount}/{len(func_inputs)}")
+            logging.info(
+                f"{bench_cfg.title}:call {callcount}/{len(func_inputs)}")
             self.call_worker_and_store_results(
                 bench_cfg,
                 idx_tuple,
@@ -367,7 +375,8 @@ class Bench(BenchPlotServer):
 
         if time_src is None:
             time_src = datetime.now()
-        bench_cfg.meta_vars = self.define_extra_vars(bench_cfg, bench_cfg.repeats, time_src)
+        bench_cfg.meta_vars = self.define_extra_vars(
+            bench_cfg, bench_cfg.repeats, time_src)
 
         bench_cfg.all_vars = bench_cfg.input_vars + bench_cfg.meta_vars
 
@@ -376,7 +385,8 @@ class Bench(BenchPlotServer):
 
         dims_cfg = DimsCfg(bench_cfg)
         function_inputs = list(
-            zip(product(*dims_cfg.dim_ranges_index), product(*dims_cfg.dim_ranges))
+            zip(product(*dims_cfg.dim_ranges_index),
+                product(*dims_cfg.dim_ranges))
         )
         # xarray stores K N-dimensional arrays of data.  Each array is named and in this case we have a nd array for each result variable
         data_vars = {}
@@ -390,11 +400,11 @@ class Bench(BenchPlotServer):
                 for i in range(rv.size):
                     result_data = np.empty(dims_cfg.dims_size)
                     result_data.fill(np.nan)
-                    data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
+                    data_vars[rv.index_name(i)] = (
+                        dims_cfg.dims_name, result_data)
             else:
                 if self.ds_dynamic is None:
                     self.ds_dynamic = {}
-
 
         bench_cfg.ds = xr.Dataset(data_vars=data_vars, coords=dims_cfg.coords)
         bench_cfg.ds_dynamic = self.ds_dynamic
@@ -496,7 +506,8 @@ class Bench(BenchPlotServer):
         if bench_cfg.use_sample_cache:
             # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
             fn_inputs_sorted = list(SortedDict(function_input).items())
-            function_input_signature_pure = hash_cust((fn_inputs_sorted, bench_cfg.tag))
+            function_input_signature_pure = hash_cust(
+                (fn_inputs_sorted, bench_cfg.tag))
 
             function_input_signature_benchmark_context = hash_cust(
                 (function_input_signature_pure, bench_cfg_sample_hash)
@@ -523,7 +534,8 @@ class Bench(BenchPlotServer):
                 self.sample_cache.set(
                     function_input_signature_benchmark_context, result, tag=bench_cfg.tag
                 )
-                self.sample_cache.set(function_input_signature_pure, result, tag=bench_cfg.tag)
+                self.sample_cache.set(
+                    function_input_signature_pure, result, tag=bench_cfg.tag)
         else:
             result = self.worker_wrapper(bench_cfg, function_input)
 
@@ -541,72 +553,34 @@ class Bench(BenchPlotServer):
             print(rv.name, result_value)
 
             if type(rv) == ResultVar:
-                set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
+                set_xarray_multidim(
+                    bench_cfg.ds[rv.name], index_tuple, result_value)
             elif type(rv) == ResultVec:
                 if isinstance(result_value, (list, np.ndarray)):
                     if len(result_value) == rv.size:
                         for i in range(rv.size):
                             set_xarray_multidim(
-                                bench_cfg.ds[rv.index_name(i)], index_tuple, result_value[i]
+                                bench_cfg.ds[rv.index_name(
+                                    i)], index_tuple, result_value[i]
                             )
             elif type(rv) == ResultList:
-                dimname =bench_cfg.input_vars[0].name
-                vec_dimname = "time"
+                # TODO generalise this for arbirary dimensions, only works for 1 input dim so far.
+                dimname = bench_cfg.input_vars[0].name
                 input_value = function_input[dimname]
-                name = rv.name
-                times_values =list(range(len(result_value)))
+                # manually create dimension indices to help concat the data later
+                dim_indices = list(range(len(result_value)))
 
-                # ,coords={dimname:function_input[dimname]}
-                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname],coords={dimname:[function_input[dimname]]*len(result_value)})
-
-                # import pandas as pd
-
-                # data = {dimname:[function_input[dimname]]*len(result_value),rv.name:result_value,vec_dimname:list(range(len(result_value)))}
-
-                # df = pd.DataFrame(data)
-                # print("df")
-                # print(df)
-
-                # new = xr.DataArray(df,name=input_value)
-
-                new= xr.DataArray([result_value],name=name,coords={dimname:[input_value], vec_dimname:times_values})
-
-                # rv1 = np.array(result_value)
-                # rv2 = rv1+1
-
-                # dat = [rv1,rv2]
-                # print(dat)
-                # new= xr.DataArray(dat,name=name,coords={dimname:[0.,2.],vec_dimname:times_values})
-
-
-                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname])
-
-                # new= xr.DataArray(result_value,name=rv.name,dims=[dimname,vec_dimname],coords={dimname:[function_input[dimname]]*len(result_value),vec_dimname:list(range(len(result_value)))})
-
-                print("new")
-                print(new)
-                print(new.to_dataframe().reset_index())
-                if rv.name in self.ds_dynamic:    
-                    self.ds_dynamic[rv.name] = xr.concat([self.ds_dynamic[rv.name],new],dimname)    
-
-                    # self.ds_dynamic[rv.name] = xr.concat([self.ds_dynamic[rv.name],new],"dim2",combine_attrs="drop")    
-                    # self.ds_dynamic[rv.name] = xr.merge([self.ds_dynamic[rv.name],new])    
-                    # self.ds_dynamic[rv.name] = xr.combine_nested([self.ds_dynamic[rv.name],new],dimname)    
-                    # self.ds_dynamic[rv.name] = xr.combine_by_coords([self.ds_dynamic[rv.name],new],dimname)    
-
-
-                    print("concat")
-                    print(self.ds_dynamic[rv.name])
-                    print(self.ds_dynamic[rv.name].to_dataframe())
-                    print(self.ds_dynamic[rv.name].to_dataframe().reset_index())
-
+                new_dataarray = xr.DataArray([result_value], name=rv.name, coords={
+                                   dimname: [input_value], rv.dim_name: dim_indices})
+                
+                dataset_key = (bench_cfg.hash_value, rv.name)
+                if dataset_key in self.ds_dynamic:
+                    self.ds_dynamic[dataset_key] = xr.concat(
+                        [self.ds_dynamic[dataset_key], new_dataarray], dimname)
                 else:
-                    self.ds_dynamic[rv.name]=new
-               
-
+                    self.ds_dynamic[dataset_key] = new_dataarray
             else:
                 raise RuntimeError("Unsupported result type")
-
 
     def clear_tag(self, tag: str):
         """Clear all samples from the cache that match a tag
@@ -636,8 +610,7 @@ class Bench(BenchPlotServer):
                     bench_cfg.ds[rv.index_name(i)].attrs["units"] = rv.units
                     bench_cfg.ds[rv.index_name(i)].attrs["long_name"] = rv.name
             else:
-                pass #todo
-
+                pass  # todo
 
         dsvar = bench_cfg.ds[input_var.name]
         dsvar.attrs["long_name"] = input_var.name

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -121,7 +121,7 @@ class Bench(BenchPlotServer):
         self.bench_cfg_hashes = []  # a list of hashes that point to benchmark results
         self.last_run_cfg = None  # cached run_cfg used to pass to the plotting function
         self.sample_cache = None  # store the results of each benchmark function call in a cache
-        self.ds_dynamic = None
+        self.ds_dynamic = {}  # A dictionary to store unstructured vector datasets
 
     def set_worker(self, worker: Callable, worker_input_cfg: ParametrizedSweep = None) -> None:
         """Set the benchmark worker function and optionally the type the worker expects
@@ -392,9 +392,6 @@ class Bench(BenchPlotServer):
                     result_data = np.empty(dims_cfg.dims_size)
                     result_data.fill(np.nan)
                     data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
-            else:
-                if self.ds_dynamic is None:
-                    self.ds_dynamic = {}
 
         bench_cfg.ds = xr.Dataset(data_vars=data_vars, coords=dims_cfg.coords)
         bench_cfg.ds_dynamic = self.ds_dynamic

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -18,7 +18,7 @@ from bencher.bench_vars import (
     ResultVar,
     ResultVec,
     ResultList,
-    hash_cust,
+    hash_sha1,
 )
 from bencher.plt_cfg import BenchPlotter
 from bencher.bench_cfg import BenchCfg, BenchRunCfg, DimsCfg
@@ -493,9 +493,9 @@ class Bench(BenchPlotServer):
         if bench_cfg.use_sample_cache:
             # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
             fn_inputs_sorted = list(SortedDict(function_input).items())
-            function_input_signature_pure = hash_cust((fn_inputs_sorted, bench_cfg.tag))
+            function_input_signature_pure = hash_sha1((fn_inputs_sorted, bench_cfg.tag))
 
-            function_input_signature_benchmark_context = hash_cust(
+            function_input_signature_benchmark_context = hash_sha1(
                 (function_input_signature_pure, bench_cfg_sample_hash)
             )
             print("inputs", fn_inputs_sorted)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -467,8 +467,8 @@ class Bench(BenchPlotServer):
         function_input_vars: List,
         dims_name: List[str],
         constant_inputs: dict,
-        bench_cfg_sample_hash,
-        bench_run_cfg,
+        bench_cfg_sample_hash: str,
+        bench_run_cfg: BenchRunCfg,
     ) -> None:
         """A wrapper around the benchmarking function to set up and store the results of the benchmark function
 
@@ -533,9 +533,9 @@ class Bench(BenchPlotServer):
                 result_value = result[rv.name]
             else:
                 result_value = result.param.values()[rv.name]
-            logging.debug(f"rn:{rv.name},rv:{result_value}")
 
-            print(rv.name, result_value)
+            if bench_run_cfg.print_bench_results:
+                logging.info(rv.name, result_value)
 
             if type(rv) == ResultVar:
                 set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
@@ -552,6 +552,12 @@ class Bench(BenchPlotServer):
                 input_value = function_input[dimname]
                 # manually create dimension indices to help concat the data later
                 dim_indices = list(range(len(result_value)))
+
+                print(result_value)
+                print(dimname)
+                print(dimname, input_value)
+                print(rv.dim_name)
+                print(dim_indices)
 
                 new_dataarray = xr.DataArray(
                     [result_value],

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -43,8 +43,7 @@ def set_xarray_multidim(data_array: xr.DataArray, index_tuple, value: float) -> 
         case 3:
             data_array[index_tuple[0], index_tuple[1], index_tuple[2]] = value
         case 4:
-            data_array[index_tuple[0], index_tuple[1],
-                       index_tuple[2], index_tuple[3]] = value
+            data_array[index_tuple[0], index_tuple[1], index_tuple[2], index_tuple[3]] = value
         case 5:
             data_array[
                 index_tuple[0], index_tuple[1], index_tuple[2], index_tuple[3], index_tuple[4]
@@ -113,8 +112,7 @@ class Bench(BenchPlotServer):
         self.worker_input_cfg = None
         self.set_worker(worker, worker_input_cfg)
 
-        self.plots_instance = pn.Tabs(
-            tabs_location="left", name=self.bench_name)
+        self.plots_instance = pn.Tabs(tabs_location="left", name=self.bench_name)
         # The number of times the wrapped worker was called
         self.worker_wrapper_call_count = 0
         self.worker_fn_call_count = 0  # The number of times the raw worker was called
@@ -230,16 +228,14 @@ class Bench(BenchPlotServer):
                     f"checking for previously calculated results with key: {bench_cfg_hash}"
                 )
                 if bench_cfg_hash in c:
-                    logging.info(
-                        f"loading cached results from key: {bench_cfg_hash}")
+                    logging.info(f"loading cached results from key: {bench_cfg_hash}")
                     bench_cfg = c[bench_cfg_hash]
                     # if not over_time:  # if over time we always want to calculate results
                     calculate_results = False
                 else:
                     logging.info("did not detect results in cache")
                     if run_cfg.only_plot:
-                        raise FileNotFoundError(
-                            "Was not able to load the results to plot!")
+                        raise FileNotFoundError("Was not able to load the results to plot!")
 
         if calculate_results:
             if run_cfg.time_event is not None:
@@ -256,8 +252,7 @@ class Bench(BenchPlotServer):
                     bench_cfg.ds, bench_cfg_hash, run_cfg.clear_history
                 )
 
-            self.report_results(
-                bench_cfg, run_cfg.print_xarray, run_cfg.print_pandas)
+            self.report_results(bench_cfg, run_cfg.print_xarray, run_cfg.print_pandas)
             self.cache_results(bench_cfg, bench_cfg_hash)
 
         self.plots_instance = BenchPlotter.plot(bench_cfg, self.plots_instance)
@@ -298,13 +293,11 @@ class Bench(BenchPlotServer):
         Returns:
             bench_cfg (BenchCfg): description of the benchmark parameters
         """
-        bench_cfg, func_inputs, dims_name = self.setup_dataset(
-            bench_cfg, time_src)
+        bench_cfg, func_inputs, dims_name = self.setup_dataset(bench_cfg, time_src)
         constant_inputs = self.define_const_inputs(bench_cfg.const_vars)
         callcount = 1
         for idx_tuple, function_input_vars in func_inputs:
-            logging.info(
-                f"{bench_cfg.title}:call {callcount}/{len(func_inputs)}")
+            logging.info(f"{bench_cfg.title}:call {callcount}/{len(func_inputs)}")
             self.call_worker_and_store_results(
                 bench_cfg,
                 idx_tuple,
@@ -375,8 +368,7 @@ class Bench(BenchPlotServer):
 
         if time_src is None:
             time_src = datetime.now()
-        bench_cfg.meta_vars = self.define_extra_vars(
-            bench_cfg, bench_cfg.repeats, time_src)
+        bench_cfg.meta_vars = self.define_extra_vars(bench_cfg, bench_cfg.repeats, time_src)
 
         bench_cfg.all_vars = bench_cfg.input_vars + bench_cfg.meta_vars
 
@@ -385,8 +377,7 @@ class Bench(BenchPlotServer):
 
         dims_cfg = DimsCfg(bench_cfg)
         function_inputs = list(
-            zip(product(*dims_cfg.dim_ranges_index),
-                product(*dims_cfg.dim_ranges))
+            zip(product(*dims_cfg.dim_ranges_index), product(*dims_cfg.dim_ranges))
         )
         # xarray stores K N-dimensional arrays of data.  Each array is named and in this case we have a nd array for each result variable
         data_vars = {}
@@ -400,8 +391,7 @@ class Bench(BenchPlotServer):
                 for i in range(rv.size):
                     result_data = np.empty(dims_cfg.dims_size)
                     result_data.fill(np.nan)
-                    data_vars[rv.index_name(i)] = (
-                        dims_cfg.dims_name, result_data)
+                    data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
             else:
                 if self.ds_dynamic is None:
                     self.ds_dynamic = {}
@@ -506,8 +496,7 @@ class Bench(BenchPlotServer):
         if bench_cfg.use_sample_cache:
             # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
             fn_inputs_sorted = list(SortedDict(function_input).items())
-            function_input_signature_pure = hash_cust(
-                (fn_inputs_sorted, bench_cfg.tag))
+            function_input_signature_pure = hash_cust((fn_inputs_sorted, bench_cfg.tag))
 
             function_input_signature_benchmark_context = hash_cust(
                 (function_input_signature_pure, bench_cfg_sample_hash)
@@ -534,8 +523,7 @@ class Bench(BenchPlotServer):
                 self.sample_cache.set(
                     function_input_signature_benchmark_context, result, tag=bench_cfg.tag
                 )
-                self.sample_cache.set(
-                    function_input_signature_pure, result, tag=bench_cfg.tag)
+                self.sample_cache.set(function_input_signature_pure, result, tag=bench_cfg.tag)
         else:
             result = self.worker_wrapper(bench_cfg, function_input)
 
@@ -553,15 +541,13 @@ class Bench(BenchPlotServer):
             print(rv.name, result_value)
 
             if type(rv) == ResultVar:
-                set_xarray_multidim(
-                    bench_cfg.ds[rv.name], index_tuple, result_value)
+                set_xarray_multidim(bench_cfg.ds[rv.name], index_tuple, result_value)
             elif type(rv) == ResultVec:
                 if isinstance(result_value, (list, np.ndarray)):
                     if len(result_value) == rv.size:
                         for i in range(rv.size):
                             set_xarray_multidim(
-                                bench_cfg.ds[rv.index_name(
-                                    i)], index_tuple, result_value[i]
+                                bench_cfg.ds[rv.index_name(i)], index_tuple, result_value[i]
                             )
             elif type(rv) == ResultList:
                 # TODO generalise this for arbirary dimensions, only works for 1 input dim so far.
@@ -570,13 +556,17 @@ class Bench(BenchPlotServer):
                 # manually create dimension indices to help concat the data later
                 dim_indices = list(range(len(result_value)))
 
-                new_dataarray = xr.DataArray([result_value], name=rv.name, coords={
-                                   dimname: [input_value], rv.dim_name: dim_indices})
-                
+                new_dataarray = xr.DataArray(
+                    [result_value],
+                    name=rv.name,
+                    coords={dimname: [input_value], rv.dim_name: dim_indices},
+                )
+
                 dataset_key = (bench_cfg.hash_value, rv.name)
                 if dataset_key in self.ds_dynamic:
                     self.ds_dynamic[dataset_key] = xr.concat(
-                        [self.ds_dynamic[dataset_key], new_dataarray], dimname)
+                        [self.ds_dynamic[dataset_key], new_dataarray], dimname
+                    )
                 else:
                     self.ds_dynamic[dataset_key] = new_dataarray
             else:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -389,7 +389,7 @@ class Bench(BenchPlotServer):
                 data_vars[rv.name] = (dims_cfg.dims_name, result_data)
             elif type(rv) == ResultVec:
                 for i in range(rv.size):
-                    result_data.full(dims_cfg.dims_size, np.nan)
+                    result_data = np.full(dims_cfg.dims_size, np.nan)
                     data_vars[rv.index_name(i)] = (dims_cfg.dims_name, result_data)
 
         bench_cfg.ds = xr.Dataset(data_vars=data_vars, coords=dims_cfg.coords)

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -4,11 +4,11 @@ from math import sin, cos
 
 
 class Cfg(bch.ParametrizedSweep):
-    offset = bch.FloatSweep(default=0, bounds=[0., 2.], samples=2,units="v")
+    offset = bch.FloatSweep(default=0, bounds=[0., 2.], samples=5, units="v")
     # angle = bch.FloatSweep(default=0,bounds=[0,6.28])
 
-    sin_sweep = bch.ResultList(dim_name = "time",dim_units="s",units="v")
-    cos_sweep = bch.ResultList(dim_name= "time",dim_units = "s",units="v")
+    sin_sweep = bch.ResultList(dim_name="time", dim_units="s", units="v")
+    cos_sweep = bch.ResultList(dim_name="time", dim_units="s", units="v")
 
 
 def sin_sweep(offset=0, **kwargs):
@@ -26,6 +26,8 @@ cfg = Cfg()
 bencher = bch.Bench("vector output example", sin_sweep)
 
 bencher.plot_sweep(title="sin", input_vars=[Cfg.param.offset], result_vars=[
+                #    Cfg.param.sin_sweep])
                    Cfg.param.sin_sweep, Cfg.param.cos_sweep])
+
 
 bencher.plot()

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -28,10 +28,10 @@ class SweepResult(bch.ParametrizedOutput):
     """A class to describe the vector outputs of the benchmark function"""
 
     sin_sweep = bch.ResultList(
-        dim_name="time", dim_units="s", units="v", doc="A list of values from a sin function"
+        index_name="time", index_units="s", units="v", doc="A list of values from a sin function"
     )
     cos_sweep = bch.ResultList(
-        dim_name="time", dim_units="s", units="v", doc="A list of values from a cos function"
+        index_name="time", index_units="s", units="v", doc="A list of values from a cos function"
     )
 
 
@@ -47,8 +47,10 @@ def sin_sweep(cfg: OffsetCfg) -> SweepResult:
     res = SweepResult()
     for i in np.arange(0, 6.28, 0.02):
         res.sin_sweep.append(sin(i + cfg.phase_offset) + cfg.dc_offset)
+        res.sin_sweep.indices.append(i)
     for i in np.arange(0, 3.28, 0.02):
         res.cos_sweep.append(cos(i + cfg.phase_offset) + cfg.dc_offset)
+        res.cos_sweep.indices.append(i)
     return res
 
 

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -24,7 +24,7 @@ class OffsetCfg(bch.ParametrizedSweep):
     )
 
 
-class SweepResult(bch.ParametrizedOutput):
+class SweepResult(bch.ParametrizedSweep):
     """A class to describe the vector outputs of the benchmark function"""
 
     sin_sweep = bch.ResultList(

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -45,12 +45,13 @@ def sin_sweep(cfg: OffsetCfg) -> SweepResult:
         SweepResult: vectors with sin and cos results
     """
     res = SweepResult()
+    print(type(res.sin_sweep))
     for i in np.arange(0, 6.28, 0.02):
-        res.sin_sweep.append(sin(i + cfg.phase_offset) + cfg.dc_offset)
-        res.sin_sweep.indices.append(i)
+        res.sin_sweep.append(sin(i + cfg.phase_offset) + cfg.dc_offset, i)
+        # res.sin_sweep.indices.append(i)
     for i in np.arange(0, 3.28, 0.02):
-        res.cos_sweep.append(cos(i + cfg.phase_offset) + cfg.dc_offset)
-        res.cos_sweep.indices.append(i)
+        res.cos_sweep.append(cos(i + cfg.phase_offset) + cfg.dc_offset, i)
+        # res.cos_sweep.indices.append(i)
     return res
 
 

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -7,41 +7,65 @@ from math import sin, cos
 
 class SweepCfg(bch.ParametrizedSweep):
     """A class for describing which parameters to sweep"""
-    dc_offset = bch.FloatSweep(default=0, bounds=[
-                            0., 2.], samples=4, units="v", doc="DC offset to add to the result of the signal")
-    phase_offset = bch.FloatSweep(default=0, bounds=[
-                                  0., 3.14], samples=4, units="rad", doc="phase offset that is added to the input before passing to the trig function")
+
+    dc_offset = bch.FloatSweep(
+        default=0,
+        bounds=[0.0, 2.0],
+        samples=4,
+        units="v",
+        doc="DC offset to add to the result of the signal",
+    )
+    phase_offset = bch.FloatSweep(
+        default=0,
+        bounds=[0.0, 3.14],
+        samples=4,
+        units="rad",
+        doc="phase offset that is added to the input before passing to the trig function",
+    )
 
 
 class SweepResult(bch.ParametrizedOutput):
     """A class to describe the vector outputs of the benchmark function"""
-    sin_sweep = bch.ResultList(dim_name="time", dim_units="s",
-                               units="v", doc="A list of values from a sin function")
-    cos_sweep = bch.ResultList(dim_name="time", dim_units="s",
-                               units="v", doc="A list of values from a cos function")
+
+    sin_sweep = bch.ResultList(
+        dim_name="time", dim_units="s", units="v", doc="A list of values from a sin function"
+    )
+    cos_sweep = bch.ResultList(
+        dim_name="time", dim_units="s", units="v", doc="A list of values from a cos function"
+    )
 
 
 def sin_sweep(cfg: SweepCfg) -> SweepResult:
     res = SweepResult()
     for i in np.arange(0, 6.28, 0.02):
-        res.sin_sweep.append(sin(i+cfg.phase_offset)+cfg.dc_offset)
+        res.sin_sweep.append(sin(i + cfg.phase_offset) + cfg.dc_offset)
     for i in np.arange(0, 3.28, 0.02):
-        res.cos_sweep.append(cos(i+cfg.phase_offset)+cfg.dc_offset)
+        res.cos_sweep.append(cos(i + cfg.phase_offset) + cfg.dc_offset)
     return res
+
 
 def example_vector() -> bch.Bench:
     """Example on how to sweep over function with vector outputs"""
     bencher = bch.Bench("vector output example", sin_sweep, SweepCfg)
 
-    bencher.plot_sweep(title="Sweep offset", input_vars=[SweepCfg.param.dc_offset], result_vars=[
-                    SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
-                    description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of dc offsets""", post_description="""The output shows stack of sin and cos functions as the dc offset increases""")
+    bencher.plot_sweep(
+        title="Sweep DC offset",
+        input_vars=[SweepCfg.param.dc_offset],
+        result_vars=[SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
+        description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of dc offsets""",
+        post_description="""The output shows stack of sin and cos functions as the dc offset increases""",
+    )
 
-    bencher.plot_sweep(title="Sweep phase offset", input_vars=[SweepCfg.param.phase_offset], result_vars=[
-                    SweepResult.param.sin_sweep, SweepResult.param.cos_sweep], description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of phase offsets""", post_description="""The output shows different phases of the sin and cos functions""")
+    bencher.plot_sweep(
+        title="Sweep phase offset",
+        input_vars=[SweepCfg.param.phase_offset],
+        result_vars=[SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
+        description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of phase offsets""",
+        post_description="""The output shows different phases of the sin and cos functions""",
+    )
 
     return bencher
 
 
-if __name__ =="__main__":
+if __name__ == "__main__":
     example_vector().plot()

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -1,33 +1,47 @@
+"""Example on how to sweep over function with vector outputs"""
+
 import bencher as bch
 import numpy as np
 from math import sin, cos
 
 
-class Cfg(bch.ParametrizedSweep):
-    offset = bch.FloatSweep(default=0, bounds=[0., 2.], samples=5, units="v")
-    # angle = bch.FloatSweep(default=0,bounds=[0,6.28])
-
-    sin_sweep = bch.ResultList(dim_name="time", dim_units="s", units="v")
-    cos_sweep = bch.ResultList(dim_name="time", dim_units="s", units="v")
-
-
-def sin_sweep(offset=0, **kwargs):
-    sin_output = []
-    cos_output = []
-    for i in np.arange(0, 6.28):
-        sin_output.append(sin(i)+offset)
-    for i in np.arange(0, 3.28):
-        cos_output.append(cos(i)+offset)
-    return {"sin_sweep": sin_output, "cos_sweep": cos_output}
+class SweepCfg(bch.ParametrizedSweep):
+    """A class for describing which parameters to sweep"""
+    dc_offset = bch.FloatSweep(default=0, bounds=[
+                            0., 2.], samples=4, units="v", doc="DC offset to add to the result of the signal")
+    phase_offset = bch.FloatSweep(default=0, bounds=[
+                                  0., 3.14], samples=4, units="rad", doc="phase offset that is added to the input before passing to the trig function")
 
 
-cfg = Cfg()
+class SweepResult(bch.ParametrizedOutput):
+    """A class to describe the vector outputs of the benchmark function"""
+    sin_sweep = bch.ResultList(dim_name="time", dim_units="s",
+                               units="v", doc="A list of values from a sin function")
+    cos_sweep = bch.ResultList(dim_name="time", dim_units="s",
+                               units="v", doc="A list of values from a cos function")
 
-bencher = bch.Bench("vector output example", sin_sweep)
 
-bencher.plot_sweep(title="sin", input_vars=[Cfg.param.offset], result_vars=[
-                #    Cfg.param.sin_sweep])
-                   Cfg.param.sin_sweep, Cfg.param.cos_sweep])
+def sin_sweep(cfg: SweepCfg) -> SweepResult:
+    res = SweepResult()
+    for i in np.arange(0, 6.28, 0.02):
+        res.sin_sweep.append(sin(i+cfg.phase_offset)+cfg.dc_offset)
+    for i in np.arange(0, 3.28, 0.02):
+        res.cos_sweep.append(cos(i+cfg.phase_offset)+cfg.dc_offset)
+    return res
+
+def example_vector() -> bch.Bench:
+    """Example on how to sweep over function with vector outputs"""
+    bencher = bch.Bench("vector output example", sin_sweep, SweepCfg)
+
+    bencher.plot_sweep(title="Sweep offset", input_vars=[SweepCfg.param.dc_offset], result_vars=[
+                    SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
+                    description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of dc offsets""", post_description="""The output shows stack of sin and cos functions as the dc offset increases""")
+
+    bencher.plot_sweep(title="Sweep phase offset", input_vars=[SweepCfg.param.phase_offset], result_vars=[
+                    SweepResult.param.sin_sweep, SweepResult.param.cos_sweep], description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of phase offsets""", post_description="""The output shows different phases of the sin and cos functions""")
+
+    return bencher
 
 
-bencher.plot()
+if __name__ =="__main__":
+    example_vector().plot()

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -5,7 +5,7 @@ import numpy as np
 from math import sin, cos
 
 
-class SweepCfg(bch.ParametrizedSweep):
+class OffsetCfg(bch.ParametrizedSweep):
     """A class for describing which parameters to sweep"""
 
     dc_offset = bch.FloatSweep(
@@ -35,7 +35,15 @@ class SweepResult(bch.ParametrizedOutput):
     )
 
 
-def sin_sweep(cfg: SweepCfg) -> SweepResult:
+def sin_sweep(cfg: OffsetCfg) -> SweepResult:
+    """A function that returns vector outputs of the sin and cos functions
+
+    Args:
+        cfg (OffsetCfg): Options for phase and dc offset
+
+    Returns:
+        SweepResult: vectors with sin and cos results
+    """
     res = SweepResult()
     for i in np.arange(0, 6.28, 0.02):
         res.sin_sweep.append(sin(i + cfg.phase_offset) + cfg.dc_offset)
@@ -46,11 +54,11 @@ def sin_sweep(cfg: SweepCfg) -> SweepResult:
 
 def example_vector() -> bch.Bench:
     """Example on how to sweep over function with vector outputs"""
-    bencher = bch.Bench("vector output example", sin_sweep, SweepCfg)
+    bencher = bch.Bench("vector output example", sin_sweep, OffsetCfg)
 
     bencher.plot_sweep(
         title="Sweep DC offset",
-        input_vars=[SweepCfg.param.dc_offset],
+        input_vars=[OffsetCfg.param.dc_offset],
         result_vars=[SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
         description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of dc offsets""",
         post_description="""The output shows stack of sin and cos functions as the dc offset increases""",
@@ -58,7 +66,7 @@ def example_vector() -> bch.Bench:
 
     bencher.plot_sweep(
         title="Sweep phase offset",
-        input_vars=[SweepCfg.param.phase_offset],
+        input_vars=[OffsetCfg.param.phase_offset],
         result_vars=[SweepResult.param.sin_sweep, SweepResult.param.cos_sweep],
         description="""This is an example of how to sample function that return a vector of unknown or varying size. In this example it returns the output of the sin and cos function for varying angles and a range of phase offsets""",
         post_description="""The output shows different phases of the sin and cos functions""",

--- a/bencher/example/example_vector.py
+++ b/bencher/example/example_vector.py
@@ -1,0 +1,31 @@
+import bencher as bch
+import numpy as np
+from math import sin, cos
+
+
+class Cfg(bch.ParametrizedSweep):
+    offset = bch.FloatSweep(default=0, bounds=[0., 2.], samples=2,units="v")
+    # angle = bch.FloatSweep(default=0,bounds=[0,6.28])
+
+    sin_sweep = bch.ResultList(dim_name = "time",dim_units="s",units="v")
+    cos_sweep = bch.ResultList(dim_name= "time",dim_units = "s",units="v")
+
+
+def sin_sweep(offset=0, **kwargs):
+    sin_output = []
+    cos_output = []
+    for i in np.arange(0, 6.28):
+        sin_output.append(sin(i)+offset)
+    for i in np.arange(0, 3.28):
+        cos_output.append(cos(i)+offset)
+    return {"sin_sweep": sin_output, "cos_sweep": cos_output}
+
+
+cfg = Cfg()
+
+bencher = bch.Bench("vector output example", sin_sweep)
+
+bencher.plot_sweep(title="sin", input_vars=[Cfg.param.offset], result_vars=[
+                   Cfg.param.sin_sweep, Cfg.param.cos_sweep])
+
+bencher.plot()

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -241,7 +241,7 @@ def bench_cfg_to_study(bench_cfg: BenchCfg, include_meta: bool) -> optuna.Study:
         optuna.Study: optuna description of the study
     """
     if include_meta:
-        df = bench_cfg.to_dataframe()
+        df = bench_cfg.get_dataframe()
         all_vars = []
         for v in bench_cfg.all_vars:
             if type(v) != TimeEvent:

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -241,7 +241,7 @@ def bench_cfg_to_study(bench_cfg: BenchCfg, include_meta: bool) -> optuna.Study:
         optuna.Study: optuna description of the study
     """
     if include_meta:
-        df = bench_cfg.ds.to_dataframe().reset_index()
+        df = bench_cfg.to_dataframe()
         all_vars = []
         for v in bench_cfg.all_vars:
             if type(v) != TimeEvent:

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -12,7 +12,7 @@ import plotly.express as px
 import logging
 
 from holoviews import opts
-from bencher.bench_vars import ParametrizedOutput, ResultVar, ResultVec,ResultList
+from bencher.bench_vars import ParametrizedOutput, ResultVar, ResultVec, ResultList
 from bencher.bench_cfg import PltCfgBase, BenchCfg
 
 hv.extension("plotly")
@@ -109,24 +109,24 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
 
         fg.set_xlabels(label=sns_cfg.xlabel, clear_inner=True)
         fg.set_ylabels(label=sns_cfg.ylabel, clear_inner=True)
-    elif type(rv) == ResultList:       
+    elif type(rv) == ResultList:
         plt.figure(figsize=(4, 4))
 
-        #get the data to plot
-        dataset_key =(bench_cfg.hash_value, rv.name)
+        # get the data to plot
+        dataset_key = (bench_cfg.hash_value, rv.name)
         df = bench_cfg.ds_dynamic[dataset_key].to_dataframe().reset_index()
 
-        #plot
-        fg =sns.lineplot(df,x=rv.dim_name,y=rv.name,hue=bench_cfg.input_vars[0].name)
+        # plot
+        fg = sns.lineplot(df, x=rv.dim_name, y=rv.name, hue=bench_cfg.input_vars[0].name)
 
-        #titles and labels and formatting
+        # titles and labels and formatting
         fg.set_xlabel(f"{rv.dim_name} [{rv.dim_units}]")
         fg.set_ylabel(f"{rv.name} [{rv.units}]")
         fg.set_title(bench_cfg.title)
         plt.tight_layout()
 
         return pn.panel(plt.gcf())
-    
+
     fg.fig.suptitle(sns_cfg.title)
     plt.tight_layout()
 

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -120,7 +120,11 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
 
         print(bench_cfg.input_vars[0].name)
         # fg =sns.lineplot(df,hue=bench_cfg.input_vars[0].name)
-        fg =sns.lineplot(df)
+        fg =sns.lineplot(df,x=rv.dim_name,y=rv.name,hue=bench_cfg.input_vars[0].name)
+        # fg =sns.lineplot(df,x="time")
+        # fg =sns.lineplot(df)
+
+
 
 
         fg.set_xlabel(f"{rv.dim_name} [{rv.dim_units}]")

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -182,7 +182,7 @@ def plot_scatter2D_hv(bench_cfg: BenchCfg, rv: ParametrizedOutput) -> pn.pane.Pl
     bench_cfg = wrap_long_time_labels(bench_cfg)
     bench_cfg.ds.drop_vars("repeat")
 
-    df = bench_cfg.ds.to_dataframe().reset_index()
+    df = bench_cfg.to_dataframe()
 
     names = rv.index_names()
 
@@ -202,7 +202,7 @@ def plot_scatter3D_px(bench_cfg: BenchCfg, rv: ParametrizedOutput) -> pn.pane.Pl
 
     bench_cfg = wrap_long_time_labels(bench_cfg)
 
-    df = bench_cfg.ds.to_dataframe().reset_index()
+    df = bench_cfg.to_dataframe()
 
     names = rv.index_names()  # get the column names of the vector result
 
@@ -425,7 +425,7 @@ def plot_cone_plotly(
 
     opacity = 1.0
 
-    df = bench_cfg.ds.to_dataframe().reset_index()
+    df = bench_cfg.to_dataframe()
 
     print("size before removing zero size vectors", df.shape)
     df = df.loc[(df[names[0]] != 0.0) | (df[names[1]] != 0.0) | (df[names[2]] != 0.0)]

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -12,7 +12,7 @@ import plotly.express as px
 import logging
 
 from holoviews import opts
-from bencher.bench_vars import ParametrizedOutput, ResultVec
+from bencher.bench_vars import ParametrizedOutput, ResultVar, ResultVec,ResultList
 from bencher.bench_cfg import PltCfgBase, BenchCfg
 
 hv.extension("plotly")
@@ -92,7 +92,7 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
             return plot_scatter3D_px(bench_cfg, rv)
         else:
             return pn.pane.Markdown("Scatter plots of >3D result vectors not supported yet")
-    else:
+    elif type(rv) == ResultVar:
         df = bench_cfg.ds[rv.name].to_dataframe().reset_index()
 
         try:
@@ -109,6 +109,28 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
 
         fg.set_xlabels(label=sns_cfg.xlabel, clear_inner=True)
         fg.set_ylabels(label=sns_cfg.ylabel, clear_inner=True)
+    else:
+        # df = bench_cfg.ds_dynamic[rv.name].to_dataframe()
+        # print("df",df)
+
+
+        df = bench_cfg.ds_dynamic[rv.name].to_dataframe().reset_index()
+        plt.figure(figsize=(4, 4))
+        print("df",df)
+
+        print(bench_cfg.input_vars[0].name)
+        # fg =sns.lineplot(df,hue=bench_cfg.input_vars[0].name)
+        fg =sns.lineplot(df)
+
+
+        fg.set_xlabel(f"{rv.dim_name} [{rv.dim_units}]")
+        fg.set_ylabel(f"{rv.name} [{rv.units}]")
+        plt.tight_layout()
+
+
+        # fg.set_ylabels(label=sns_cfg.ylabel, clear_inner=True)
+        return pn.panel(plt.gcf())
+        # return pn.panel(bench_cfg.ds_dynamic[-1].plot())
     fg.fig.suptitle(sns_cfg.title)
     plt.tight_layout()
 

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -109,32 +109,24 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
 
         fg.set_xlabels(label=sns_cfg.xlabel, clear_inner=True)
         fg.set_ylabels(label=sns_cfg.ylabel, clear_inner=True)
-    else:
-        # df = bench_cfg.ds_dynamic[rv.name].to_dataframe()
-        # print("df",df)
-
-
-        df = bench_cfg.ds_dynamic[rv.name].to_dataframe().reset_index()
+    elif type(rv) == ResultList:       
         plt.figure(figsize=(4, 4))
-        print("df",df)
 
-        print(bench_cfg.input_vars[0].name)
-        # fg =sns.lineplot(df,hue=bench_cfg.input_vars[0].name)
+        #get the data to plot
+        dataset_key =(bench_cfg.hash_value, rv.name)
+        df = bench_cfg.ds_dynamic[dataset_key].to_dataframe().reset_index()
+
+        #plot
         fg =sns.lineplot(df,x=rv.dim_name,y=rv.name,hue=bench_cfg.input_vars[0].name)
-        # fg =sns.lineplot(df,x="time")
-        # fg =sns.lineplot(df)
 
-
-
-
+        #titles and labels and formatting
         fg.set_xlabel(f"{rv.dim_name} [{rv.dim_units}]")
         fg.set_ylabel(f"{rv.name} [{rv.units}]")
+        fg.set_title(bench_cfg.title)
         plt.tight_layout()
 
-
-        # fg.set_ylabels(label=sns_cfg.ylabel, clear_inner=True)
         return pn.panel(plt.gcf())
-        # return pn.panel(bench_cfg.ds_dynamic[-1].plot())
+    
     fg.fig.suptitle(sns_cfg.title)
     plt.tight_layout()
 

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -112,17 +112,20 @@ def plot_sns(bench_cfg: BenchCfg, rv: ParametrizedOutput, sns_cfg: PltCfgBase) -
     elif type(rv) == ResultList:
         plt.figure(figsize=(4, 4))
 
+        in_var = bench_cfg.input_vars[0].name
+
         # get the data to plot
         dataset_key = (bench_cfg.hash_value, rv.name)
         df = bench_cfg.ds_dynamic[dataset_key].to_dataframe().reset_index()
 
         # plot
-        fg = sns.lineplot(df, x=rv.dim_name, y=rv.name, hue=bench_cfg.input_vars[0].name)
+        fg = sns.lineplot(df, x=rv.dim_name, y=rv.name, hue=in_var)
 
         # titles and labels and formatting
         fg.set_xlabel(f"{rv.dim_name} [{rv.dim_units}]")
         fg.set_ylabel(f"{rv.name} [{rv.units}]")
-        fg.set_title(bench_cfg.title)
+        fg.set_title(f"{in_var} vs ({rv.name} vs {rv.dim_name})")
+
         plt.tight_layout()
 
         return pn.panel(plt.gcf())

--- a/bencher/plotting_functions.py
+++ b/bencher/plotting_functions.py
@@ -182,7 +182,7 @@ def plot_scatter2D_hv(bench_cfg: BenchCfg, rv: ParametrizedOutput) -> pn.pane.Pl
     bench_cfg = wrap_long_time_labels(bench_cfg)
     bench_cfg.ds.drop_vars("repeat")
 
-    df = bench_cfg.to_dataframe()
+    df = bench_cfg.get_dataframe()
 
     names = rv.index_names()
 
@@ -202,7 +202,7 @@ def plot_scatter3D_px(bench_cfg: BenchCfg, rv: ParametrizedOutput) -> pn.pane.Pl
 
     bench_cfg = wrap_long_time_labels(bench_cfg)
 
-    df = bench_cfg.to_dataframe()
+    df = bench_cfg.get_dataframe()
 
     names = rv.index_names()  # get the column names of the vector result
 
@@ -425,7 +425,7 @@ def plot_cone_plotly(
 
     opacity = 1.0
 
-    df = bench_cfg.to_dataframe()
+    df = bench_cfg.get_dataframe()
 
     print("size before removing zero size vectors", df.shape)
     df = df.loc[(df[names[0]] != 0.0) | (df[names[1]] != 0.0) | (df[names[2]] != 0.0)]

--- a/bencher/plt_cfg.py
+++ b/bencher/plt_cfg.py
@@ -96,7 +96,7 @@ class BenchPlotter:
                         pn.pane.Markdown(
                             """This page shows the with the inputs of the parameter sweep and the results as a flattened padas dataframe."""
                         ),
-                        bench_cfg.to_dataframe(),
+                        bench_cfg.get_dataframe(),
                         name="Pandas Dataframe Flattened View",
                     )
                 )

--- a/bencher/plt_cfg.py
+++ b/bencher/plt_cfg.py
@@ -96,7 +96,7 @@ class BenchPlotter:
                         pn.pane.Markdown(
                             """This page shows the with the inputs of the parameter sweep and the results as a flattened padas dataframe."""
                         ),
-                        bench_cfg.ds.to_dataframe().reset_index(),
+                        bench_cfg.to_dataframe(),
                         name="Pandas Dataframe Flattened View",
                     )
                 )

--- a/bencher/plt_cfg.py
+++ b/bencher/plt_cfg.py
@@ -116,7 +116,7 @@ class BenchPlotter:
         Returns:
             pn.Row: A panel row with plots in it
         """
-        plot_rows = pn.FlexBox(
+        plot_rows = pn.Row(
             name=bench_cfg.bench_name,
         )
         plt_cnt_cfg = BenchPlotter.generate_plt_cnt_cfg(bench_cfg)

--- a/bencher/plt_cfg.py
+++ b/bencher/plt_cfg.py
@@ -116,7 +116,9 @@ class BenchPlotter:
         Returns:
             pn.Row: A panel row with plots in it
         """
-        plot_rows = pn.Row(name=bench_cfg.bench_name)
+        plot_rows = pn.FlexBox(
+            name=bench_cfg.bench_name,
+        )
         plt_cnt_cfg = BenchPlotter.generate_plt_cnt_cfg(bench_cfg)
         for rv in bench_cfg.result_vars:
             plot_rows.append(BenchPlotter.plot_result_variable(bench_cfg, rv, plt_cnt_cfg))

--- a/test/test_bench_examples.py
+++ b/test/test_bench_examples.py
@@ -13,6 +13,7 @@ from bencher.example.example_float3D import example_floats3D
 from bencher.example.example_float3D_cone import example_cone
 from bencher.example.example_custom_sweep import example_custom_sweep
 from bencher.example.example_workflow import example_floats2D_workflow, example_floats3D_workflow
+from bencher.example.example_vector import example_vector
 
 
 class TestBenchExamples(unittest.TestCase):
@@ -66,3 +67,6 @@ class TestBenchExamples(unittest.TestCase):
 
     def test_example_floats3D_workflow(self) -> None:
         self.assertIsNotNone(example_floats3D_workflow(self.create_run_cfg()))
+
+    def test_example_vector(self) -> None:
+        self.assertIsNotNone(example_vector(self.create_run_cfg()))

--- a/test/test_bench_examples.py
+++ b/test/test_bench_examples.py
@@ -69,4 +69,4 @@ class TestBenchExamples(unittest.TestCase):
         self.assertIsNotNone(example_floats3D_workflow(self.create_run_cfg()))
 
     def test_example_vector(self) -> None:
-        self.assertIsNotNone(example_vector(self.create_run_cfg()))
+        self.assertIsNotNone(example_vector())

--- a/test/test_bencher.py
+++ b/test/test_bencher.py
@@ -22,7 +22,7 @@ def get_hash_isolated_process() -> bytes:
         [
             "python3",
             "-c",
-            "'from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut;import bencher as bch;cfg1 = bch.BenchCfg(input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noise_distribution],result_vars=[ExampleBenchCfgOut.param.out_sin],const_vars=[ExampleBenchCfgIn.param.noisy],repeats=5,over_time=False);print(cfg1.hash_custom())'",
+            "'from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut;import bencher as bch;cfg1 = bch.BenchCfg(input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noise_distribution],result_vars=[ExampleBenchCfgOut.param.out_sin],const_vars=[ExampleBenchCfgIn.param.noisy],repeats=5,over_time=False);print(cfg1.hash_persistent())'",
         ],
         stdout=subprocess.PIPE,
         check=False,
@@ -124,8 +124,8 @@ class TestBencher(unittest.TestCase):
         )
 
         self.assertEqual(
-            cfg1.hash_custom(include_repeats=True),
-            cfg2.hash_custom(include_repeats=True),
+            cfg1.hash_persistent(include_repeats=True),
+            cfg2.hash_persistent(include_repeats=True),
         )
 
     def test_bench_cfg_hash_isolated(self):

--- a/test/test_vars.py
+++ b/test/test_vars.py
@@ -20,7 +20,9 @@ class TestBencherHashing(unittest.TestCase):
         ex = AllSweepVars()
         ex2 = AllSweepVars()
 
-        self.assertEqual(ex.param.var_float.hash_persistent(), ex2.param.var_float.hash_persistent())
+        self.assertEqual(
+            ex.param.var_float.hash_persistent(), ex2.param.var_float.hash_persistent()
+        )
         self.assertEqual(ex.param.var_int.hash_persistent(), ex2.param.var_int.hash_persistent())
         self.assertEqual(ex.param.var_enum.hash_persistent(), ex2.param.var_enum.hash_persistent())
 

--- a/test/test_vars.py
+++ b/test/test_vars.py
@@ -7,7 +7,7 @@ from bencher.example.benchmark_data import AllSweepVars
 def get_sweep_hash_isolated_process():
     """get has values from a separate process as by default hashes across process are not the same"""
     os.system(
-        "python3 -c 'from bencher.example.benchmark_data import AllSweepVars;ex = AllSweepVars();print(ex.__repr__());print(ex.hash_custom())' > hashed_vars_comparison_tmp"
+        "python3 -c 'from bencher.example.benchmark_data import AllSweepVars;ex = AllSweepVars();print(ex.__repr__());print(ex.hash_persistent())' > hashed_vars_comparison_tmp"
     )
     res = open("hashed_vars_comparison_tmp", "r", encoding="utf-8").read()
     os.remove("hashed_vars_comparison_tmp")
@@ -20,14 +20,14 @@ class TestBencherHashing(unittest.TestCase):
         ex = AllSweepVars()
         ex2 = AllSweepVars()
 
-        self.assertEqual(ex.param.var_float.hash_custom(), ex2.param.var_float.hash_custom())
-        self.assertEqual(ex.param.var_int.hash_custom(), ex2.param.var_int.hash_custom())
-        self.assertEqual(ex.param.var_enum.hash_custom(), ex2.param.var_enum.hash_custom())
+        self.assertEqual(ex.param.var_float.hash_persistent(), ex2.param.var_float.hash_persistent())
+        self.assertEqual(ex.param.var_int.hash_persistent(), ex2.param.var_int.hash_persistent())
+        self.assertEqual(ex.param.var_enum.hash_persistent(), ex2.param.var_enum.hash_persistent())
 
         print(ex.__repr__())
         print(ex2.__repr__())
 
-        self.assertEqual(ex.hash_custom(), ex2.hash_custom())
+        self.assertEqual(ex.hash_persistent(), ex2.hash_persistent())
 
     def test_hash_sweep(self) -> None:
         """hash values only seem to not match if run in a separate process, so run the hash test in separate processes"""
@@ -36,15 +36,15 @@ class TestBencherHashing(unittest.TestCase):
         asv2 = AllSweepVars()
 
         self.assertEqual(
-            asv.hash_custom(),
-            asv2.hash_custom(),
+            asv.hash_persistent(),
+            asv2.hash_persistent(),
             "The classes should have equal hash when it has identical values",
         )
 
         asv2.var_float = 1
         self.assertNotEqual(
-            asv.hash_custom(),
-            asv2.hash_custom(),
+            asv.hash_persistent(),
+            asv2.hash_persistent(),
             "The classes should not have equal hash when they have different values",
         )
 


### PR DESCRIPTION
Add support for plotting vector outputs.  Until now bencher has only operated on scalar inputs and outputs and due to the way it is stored in a structured xarray dataset it is difficult to unify the two modes of operation.  This pr creates a dictionary to store the vector results as they are currently incompatible with the scalar datatypes.   This pr only allows for 1D input sweeps and future work is to generalise this across N dimensions (to match the features of scalar inputs and outputs). 

This adds an example of how to use the vector outputs:
![image](https://github.com/dyson-ai/bencher/assets/1213400/754ab032-d99c-4cf1-beeb-d16c3cb02cdc)

![image](https://github.com/dyson-ai/bencher/assets/1213400/e9ffcb08-ab5c-4064-9384-cf7a8d9a4fdf)

