### PR TITLE
Feature/singleton docs

### DIFF
--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -42,7 +42,7 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
         self._singleton_inited = True
 
     @classmethod
-    def first_time(cls) -> bool:
+    def init_singleton(cls) -> bool:
         """Return True the first time a subclass is constructed in this process."""
         if cls in cls._seen:
             return False

--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -1,36 +1,17 @@
-"""Singleton variant of ParametrizedSweep.
+"""Singleton variant of ParametrizedSweep (minimal).
 
-This module provides a base class for creating Param "param.Parameterized"-based
-benchmark sweep classes that are instantiated exactly once per subclass. The
-singleton semantics help when:
+Provides a per-subclass singleton with the smallest useful surface:
 
-- You wire a sweep class into BenchRunner or other orchestration that may
-  construct the class multiple times during a session.
-- You want per-class state to persist across reruns (e.g., caches, buffers,
-  heavy initializations) without redoing work.
-- You need deterministic, single-time initialization while still using the
-  familiar ParametrizedSweep interface.
+- One instance per subclass via ``__new__``.
+- Base ``__init__`` calls the Parametrized chain exactly once.
+- A simple classmethod ``first_time()`` you can call to know if this
+  is the first time the class has been created in this process.
 
-Key features
-- One instance per subclass: repeated construction returns the same object.
-- First-time initialization helpers:
-  - override "on_first_init()" to run setup once with zero boilerplate; or
-  - use "init_singleton()" in your __init__ to guard setup explicitly.
-- Test support: call "reset_singletons()" between tests to avoid leaks.
-
-Usage examples
-1) Hook-based (no guards):
-    class MySweep(SingletonParametrizedSweep):
-        theta = FloatSweep(default=0, bounds=[0, 1])
-
-        def on_first_init(self):
-            self.cache = {}
-
-2) Guard-based (explicit, pylint-friendly):
-    class MySweep(SingletonParametrizedSweep):
-        def __init__(self):
-            if self.init_singleton():
-                self.cache = {}
+Example
+    class MySweep(ParametrizedSweepSingleton):
+        def __init__(self, value=0):
+            if self.first_time():
+                self.value = value  # only set once
             super().__init__()  # safe no-op after the first call
 """
 
@@ -38,78 +19,32 @@ from .parametrised_sweep import ParametrizedSweep
 
 
 class ParametrizedSweepSingleton(ParametrizedSweep):
-    """A ParametrizedSweep that guarantees a single instance per subclass.
+    """A minimal per-subclass singleton for ParametrizedSweep.
 
-    This class implements a per-subclass singleton using __new__. Subclasses can
-    initialize their one-time state in either of two ways:
-
-    - Override on_first_init(): Called exactly once prior to the Parametrized
-      init chain; ideal when you prefer no guards in your __init__.
-    - Call init_singleton() from __init__: Returns True on the first call, so
-      you can conditionally set fields and then call super().__init__().
-
-    See reset_singletons() for a testing aid that clears the singleton cache.
+    - Repeated construction returns the same instance for each subclass.
+    - Ensures the Parametrized ``__init__`` chain runs only once.
+    - ``first_time()`` returns True once per subclass to gate one-time setup.
     """
 
     _instances = {}
+    _seen = set()
 
     def __new__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super().__new__(cls)
-            cls._instances[cls]._singleton_initialized = False
         return cls._instances[cls]
 
     def __init__(self, **params):
-        # Only initialize once due to singleton pattern, including all subclass logic
-        if getattr(self, "_singleton_initialized", False):
+        # Only run the Parametrized init chain once
+        if getattr(self, "_singleton_inited", False):
             return
-        # Hook for subclasses that prefer a no-boilerplate override point
-        try:
-            self.on_first_init()  # type: ignore[attr-defined]
-        except AttributeError:
-            # Subclass did not define the hook; that's fine
-            pass
         super().__init__(**params)
-        self._singleton_initialized = True
-
-    # Optional template hook for subclasses that want zero guard boilerplate
-    # Subclasses may override this and set up fields. It is called exactly once.
-    def on_first_init(self) -> None:  # pragma: no cover - optional hook
-        pass
+        self._singleton_inited = True
 
     @classmethod
