### PR TITLE
hotfix: address error that grabbing the last frame of the image retur…

### DIFF
--- a/bencher/video_writer.py
+++ b/bencher/video_writer.py
@@ -88,7 +88,7 @@ class VideoWriter:
             output_path = Path(output_path)
 
         with moviepy.video.io.VideoFileClip.VideoFileClip(video_path) as video:
-            frame_time = time if time is not None else video.duration
+            frame_time = time if time is not None else video.duration - 2.0 / video.fps
             frame = video.get_frame(frame_time)
             Image.fromarray(frame).save(output_path)
 

--- a/bencher/video_writer.py
+++ b/bencher/video_writer.py
@@ -89,6 +89,7 @@ class VideoWriter:
 
         with moviepy.video.io.VideoFileClip.VideoFileClip(video_path) as video:
             frame_time = time if time is not None else video.duration - 2.0 / video.fps
+            frame_time = max(frame_time, 0)
             frame = video.get_frame(frame_time)
             Image.fromarray(frame).save(output_path)
 


### PR DESCRIPTION
…ns the first frame??

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where extracting the last frame of a video would return the first frame instead.