### PR TITLE
Feature/reverse sample order

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -94,3 +94,4 @@ from .bench_report import BenchReport, GithubPagesCfg
 from .job import Executors
 from .video_writer import VideoWriter, add_image
 from .class_enum import ClassEnum, ExampleEnum
+from .sample_order import SampleOrder

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -150,7 +150,7 @@ class BenchResultBase:
         reduce: ReduceType = ReduceType.AUTO,
         result_var: ResultVar = None,
         level: int = None,
-        agg_dims: list[str] | None = None,
+        agg_over_dims: list[str] | None = None,
         agg_fn: Literal["sum", "mean", "max", "min", "median"] | None = None,
     ) -> hv.Dataset:
         """Generate a holoviews dataset from the xarray dataset.
@@ -166,13 +166,21 @@ class BenchResultBase:
             kdims = [i.name for i in self.bench_cfg.all_vars]
             return hv.Dataset(
                 self.to_dataset(
-                    reduce, result_var=result_var, level=level, agg_dims=agg_dims, agg_fn=agg_fn
+                    reduce,
+                    result_var=result_var,
+                    level=level,
+                    agg_over_dims=agg_over_dims,
+                    agg_fn=agg_fn,
                 ),
                 kdims=kdims,
             )
         return hv.Dataset(
             self.to_dataset(
-                reduce, result_var=result_var, level=level, agg_dims=agg_dims, agg_fn=agg_fn
+                reduce,
+                result_var=result_var,
+                level=level,
+                agg_over_dims=agg_over_dims,
+                agg_fn=agg_fn,
             )
         )
 
@@ -181,7 +189,7 @@ class BenchResultBase:
         reduce: ReduceType = ReduceType.AUTO,
         result_var: ResultVar | str = None,
         level: int = None,
-        agg_dims: list[str] | None = None,
+        agg_over_dims: list[str] | None = None,
         agg_fn: Literal["sum", "mean", "max", "min", "median"] | None = None,
     ) -> xr.Dataset:
         """Generate a summarised xarray dataset.
@@ -236,16 +244,16 @@ class BenchResultBase:
                 ds_out = ds_out.squeeze(drop=True)
 
         # Optional aggregation across non-repeat dimensions (e.g., categorical)
-        if agg_dims:
+        if agg_over_dims:
             # Only aggregate over dims that actually exist in the dataset
-            dims_present = [d for d in agg_dims if d in ds_out.dims]
+            dims_present = [d for d in agg_over_dims if d in ds_out.dims]
             if dims_present:
                 # If some requested dims are missing, log an info for visibility
-                missing = [d for d in agg_dims if d not in dims_present]
+                missing = [d for d in agg_over_dims if d not in dims_present]
                 if missing:
                     logging.info(
                         "Aggregation requested for dims %s but only found %s in dataset dims %s",
-                        agg_dims,
+                        agg_over_dims,
                         dims_present,
                         list(ds_out.dims),
                     )
@@ -268,7 +276,7 @@ class BenchResultBase:
             else:
                 logging.warning(
                     "Aggregation requested for dims %s but none were found in dataset dims %s; returning unaggregated dataset",
-                    agg_dims,
+                    agg_over_dims,
                     list(ds_out.dims),
                 )
         if level is not None:
@@ -541,7 +549,9 @@ class BenchResultBase:
             if hv_dataset is None:
                 agg_dims = list(dict.fromkeys(agg_over_dims)) if agg_over_dims else None
                 if agg_dims:
