### PR TITLE
aggregate defaults to mean

### DIFF
--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -72,7 +72,7 @@ class BenchResult(
         reduce: ReduceType | None = None,
         # Aggregation controls (applied in filter())
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "mean",
+        agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
         **kwargs: Any,
     ) -> BenchResult:
         """Return the current instance of BenchResult.

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -72,7 +72,7 @@ class BenchResult(
         reduce: ReduceType | None = None,
         # Aggregation controls (applied in filter())
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "sum",
+        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "mean",
         **kwargs: Any,
     ) -> BenchResult:
         """Return the current instance of BenchResult.

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -151,7 +151,7 @@ class BenchResultBase:
         result_var: ResultVar = None,
         level: int = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] | None = None,
+        agg_fn: Literal["mean", "sum", "max", "min", "median"] | None = None,
     ) -> hv.Dataset:
         """Generate a holoviews dataset from the xarray dataset.
 
@@ -190,7 +190,7 @@ class BenchResultBase:
         result_var: ResultVar | str = None,
         level: int = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] | None = None,
+        agg_fn: Literal["mean", "sum", "max", "min", "median"] | None = None,
     ) -> xr.Dataset:
         """Generate a summarised xarray dataset.
 
@@ -514,7 +514,7 @@ class BenchResultBase:
         override=False,
         hv_dataset: hv.Dataset | None = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "mean",
+        agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
         **kwargs,
     ) -> Optional[pn.panel]:
         # Initialize default filters if not provided to avoid shared mutable defaults

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -258,8 +258,8 @@ class BenchResultBase:
                         list(ds_out.dims),
                     )
 
-                # Support basic aggregations; default to sum
-                fn = (agg_fn or "sum").lower()
+                # Support basic aggregations; default to mean
+                fn = (agg_fn or "mean").lower()
                 if fn == "sum":
                     ds_out = ds_out.sum(dim=dims_present, skipna=True)
                 elif fn == "mean":
@@ -271,8 +271,8 @@ class BenchResultBase:
                 elif fn == "median":
                     ds_out = ds_out.median(dim=dims_present, skipna=True)
                 else:
-                    # Fall back to sum if unknown string provided
-                    ds_out = ds_out.sum(dim=dims_present, skipna=True)
+                    # Fall back to mean if unknown string provided
+                    ds_out = ds_out.mean(dim=dims_present, skipna=True)
             else:
                 logging.warning(
                     "Aggregation requested for dims %s but none were found in dataset dims %s; returning unaggregated dataset",
@@ -514,7 +514,7 @@ class BenchResultBase:
         override=False,
         hv_dataset: hv.Dataset | None = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "sum",
+        agg_fn: Literal["sum", "mean", "max", "min", "median"] = "mean",
         **kwargs,
     ) -> Optional[pn.panel]:
         # Initialize default filters if not provided to avoid shared mutable defaults

--- a/pixi.lock
+++ b/pixi.lock
@@ -1298,8 +1298,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: .
   name: holobench
-  version: 1.56.0
-  sha256: b7f3e0c090dd3fc4e5d5c7c576fedf87667dc9ccdb46aa9b4a6288866fa57ae3
+  version: 1.56.1
+  sha256: 7c6c99f81a09a60ab4aa7271b03a201485a7a844fe43ff2ee964c404b7993e1f
   requires_dist:
   - holoviews>=1.15,<=1.21.0
   - numpy>=1.0,<=2.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.56.0"
+version = "1.56.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary by Sourcery

Default aggregation behavior now uses mean instead of sum across core methods and update version accordingly

Enhancements:
- Change default aggregation function from sum to mean in dataset renaming and filtering methods
- Update fallback behavior for unknown aggregation functions to use mean instead of sum

Build:
- Bump package version to 1.56.1