-    def reset_singletons(cls) -> None:
-        """Clear the singleton instance cache for all subclasses.
-
-        Intended primarily for tests to ensure isolation between test cases
-        without reaching into protected attributes from outside the class.
-        """
-        cls._instances.clear()
-
-    def init_singleton(self, initializer=None, **params) -> bool:
-        """Run subclass initialization exactly once and finalize the singleton.
-
-        Use inside your subclass __init__ to avoid manual guards. If you pass an
-        initializer, it is invoked only on the first call, before the parent
-        ParametrizedSweep initialization.
-
-        Example:
-            if self.init_singleton():
-                self.buf = []
-            super().__init__()
-
-        Args:
-            initializer (Callable[[], None] | None): Optional one-time setup function.
-            **params: Optional params forwarded to ParametrizedSweep.__init__.
-
-        Returns:
-            bool: True if initialization ran this call, False if already initialized.
-        """
-        if getattr(self, "_singleton_initialized", False):
+    def first_time(cls) -> bool:
+        """Return True the first time a subclass is constructed in this process."""
+        if cls in cls._seen:
             return False
-        if initializer is not None:
-            initializer()
-        # Call the Parametrized init chain once
-        super().__init__(**params)
-        self._singleton_initialized = True
+        cls._seen.add(cls)
         return True

--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -1,8 +1,55 @@
+"""Singleton variant of ParametrizedSweep.
+
+This module provides a base class for creating Param "param.Parameterized"-based
+benchmark sweep classes that are instantiated exactly once per subclass. The
+singleton semantics help when:
+
+- You wire a sweep class into BenchRunner or other orchestration that may
+  construct the class multiple times during a session.
+- You want per-class state to persist across reruns (e.g., caches, buffers,
+  heavy initializations) without redoing work.
+- You need deterministic, single-time initialization while still using the
+  familiar ParametrizedSweep interface.
+
+Key features
+- One instance per subclass: repeated construction returns the same object.
+- First-time initialization helpers:
+  - override "on_first_init()" to run setup once with zero boilerplate; or
+  - use "init_singleton()" in your __init__ to guard setup explicitly.
+- Test support: call "reset_singletons()" between tests to avoid leaks.
+
+Usage examples
+1) Hook-based (no guards):
+    class MySweep(SingletonParametrizedSweep):
+        theta = FloatSweep(default=0, bounds=[0, 1])
+
+        def on_first_init(self):
+            self.cache = {}
+
+2) Guard-based (explicit, pylint-friendly):
+    class MySweep(SingletonParametrizedSweep):
+        def __init__(self):
+            if self.init_singleton():
+                self.cache = {}
+            super().__init__()  # safe no-op after the first call
+"""
+
 from .parametrised_sweep import ParametrizedSweep
 
 
 class ParametrizedSweepSingleton(ParametrizedSweep):
-    """Base class that adds singleton behavior to ParametrizedSweep."""
+    """A ParametrizedSweep that guarantees a single instance per subclass.
+
+    This class implements a per-subclass singleton using __new__. Subclasses can
+    initialize their one-time state in either of two ways:
+
+    - Override on_first_init(): Called exactly once prior to the Parametrized
+      init chain; ideal when you prefer no guards in your __init__.
+    - Call init_singleton() from __init__: Returns True on the first call, so
+      you can conditionally set fields and then call super().__init__().
+
+    See reset_singletons() for a testing aid that clears the singleton cache.
+    """
 
     _instances = {}
 
