### PR TITLE
update SingletonParametrizedSweep to ParametrizedSweepSingleton

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -85,7 +85,7 @@ except ModuleNotFoundError as e:
 
 from .plotting.plot_filter import VarRange, PlotFilter
 from .variables.parametrised_sweep import ParametrizedSweep
-from .variables.singleton_parametrized_sweep import SingletonParametrizedSweep
+from .variables.singleton_parametrized_sweep import ParametrizedSweepSingleton
 from .caching import CachedParams
 from .results.bench_result import BenchResult
 from .results.video_result import VideoResult

--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -1,7 +1,7 @@
 from .parametrised_sweep import ParametrizedSweep
 
 
-class SingletonParametrizedSweep(ParametrizedSweep):
+class ParametrizedSweepSingleton(ParametrizedSweep):
     """Base class that adds singleton behavior to ParametrizedSweep."""
 
     _instances = {}

--- a/pixi.lock
+++ b/pixi.lock
@@ -789,8 +789,6 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
-  arch: x86_64
-  platform: linux
   license: None
   purls: []
   size: 2562
@@ -804,8 +802,6 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -931,8 +927,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -1306,8 +1300,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: holobench
-  version: 1.54.0
-  sha256: eab0e4541a18ac924318cc6d6494a55323b69b0815c000b1ed865ccfae16eb03
+  version: 1.54.1
+  sha256: 8c4db8756db7b8a517fb7d15feb1d50b89d9b0bcd51e2f7f79f929fe91d370fd
   requires_dist:
   - holoviews>=1.15,<=1.21.0
   - numpy>=1.0,<=2.2.6
@@ -2018,8 +2012,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.44
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -2033,8 +2025,6 @@ packages:
   - libgcc >=14
   constrains:
   - expat 2.7.1.*
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -2046,8 +2036,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -2062,8 +2050,6 @@ packages:
   constrains:
   - libgomp 15.1.0 h767d61c_5
   - libgcc-ng ==15.1.0=*_5
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2074,8 +2060,6 @@ packages:
   md5: 069afdf8ea72504e48d23ae1171d951c
   depends:
   - libgcc 15.1.0 h767d61c_5
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2086,8 +2070,6 @@ packages:
   md5: dcd5ff1940cd38f6df777cac86819d60
   depends:
   - __glibc >=2.17,<3.0.a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2101,8 +2083,6 @@ packages:
   - libgcc >=13
   constrains:
   - xz 5.8.1.*
-  arch: x86_64
-  platform: linux
   license: 0BSD
   purls: []
   size: 112894
@@ -2113,8 +2093,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -2126,8 +2104,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -2140,8 +2116,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: Unlicense
   purls: []
   size: 878223
@@ -2151,8 +2125,6 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -2163,8 +2135,6 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -2177,8 +2147,6 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -2386,8 +2354,6 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  arch: x86_64
-  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -2429,8 +2395,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=14
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3405,8 +3369,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 25199631
@@ -3435,8 +3397,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 30624804
@@ -3464,8 +3424,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 31581682
@@ -3492,8 +3450,6 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  arch: x86_64
-  platform: linux
   license: Python-2.0
   purls: []
   size: 33233150
@@ -3596,8 +3552,6 @@ packages:
   depends:
   - libgcc >=13
   - ncurses >=6.5,<7.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -4265,8 +4219,6 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
-  arch: x86_64
-  platform: linux
   license: Unlicense
   purls: []
   size: 888207
@@ -4310,8 +4262,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: TCL
   license_family: BSD
   purls: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.54.0"
+version = "1.54.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -1,5 +1,5 @@
 import pytest
-from bencher.variables.singleton_parametrized_sweep import SingletonParametrizedSweep
+from bencher.variables.singleton_parametrized_sweep import ParametrizedSweepSingleton
 import bencher as bch
 
 
@@ -7,10 +7,10 @@ import bencher as bch
 @pytest.fixture(autouse=True)
 def clear_singleton_cache():
     # Use the public method to avoid touching protected members
-    SingletonParametrizedSweep.reset_singletons()
+    ParametrizedSweepSingleton.reset_singletons()
 
 
-class ChildA(SingletonParametrizedSweep):
+class ChildA(ParametrizedSweepSingleton):
     def __init__(self, value=1):
         # Use the helper to avoid boilerplate; only runs once
         if self.init_singleton():
@@ -20,7 +20,7 @@ class ChildA(SingletonParametrizedSweep):
         super().__init__()
 
 
-class ChildB(SingletonParametrizedSweep):
+class ChildB(ParametrizedSweepSingleton):
     def __init__(self, value=2):
         if self.init_singleton():
             self.init_count = 1
@@ -57,7 +57,7 @@ def test_singleton_value_persistence():
 # ---- BenchRunner integration test with SingletonParametrizedSweep ----
 
 
-class MySingletonSweep(SingletonParametrizedSweep):
+class MySingletonSweep(ParametrizedSweepSingleton):
     """Simple singleton sweep used to validate BenchRunner reruns."""
 
     # One float input and a single numeric result


### PR DESCRIPTION
## Summary by Sourcery

Rename the singleton sweep base class and its references, update tests accordingly, and bump the project version

Enhancements:
- Rename SingletonParametrizedSweep to ParametrizedSweepSingleton in code and tests

Build:
- Bump project version from 1.54.0 to 1.54.1 in pyproject.toml

Chores:
- Regenerate dependency lock file