### PR TITLE
remove refactor flag from pyling disable

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [pull_request]
 
 jobs:
-  lint:
+  black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,6 @@ max-line-length=100
 disable=
   C,
   logging-fstring-interpolation,line-too-long,fixme,broad-exception-caught,missing-module-docstring,
-  too-many-instance-attributes,too-few-public-methods,too-many-arguments,too-many-locals,too-many-branches,too-many-statements,use-dict-literal,duplicate-code
+  too-many-instance-attributes,too-few-public-methods,too-many-arguments,too-many-locals,too-many-branches,too-many-statements,use-dict-literal,cyclic-import
 
 enable=no-else-return,consider-using-in

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,7 @@ max-line-length=100
 
 [MESSAGES CONTROL]
 disable=
-  C,R,
+  C,
   logging-fstring-interpolation,line-too-long,fixme,broad-exception-caught,missing-module-docstring,
   too-many-instance-attributes,too-few-public-methods,too-many-arguments,too-many-locals,too-many-branches,too-many-statements,use-dict-literal
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,6 @@ max-line-length=100
 disable=
   C,
   logging-fstring-interpolation,line-too-long,fixme,broad-exception-caught,missing-module-docstring,
-  too-many-instance-attributes,too-few-public-methods,too-many-arguments,too-many-locals,too-many-branches,too-many-statements,use-dict-literal
+  too-many-instance-attributes,too-few-public-methods,too-many-arguments,too-many-locals,too-many-branches,too-many-statements,use-dict-literal,duplicate-code
 
 enable=no-else-return,consider-using-in

--- a/bencher/example/example_categorical.py
+++ b/bencher/example/example_categorical.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 from bencher.bencher import Bench, BenchRunCfg
 import pathlib
 
@@ -47,7 +49,8 @@ def example_categorical(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.noisy, ExampleBenchCfgIn.param.noise_distribution],
+        input_vars=[ExampleBenchCfgIn.param.noisy,
+                    ExampleBenchCfgIn.param.noise_distribution],
         result_vars=[ExampleBenchCfgOut.param.out_sin],
         title="Categorical 2D Example",
         description="""Adding another categorical value creates a facet plot over that dimension""",

--- a/bencher/example/example_categorical.py
+++ b/bencher/example/example_categorical.py
@@ -49,8 +49,7 @@ def example_categorical(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.noisy,
-                    ExampleBenchCfgIn.param.noise_distribution],
+        input_vars=[ExampleBenchCfgIn.param.noisy, ExampleBenchCfgIn.param.noise_distribution],
         result_vars=[ExampleBenchCfgOut.param.out_sin],
         title="Categorical 2D Example",
         description="""Adding another categorical value creates a facet plot over that dimension""",

--- a/bencher/example/example_float3D.py
+++ b/bencher/example/example_float3D.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 import numpy as np
 import bencher as bch
 

--- a/bencher/example/example_floats.py
+++ b/bencher/example/example_floats.py
@@ -50,8 +50,7 @@ def example_floats(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta,
-                    ExampleBenchCfgIn.param.noisy],
+        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
         result_vars=[ExampleBenchCfgOut.param.out_sin],
         title="Float 1D and Bool Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
@@ -60,10 +59,8 @@ def example_floats(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta,
-                    ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin,
-                     ExampleBenchCfgOut.param.out_cos],
+        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
+        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
         title="Float 1D and Bool Example with multiple outputs",
         description="""Following from the previous example here the second output is added to the result variables""",
         post_description="Another column is added for the result variable that shows cos(theta)",

--- a/bencher/example/example_floats.py
+++ b/bencher/example/example_floats.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 from bencher import Bench, BenchRunCfg
 import pathlib
 