-                    hv_dataset = self.to_hv_dataset(reduce=reduce, agg_dims=agg_dims, agg_fn=agg_fn)
+                    hv_dataset = self.to_hv_dataset(
+                        reduce=reduce, agg_over_dims=agg_dims, agg_fn=agg_fn
+                    )
             return self.map_plot_panes(
                 plot_callback=plot_callback,
                 hv_dataset=hv_dataset,

--- a/bencher/sample_order.py
+++ b/bencher/sample_order.py
@@ -1,0 +1,16 @@
+from enum import auto
+from strenum import StrEnum
+
+
+class SampleOrder(StrEnum):
+    """Controls the sampling traversal order for plot_sweep.
+
+    - INORDER: Traverse inputs in the natural Cartesian product order
+                (right-most dimension varies fastest).
+    - REVERSED: Traverse the same set of samples in the reverse order.
+
+    Note: This only affects sampling order, not plotting or dataset dimension order.
+    """
+
+    INORDER = auto()
+    REVERSED = auto()

--- a/test/test_sample_order.py
+++ b/test/test_sample_order.py
@@ -1,0 +1,103 @@
+import unittest
+import bencher as bch
+
+
+# Single-class format to ensure picklability and capture traversal order
+class OrderExample(bch.ParametrizedSweep):
+    # INPUTS
+    a = bch.IntSweep(default=0, bounds=[0, 2])  # 3 samples
+    b = bch.IntSweep(default=0, bounds=[0, 1])  # 2 samples
+
+    # RESULTS
+    call_index = bch.ResultVar()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+
+        # Maintain a per-instance counter to reflect traversal order
+        idx = getattr(self, "_call_counter", 0)
+        self.call_index = idx
+        setattr(self, "_call_counter", idx + 1)
+
+        return super().__call__()
+
+
+class TestSampleOrder(unittest.TestCase):
+    def test_sample_order_does_not_change_results_or_dims(self):
+        # Use deterministic example worker (no noise by default)
+        bench1 = bch.Bench("sample_order_eq_1", bch.bench_function, bch.ExampleBenchCfgIn)
+        bench2 = bch.Bench("sample_order_eq_2", bch.bench_function, bch.ExampleBenchCfgIn)
+
+        input_vars = [
+            bch.ExampleBenchCfgIn.param.theta,
+            bch.ExampleBenchCfgIn.param.postprocess_fn,
+        ]
+        result_vars = [bch.ExampleBenchCfgOut.param.out_sin]
+        run_cfg = bch.BenchRunCfg(
+            repeats=1,
+            over_time=False,
+            auto_plot=False,
+            cache_results=False,
+            cache_samples=False,
+            executor=bch.Executors.SERIAL,
+            level=2,  # keep dataset small and consistent without mutating class defaults
+        )
+
+        res_in = bench1.plot_sweep(
+            title="inorder",
+            input_vars=input_vars,
+            result_vars=result_vars,
+            run_cfg=run_cfg,
+            sample_order=bch.SampleOrder.INORDER,
+        )
+        res_rev = bench2.plot_sweep(
+            title="reversed",
+            input_vars=input_vars,
+            result_vars=result_vars,
+            run_cfg=run_cfg,
+            sample_order=bch.SampleOrder.REVERSED,
+        )
+
+        ds_in = res_in.to_xarray()
+        ds_rev = res_rev.to_xarray()
+
+        # Dataset values must be identical regardless of sampling order
+        self.assertTrue(ds_in.equals(ds_rev))
+
+        # Dimension order should match input_vars order and remain unchanged
+        var_name = bch.ExampleBenchCfgOut.param.out_sin.name
+        self.assertEqual(
+            list(ds_in[var_name].dims)[:2],
+            [v.name for v in input_vars],
+        )
+        self.assertEqual(list(ds_in[var_name].dims), list(ds_rev[var_name].dims))
+
+    def test_sample_order_reverses_traversal_only(self):
+        def run(sample_order: bch.SampleOrder):
+            bench = bch.Bench("order_test", OrderExample())
+            res = bench.plot_sweep(
+                title="order",
+                input_vars=[OrderExample.param.a, OrderExample.param.b],
+                result_vars=[OrderExample.param.call_index],
+                run_cfg=bch.BenchRunCfg(
+                    repeats=1,
+                    over_time=False,
+                    auto_plot=False,
+                    cache_results=False,
+                    cache_samples=False,
+                    executor=bch.Executors.SERIAL,
+                ),
+                sample_order=sample_order,
+            )
+            return res.to_xarray()[OrderExample.param.call_index.name].values.flatten().tolist()
+
+        inorder = run(bch.SampleOrder.INORDER)
+        reversed_order = run(bch.SampleOrder.REVERSED)
+
+        # In-order should be 0..N-1, reversed should be reversed
+        self.assertEqual(inorder, list(range(len(inorder))))
+        self.assertEqual(reversed_order, list(reversed(inorder)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_sample_order.py
+++ b/test/test_sample_order.py
@@ -94,9 +94,22 @@ class TestSampleOrder(unittest.TestCase):
         inorder = run(bch.SampleOrder.INORDER)
         reversed_order = run(bch.SampleOrder.REVERSED)
 
-        # In-order should be 0..N-1, reversed should be reversed
+        # In-order should be 0..N-1
         self.assertEqual(inorder, list(range(len(inorder))))
-        self.assertEqual(reversed_order, list(reversed(inorder)))
+
+        # For reversed traversal, the left-most input (a) varies fastest.
+        # Compute expected flattened sequence using dims order (a,b).
+        la = len(OrderExample.param.a.values())
+        lb = len(OrderExample.param.b.values())
+        expected_rev = [None] * (la * lb)
+        for i in range(la):
+            for j in range(lb):
+                # Flatten index position for (i,j) in C-order is i*lb + j
+                pos = i * lb + j
+                # Sampling sequence index when 'a' varies fastest: j*la + i
+                expected_rev[pos] = j * la + i
+
+        self.assertEqual(reversed_order, expected_rev)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary by Sourcery

Integrate a new sample_order parameter and SampleOrder enum to control the traversal order of benchmark sampling (in-order or reversed), propagate the setting through plotting and sweeping functions with implemented reversed traversal logic, and rename agg_dims to agg_over_dims for clearer API, accompanied by tests validating the ordering behavior.

New Features:
- Introduce SampleOrder enum to specify sampling traversal order
- Add sample_order argument to plot_sweep and run_sweep for customizable sampling traversal
- Implement reversed sampling traversal logic in calculate_benchmark_results

Enhancements:
- Rename 'agg_dims' parameter to 'agg_over_dims' across dataset aggregation and plotting methods

Tests:
- Add tests ensuring sample_order preserves dataset values and dims and correctly reverses sampling order