### PR TITLE
remove space

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,6 @@ build:
     # golang: "1.19"
 
 # Build documentation in the "docs/" directory with Sphinx
-
 conda:
   environment: docs/conda-environment.yml  # Reference the Conda environment file
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,11 @@
 # Welcome to bencher's documentation!
 
+This is a gallery of plots
+
+reference/index
 
 ```{toctree}
 :maxdepth: 3
 
-reference/index
 intro
 ```


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove a superfluous space in `.readthedocs.yaml`.