@@ -48,7 +50,8 @@ def example_floats(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
+        input_vars=[ExampleBenchCfgIn.param.theta,
+                    ExampleBenchCfgIn.param.noisy],
         result_vars=[ExampleBenchCfgOut.param.out_sin],
         title="Float 1D and Bool Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
@@ -57,8 +60,10 @@ def example_floats(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        input_vars=[ExampleBenchCfgIn.param.theta,
+                    ExampleBenchCfgIn.param.noisy],
+        result_vars=[ExampleBenchCfgOut.param.out_sin,
+                     ExampleBenchCfgOut.param.out_cos],
         title="Float 1D and Bool Example with multiple outputs",
         description="""Following from the previous example here the second output is added to the result variables""",
         post_description="Another column is added for the result variable that shows cos(theta)",

--- a/bencher/example/example_floats2D.py
+++ b/bencher/example/example_floats2D.py
@@ -30,8 +30,7 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
 
     bench.plot_sweep(
         input_vars=[cfg.param.theta, cfg.param.offset],
-        result_vars=[ExampleBenchCfgOut.param.out_sin,
-                     ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),
@@ -60,10 +59,8 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[cfg.param.theta, cfg.param.offset,
-                    cfg.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_sin,
-                     ExampleBenchCfgOut.param.out_cos],
+        input_vars=[cfg.param.theta, cfg.param.offset, cfg.param.postprocess_fn],
+        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),
@@ -82,8 +79,7 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
             cfg.param.postprocess_fn,
             cfg.param.noise_distribution,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin,
-                     ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),

--- a/bencher/example/example_floats2D.py
+++ b/bencher/example/example_floats2D.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 from bencher import Bench, BenchRunCfg
 
 # All the examples will be using the data structures and benchmark function defined in this file
@@ -29,7 +30,8 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
 
     bench.plot_sweep(
         input_vars=[cfg.param.theta, cfg.param.offset],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfgOut.param.out_sin,
+                     ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),
@@ -58,8 +60,10 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
     )
 
     bench.plot_sweep(
-        input_vars=[cfg.param.theta, cfg.param.offset, cfg.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        input_vars=[cfg.param.theta, cfg.param.offset,
+                    cfg.param.postprocess_fn],
+        result_vars=[ExampleBenchCfgOut.param.out_sin,
+                     ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),
@@ -78,7 +82,8 @@ def example_floats2D(run_cfg: BenchRunCfg) -> Bench:
             cfg.param.postprocess_fn,
             cfg.param.noise_distribution,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfgOut.param.out_sin,
+                     ExampleBenchCfgOut.param.out_cos],
         const_vars=[
             (cfg.param.sigma, 0.1),
             (cfg.param.noise_distribution, NoiseDistribution.gaussian),

--- a/bencher/example/example_hvplot_explorer.py
+++ b/bencher/example/example_hvplot_explorer.py
@@ -1,4 +1,4 @@
-# pylinnt: disable=duplicate-code
+# pylint: disable=duplicate-code
 from bencher import Bench, BenchRunCfg, ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
 
 

--- a/bencher/example/example_hvplot_explorer.py
+++ b/bencher/example/example_hvplot_explorer.py
@@ -1,3 +1,4 @@
+# pylinnt: disable=duplicate-code
 from bencher import Bench, BenchRunCfg, ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
 
 

--- a/bencher/example/example_pareto.py
+++ b/bencher/example/example_pareto.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 from bencher.bencher import Bench, BenchRunCfg
 
 # All the examples will be using the data structures and benchmark function defined in this file

--- a/bencher/example/example_simple_cat.py
+++ b/bencher/example/example_simple_cat.py
@@ -17,15 +17,13 @@ def example_1D_cat(run_cfg: bch.BenchRunCfg) -> bch.Bench:
         Bench: results of the parameter sweep
     """
 
-    bencher = bch.Bench("benchmarking_example_categorical1D",
-                        bench_function, ExampleBenchCfgIn)
+    bencher = bch.Bench("benchmarking_example_categorical1D", bench_function, ExampleBenchCfgIn)
 
     # here we sample the input variable theta and plot the value of output1. The (noisy) function is sampled 20 times so you can see the distribution
     bencher.plot_sweep(
         title="Example 1D Categorical",
         input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_cos,
-                     ExampleBenchCfgOut.param.out_sin],
+        result_vars=[ExampleBenchCfgOut.param.out_cos, ExampleBenchCfgOut.param.out_sin],
         description=example_1D_cat.__doc__,
         run_cfg=run_cfg,
     )

--- a/bencher/example/example_simple_cat.py
+++ b/bencher/example/example_simple_cat.py
@@ -1,4 +1,5 @@
 """This file has some examples for how to perform basic benchmarking parameter sweeps"""
+# pylint: disable=duplicate-code
 
 import bencher as bch
 
@@ -16,13 +17,15 @@ def example_1D_cat(run_cfg: bch.BenchRunCfg) -> bch.Bench:
         Bench: results of the parameter sweep
     """
 
-    bencher = bch.Bench("benchmarking_example_categorical1D", bench_function, ExampleBenchCfgIn)
+    bencher = bch.Bench("benchmarking_example_categorical1D",
+                        bench_function, ExampleBenchCfgIn)
 
     # here we sample the input variable theta and plot the value of output1. The (noisy) function is sampled 20 times so you can see the distribution
     bencher.plot_sweep(
         title="Example 1D Categorical",
         input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_cos, ExampleBenchCfgOut.param.out_sin],
+        result_vars=[ExampleBenchCfgOut.param.out_cos,
+                     ExampleBenchCfgOut.param.out_sin],
         description=example_1D_cat.__doc__,
         run_cfg=run_cfg,
     )

--- a/bencher/example/example_time_event.py
+++ b/bencher/example/example_time_event.py
@@ -1,4 +1,6 @@
 """This file has some examples for how to perform basic benchmarking parameter sweeps"""
+# pylint: disable=duplicate-code
+
 
 from bencher.bencher import Bench, BenchRunCfg
 

--- a/bencher/example/example_workflow.py
+++ b/bencher/example/example_workflow.py
@@ -1,3 +1,6 @@
+# pylint: disable=duplicate-code
+
+
 import bencher as bch
 import numpy as np
 
@@ -98,11 +101,13 @@ def example_floats2D_workflow(run_cfg: bch.BenchRunCfg, bench: bch.Bench = None)
     )
     recovered_p1 = res.get_optimal_vec(VolumeResult.param.p1_dis, res.input_vars)
     print(f"recovered p1: {recovered_p1}, distance: {np.linalg.norm(recovered_p1 - p1[:2])}")
