### PR TITLE
allow string parameters to get dataset

### DIFF
--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -80,7 +80,7 @@ class BenchResultBase(OptunaResult):
     def to_dataset(
         self,
         reduce: ReduceType = ReduceType.AUTO,
-        result_var: ResultVar = None,
+        result_var: ResultVar | str = None,
         level: int = None,
     ) -> xr.Dataset:
         """Generate a summarised xarray dataset.
@@ -97,7 +97,11 @@ class BenchResultBase(OptunaResult):
         ds_out = self.ds.copy()
 
         if result_var is not None:
-            ds_out = ds_out[result_var.name].to_dataset(name=result_var.name)
+            if isinstance(result_var, Parameter):
+                var_name = result_var.name
+            else:
+                var_name = result_var
+            ds_out = ds_out[var_name].to_dataset(name=var_name)
 
         def rename_ds(dataset: xr.Dataset, suffix: str):
             # var_name =

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -102,7 +102,9 @@ class BenchResultBase(OptunaResult):
             elif isinstance(result_var, str):
                 var_name = result_var
             else:
-                raise TypeError(f"Unsupported type for result_var: {type(result_var)}. Expected Parameter or str.")
+                raise TypeError(
+                    f"Unsupported type for result_var: {type(result_var)}. Expected Parameter or str."
+                )
             ds_out = ds_out[var_name].to_dataset(name=var_name)
 
         def rename_ds(dataset: xr.Dataset, suffix: str):

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -99,8 +99,10 @@ class BenchResultBase(OptunaResult):
         if result_var is not None:
             if isinstance(result_var, Parameter):
                 var_name = result_var.name
-            else:
+            elif isinstance(result_var, str):
                 var_name = result_var
+            else:
+                raise TypeError(f"Unsupported type for result_var: {type(result_var)}. Expected Parameter or str.")
             ds_out = ds_out[var_name].to_dataset(name=var_name)
 
         def rename_ds(dataset: xr.Dataset, suffix: str):

--- a/bencher/results/holoview_result.py
+++ b/bencher/results/holoview_result.py
@@ -446,8 +446,10 @@ class HoloviewResult(PanelResult):
         bound_plot = pn.Column(title, *cont_instances)
         return pn.Row(htmap, bound_plot)
 
-    def to_error_bar(self) -> hv.Bars:
-        return self.to_hv_dataset(ReduceType.REDUCE).to(hv.ErrorBars)
+    def to_error_bar(self, result_var: Parameter | str = None, **kwargs) -> hv.Bars:
+        return self.to_hv_dataset(ReduceType.REDUCE, result_var=result_var, **kwargs).to(
+            hv.ErrorBars
+        )
 
     def to_points(self, reduce: ReduceType = ReduceType.AUTO) -> hv.Points:
         ds = self.to_hv_dataset(reduce)

--- a/pixi.lock
+++ b/pixi.lock
@@ -632,6 +632,8 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   purls: []
   size: 2562
@@ -645,6 +647,8 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -768,6 +772,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -776,6 +782,8 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2025.1.31-hbcca054_0.conda
   sha256: bf832198976d559ab44d6cdb315642655547e26d826e34da67cbee6624cda189
   md5: 19f3a56f68d2fd06c516076bff482c52
+  arch: x86_64
+  platform: linux
   license: ISC
   purls: []
   size: 158144
@@ -1716,6 +1724,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.43
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -1729,6 +1739,8 @@ packages:
   - libgcc >=13
   constrains:
   - expat 2.7.0.*
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1740,6 +1752,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -1754,6 +1768,8 @@ packages:
   constrains:
   - libgomp 14.2.0 h767d61c_2
   - libgcc-ng ==14.2.0=*_2
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1764,6 +1780,8 @@ packages:
   md5: a2222a6ada71fb478682efe483ce0f92
   depends:
   - libgcc 14.2.0 h767d61c_2
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1774,6 +1792,8 @@ packages:
   md5: 06d02030237f4d5b3d9a7e7d348fe3c6
   depends:
   - __glibc >=2.17,<3.0.a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -1785,6 +1805,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: 0BSD
   purls: []
   size: 112709
@@ -1794,6 +1816,8 @@ packages:
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -1806,6 +1830,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: Unlicense
   purls: []
   size: 878223
@@ -1815,6 +1841,8 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -1825,6 +1853,8 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -1837,6 +1867,8 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
+  arch: x86_64
+  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -2036,6 +2068,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -2072,6 +2106,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -2979,6 +3015,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 25199631
@@ -3007,6 +3045,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 30624804
@@ -3034,6 +3074,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 31581682
@@ -3119,6 +3161,8 @@ packages:
   depends:
   - libgcc >=13
   - ncurses >=6.5,<7.0a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -3636,6 +3680,8 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
+  arch: x86_64
+  platform: linux
   license: Unlicense
   purls: []
   size: 888207
@@ -3678,6 +3724,8 @@ packages:
   depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
+  arch: x86_64
+  platform: linux
   license: TCL
   license_family: BSD
   purls: []


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Modify the `to_dataset` method to accept both `ResultVar` and string types for the `result_var` parameter