### PR TITLE
set default args to none rather than init class

### DIFF
--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -20,17 +20,20 @@ class BenchPlotServer:
         """Create a new BenchPlotServer object"""
 
     def plot_server(
-        self, bench_name: str, plot_cfg: BenchPlotSrvCfg = BenchPlotSrvCfg(), plots_instance=None
+        self, bench_name: str, plot_cfg: BenchPlotSrvCfg | None = None, plots_instance=None
     ) -> Thread:
         """Load previously calculated benchmark data from the database and start a plot server to display it
 
         Args:
             bench_name (str): The name of the benchmark and output folder for the figures
-            plot_cfg (BenchPlotSrvCfg, optional): Options for the plot server. Defaults to BenchPlotSrvCfg().
+            plot_cfg (BenchPlotSrvCfg, optional): Options for the plot server. Defaults to None.
 
         Raises:
             FileNotFoundError: No data found was found in the database to plot
         """
+
+        if plot_cfg is None:
+            plot_cfg = BenchPlotSrvCfg()
 
         if plots_instance is None:
             plots_instance = self.load_data_from_cache(bench_name)

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -104,10 +104,7 @@ class BenchRunner:
         Returns:
             BenchRunCfg: A new configuration object with the specified settings
         """
-        if run_cfg is None:
-            run_cfg_out = BenchRunCfg()
-        else:
-            run_cfg_out = deepcopy(run_cfg)
+        run_cfg_out = BenchRunCfg() if run_cfg is None else deepcopy(run_cfg)
         run_cfg_out.cache_samples = cache_results
         run_cfg_out.only_hash_tag = cache_results
         run_cfg_out.level = level

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -26,7 +26,7 @@ class BenchRunner:
         self,
         name: str | Benchable = None,
         bench_class: ParametrizedSweep = None,
-        run_cfg: BenchRunCfg = BenchRunCfg(),
+        run_cfg: BenchRunCfg | None = None,
         publisher: Callable = None,
         run_tag: str = None,
     ) -> None:
@@ -36,7 +36,7 @@ class BenchRunner:
             name (str, optional): The name of the benchmark runner, used for reports and caching.
                 If None, auto-generates a unique name. Defaults to None.
             bench_class (ParametrizedSweep, optional): An initial benchmark class to add. Defaults to None.
-            run_cfg (BenchRunCfg, optional): Configuration for benchmark execution. Defaults to BenchRunCfg().
+            run_cfg (BenchRunCfg, optional): Configuration for benchmark execution. Defaults to None.
             publisher (Callable, optional): Function to publish results. Defaults to None.
             run_tag (str, optional): Tag for the run, used in naming and caching. If provided,
                 overrides the run_tag in run_cfg. Defaults to None.
@@ -89,7 +89,7 @@ class BenchRunner:
 
     @staticmethod
     def setup_run_cfg(
-        run_cfg: BenchRunCfg = BenchRunCfg(), level: int = 2, cache_results: bool = True
+        run_cfg: BenchRunCfg | None = None, level: int = 2, cache_results: bool = True
     ) -> BenchRunCfg:
         """Configure benchmark run settings with reasonable defaults.
 
@@ -97,14 +97,17 @@ class BenchRunner:
         caching behavior settings applied.
 
         Args:
-            run_cfg (BenchRunCfg, optional): Base configuration to modify. Defaults to BenchRunCfg().
+            run_cfg (BenchRunCfg, optional): Base configuration to modify. Defaults to None.
             level (int, optional): Benchmark sampling resolution level. Defaults to 2.
             cache_results (bool, optional): Whether to enable result caching. Defaults to True.
 
         Returns:
             BenchRunCfg: A new configuration object with the specified settings
         """
-        run_cfg_out = deepcopy(run_cfg)
+        if run_cfg is None:
+            run_cfg_out = BenchRunCfg()
+        else:
+            run_cfg_out = deepcopy(run_cfg)
         run_cfg_out.cache_samples = cache_results
         run_cfg_out.only_hash_tag = cache_results
         run_cfg_out.level = level
@@ -113,19 +116,23 @@ class BenchRunner:
     @staticmethod
     def from_parametrized_sweep(
         class_instance: ParametrizedSweep,
-        run_cfg: BenchRunCfg = BenchRunCfg(),
-        report: BenchReport = BenchReport(),
+        run_cfg: BenchRunCfg | None = None,
+        report: BenchReport | None = None,
     ) -> Bench:
         """Create a Bench instance from a ParametrizedSweep class.
 
         Args:
             class_instance (ParametrizedSweep): The parametrized sweep class instance to benchmark