-    assert np.linalg.norm(recovered_p1 - p1[:2]) < 0.15  # within tolerance of sampling
+    # within tolerance of sampling
+    assert np.linalg.norm(recovered_p1 - p1[:2]) < 0.15
 
     recovered_p2 = res.get_optimal_vec(VolumeResult.param.p2_dis, res.input_vars)
     print(f"recovered p2: {recovered_p2} distance: {np.linalg.norm(recovered_p2 - p2[:2])}")
-    assert np.linalg.norm(recovered_p2 - p2[:2]) < 0.15  # within tolerance of sampling
+    # within tolerance of sampling
+    assert np.linalg.norm(recovered_p2 - p2[:2]) < 0.15
 
     run_cfg.use_optuna = True
     for rv in res.result_vars:
@@ -150,11 +155,13 @@ def example_floats3D_workflow(run_cfg: bch.BenchRunCfg, bench: bch.Bench = None)
 
     recovered_p1 = res.get_optimal_vec(VolumeResult.param.p1_dis, res.input_vars)
     print(f"recovered p1: {recovered_p1}, distance: {np.linalg.norm(recovered_p1 - p1)}")
-    assert np.linalg.norm(recovered_p1 - p1) < 0.15  # within tolerance of sampling
+    # within tolerance of sampling
+    assert np.linalg.norm(recovered_p1 - p1) < 0.15
 
     recovered_p2 = res.get_optimal_vec(VolumeResult.param.p2_dis, res.input_vars)
     print(f"recovered p2: {recovered_p2} distance: {np.linalg.norm(recovered_p2 - p2)}")
-    assert np.linalg.norm(recovered_p2 - p2) < 0.15  # within tolerance of sampling
+    # within tolerance of sampling
+    assert np.linalg.norm(recovered_p2 - p2) < 0.15
 
     run_cfg.use_optuna = True
     for rv in res.result_vars:

