### PR TITLE
hotfix - set environment variable to allow the selected port

### DIFF
--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -58,13 +58,11 @@ class BenchPlotServer:
                 for bench_cfg_hash in bench_cfg_hashes:
                     # load the results based on the hash retrieved from the benchmark name
                     if bench_cfg_hash in cache:
-                        logging.info(
-                            f"loading cached results from key: {bench_cfg_hash}")
+                        logging.info(f"loading cached results from key: {bench_cfg_hash}")
                         bench_cfg = cache[bench_cfg_hash]
                         logging.info(f"loaded: {bench_cfg.title}")
 
-                        plots_instance = BenchPlotter.plot(
-                            bench_cfg, plots_instance)
+                        plots_instance = BenchPlotter.plot(bench_cfg, plots_instance)
                     else:
                         raise FileNotFoundError(
                             "The benchmarks have been run and saved, but the specific results you are trying to load do not exist.  This should not happen and could be because the cache was cleared."
@@ -85,8 +83,7 @@ class BenchPlotServer:
         """
 
         if port is not None:
-            pn.serve(plots_instance, title=bench_name,
-                     websocket_origin=["*"], port=port)
+            pn.serve(plots_instance, title=bench_name, websocket_origin=["*"], port=port)
         else:
             logging.getLogger().setLevel(logging.WARNING)
             pn.serve(plots_instance, title=bench_name)

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -1,5 +1,5 @@
 """A server for display plots of benchmark results"""
-
+import os
 import logging
 from typing import Tuple, List
 from diskcache import Cache
@@ -31,6 +31,9 @@ class BenchPlotServer:
         """
         if plots_instance is None:
             plots_instance = self.load_data_from_cache(bench_name)
+        if plot_cfg.port is not None:
+            os.environ["BOKEH_ALLOW_WS_ORIGIN"] = f"localhost:{plot_cfg.port}"
+
         self.serve(bench_name, plots_instance, port=plot_cfg.port)
 
     def load_data_from_cache(self, bench_name: str) -> Tuple[BenchCfg, List[pn.panel]] | None:
@@ -55,11 +58,13 @@ class BenchPlotServer:
                 for bench_cfg_hash in bench_cfg_hashes:
                     # load the results based on the hash retrieved from the benchmark name
                     if bench_cfg_hash in cache:
-                        logging.info(f"loading cached results from key: {bench_cfg_hash}")
+                        logging.info(
+                            f"loading cached results from key: {bench_cfg_hash}")
                         bench_cfg = cache[bench_cfg_hash]
                         logging.info(f"loaded: {bench_cfg.title}")
 
-                        plots_instance = BenchPlotter.plot(bench_cfg, plots_instance)
+                        plots_instance = BenchPlotter.plot(
+                            bench_cfg, plots_instance)
                     else:
                         raise FileNotFoundError(
                             "The benchmarks have been run and saved, but the specific results you are trying to load do not exist.  This should not happen and could be because the cache was cleared."
@@ -80,7 +85,8 @@ class BenchPlotServer:
         """
 
         if port is not None:
-            pn.serve(plots_instance, title=bench_name, websocket_origin=["*"], port=port)
+            pn.serve(plots_instance, title=bench_name,
+                     websocket_origin=["*"], port=port)
         else:
             logging.getLogger().setLevel(logging.WARNING)
             pn.serve(plots_instance, title=bench_name)


### PR DESCRIPTION
The ports can sometimes be blocked depending on the docker network mode. This sets up environment variables to override the blocked ports