### PR TITLE
update obsolete dyson-ai repo name -> blooop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
  
  ## Continuous Integration Status
 
-[![Ci](https://github.com/dyson-ai/bencher/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/dyson-ai/bencher/actions/workflows/ci.yml?query=branch%3Amain)
+[![Ci](https://github.com/blooop/bencher/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/blooop/bencher/actions/workflows/ci.yml?query=branch%3Amain)
 ![Read the Docs](https://img.shields.io/readthedocs/bencher)
-[![Codecov](https://codecov.io/gh/dyson-ai/bencher/branch/main/graph/badge.svg?token=Y212GW1PG6)](https://codecov.io/gh/dyson-ai/bencher)
-[![GitHub issues](https://img.shields.io/github/issues/dyson-ai/bencher.svg)](https://GitHub.com/dyson-ai/bencher/issues/)
-[![GitHub pull-requests merged](https://badgen.net/github/merged-prs/dyson-ai/bencher)](https://github.com/dyson-ai/bencher/pulls?q=is%3Amerged)
+[![Codecov](https://codecov.io/gh/blooop/bencher/branch/main/graph/badge.svg?token=Y212GW1PG6)](https://codecov.io/gh/blooop/bencher)
+[![GitHub issues](https://img.shields.io/github/issues/blooop/bencher.svg)](https://GitHub.com/blooop/bencher/issues/)
+[![GitHub pull-requests merged](https://badgen.net/github/merged-prs/blooop/bencher)](https://github.com/blooop/bencher/pulls?q=is%3Amerged)
 [![PyPI](https://img.shields.io/pypi/v/holobench)](https://pypi.org/project/holobench/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/holobench)](https://pypistats.org/packages/holobench)
 [![License](https://img.shields.io/pypi/l/bencher)](https://opensource.org/license/mit/)

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -162,8 +162,8 @@ class BenchReport(BenchPlotServer):
 
             def publish_args(branch_name) -> Tuple[str, str]:
                 return (
-                    "https://github.com/dyson-ai/bencher.git",
-                    f"https://github.com/dyson-ai/bencher/blob/{branch_name}")
+                    "https://github.com/blooop/bencher.git",
+                    f"https://github.com/blooop/bencher/blob/{branch_name}")
 
 
         Args:

--- a/bencher/example/example_rerun2.py
+++ b/bencher/example/example_rerun2.py
@@ -23,7 +23,7 @@ else:
     # publish data to a github branch
     bch.publish_and_view_rrd(
         file_path,
-        remote="https://github.com/dyson-ai/bencher.git",
+        remote="https://github.com/blooop/bencher.git",
         branch_name="test_rrd",
         content_callback=bch.github_content,
     ).show()

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -361,8 +361,8 @@ def publish_file(filepath: str, remote: str, branch_name: str) -> str:  # pragma
 
         def publish_args(branch_name) -> Tuple[str, str]:
             return (
-                "https://github.com/dyson-ai/bencher.git",
-                f"https://github.com/dyson-ai/bencher/blob/{branch_name}")
+                "https://github.com/blooop/bencher.git",
+                f"https://github.com/blooop/bencher/blob/{branch_name}")
 
 
     Args:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -41,7 +41,7 @@ pixi run demo
 
 An example of the type of output bencher produces can be seen here:
 
-https://dyson-ai.github.io/bencher/ 
+https://blooop.github.io/bencher/ 
 
 
 ## Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/dyson-ai/bencher"
-Home = "https://github.com/dyson-ai/bencher"
+Repository = "https://github.com/blooop/bencher"
+Home = "https://github.com/blooop/bencher"
 Documentation = "https://bencher.readthedocs.io/en/latest/"
 
 [tool.pixi.project]


### PR DESCRIPTION
## Summary by Sourcery

Rename repository references and badges from dyson-ai to blooop across codebase, documentation, and project configuration, and tighten numpy and optuna version constraints

Enhancements:
- Tighten numpy upper bound to 2.2.4 and optuna to 4.2.1 for compatibility
- Update example script to publish results to the blooop repository

Documentation:
- Revise README badges and docs links to point to the blooop GitHub organization

Chores:
- Update project URLs in pyproject.toml and internal publishing functions to use the blooop repository URL