--- a/test/plots/test_catplot.py
+++ b/test/plots/test_catplot.py
@@ -14,16 +14,14 @@ class TestCatPlot(TestPlotsCommon):
     @settings(deadline=10000)
     @given(
         st.sampled_from(
-            [PlotTypes.swarmplot, PlotTypes.barplot,
-                PlotTypes.boxenplot, PlotTypes.violinplot]
+            [PlotTypes.swarmplot, PlotTypes.barplot, PlotTypes.boxenplot, PlotTypes.violinplot]
         )
     )
     def test_plot_name(self, plot_name) -> None:
         bench_cfg = self.create_bench_cfg(plot_name)
 
         plt_cnt_cfg = PltCntCfg(float_cnt=0, cat_cnt=1)
-        pl_in = PlotInput(
-            bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
+        pl_in = PlotInput(bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
         cp = Catplot()
         plot_fn = getattr(cp, plot_name)
         result = plot_fn(pl_in)

--- a/test/plots/test_catplot.py
+++ b/test/plots/test_catplot.py
@@ -5,35 +5,30 @@ from bencher.plotting.plot_collection import PlotInput
 from bencher.plotting.plot_types import PlotTypes
 from bencher.plotting.plots.catplot import Catplot
 from bencher.bench_cfg import PltCntCfg
-import bencher as bch
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
 from hypothesis import given, settings, strategies as st
 
+from bencher.example.benchmark_data import ExampleBenchCfgOut
 
-class TestCatPlot(unittest.TestCase):
+
+from .test_plots_common import TestPlotsCommon
+
+
+class TestCatPlot(TestPlotsCommon):
     @settings(deadline=10000)
     @given(
         st.sampled_from(
-            [PlotTypes.swarmplot, PlotTypes.barplot, PlotTypes.boxenplot, PlotTypes.violinplot]
+            [PlotTypes.swarmplot, PlotTypes.barplot,
+                PlotTypes.boxenplot, PlotTypes.violinplot]
         )
     )
     def test_plot_name(self, plot_name) -> None:
-        bencher = bch.Bench("test_catplot", bench_function, ExampleBenchCfgIn)
-
-        bench_cfg = bencher.plot_sweep(
-            title="Test Cat Plots",
-            input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-            const_vars=[(ExampleBenchCfgIn.param.noisy, True)],
-            result_vars=[ExampleBenchCfgOut.param.out_cos],
-            plot_lib=bch.PlotLibrary.none().add(plot_name),
-            run_cfg=bch.BenchRunCfg(auto_plot=False),
-        )
+        bench_cfg = self.create_bench_cfg()
 
         plt_cnt_cfg = PltCntCfg(float_cnt=0, cat_cnt=1)
-        pl_in = PlotInput(bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
+        pl_in = PlotInput(
+            bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
         cp = Catplot()
         plot_fn = getattr(cp, plot_name)
         result = plot_fn(pl_in)
-        self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], pn.viewable.Viewable)
-        self.assertEqual(result[0].name, plot_name)
+
+        self.basic_plot_asserts(result, plot_name)

--- a/test/plots/test_catplot.py
+++ b/test/plots/test_catplot.py
@@ -1,6 +1,3 @@
-import unittest
-import panel as pn
-
 from bencher.plotting.plot_collection import PlotInput
 from bencher.plotting.plot_types import PlotTypes
 from bencher.plotting.plots.catplot import Catplot
@@ -22,7 +19,7 @@ class TestCatPlot(TestPlotsCommon):
         )
     )
     def test_plot_name(self, plot_name) -> None:
