### PR TITLE
remove apt deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pixi run demo
 
 An example of the type of output bencher produces can be seen here:
 
-https://dyson-ai.github.io/bencher/ 
+https://blooop.github.io/bencher/ 
 
 
 ## Examples

--- a/bencher.deps.yaml
+++ b/bencher.deps.yaml
@@ -10,7 +10,7 @@ pip_language-toolchain:
   - pre-commit
 
 
-apt_docs:
-  - firefox
-  - chromium-browser
-  - chromium-chromedriver
+# apt_docs:
+#   - firefox
+#   - chromium-browser
+#   - chromium-chromedriver

--- a/rockerc.yaml
+++ b/rockerc.yaml
@@ -17,4 +17,4 @@ args:
   - lazygit
   - pixi
   - cwd
-  - locales
+  # - locales


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove Firefox, Chromium, and ChromeDriver dependencies, which simplifies the Docker build.