### PR TITLE
Squashed commit of the following:

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -892,9 +892,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: hypothesis
-  version: 6.102.6
-  url: https://files.pythonhosted.org/packages/b5/f7/89b6869874387d22b8eee5a218613653f7b4ea40bc72e8cac8b051af4867/hypothesis-6.102.6-py3-none-any.whl
-  sha256: ef281ba8b2626ebade9f463fbe8851ae6ff6ae4a8621a9e54c7c2477a97ccff0
+  version: 6.100.5
+  url: https://files.pythonhosted.org/packages/3b/43/3bdab48c6bdd09216c19f4f1d11430869880c387af5c4a759a3eff47dd8f/hypothesis-6.100.5-py3-none-any.whl
+  sha256: d2f875a8791abdf68599e85cc9238f7239a73b72362d34be95e532e811766723
   requires_dist:
   - attrs>=22.2.0
   - sortedcontainers<3.0.0,>=2.1.0
@@ -904,7 +904,7 @@ packages:
   - crosshair-tool>=0.0.54 ; extra == 'all'
   - django>=3.2 ; extra == 'all'
   - dpcontracts>=0.4 ; extra == 'all'
-  - hypothesis-crosshair>=0.0.4 ; extra == 'all'
+  - hypothesis-crosshair>=0.0.2 ; extra == 'all'
   - lark>=0.10.1 ; extra == 'all'
   - libcst>=0.3.16 ; extra == 'all'
   - numpy>=1.17.3 ; extra == 'all'
@@ -920,7 +920,7 @@ packages:
   - black>=19.10b0 ; extra == 'cli'
   - rich>=9.0.0 ; extra == 'cli'
   - libcst>=0.3.16 ; extra == 'codemods'
-  - hypothesis-crosshair>=0.0.4 ; extra == 'crosshair'
+  - hypothesis-crosshair>=0.0.2 ; extra == 'crosshair'
   - crosshair-tool>=0.0.54 ; extra == 'crosshair'
   - python-dateutil>=1.4 ; extra == 'dateutil'
   - django>=3.2 ; extra == 'django'
@@ -1947,9 +1947,9 @@ packages:
   requires_python: '>=3.6.8'
 - kind: pypi
   name: pytest
-  version: 8.2.1
-  url: https://files.pythonhosted.org/packages/b4/c1/27a1274b73712232328cb5115030057b7dec377f36a518c83f2e01d4f305/pytest-8.2.1-py3-none-any.whl
-  sha256: faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1
+  version: 8.2.0
+  url: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
+  sha256: 1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233
   requires_dist:
   - iniconfig
   - packaging
@@ -2084,9 +2084,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: ruff
-  version: 0.4.5
-  url: https://files.pythonhosted.org/packages/d8/ae/aca5966c5017df4ace52a6222d0ca3439a6e0e806771b9e8d95ac9dacfb3/ruff-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: f4b02a65985be2b34b170025a8b92449088ce61e33e69956ce4d316c0fe7cce0
+  version: 0.4.3
+  url: https://files.pythonhosted.org/packages/5a/6b/9c1b94d5a5720390029c810428c60f791ba77cfd3de2c13a51f3beb02916/ruff-0.4.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 18b00e0bcccf0fc8d7186ed21e311dffd19761cb632241a6e4fe4477cc80ef6e
   requires_python: '>=3.7'
 - kind: pypi
   name: scikit-learn

--- a/pixi.lock
+++ b/pixi.lock
@@ -892,9 +892,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: hypothesis
-  version: 6.100.5
-  url: https://files.pythonhosted.org/packages/3b/43/3bdab48c6bdd09216c19f4f1d11430869880c387af5c4a759a3eff47dd8f/hypothesis-6.100.5-py3-none-any.whl
-  sha256: d2f875a8791abdf68599e85cc9238f7239a73b72362d34be95e532e811766723
+  version: 6.102.6
+  url: https://files.pythonhosted.org/packages/b5/f7/89b6869874387d22b8eee5a218613653f7b4ea40bc72e8cac8b051af4867/hypothesis-6.102.6-py3-none-any.whl
+  sha256: ef281ba8b2626ebade9f463fbe8851ae6ff6ae4a8621a9e54c7c2477a97ccff0
   requires_dist:
   - attrs>=22.2.0
   - sortedcontainers<3.0.0,>=2.1.0
