### PR TITLE
Feature/increase samples

### DIFF
--- a/docs/reference/0D_inputs/example_in_0_out_1float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_1float.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 0 Float input and 1 Float output"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},

--- a/docs/reference/0D_inputs/example_in_0_out_1float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_1float.ipynb
@@ -23,7 +23,7 @@
     "        return super().__call__(**kwargs)\n",
     "\n",
     "\n",
-    "bench = SimpleFloat0D().to_bench(bch.BenchRunCfg(repeats=10))\n",
+    "bench = SimpleFloat0D().to_bench(bch.BenchRunCfg(repeats=100))\n",
     "res = bench.plot_sweep(\"title1\")"
    ]
   },

--- a/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
@@ -40,7 +40,7 @@
     "    def __call__(self, **kwargs) -> dict:\n",
     "        self.update_params_from_kwargs(**kwargs)\n",
     "        self.output = random.gauss(mu=0.0, sigma=1.0)\n",
-    "        self.output = random.gauss(mu=5.0, sigma=3.0)\n",
+    "        self.output2 = random.gauss(mu=5.0, sigma=3.0)\n",
     "        return super().__call__(**kwargs)\n",
     "\n",
     "\n",

--- a/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example Notebook 2\n",
-    "\n",
-    "This is a **test notebook** to ensure nbsite is picking it up."
+    "# Example 0 Float input and 2 Float output"
    ]
   },
   {
@@ -37,9 +35,13 @@
     "\n",
     "    # This defines a variable that we want to plot\n",
     "    output = bch.ResultVar(units=\"ul\", doc=\"a sample from a gaussian distribution\")\n",
+    "    output2 = bch.ResultVar(units=\"ul\", doc=\"a sample from a gaussian distribution\")\n",
     "\n",
     "    def __call__(self, **kwargs) -> dict:\n",
-    "        return dict(output=random.gauss(mu=0.0, sigma=1.0))\n",
+    "        self.update_params_from_kwargs(**kwargs)\n",
+    "        self.output = random.gauss(mu=0.0, sigma=1.0)\n",
+    "        self.output = random.gauss(mu=5.0, sigma=3.0)\n",
+    "        return super().__call__(**kwargs)\n",
     "\n",
     "\n",
     "bench = SimpleFloat0D().to_bench(bch.BenchRunCfg(repeats=100))\n",

--- a/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
@@ -42,7 +42,7 @@
     "        return dict(output=random.gauss(mu=0.0, sigma=1.0))\n",
     "\n",
     "\n",
-    "bench = SimpleFloat0D().to_bench(bch.BenchRunCfg(repeats=10))\n",
+    "bench = SimpleFloat0D().to_bench(bch.BenchRunCfg(repeats=100))\n",
     "res = bench.plot_sweep(\"title\")"
    ]
   },


### PR DESCRIPTION
## Summary by Sourcery

Increase the number of samples collected by benchmarks in example notebooks.

Enhancements:
- Increase the number of repeats for benchmark runs in example notebooks from 10 to 100.

Documentation:
- Update example notebooks to reflect the increased sample count.