@@ -34,23 +81,25 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
     def reset_singletons(cls) -> None:
         """Clear the singleton instance cache for all subclasses.
 
-        Intended primarily for tests to ensure isolation between test cases without
-        reaching into protected attributes from outside the class.
+        Intended primarily for tests to ensure isolation between test cases
+        without reaching into protected attributes from outside the class.
         """
         cls._instances.clear()
 
     def init_singleton(self, initializer=None, **params) -> bool:
         """Run subclass initialization exactly once and finalize the singleton.
 
-        This helper removes boilerplate from subclasses. Use it inside your
-        subclass __init__ like:
+        Use inside your subclass __init__ to avoid manual guards. If you pass an
+        initializer, it is invoked only on the first call, before the parent
+        ParametrizedSweep initialization.
 
-            def __init__(self, some_arg=1):
+        Example:
             if self.init_singleton():
-                self.field = some_arg
+                self.buf = []
+            super().__init__()
 
         Args:
-            initializer (Callable[[], None] | None): Optional function that sets up instance fields.
+            initializer (Callable[[], None] | None): Optional one-time setup function.
             **params: Optional params forwarded to ParametrizedSweep.__init__.
 
         Returns:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1300,8 +1300,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: holobench
-  version: 1.54.1
-  sha256: 8c4db8756db7b8a517fb7d15feb1d50b89d9b0bcd51e2f7f79f929fe91d370fd
+  version: 1.54.2
+  sha256: c65597484eceeaef0fa5cd37340603a3230ddf7fce407c1e14bef15280af3d6c
   requires_dist:
   - holoviews>=1.15,<=1.21.0
   - numpy>=1.0,<=2.2.6

--- a/pixi.lock
+++ b/pixi.lock
@@ -61,7 +61,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/75/d451b9a0ab3a9c0b2c7d1d3cf0bcf797ccac420f3479476f9867e1737d39/holoviews-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/51/b8cd6be4a303e6b88ca4b56feecf523f2a2e286ebd7cb56f0dbe986917f7/hvplot-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ab/012b126e5be088b8de28a6f7eed2cf71b7c009233d9cd3f730419fda22ae/hypothesis-6.138.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -76,7 +76,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/78/33b2294aad62e5f95b89a89379c5995c2bd978018387ef8bec79f6dc272c/jupyter_bokeh-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl
@@ -218,7 +218,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/75/d451b9a0ab3a9c0b2c7d1d3cf0bcf797ccac420f3479476f9867e1737d39/holoviews-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/51/b8cd6be4a303e6b88ca4b56feecf523f2a2e286ebd7cb56f0dbe986917f7/hvplot-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ab/012b126e5be088b8de28a6f7eed2cf71b7c009233d9cd3f730419fda22ae/hypothesis-6.138.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -232,7 +232,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/78/33b2294aad62e5f95b89a89379c5995c2bd978018387ef8bec79f6dc272c/jupyter_bokeh-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl
@@ -375,7 +375,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/75/d451b9a0ab3a9c0b2c7d1d3cf0bcf797ccac420f3479476f9867e1737d39/holoviews-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/51/b8cd6be4a303e6b88ca4b56feecf523f2a2e286ebd7cb56f0dbe986917f7/hvplot-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ab/012b126e5be088b8de28a6f7eed2cf71b7c009233d9cd3f730419fda22ae/hypothesis-6.138.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -390,7 +390,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/78/33b2294aad62e5f95b89a89379c5995c2bd978018387ef8bec79f6dc272c/jupyter_bokeh-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl
@@ -532,7 +532,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/75/d451b9a0ab3a9c0b2c7d1d3cf0bcf797ccac420f3479476f9867e1737d39/holoviews-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/51/b8cd6be4a303e6b88ca4b56feecf523f2a2e286ebd7cb56f0dbe986917f7/hvplot-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ab/012b126e5be088b8de28a6f7eed2cf71b7c009233d9cd3f730419fda22ae/hypothesis-6.138.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -547,7 +547,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/78/33b2294aad62e5f95b89a89379c5995c2bd978018387ef8bec79f6dc272c/jupyter_bokeh-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl
@@ -689,7 +689,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/75/d451b9a0ab3a9c0b2c7d1d3cf0bcf797ccac420f3479476f9867e1737d39/holoviews-1.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/51/b8cd6be4a303e6b88ca4b56feecf523f2a2e286ebd7cb56f0dbe986917f7/hvplot-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ab/012b126e5be088b8de28a6f7eed2cf71b7c009233d9cd3f730419fda22ae/hypothesis-6.138.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/bd/b394387b598ed84d8d0fa90611a90bee0adc2021820ad5729f7ced74a8e2/imageio-2.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -704,7 +704,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/e8/685f47e0d754320684db4425a0967f7d3fa70126bffd76110b7009a0090f/joblib-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/78/33b2294aad62e5f95b89a89379c5995c2bd978018387ef8bec79f6dc272c/jupyter_bokeh-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl
@@ -789,6 +789,8 @@ packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   purls: []
   size: 2562
@@ -802,6 +804,8 @@ packages:
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -927,6 +931,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
@@ -1574,10 +1580,10 @@ packages:
   - tzdata>=2025.2 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
   - watchdog>=4.0.0 ; extra == 'all'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl
   name: identify
-  version: 2.6.13
-  sha256: 60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b
+  version: 2.6.14
+  sha256: 11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e
   requires_dist:
   - ukkonen ; extra == 'license'
   requires_python: '>=3.9'
@@ -1919,10 +1925,10 @@ packages:
   - uri-template ; extra == 'format-nongpl'
   - webcolors>=24.6.0 ; extra == 'format-nongpl'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
   name: jsonschema-specifications
-  version: 2025.4.1
-  sha256: 4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af
+  version: 2025.9.1
+  sha256: 98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe
   requires_dist:
   - referencing>=0.31.0
   requires_python: '>=3.9'
@@ -2012,6 +2018,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   constrains:
   - binutils_impl_linux-64 2.44
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -2025,6 +2033,8 @@ packages:
   - libgcc >=14
   constrains:
   - expat 2.7.1.*
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -2036,6 +2046,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   purls: []
@@ -2050,6 +2062,8 @@ packages:
   constrains:
   - libgomp 15.1.0 h767d61c_5
   - libgcc-ng ==15.1.0=*_5
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2060,6 +2074,8 @@ packages:
   md5: 069afdf8ea72504e48d23ae1171d951c
   depends:
   - libgcc 15.1.0 h767d61c_5
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2070,6 +2086,8 @@ packages:
   md5: dcd5ff1940cd38f6df777cac86819d60
   depends:
   - __glibc >=2.17,<3.0.a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -2083,6 +2101,8 @@ packages:
   - libgcc >=13
   constrains:
   - xz 5.8.1.*
+  arch: x86_64
+  platform: linux
   license: 0BSD
   purls: []
   size: 112894
@@ -2093,6 +2113,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -2104,6 +2126,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
@@ -2116,6 +2140,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: Unlicense
   purls: []
   size: 878223
@@ -2125,6 +2151,8 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -2135,6 +2163,8 @@ packages:
   md5: 5aa797f8787fe7a17d1b0821485b5adc
   depends:
   - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-or-later
   purls: []
   size: 100393
@@ -2147,6 +2177,8 @@ packages:
   - libgcc >=13
   constrains:
   - zlib 1.3.1 *_2
+  arch: x86_64
+  platform: linux
   license: Zlib
   license_family: Other
   purls: []
@@ -2354,6 +2386,8 @@ packages:
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  arch: x86_64
+  platform: linux
   license: X11 AND BSD-3-Clause
   purls: []
   size: 891641
@@ -2395,6 +2429,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=14
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -3369,6 +3405,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.10.* *_cp310
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 25199631
@@ -3397,6 +3435,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.11.* *_cp311
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 30624804
@@ -3424,6 +3464,8 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 31581682
@@ -3450,6 +3492,8 @@ packages:
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  arch: x86_64
+  platform: linux
   license: Python-2.0
   purls: []
   size: 33233150
@@ -3552,6 +3596,8 @@ packages:
   depends:
   - libgcc >=13
   - ncurses >=6.5,<7.0a0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   purls: []
@@ -4219,6 +4265,8 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
+  arch: x86_64
+  platform: linux
   license: Unlicense
   purls: []
   size: 888207
@@ -4262,6 +4310,8 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  arch: x86_64
+  platform: linux
   license: TCL
   license_family: BSD
   purls: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.54.1"
+version = "1.54.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 from bencher.variables.singleton_parametrized_sweep import ParametrizedSweepSingleton
 import bencher as bch

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -11,7 +11,7 @@ class MySingletonSweep(ParametrizedSweepSingleton):
     result = bch.ResultVar()
 
     def __init__(self):
-        if self.first_time():
+        if self.init_singleton():
             self.init_count = 1
         super().__init__()
 
@@ -32,14 +32,14 @@ def benchable_singleton_fn(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) ->
 def test_singleton_per_child():
     class ChildA(ParametrizedSweepSingleton):
         def __init__(self, value=1):
-            if self.first_time():
+            if self.init_singleton():
                 self.init_count = 1
                 self.value = value
             super().__init__()
 
     class ChildB(ParametrizedSweepSingleton):
         def __init__(self, value=2):
-            if self.first_time():
+            if self.init_singleton():
                 self.init_count = 1
                 self.value = value
             super().__init__()
@@ -56,14 +56,14 @@ def test_singleton_per_child():
 def test_singleton_init_only_once():
     class ChildA(ParametrizedSweepSingleton):
         def __init__(self, value=1):
-            if self.first_time():
+            if self.init_singleton():
                 self.init_count = 1
                 self.value = value
             super().__init__()
 
     class ChildB(ParametrizedSweepSingleton):
         def __init__(self, value=2):
-            if self.first_time():
+            if self.init_singleton():
                 self.init_count = 1
                 self.value = value
             super().__init__()
@@ -79,7 +79,7 @@ def test_singleton_init_only_once():
 def test_singleton_value_persistence():
     class ChildA(ParametrizedSweepSingleton):
         def __init__(self, value=1):
-            if self.first_time():
+            if self.init_singleton():
                 self.init_count = 1
                 self.value = value
             super().__init__()

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -92,6 +92,9 @@ def test_singleton_value_persistence():
 
 
 def test_benchrunner_rerun_with_singleton():
+    # Grab the singleton instance before any run
+    singleton_before = MySingletonSweep()
+
     # Use a fixed run_tag so naming is deterministic and cache isolation is explicit
     run_cfg = bch.BenchRunCfg(run_tag="singleton_rerun_test")
     br = bch.BenchRunner(name="singleton_runner", run_cfg=run_cfg)
@@ -108,8 +111,12 @@ def test_benchrunner_rerun_with_singleton():
     # Ensure rerunning appends results and does not error
     assert len(br.results) == 2
 
-    # Verify the singleton was only initialised once across both runs
-    assert MySingletonSweep().init_count == 1
+    # Verify the same instance is returned and init only happened once
+    singleton_after = MySingletonSweep()
+    assert singleton_before is singleton_after, "Singleton instance changed across reruns"
+    assert singleton_after.init_count == 1, "Singleton reinitialised across reruns"
+    # Ensure the singleton class was marked as seen (no re-first-time)
+    assert MySingletonSweep in ParametrizedSweepSingleton._seen
 
 
 def test_singleton_report_save_and_pickling():

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 from bencher.variables.singleton_parametrized_sweep import ParametrizedSweepSingleton
 import bencher as bch
 
@@ -109,3 +110,19 @@ def test_benchrunner_rerun_with_singleton():
 
     # Verify the singleton was only initialised once across both runs
     assert MySingletonSweep().init_count == 1
+
+
+def test_singleton_report_save_and_pickling():
+    # Ensure running and saving the report works and the result is pickled
+    run_cfg = bch.BenchRunCfg(run_tag="singleton_save_test")
+    br = bch.BenchRunner(name="singleton_runner_save", run_cfg=run_cfg)
+    br.add(benchable_singleton_fn)
+
+    # Run and save report; also exercises diskcache pickling of results
+    br.run(level=1, repeats=1, cache_results=False, save=True)
+
+    expected_filename = f"MySingletonSweep_benchable_singleton_fn_{run_cfg.run_tag}.html"
+    expected_path = Path("reports") / expected_filename
+    assert expected_path.exists(), f"Report not saved at {expected_path}"
+    # Cleanup saved report to avoid polluting workspace
+    expected_path.unlink(missing_ok=True)

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -3,76 +3,20 @@ from bencher.variables.singleton_parametrized_sweep import ParametrizedSweepSing
 import bencher as bch
 
 
-# Ensure singleton cache is cleared before each test for isolation
-@pytest.fixture(autouse=True)
-def clear_singleton_cache():
-    # Use the public method to avoid touching protected members
-    ParametrizedSweepSingleton.reset_singletons()
-
-
-class ChildA(ParametrizedSweepSingleton):
-    def __init__(self, value=1):
-        # Use the helper to avoid boilerplate; only runs once
-        if self.init_singleton():
-            self.init_count = 1
-            self.value = value
-        # Call super for pylint; base no-ops on subsequent calls
-        super().__init__()
-
-
-class ChildB(ParametrizedSweepSingleton):
-    def __init__(self, value=2):
-        if self.init_singleton():
-            self.init_count = 1
-            self.value = value
-        super().__init__()
-
-
-def test_singleton_per_child():
-    a1 = ChildA()
-    a2 = ChildA()
-    b1 = ChildB()
-    b2 = ChildB()
-    assert a1 is a2, "ChildA should return the same instance"
-    assert b1 is b2, "ChildB should return the same instance"
-    assert a1 is not b1, "ChildA and ChildB should have different singleton instances"
-
-
-def test_singleton_init_only_once():
-    a1 = ChildA()
-    ChildA()  # second construction should not re-run init
-    assert a1.init_count == 1, "__init__ should only run once for ChildA"
-    b1 = ChildB()
-    ChildB()  # second construction should not re-run init
-    assert b1.init_count == 1, "__init__ should only run once for ChildB"
-
-
-def test_singleton_value_persistence():
-    a1 = ChildA(value=10)
-    a2 = ChildA(value=20)
-    assert a1.value == 10, "Value should be set only on first init and persist"
-    assert a2.value == 10, "Subsequent inits should not overwrite value"
-
-
-# ---- BenchRunner integration test with SingletonParametrizedSweep ----
-
-
+# A module-scope class for the BenchRunner integration test must be picklable.
 class MySingletonSweep(ParametrizedSweepSingleton):
     """Simple singleton sweep used to validate BenchRunner reruns."""
 
-    # One float input and a single numeric result
     theta = bch.FloatSweep(default=0.0, bounds=[0.0, 1.0], samples=3, doc="angle")
     result = bch.ResultVar()
 
     def __init__(self):
-        if self.init_singleton():
+        if self.first_time():
             self.init_count = 1
         super().__init__()
 
     def __call__(self, **kwargs):
-        # Standard pattern: update params and report results
         self.update_params_from_kwargs(**kwargs)
-        # Just echo theta as the result; minimal logic for the test
         self.result = float(self.theta)
         return super().__call__(**kwargs)
 
@@ -83,6 +27,67 @@ def benchable_singleton_fn(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) ->
     # Disable plotting to avoid hvplot/xarray requirements in headless tests
     # We still exercise the full compute path and BenchRunner integration
     return bench.plot_sweep(plot_callbacks=False)
+
+
+def test_singleton_per_child():
+    class ChildA(ParametrizedSweepSingleton):
+        def __init__(self, value=1):
+            if self.first_time():
+                self.init_count = 1
+                self.value = value
+            super().__init__()
+
+    class ChildB(ParametrizedSweepSingleton):
+        def __init__(self, value=2):
+            if self.first_time():
+                self.init_count = 1
+                self.value = value
+            super().__init__()
+
+    a1 = ChildA()
+    a2 = ChildA()
+    b1 = ChildB()
+    b2 = ChildB()
+    assert a1 is a2, "ChildA should return the same instance"
+    assert b1 is b2, "ChildB should return the same instance"
+    assert a1 is not b1, "ChildA and ChildB should have different singleton instances"
+
+
+def test_singleton_init_only_once():
+    class ChildA(ParametrizedSweepSingleton):
+        def __init__(self, value=1):
+            if self.first_time():
+                self.init_count = 1
+                self.value = value
+            super().__init__()
+
+    class ChildB(ParametrizedSweepSingleton):
+        def __init__(self, value=2):
+            if self.first_time():
+                self.init_count = 1
+                self.value = value
+            super().__init__()
+
+    a1 = ChildA()
+    ChildA()  # second construction should not re-run init
+    assert a1.init_count == 1, "__init__ should only run once for ChildA"
+    b1 = ChildB()
+    ChildB()  # second construction should not re-run init
+    assert b1.init_count == 1, "__init__ should only run once for ChildB"
+
+
+def test_singleton_value_persistence():
+    class ChildA(ParametrizedSweepSingleton):
+        def __init__(self, value=1):
+            if self.first_time():
+                self.init_count = 1
+                self.value = value
+            super().__init__()
+
+    a1 = ChildA(value=10)
+    a2 = ChildA(value=20)
+    assert a1.value == 10, "Value should be set only on first init and persist"
+    assert a2.value == 10, "Subsequent inits should not overwrite value"
 
 
 def test_benchrunner_rerun_with_singleton():

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -115,8 +115,7 @@ def test_benchrunner_rerun_with_singleton():
     singleton_after = MySingletonSweep()
     assert singleton_before is singleton_after, "Singleton instance changed across reruns"
     assert singleton_after.init_count == 1, "Singleton reinitialised across reruns"
-    # Ensure the singleton class was marked as seen (no re-first-time)
-    assert MySingletonSweep in ParametrizedSweepSingleton._seen
+    # No reinitialization or instance change across reruns
 
 
 def test_singleton_report_save_and_pickling():


### PR DESCRIPTION
## Summary by Sourcery

Refactor the singleton variant of ParametrizedSweep to simplify one-time initialization, replace legacy helpers with a first_time guard, update associated tests accordingly, and bump version to 1.54.2.

Enhancements:
- Revamp ParametrizedSweepSingleton to enforce per-subclass singleton via __new__ and a _singleton_inited guard
- Introduce first_time classmethod and remove legacy reset_singletons, init_singleton, and on_first_init hooks

Build:
- Bump project version to 1.54.2

Tests:
- Remove reset_singletons fixture and update singleton tests to use first_time
- Refactor tests to inline ChildA/ChildB implementations and relocate MySingletonSweep and benchable_singleton_fn
- Adjust BenchRunner integration test to exercise singleton behavior without plotting