-        bench_cfg = self.create_bench_cfg()
+        bench_cfg = self.create_bench_cfg(plot_name)
 
         plt_cnt_cfg = PltCntCfg(float_cnt=0, cat_cnt=1)
         pl_in = PlotInput(

--- a/test/plots/test_plots_common.py
+++ b/test/plots/test_plots_common.py
@@ -6,7 +6,6 @@ from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut
 
 
 class TestPlotsCommon(unittest.TestCase):
-
     def create_bench_cfg(self, plot_name: str) -> bch.BenchCfg:
         """Given a plot name, run a sweep and plot with that plotting function
 

--- a/test/plots/test_plots_common.py
+++ b/test/plots/test_plots_common.py
@@ -1,0 +1,39 @@
+import unittest
+import panel as pn
+
+import bencher as bch
+from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+
+
+class TestPlotsCommon(unittest.TestCase):
+
+    def create_bench_cfg(self, plot_name: str) -> bch.BenchCfg:
+        """Given a plot name, run a sweep and plot with that plotting function
+
+        Args:
+            plot_name (str): name of the plot to use
+
+        Returns:
+            BenchCfg: Results with plots
+        """
+        bencher = bch.Bench("test_catplot", bench_function, ExampleBenchCfgIn)
+        return bencher.plot_sweep(
+            title="Test Cat Plots",
+            input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
+            const_vars=[(ExampleBenchCfgIn.param.noisy, True)],
+            result_vars=[ExampleBenchCfgOut.param.out_cos],
+            plot_lib=bch.PlotLibrary.none().add(plot_name),
+            run_cfg=bch.BenchRunCfg(auto_plot=False),
+        )
+
+    def basic_plot_asserts(self, result: bch.BenchCfg, plot_name: str) -> None:
+        """Check that the expected plots are generated
+
+        Args:
+            result (bch.BenchCfg): bench result to check
+            plot_name (str): expected name of the plot
+        """
+
+        self.assertIsInstance(result, list)
+        self.assertIsInstance(result[0], pn.viewable.Viewable)
+        self.assertEqual(result[0].name, plot_name)

--- a/test/plots/test_tables.py
+++ b/test/plots/test_tables.py
@@ -21,12 +21,10 @@ class TestCatPlot(TestPlotsCommon):
         )
     )
     def test_plot_name(self, plot_name) -> None:
-
         bench_cfg = self.create_bench_cfg(plot_name)
 
         plt_cnt_cfg = PltCntCfg(float_cnt=0, cat_cnt=1)
-        pl_in = PlotInput(
-            bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
+        pl_in = PlotInput(bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
         cp = Tables()
         plot_fn = getattr(cp, plot_name)
         result = plot_fn(pl_in)

--- a/test/plots/test_tables.py
+++ b/test/plots/test_tables.py
@@ -1,16 +1,14 @@
-import unittest
-import panel as pn
-
 from bencher.plotting.plot_collection import PlotInput
 from bencher.plotting.plot_types import PlotTypes
 from bencher.plotting.plots.tables import Tables
 from bencher.bench_cfg import PltCntCfg
-import bencher as bch
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfgOut
 from hypothesis import given, settings, strategies as st
 
+from .test_plots_common import TestPlotsCommon
 
-class TestCatPlot(unittest.TestCase):
+
+class TestCatPlot(TestPlotsCommon):
     @settings(deadline=10000)
     @given(
         st.sampled_from(
@@ -23,22 +21,14 @@ class TestCatPlot(unittest.TestCase):
         )
     )
     def test_plot_name(self, plot_name) -> None:
-        bencher = bch.Bench("test_tables", bench_function, ExampleBenchCfgIn)
 
-        bench_cfg = bencher.plot_sweep(
-            title="Test Cat Plots",
-            input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-            const_vars=[(ExampleBenchCfgIn.param.noisy, True)],
-            result_vars=[ExampleBenchCfgOut.param.out_cos],
-            plot_lib=bch.PlotLibrary.none().add(plot_name),
-            run_cfg=bch.BenchRunCfg(auto_plot=False),
-        )
+        bench_cfg = self.create_bench_cfg(plot_name)
 
         plt_cnt_cfg = PltCntCfg(float_cnt=0, cat_cnt=1)
-        pl_in = PlotInput(bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
+        pl_in = PlotInput(
+            bench_cfg, ExampleBenchCfgOut.param.out_cos, plt_cnt_cfg)
         cp = Tables()
         plot_fn = getattr(cp, plot_name)
         result = plot_fn(pl_in)
-        self.assertIsInstance(result, list)
-        self.assertIsInstance(result[0], pn.viewable.Viewable)
-        self.assertEqual(result[0].name, plot_name)
+
+        self.basic_plot_asserts(result, plot_name)

--- a/test/test_plot_library.py
+++ b/test/test_plot_library.py
@@ -22,7 +22,7 @@ class TestPlotLibrary(unittest.TestCase):
     # Tests that the all PlotCollection contains all possible plots
     def test_all_plot_collection(self) -> None:
         all_plots = PlotLibrary.all()
-        for pt in [p for p in PlotTypes]:
+        for pt in list(PlotTypes):
             self.assertIn(pt, all_plots.plotters)
         self.assertEqual(len(all_plots.plotters), len(PlotTypes))
 

--- a/test/test_vars.py
+++ b/test/test_vars.py
@@ -25,10 +25,8 @@ class TestBencherHashing(unittest.TestCase):
         self.assertEqual(
             ex.param.var_float.hash_persistent(), ex2.param.var_float.hash_persistent()
         )
-        self.assertEqual(ex.param.var_int.hash_persistent(),
-                         ex2.param.var_int.hash_persistent())
-        self.assertEqual(ex.param.var_enum.hash_persistent(),
-                         ex2.param.var_enum.hash_persistent())
+        self.assertEqual(ex.param.var_int.hash_persistent(), ex2.param.var_int.hash_persistent())
+        self.assertEqual(ex.param.var_enum.hash_persistent(), ex2.param.var_enum.hash_persistent())
 
         print(ex.__repr__())
         print(ex2.__repr__())
@@ -58,8 +56,7 @@ class TestBencherHashing(unittest.TestCase):
         """hash values only seem to not match if run in a separate process, so run the hash test in separate processes"""
 
         self.assertNotEqual(
-            len(get_sweep_hash_isolated_process()
-                ), 0, "make sure the hash is getting returned"
+            len(get_sweep_hash_isolated_process()), 0, "make sure the hash is getting returned"
         )
 
         self.assertEqual(

--- a/test/test_vars.py
+++ b/test/test_vars.py
@@ -4,18 +4,20 @@ import os
 from bencher.example.benchmark_data import AllSweepVars
 
 
-def get_sweep_hash_isolated_process():
+def get_sweep_hash_isolated_process() -> str:
     """get has values from a separate process as by default hashes across process are not the same"""
     os.system(
         "python3 -c 'from bencher.example.benchmark_data import AllSweepVars;ex = AllSweepVars();print(ex.__repr__());print(ex.hash_persistent())' > hashed_vars_comparison_tmp"
     )
-    res = open("hashed_vars_comparison_tmp", "r", encoding="utf-8").read()
+
+    with open("hashed_vars_comparison_tmp", "r", encoding="utf-8") as myfile:
+        res = myfile.read()
     os.remove("hashed_vars_comparison_tmp")
     return res
 
 
 class TestBencherHashing(unittest.TestCase):
-    def test_sweep_hashes(self):
+    def test_sweep_hashes(self) -> None:
         """check that separate instances with identical data have the same hash"""
         ex = AllSweepVars()
         ex2 = AllSweepVars()
@@ -23,8 +25,10 @@ class TestBencherHashing(unittest.TestCase):
         self.assertEqual(
             ex.param.var_float.hash_persistent(), ex2.param.var_float.hash_persistent()
         )
-        self.assertEqual(ex.param.var_int.hash_persistent(), ex2.param.var_int.hash_persistent())
-        self.assertEqual(ex.param.var_enum.hash_persistent(), ex2.param.var_enum.hash_persistent())
+        self.assertEqual(ex.param.var_int.hash_persistent(),
+                         ex2.param.var_int.hash_persistent())
+        self.assertEqual(ex.param.var_enum.hash_persistent(),
+                         ex2.param.var_enum.hash_persistent())
 
         print(ex.__repr__())
         print(ex2.__repr__())
@@ -54,7 +58,8 @@ class TestBencherHashing(unittest.TestCase):
         """hash values only seem to not match if run in a separate process, so run the hash test in separate processes"""
 
         self.assertNotEqual(
-            len(get_sweep_hash_isolated_process()), 0, "make sure the hash is getting returned"
+            len(get_sweep_hash_isolated_process()
+                ), 0, "make sure the hash is getting returned"
         )
 
         self.assertEqual(


### PR DESCRIPTION
This pr removes the global disable R (refactor) flag and then fixes some of the suggestions, disables some suggestions globally (to be removed in another pr). and disables some suggests on a file by file basis (disable duplicate code warnings for the examples as the duplicate code helps them be more standalone). 