-            run_cfg (BenchRunCfg, optional): Configuration for benchmark execution. Defaults to BenchRunCfg().
-            report (BenchReport, optional): Report to store benchmark results. Defaults to BenchReport().
+            run_cfg (BenchRunCfg, optional): Configuration for benchmark execution. Defaults to None.
+            report (BenchReport, optional): Report to store benchmark results. Defaults to None.
 
         Returns:
             Bench: A configured Bench instance ready to run the benchmark
         """
+        if run_cfg is None:
+            run_cfg = BenchRunCfg()
+        if report is None:
+            report = BenchReport()
         return Bench(
             f"bench_{class_instance.name}",
             class_instance,

--- a/bencher/example/example_float_cat.py
+++ b/bencher/example/example_float_cat.py
@@ -63,7 +63,9 @@ def example_float_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport =
     return bench
 
 
-def run_example_float_cat(ex_run_cfg=bch.BenchRunCfg()) -> None:
+def run_example_float_cat(ex_run_cfg: bch.BenchRunCfg | None = None) -> None:
+    if ex_run_cfg is None:
+        ex_run_cfg = bch.BenchRunCfg()
     ex_run_cfg.repeats = 2
     ex_run_cfg.over_time = True
     ex_run_cfg.clear_cache = True

--- a/bencher/plotting/plot_filter.py
+++ b/bencher/plotting/plot_filter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from bencher.plotting.plt_cnt_cfg import PltCntCfg
 import logging
 import panel as pn
@@ -68,13 +68,13 @@ class VarRange:
 class PlotFilter:
     """A class for representing the types of results a plot is able to represent."""
 
-    float_range: VarRange = VarRange()
-    cat_range: VarRange = VarRange()
-    vector_len: VarRange = VarRange(1, 1)
-    result_vars: VarRange = VarRange(1, 1)
-    panel_range: VarRange = VarRange(0, 0)
-    repeats_range: VarRange = VarRange(1, None)
-    input_range: VarRange = VarRange(1, None)
+    float_range: VarRange = field(default_factory=VarRange)
+    cat_range: VarRange = field(default_factory=VarRange)
+    vector_len: VarRange = field(default_factory=lambda: VarRange(1, 1))
+    result_vars: VarRange = field(default_factory=lambda: VarRange(1, 1))
+    panel_range: VarRange = field(default_factory=lambda: VarRange(0, 0))
+    repeats_range: VarRange = field(default_factory=lambda: VarRange(1, None))
+    input_range: VarRange = field(default_factory=lambda: VarRange(1, None))
 
     def matches_result(
         self, plt_cnt_cfg: PltCntCfg, plot_name: str, override: bool

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -441,13 +441,13 @@ class BenchResultBase:
         self,
         plot_callback: callable,
         plot_filter=None,
-        float_range: VarRange = VarRange(0, None),
-        cat_range: VarRange = VarRange(0, None),
-        vector_len: VarRange = VarRange(1, 1),
-        result_vars: VarRange = VarRange(1, 1),
-        panel_range: VarRange = VarRange(0, 0),
-        repeats_range: VarRange = VarRange(1, None),
-        input_range: VarRange = VarRange(1, None),
+        float_range: VarRange | None = None,
+        cat_range: VarRange | None = None,
+        vector_len: VarRange | None = None,
+        result_vars: VarRange | None = None,
+        panel_range: VarRange | None = None,
+        repeats_range: VarRange | None = None,
+        input_range: VarRange | None = None,
         reduce: ReduceType = ReduceType.AUTO,
         target_dimension: int = 2,
         result_var: ResultVar = None,
@@ -456,6 +456,21 @@ class BenchResultBase:
         override=False,
         **kwargs,
     ) -> Optional[pn.panel]:
+        # Initialize default filters if not provided to avoid shared mutable defaults
+        if float_range is None:
+            float_range = VarRange(0, None)
+        if cat_range is None:
+            cat_range = VarRange(0, None)
+        if vector_len is None:
+            vector_len = VarRange(1, 1)
+        if result_vars is None:
+            result_vars = VarRange(1, 1)
+        if panel_range is None:
+            panel_range = VarRange(0, 0)
+        if repeats_range is None:
+            repeats_range = VarRange(1, None)
+        if input_range is None:
+            input_range = VarRange(1, None)
         plot_filter = PlotFilter(
             float_range=float_range,
             cat_range=cat_range,

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -48,11 +48,14 @@ class OptunaResult(BenchResultBase):
         worker,
         n_trials=100,
         extra_results: List[OptunaResult] = None,
-        sampler=optuna.samplers.TPESampler(),
+        sampler=None,
     ):
         directions = []
         for rv in self.bench_cfg.optuna_targets(True):
             directions.append(rv.direction)
+
+        if sampler is None:
+            sampler = optuna.samplers.TPESampler()
 
         study = optuna.create_study(
             sampler=sampler, directions=directions, study_name=self.bench_cfg.title


### PR DESCRIPTION
## Summary by Sourcery

Replace direct instantiation of default argument objects with None defaults and internal initialization to avoid shared mutable state, and update dataclass fields to use default_factory for VarRange attributes.

Enhancements:
- Use None defaults for VarRange parameters in filter and initialize them inside the method.
- Change BenchRunCfg, BenchPlotSrvCfg, Optuna sampler, and example run_cfg parameters to default to None and instantiate internally.
- Convert PlotFilter VarRange fields to use default_factory to prevent shared mutable defaults.