### PR TITLE
deps: remove sorted_containers dependency

### DIFF
--- a/bencher/caching.py
+++ b/bencher/caching.py
@@ -17,7 +17,7 @@ class CachedParams(ParametrizedSweep):
             self.cache.clear()
 
     def kwargs_to_hash_key(self, **kwargs):
-        return tuple(sorted(kwargs.items()))
+        return tuple(sorted(kwargs.items(), key=lambda item: str(item[0])))
 
     def in_cache(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)

--- a/bencher/caching.py
+++ b/bencher/caching.py
@@ -3,9 +3,6 @@ from diskcache import Cache
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.utils import hash_sha1
 import logging
-from sortedcontainers import SortedDict
-
-# from job import job,JobCache,JobFunctionCache
 
 
 class CachedParams(ParametrizedSweep):
@@ -20,7 +17,7 @@ class CachedParams(ParametrizedSweep):
             self.cache.clear()
 
     def kwargs_to_hash_key(self, **kwargs):
-        return tuple(SortedDict(kwargs).items())
+        return tuple(sorted(kwargs.items()))
 
     def in_cache(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import Callable
-from sortedcontainers import SortedDict
 import logging
 from diskcache import Cache
 from concurrent.futures import Future, ProcessPoolExecutor
@@ -23,7 +22,7 @@ class Job:
         self.function = function
         self.job_args = job_args
         if job_key is None:
-            self.job_key = hash_sha1(tuple(SortedDict(self.job_args).items()))
+            self.job_key = hash_sha1(tuple(sorted(self.job_args.items())))
         else:
             self.job_key = job_key
         self.tag = tag

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -27,7 +27,7 @@ def hmap_canonical_input(dic: dict) -> tuple:
     Returns:
         tuple: values of the dictionary always in the same order and hashable
     """
-    return tuple(dict(sorted(dic.items())).values())
+    return tuple(value for _, value in sorted(dic.items()))
 
 
 def make_namedtuple(class_name: str, **fields) -> namedtuple:

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 import xarray as xr
-from sortedcontainers import SortedDict
 import hashlib
 import re
 import math

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -27,9 +27,7 @@ def hmap_canonical_input(dic: dict) -> tuple:
     Returns:
         tuple: values of the dictionary always in the same order and hashable
     """
-
-    function_input = SortedDict(dic)
-    return tuple(function_input.values())
+    return tuple(dict(sorted(dic.items())).values())
 
 
 def make_namedtuple(class_name: str, **fields) -> namedtuple:

--- a/bencher/worker_job.py
+++ b/bencher/worker_job.py
@@ -1,6 +1,5 @@
 from typing import List, Tuple, Any
 from dataclasses import dataclass, field
-from sortedcontainers import SortedDict
 from .utils import hash_sha1
 from bencher.utils import hmap_canonical_input
 
@@ -14,7 +13,7 @@ class WorkerJob:
     bench_cfg_sample_hash: str
     tag: str
 
-    function_input: SortedDict = None
+    function_input: dict = None
     canonical_input: Tuple[Any] = None
     fn_inputs_sorted: List[str] = None
     function_input_signature_pure: str = None
@@ -23,7 +22,7 @@ class WorkerJob:
     msgs: List[str] = field(default_factory=list)
 
     def setup_hashes(self) -> None:
-        self.function_input = SortedDict(zip(self.dims_name, self.function_input_vars))
+        self.function_input = dict(zip(self.dims_name, self.function_input_vars))
 
         self.canonical_input = hmap_canonical_input(self.function_input)
 
@@ -32,7 +31,7 @@ class WorkerJob:
 
         # store a tuple of the inputs as keys for a holomap
         # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
-        self.fn_inputs_sorted = list(SortedDict(self.function_input).items())
+        self.fn_inputs_sorted = sorted(self.function_input.items())
         self.function_input_signature_pure = hash_sha1((self.fn_inputs_sorted, self.tag))
 
         self.function_input_signature_benchmark_context = hash_sha1(

--- a/pixi.lock
+++ b/pixi.lock
@@ -1098,7 +1098,7 @@ packages:
 - pypi: .
   name: holobench
   version: 1.40.1
-  sha256: a66f546623c853315a0236ca36c4014be502cfd21afe7b02cda1165dccae884b
+  sha256: 534c75fb6ddf19070d85af794bf0f9defc8a922c9fb1e417f9d82163ff8c8560
   requires_dist:
   - holoviews>=1.15,<=1.20.0
   - numpy>=1.0,<=2.2.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -629,8 +629,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
-  arch: x86_64
-  platform: linux
   license: None
   purls: []
   size: 2562
@@ -644,8 +642,6 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -781,8 +777,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -791,8 +785,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
   sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
   md5: 19f3a56f68d2fd06c516076bff482c52
-  arch: x86_64
-  platform: linux
   license: ISC
   purls: []
   size: 158144
@@ -1110,7 +1102,7 @@ packages:
 - pypi: .
   name: holobench
   version: 1.40.1
-  sha256: 31c99c000196e57878283bc9458a2859f01c2385b268a3991beb15c92ddc34d7
+  sha256: a66f546623c853315a0236ca36c4014be502cfd21afe7b02cda1165dccae884b
   requires_dist:
   - holoviews>=1.15,<=1.20.0
   - numpy>=1.0,<=2.2.2
@@ -1121,7 +1113,6 @@ packages:
   - optuna>=3.2,<=4.2.0
   - xarray>=2023.7,<=2025.1.2
   - plotly>=5.15,<=6.0.0
-  - sortedcontainers>=2.4,<=2.4
   - pandas>=2.0,<=2.2.3
   - strenum>=0.4.0,<=0.4.15
   - scikit-learn>=1.2,<=1.6.1
@@ -1676,8 +1667,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.43
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -1691,8 +1680,6 @@ packages:
   - libgcc >=13
   constrains:
   - expat 2.6.4.*
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1704,8 +1691,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1720,8 +1705,6 @@ packages:
   constrains:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1732,8 +1715,6 @@ packages:
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
   - libgcc 14.2.0 h77fa898_1
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1744,8 +1725,6 @@ packages:
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1757,8 +1736,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: 0BSD
   purls: []
   size: 111357
@@ -1768,8 +1745,6 @@ packages:
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -1782,8 +1757,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: Unlicense
   purls: []
   size: 878223
@@ -1793,8 +1766,6 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -1805,8 +1776,6 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -1819,8 +1788,6 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -2049,8 +2016,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -2087,8 +2052,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -2999,8 +2962,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 25199631
@@ -3029,8 +2990,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 30624804
@@ -3058,8 +3017,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 31581682
@@ -3138,8 +3095,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -3697,8 +3652,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
-  arch: x86_64
-  platform: linux
   license: TCL
   license_family: BSD
   purls: []

--- a/pixi.lock
+++ b/pixi.lock
@@ -625,6 +625,8 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   purls: []
   size: 2562
@@ -638,6 +640,8 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -773,6 +777,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -781,6 +787,8 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
   sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
   md5: 19f3a56f68d2fd06c516076bff482c52
+  arch: x86_64
+  platform: linux
   license: ISC
   purls: []
   size: 158144
@@ -1663,6 +1671,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.43
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -1676,6 +1686,8 @@ packages:
   - libgcc >=13
   constrains:
   - expat 2.6.4.*
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1687,6 +1699,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1701,6 +1715,8 @@ packages:
   constrains:
   - libgomp 14.2.0 h77fa898_1
   - libgcc-ng ==14.2.0=*_1
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1711,6 +1727,8 @@ packages:
   md5: e39480b9ca41323497b05492a63bc35b
   depends:
   - libgcc 14.2.0 h77fa898_1
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1721,6 +1739,8 @@ packages:
   md5: cc3573974587f12dda90d96e3e55a702
   depends:
   - _libgcc_mutex 0.1 conda_forge
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1732,6 +1752,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: 0BSD
   purls: []
   size: 111357
@@ -1741,6 +1763,8 @@ packages:
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -1753,6 +1777,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: Unlicense
   purls: []
   size: 878223
@@ -1762,6 +1788,8 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -1772,6 +1800,8 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -1784,6 +1814,8 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
+  arch: x86_64
+  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -2012,6 +2044,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -2048,6 +2082,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -2958,6 +2994,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 25199631
@@ -2986,6 +3024,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 30624804
@@ -3013,6 +3053,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 31581682
@@ -3091,6 +3133,8 @@ packages:
   depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -3640,6 +3684,8 @@ packages:
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
+  arch: x86_64
+  platform: linux
   license: TCL
   license_family: BSD
   purls: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,12 @@ dependencies = [
     "holoviews>=1.15,<=1.20.0",
     "numpy>=1.0,<=2.2.2",
     "param>=1.13.0,<=2.2.0",
-    "hvplot>=0.8,<=0.10.0",        #greater versions cause an error
+    "hvplot>=0.8,<=0.10.0",      #greater versions cause an error
     "panel>=1.3.6,<=1.6.0",
     "diskcache>=5.6,<=5.6.3",
     "optuna>=3.2,<=4.2.0",
     "xarray>=2023.7,<=2025.1.2",
     "plotly>=5.15,<=6.0.0",
-    "sortedcontainers>=2.4,<=2.4",
     "pandas>=2.0,<=2.2.3",
     "strenum>=0.4.0,<=0.4.15",
     "scikit-learn>=1.2,<=1.6.1",


### PR DESCRIPTION
## Summary by Sourcery

Remove the `sortedcontainers` dependency and replace its usage with the built-in `dict` type. Implement explicit sorting to ensure the order of dictionary items remains consistent.

Enhancements:
- Replace `SortedDict` with `dict` and add sorting logic to maintain consistent order

Build:
- Remove the `sortedcontainers` dependency from `pyproject.toml`