@@ -904,7 +904,7 @@ packages:
   - crosshair-tool>=0.0.54 ; extra == 'all'
   - django>=3.2 ; extra == 'all'
   - dpcontracts>=0.4 ; extra == 'all'
-  - hypothesis-crosshair>=0.0.2 ; extra == 'all'
+  - hypothesis-crosshair>=0.0.4 ; extra == 'all'
   - lark>=0.10.1 ; extra == 'all'
   - libcst>=0.3.16 ; extra == 'all'
   - numpy>=1.17.3 ; extra == 'all'
@@ -920,7 +920,7 @@ packages:
   - black>=19.10b0 ; extra == 'cli'
   - rich>=9.0.0 ; extra == 'cli'
   - libcst>=0.3.16 ; extra == 'codemods'
-  - hypothesis-crosshair>=0.0.2 ; extra == 'crosshair'
+  - hypothesis-crosshair>=0.0.4 ; extra == 'crosshair'
   - crosshair-tool>=0.0.54 ; extra == 'crosshair'
   - python-dateutil>=1.4 ; extra == 'dateutil'
   - django>=3.2 ; extra == 'django'
@@ -1947,9 +1947,9 @@ packages:
   requires_python: '>=3.6.8'
 - kind: pypi
   name: pytest
-  version: 8.2.0
-  url: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
-  sha256: 1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233
+  version: 8.2.1
+  url: https://files.pythonhosted.org/packages/b4/c1/27a1274b73712232328cb5115030057b7dec377f36a518c83f2e01d4f305/pytest-8.2.1-py3-none-any.whl
+  sha256: faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1
   requires_dist:
   - iniconfig
   - packaging
@@ -2084,9 +2084,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: ruff
-  version: 0.4.3
-  url: https://files.pythonhosted.org/packages/5a/6b/9c1b94d5a5720390029c810428c60f791ba77cfd3de2c13a51f3beb02916/ruff-0.4.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 18b00e0bcccf0fc8d7186ed21e311dffd19761cb632241a6e4fe4477cc80ef6e
+  version: 0.4.5
+  url: https://files.pythonhosted.org/packages/d8/ae/aca5966c5017df4ace52a6222d0ca3439a6e0e806771b9e8d95ac9dacfb3/ruff-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: f4b02a65985be2b34b170025a8b92449088ce61e33e69956ce4d316c0fe7cce0
   requires_python: '>=3.7'
 - kind: pypi
   name: scikit-learn

--- a/scripts/update_from_template.sh
+++ b/scripts/update_from_template.sh
@@ -5,6 +5,6 @@ git remote add template https://github.com/blooop/python_template.git
 git fetch --all
 git checkout main && git pull origin main
 git checkout -B feature/update_from_template; git pull
-git merge template/main --squash --allow-unrelated-histories -m 'feat: pull changes from remote template'
+git merge template/main --allow-unrelated-histories -m 'feat: pull changes from remote template'
 git remote remove template
 git push --set-upstream origin feature/update_from_template


### PR DESCRIPTION
commit eff5e8a3e40a26734bafcdce5275532964ca6221
Merge: 525407a 068f75e
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:19:16 2024 +0100

    Merge pull request #11 from blooop/feature/pixi_badge

    add pixi badge

commit 068f75e55a52536d76b18848b5cb1e1bc0de60b9
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:18:34 2024 +0100

    add pixi badge

commit 525407ae0feb8e3cd0e4ca4bfc7908ab59da1978
Merge: 937e33d 52ad169
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:15:53 2024 +0100

    Merge pull request #9 from blooop/dependabot/pip/dev-dependencies-13ad7100e2

    Bump the dev-dependencies group with 4 updates

commit 52ad1690e0b2e2e7fd06268a1fd56cccb2b0c274
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:14:46 2024 +0100

    update pixi.lock

commit 080079c8653f40afe5baca962f93f2e0bb58f840
Merge: 8c78564 937e33d
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:14:30 2024 +0100

    Merge remote-tracking branch 'origin/main' into dependabot/pip/dev-dependencies-13ad7100e2

