### PR TITLE
remove warning about scoop

### DIFF
--- a/bencher/job.py
+++ b/bencher/job.py
@@ -10,7 +10,6 @@ from enum import auto
 try:
     from scoop import futures as scoop_future_executor
 except ImportError as e:
-    logging.warning(e.msg)
     scoop_future_executor = None
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1100,8 +1100,8 @@ packages:
   requires_python: '>=3.7'
 - pypi: .
   name: holobench
-  version: 1.40.1
-  sha256: abc8828160c17405aa8685ffaee2aa84848bf2218ddd4c34992f34b52c18473b
+  version: 1.41.0
+  sha256: 4c8e61687b18716148492c50ed6668ed9f35b707cc031abd296db99dd261e7cd
   requires_dist:
   - holoviews>=1.15,<=1.20.0
   - numpy>=1.0,<=2.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.40.1"
+version = "1.41.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removed the warning message displayed when the `scoop` package is not installed.