### PR TITLE
run pixi update before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           environments: ${{ matrix.environment }}
       - name: CI
         run: |
-          pixi run -e ${{ matrix.environment }} ci 
+          pixi update; pixi run -e ${{ matrix.environment }} ci 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         env:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Pixi before running the CI tests.