commit 937e33de2133c1e4cde9d9299f0b11f0143c3982
Merge: ce0954e eab0615
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 18:13:33 2024 +0100

    Merge pull request #10 from blooop/feature/coverage_excludes

    Feature/coverage excludes

commit eab0615a3259ed97009c7a4606c54704c77563cb
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 17:55:13 2024 +0100

    update pixi.lock

commit 9dd1c1449ae72d30b2b484838cfaee6b3d60585c
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 16:34:12 2024 +0100

    update pixi.lock

commit 9d497dc26ad5f4f2afcbc328a0fb29a50ff15e74
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 16:30:25 2024 +0100

    add ci task and fix ruff linting

commit 1382323993be995e35abdaaff902c759c821351b
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 16:13:10 2024 +0100

    add frozen: True for lockfile

commit 8c78564b812faecacd7612bd9017c61d5fbb1744
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat May 25 15:12:05 2024 +0000

    Bump the dev-dependencies group with 4 updates

    Updates the requirements on [pylint](https://github.com/pylint-dev/pylint), [pytest](https://github.com/pytest-dev/pytest), [hypothesis](https://github.com/HypothesisWorks/hypothesis) and [ruff](https://github.com/astral-sh/ruff) to permit the latest version.

    Updates `pylint` to 3.2.2
    - [Release notes](https://github.com/pylint-dev/pylint/releases)
    - [Commits](https://github.com/pylint-dev/pylint/compare/pylint-3.0.0a0...v3.2.2)

    Updates `pytest` to 8.2.1
    - [Release notes](https://github.com/pytest-dev/pytest/releases)
    - [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
    - [Commits](https://github.com/pytest-dev/pytest/compare/7.4.0...8.2.1)

    Updates `hypothesis` to 6.102.6
    - [Release notes](https://github.com/HypothesisWorks/hypothesis/releases)
    - [Commits](https://github.com/HypothesisWorks/hypothesis/compare/hypothesis-python-6.82.0...hypothesis-python-6.102.6)

    Updates `ruff` to 0.4.5
    - [Release notes](https://github.com/astral-sh/ruff/releases)
    - [Changelog](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/astral-sh/ruff/compare/v0.0.280...v0.4.5)

    ---
    updated-dependencies:
    - dependency-name: pylint
      dependency-type: direct:production
      dependency-group: dev-dependencies
    - dependency-name: pytest
      dependency-type: direct:production
      dependency-group: dev-dependencies
    - dependency-name: hypothesis
      dependency-type: direct:production
      dependency-group: dev-dependencies
    - dependency-name: ruff
      dependency-type: direct:production
      dependency-group: dev-dependencies
    ...

    Signed-off-by: dependabot[bot] <support@github.com>

commit 902e18f92055628330839daf8e91dbb4d6c9ed25
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 12:51:25 2024 +0100

    update pixi.lock

commit 67f8d8003c307d6ac45d8900096d0f02879e3ce1
Merge: 48667a3 ce0954e
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 12:51:14 2024 +0100

    Merge remote-tracking branch 'origin/main' into feature/coverage_excludes

commit ce0954e5eb5c8ff2233c7237367d984d308b0026
Merge: cefba2a 2f1b97e
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 12:50:15 2024 +0100

    Merge pull request #8 from blooop/dependabot/github_actions/codecov/codecov-action-4

    Bump codecov/codecov-action from 3 to 4

commit 48667a3cedc4e1ef95d05a867ab8f020e014f754
Author: Austin Gregg-Smith <blooop@gmail.com>
Date:   Sat May 25 12:40:07 2024 +0100

    [add] coverage excluded

commit 2f1b97e995ce377a7e22d1b91751fc5ae3e121ec
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Sat May 25 11:27:44 2024 +0000

    Bump codecov/codecov-action from 3 to 4

    Bumps [codecov/codecov-action](https://github.com/codecov/codecov-action) from 3 to 4.
    - [Release notes](https://github.com/codecov/codecov-action/releases)
    - [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/codecov/codecov-action/compare/v3...v4)

    ---
    updated-dependencies:
    - dependency-name: codecov/codecov-action
      dependency-type: direct:production
      update-type: version-update:semver-major
    ...

    Signed-off-by: dependabot[bot] <support@github.com>