### PR TITLE
fix output2

### DIFF
--- a/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
+++ b/docs/reference/0D_inputs/example_in_0_out_2float.ipynb
@@ -40,7 +40,7 @@
     "    def __call__(self, **kwargs) -> dict:\n",
     "        self.update_params_from_kwargs(**kwargs)\n",
     "        self.output = random.gauss(mu=0.0, sigma=1.0)\n",
-    "        self.output = random.gauss(mu=5.0, sigma=3.0)\n",
+    "        self.output2 = random.gauss(mu=5.0, sigma=3.0)\n",
     "        return super().__call__(**kwargs)\n",
     "\n",
     "\n",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correctly assign the second output value in the example notebook.