### PR TITLE
bump version of readthedoct ubuntu container

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
     # You can also specify other tool versions:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the Read the Docs configuration to use Ubuntu 24.04.