### PR TITLE
remove ExampleBenchCfgIn, ExampleBenchCfgOut

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -1,10 +1,6 @@
 from .bencher import Bench, BenchCfg, BenchRunCfg
 from .bench_runner import BenchRunner
-from .example.benchmark_data import (
-    ExampleBenchCfgIn,
-    ExampleBenchCfgOut,
-    bench_function,
-)
+from .example.benchmark_data import ExampleBenchCfg
 from .bench_plot_server import BenchPlotServer
 from .variables.sweep_base import hash_sha1
 from .variables.inputs import (

--- a/bencher/example/benchmark_data.py
+++ b/bencher/example/benchmark_data.py
@@ -27,60 +27,6 @@ class NoiseDistribution(StrEnum):
     lognorm = auto()  # lognorm noise
 
 
-class NoiseCfg(ParametrizedSweep):
-    """A class for storing the parameters for generating various types of noise"""
-
-    noisy = BoolSweep(
-        default=False, doc="Optionally add random noise to the output of the function"
-    )
-
-    noise_distribution = EnumSweep(NoiseDistribution, doc=NoiseDistribution.__doc__)
-
-    sigma = FloatSweep(
-        default=1,
-        bounds=[0, 10],
-        doc="The standard deviation of the noise",
-        units="v",
-    )
-
-
-def calculate_noise(config: NoiseCfg) -> float:
-    """Generate a float value based on a noise distribution and scale
-
-    Args:
-        config (NoiseCfg): see NoiseCfg type
-
-    Returns:
-        float: a noisy float value
-    """
-
-    noise = 0.0
-    if config.noisy:
-        match config.noise_distribution:
-            case NoiseDistribution.uniform:
-                noise = random.uniform(0, config.sigma)
-            case NoiseDistribution.gaussian:
-                noise = random.gauss(0, config.sigma)
-            case NoiseDistribution.lognorm:
-                noise = random.lognormvariate(0, config.sigma)
-
-    return noise
-
-
-class ExampleBenchCfgIn(NoiseCfg):
-    """A class for representing a set of configuration options for the example worker. This class inherits from NoiseCfg so it also stores all its values as well."""
-
-    theta = FloatSweep(default=0, bounds=[0, math.pi], doc="Input angle", units="rad", samples=30)
-    offset = FloatSweep(default=0, bounds=[0, 0.3], doc="dc offset", units="v", samples=30)
-    postprocess_fn = EnumSweep(PostprocessFn)
-
-
-class ExampleBenchCfgOut(ParametrizedSweep):
-    out_sin = ResultVar(units="v", direction=OptDir.minimize, doc="sin of theta with some noise")
-    out_cos = ResultVar(units="v", direction=OptDir.minimize, doc="cos of theta with some noise")
-    out_bool = ResultVar(units="%", doc="sin > 0.5")
-
-
 def negate_fn(fn_input: float):
     """returns the negative of the input
 
@@ -91,20 +37,6 @@ def negate_fn(fn_input: float):
         float: negative of the input
     """
     return -fn_input
-
-
-def bench_function(cfg: ExampleBenchCfgIn) -> ExampleBenchCfgOut:
-    """Takes an ExampleBenchCfgIn and returns a ExampleBenchCfgOut output"""
-    out = ExampleBenchCfgOut()
-    noise = calculate_noise(cfg)
-
-    postprocess_fn = abs if cfg.postprocess_fn == PostprocessFn.absolute else negate_fn
-
-    out.out_sin = postprocess_fn(cfg.offset + math.sin(cfg.theta) + noise)
-    out.out_cos = postprocess_fn(cfg.offset + math.cos(cfg.theta) + noise)
-
-    out.out_bool = out.out_sin > 0.5
-    return out
 
 
 class ExampleBenchCfg(ParametrizedSweep):

--- a/bencher/example/example_categorical.py
+++ b/bencher/example/example_categorical.py
@@ -3,7 +3,7 @@
 import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_categorical(
@@ -25,8 +25,7 @@ def example_categorical(
 
     bench = bch.Bench(
         "Bencher_Example_Categorical",
-        bench_function,
-        ExampleBenchCfgIn,
+        ExampleBenchCfg(),
         run_cfg=run_cfg,
         report=report,
     )
@@ -34,32 +33,25 @@ def example_categorical(
     bench.report.append(readme, "Intro")
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.noisy],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Categorical 1D Example",
-        description="""This example shows how to sample categorical values. The same objective from the float examples is used but theta is kept constant with a value of 0 (as described in the ExampleBenchCfgIn class definition).
+        description="""This example shows how to sample categorical values. The same objective from the float examples is used but theta is kept constant with a value of 0 (as described in the ExampleBenchCfg class definition).
 
-        
+
 ```
-    def bench_function(cfg: ExampleBenchCfgIn) -> ExampleBenchCfgOut:
-        "Takes an ExampleBenchCfgIn and returns a ExampleBenchCfgOut output"
-        out = ExampleBenchCfgOut()
-        noise = calculate_noise(cfg)
-        offset = 0.0
-
-        postprocess_fn = abs if cfg.postprocess_fn == PostprocessFn.absolute else negate_fn
-
-        out.out_sin = postprocess_fn(offset + math.sin(cfg.theta) + noise)          
-        return out
+    def bench_function(cfg: ExampleBenchCfg) -> dict:
+        "Takes an ExampleBenchCfg and returns a dict output"
+        return cfg()
 ```
-        
+
         """,
         post_description="The plot shows when noise=True the output has uniform random noise.",
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.noisy, ExampleBenchCfgIn.param.noise_distribution],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.noisy, ExampleBenchCfg.param.noise_distribution],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Categorical 2D Example",
         description="""Adding another categorical value creates a facet plot over that dimension""",
         post_description="The output shows swarm plots of different noise distributions",
@@ -67,11 +59,11 @@ def example_categorical(
 
     bench.plot_sweep(
         input_vars=[
-            ExampleBenchCfgIn.param.noisy,
-            ExampleBenchCfgIn.param.noise_distribution,
-            ExampleBenchCfgIn.param.postprocess_fn,
+            ExampleBenchCfg.param.noisy,
+            ExampleBenchCfg.param.noise_distribution,
+            ExampleBenchCfg.param.postprocess_fn,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Categorical 3D Example",
         description="""Adding another categorical value extends the facets to the right""",
         post_description="The output shows swarm plots of different noise distributions",
@@ -80,12 +72,12 @@ def example_categorical(
     run_cfg.over_time = True
     bench.plot_sweep(
         input_vars=[
-            ExampleBenchCfgIn.param.noisy,
-            ExampleBenchCfgIn.param.noise_distribution,
-            ExampleBenchCfgIn.param.postprocess_fn,
+            ExampleBenchCfg.param.noisy,
+            ExampleBenchCfg.param.noise_distribution,
+            ExampleBenchCfg.param.postprocess_fn,
         ],
         title="Categorical 3D Example Over Time",
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         description="""Lastly, what if you want to track these distributions over time? Set over_time=True and bencher will cache and display historical results alongside the latest result.  Use clear_history=True to clear that cache.""",
         post_description="The output shows faceted line plot with confidence intervals for the mean value over time.",
         run_cfg=run_cfg,

--- a/bencher/example/example_float_cat.py
+++ b/bencher/example/example_float_cat.py
@@ -4,7 +4,7 @@ import bencher as bch
 
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_float_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = None) -> bch.Bench:
@@ -18,29 +18,28 @@ def example_float_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport =
     """
     bench = bch.Bench(
         "Bencher_Example_Float_Cat",
-        bench_function,
-        ExampleBenchCfgIn,
+        ExampleBenchCfg(),
         run_cfg=run_cfg,
         report=report,
     )
 
     bench.plot_sweep(
         input_vars=[
-            ExampleBenchCfgIn.param.theta,
-            ExampleBenchCfgIn.param.offset,
-            ExampleBenchCfgIn.param.postprocess_fn,
+            ExampleBenchCfg.param.theta,
+            ExampleBenchCfg.param.offset,
+            ExampleBenchCfg.param.postprocess_fn,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
-        const_vars=[ExampleBenchCfgIn.param.noisy.with_const(True)],
+        result_vars=[ExampleBenchCfg.param.out_sin],
+        const_vars=[ExampleBenchCfg.param.noisy.with_const(True)],
         title="Float 2D Cat 1D Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
         post_description="Now the plot has two lines, one for each of the boolean values where noisy=true and noisy=false.",
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
-        const_vars=[ExampleBenchCfgIn.param.noisy.with_const(True)],
+        input_vars=[ExampleBenchCfg.param.theta],
+        result_vars=[ExampleBenchCfg.param.out_sin],
+        const_vars=[ExampleBenchCfg.param.noisy.with_const(True)],
         title="Float 1D Cat 1D  Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
         post_description="Now the plot has two lines, one for each of the boolean values where noisy=true and noisy=false.",
@@ -51,9 +50,9 @@ def example_float_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport =
 
     # # this does not work yet because it tries to find min and max of categorical values
     # bench.plot_sweep(
-    #     input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.postprocess_fn],
-    #     result_vars=[ExampleBenchCfgOut.param.out_sin],
-    #     const_vars=[ExampleBenchCfgIn.param.noisy.with_const(True)],
+    #     input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.postprocess_fn],
+    #     result_vars=[ExampleBenchCfg.param.out_sin],
+    #     const_vars=[ExampleBenchCfg.param.noisy.with_const(True)],
     #     title="Float 1D Cat 1D  Example",
     #     description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
     #     post_description="Now the plot has two lines, one for each of the boolean values where noisy=true and noisy=false.",

--- a/bencher/example/example_floats.py
+++ b/bencher/example/example_floats.py
@@ -4,7 +4,7 @@
 import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, ExampleBenchCfg
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_floats(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = None) -> bch.Bench:
@@ -24,15 +24,15 @@ def example_floats(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
     bench.report.append(readme, "Intro")
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.theta],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Float 1D Example",
         description="""Bencher is a tool to make it easy to explore how input parameter affect a range of output metrics.  In these examples we are going to benchmark an example function which has been selected to show the features of bencher.
         The example function takes an input theta and returns the absolute value of sin(theta) and cos(theta) +- various types of noise.
 
-        def bench_function(cfg: ExampleBenchCfgIn) -> ExampleBenchCfgOut:
-            "Takes an ExampleBenchCfgIn and returns a ExampleBenchCfgOut output"
-            out = ExampleBenchCfgOut()
+        def bench_function(cfg: ExampleBenchCfg) -> dict:
+            "Takes an ExampleBenchCfg and returns a dict output"
+            return cfg()
             noise = calculate_noise(cfg)
             offset = 0.0
 
@@ -48,16 +48,16 @@ def example_floats(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.noisy],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Float 1D and Bool Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We pass the boolean  'noisy' and keep the other parameters the same""",
         post_description="Now the plot has two lines, one for each of the boolean values where noisy=true and noisy=false.",
     )
 
     bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.noisy],
+        result_vars=[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
         title="Float 1D and Bool Example with multiple outputs",
         description="""Following from the previous example here the second output is added to the result variables""",
         post_description="Another column is added for the result variable that shows cos(theta)",
@@ -65,13 +65,13 @@ def example_floats(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
 
     bench.plot_sweep(
         input_vars=[
-            ExampleBenchCfgIn.param.theta,
-            ExampleBenchCfgIn.param.noisy,
-            ExampleBenchCfgIn.param.postprocess_fn,
+            ExampleBenchCfg.param.theta,
+            ExampleBenchCfg.param.noisy,
+            ExampleBenchCfg.param.postprocess_fn,
         ],
         result_vars=[
-            ExampleBenchCfgOut.param.out_sin,
-            ExampleBenchCfgOut.param.out_cos,
+            ExampleBenchCfg.param.out_sin,
+            ExampleBenchCfg.param.out_cos,
         ],
         title="Float 1D, Bool and Categorical Example",
         description="""Following from the previous example lets add another input parameter to see how that affects the output.  We add the 'postprocess_fn' categorical enum value which either takes the absolute value or negates the output of the function.""",

--- a/bencher/example/example_floats2D.py
+++ b/bencher/example/example_floats2D.py
@@ -3,7 +3,6 @@ import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
 from bencher.example.benchmark_data import (
-    ExampleBenchCfgOut,
     NoiseDistribution,
     ExampleBenchCfg,
     call,
@@ -29,7 +28,7 @@ def example_floats2D(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = 
 
     bench.plot_sweep(
         input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.offset],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
         const_vars=[
             ExampleBenchCfg.param.sigma.with_const(0.1),
             ExampleBenchCfg.param.noise_distribution.with_const(NoiseDistribution.gaussian),
@@ -52,7 +51,7 @@ def example_floats2D(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = 
             ExampleBenchCfg.param.offset,
             ExampleBenchCfg.param.postprocess_fn,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
         const_vars=[
             (ExampleBenchCfg.param.sigma, 0.1),
             (ExampleBenchCfg.param.noise_distribution, NoiseDistribution.gaussian),
@@ -71,7 +70,7 @@ def example_floats2D(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = 
             ExampleBenchCfg.param.postprocess_fn,
             ExampleBenchCfg.param.noise_distribution,
         ],
-        result_vars=[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+        result_vars=[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
         const_vars=[
             (ExampleBenchCfg.param.sigma, 0.1),
             (ExampleBenchCfg.param.noise_distribution, NoiseDistribution.gaussian),

--- a/bencher/example/example_simple.py
+++ b/bencher/example/example_simple.py
@@ -56,7 +56,7 @@ class InputCfg(bch.ParametrizedSweep):
     # define the objective function you want to benchmark. It must be static and have no side effects. It should accept 1 input of type InputCfg (or whatever your input config class is called) and return the OutputCfg class you have defined
     @staticmethod
     def bench_function(cfg: InputCfg) -> OutputCfg:
-        """Takes an ExampleBenchCfgIn and returns a ExampleBenchCfgOut output.  This is just a dummy example so the behavior of the function is rather transparent, but in a real use case the function would be a black box you want to characterise."""
+        """Takes an InputCfg and returns an OutputCfg output.  This is just a dummy example so the behavior of the function is rather transparent, but in a real use case the function would be a black box you want to characterise."""
         output = OutputCfg()
 
         output.accuracy = 50 + math.sin(cfg.algo_setting_float) * 5

--- a/bencher/example/example_simple_bool.py
+++ b/bencher/example/example_simple_bool.py
@@ -3,7 +3,7 @@
 import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_1D_bool(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) -> bch.Bench:
@@ -11,16 +11,15 @@ def example_1D_bool(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) -> bch.Be
 
     bench = bch.Bench(
         "benchmarking_example_categorical1D",
-        bench_function,
-        ExampleBenchCfgIn,
+        ExampleBenchCfg(),
         report=report,
     )
 
     # here we sample the input variable theta and plot the value of output1. The (noisy) function is sampled 20 times so you can see the distribution
     bench.plot_sweep(
         title="Example 1D Bool",
-        input_vars=[ExampleBenchCfgIn.param.noisy],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.noisy],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         description=example_1D_bool.__doc__,
         run_cfg=run_cfg,
     )

--- a/bencher/example/example_simple_cat.py
+++ b/bencher/example/example_simple_cat.py
@@ -5,7 +5,7 @@
 import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_1D_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = None) -> bch.Bench:
@@ -18,11 +18,10 @@ def example_1D_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
         Bench: results of the parameter sweep
     """
 
-    explorer = ExampleBenchCfgIn()
+    explorer = ExampleBenchCfg()
     bench = bch.Bench(
         "benchmarking_example_categorical1D",
-        bench_function,
-        ExampleBenchCfgIn,
+        ExampleBenchCfg(),
         run_cfg=run_cfg,
         report=report,
     )
@@ -31,8 +30,8 @@ def example_1D_cat(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
     bench.plot_sweep(
         title="Example 1D Categorical",
         description="""This example shows how to sample a 1 dimensional categorical variable and plot the result of passing that parameter sweep to the benchmarking function""",
-        input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_cos, ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.postprocess_fn],
+        result_vars=[ExampleBenchCfg.param.out_cos, ExampleBenchCfg.param.out_sin],
         const_vars=explorer.get_input_defaults(),
     )
 

--- a/bencher/example/example_time_event.py
+++ b/bencher/example/example_time_event.py
@@ -5,7 +5,7 @@
 import bencher as bch
 
 # All the examples will be using the data structures and benchmark function defined in this file
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
 
 def example_time_event(
@@ -15,22 +15,21 @@ def example_time_event(
 
     bencher = bch.Bench(
         "benchmarking_example_categorical1D",
-        bench_function,
-        ExampleBenchCfgIn,
+        ExampleBenchCfg(),
         run_cfg=run_cfg,
         report=report,
     )
 
-    ExampleBenchCfgIn.param.offset.bounds = [0, 100]
+    ExampleBenchCfg.param.offset.bounds = [0, 100]
 
     # manually override the default value based on the time event string so that the graphs are not all just straight lines
-    ExampleBenchCfgIn.param.offset.default = int(str(hash(run_cfg.time_event))[-1])
+    ExampleBenchCfg.param.offset.default = int(str(hash(run_cfg.time_event))[-1])
 
     # here we sample the input variable theta and plot the value of output1. The (noisy) function is sampled 20 times so you can see the distribution
     bencher.plot_sweep(
         title="Example 1D Categorical",
-        input_vars=[ExampleBenchCfgIn.param.postprocess_fn],
-        result_vars=[ExampleBenchCfgOut.param.out_cos],
+        input_vars=[ExampleBenchCfg.param.postprocess_fn],
+        result_vars=[ExampleBenchCfg.param.out_cos],
         description=example_time_event.__doc__,
         run_cfg=run_cfg,
     )

--- a/bencher/example/experimental/example_hvplot_explorer.py
+++ b/bencher/example/experimental/example_hvplot_explorer.py
@@ -1,22 +1,22 @@
 # THIS IS NOT A WORKING EXAMPLE YET
 # pylint: disable=duplicate-code
 import bencher as bch
-from bencher import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 
-bench = bch.Bench("Bencher_Example_Simple", bench_function, ExampleBenchCfgIn)
+bench = bch.Bench("Bencher_Example_Simple", ExampleBenchCfg())
 
 
 if __name__ == "__main__":
     res = bench.plot_sweep(
-        input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.offset],
-        result_vars=[ExampleBenchCfgOut.param.out_sin],
+        input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.offset],
+        result_vars=[ExampleBenchCfg.param.out_sin],
         title="Float 1D Example",
         description="""Bencher is a tool to make it easy to explore how input parameter affect a range of output metrics.  In these examples we are going to benchmark an example function which has been selected to show the features of bencher.
         The example function takes an input theta and returns the absolute value of sin(theta) and cos(theta) +- various types of noise.
 
-        def bench_function(cfg: ExampleBenchCfgIn) -> ExampleBenchCfgOut:
-            "Takes an ExampleBenchCfgIn and returns a ExampleBenchCfgOut output"
-            out = ExampleBenchCfgOut()
+        def bench_function(cfg: ExampleBenchCfg) -> dict:
+            "Takes an ExampleBenchCfg and returns a dict output"
+            return cfg()
             noise = calculate_noise(cfg)
             offset = 0.0
 

--- a/test/test_bencher.py
+++ b/test/test_bencher.py
@@ -12,7 +12,7 @@ from hypothesis import given, settings, strategies as st
 from datetime import datetime
 from diskcache import Cache
 
-from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut, bench_function
+from bencher.example.benchmark_data import ExampleBenchCfg
 from bencher import Bench, BenchCfg, BenchRunCfg
 
 
@@ -22,7 +22,7 @@ def get_hash_isolated_process() -> bytes:
         [
             "python3",
             "-c",
-            "'from bencher.example.benchmark_data import ExampleBenchCfgIn, ExampleBenchCfgOut;import bencher as bch;cfg1 = bch.BenchCfg(input_vars=[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.noise_distribution],result_vars=[ExampleBenchCfgOut.param.out_sin],const_vars=[ExampleBenchCfgIn.param.noisy],repeats=5,over_time=False);print(cfg1.hash_persistent())'",
+            "'from bencher.example.benchmark_data import ExampleBenchCfg;import bencher as bch;cfg1 = bch.BenchCfg(input_vars=[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.noise_distribution],result_vars=[ExampleBenchCfg.param.out_sin],const_vars=[ExampleBenchCfg.param.noisy],repeats=5,over_time=False);print(cfg1.hash_persistent())'",
         ],
         stdout=subprocess.PIPE,
         check=False,
@@ -48,19 +48,19 @@ with Cache("unique_names") as c:
 
 # define a set of input variables that are used across multiple tests.  These configurations are
 input_var_cat_permutations = [
-    [ExampleBenchCfgIn.param.postprocess_fn],
-    [ExampleBenchCfgIn.param.postprocess_fn, ExampleBenchCfgIn.param.noisy],
+    [ExampleBenchCfg.param.postprocess_fn],
+    [ExampleBenchCfg.param.postprocess_fn, ExampleBenchCfg.param.noisy],
     [
-        ExampleBenchCfgIn.param.postprocess_fn,
-        ExampleBenchCfgIn.param.noisy,
-        ExampleBenchCfgIn.param.noise_distribution,
+        ExampleBenchCfg.param.postprocess_fn,
+        ExampleBenchCfg.param.noisy,
+        ExampleBenchCfg.param.noise_distribution,
     ],
 ]
 
 # set up float variable permutations
 input_var_float_permutations = [
-    [ExampleBenchCfgIn.param.theta],
-    [ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.postprocess_fn],
+    [ExampleBenchCfg.param.theta],
+    [ExampleBenchCfg.param.theta, ExampleBenchCfg.param.postprocess_fn],
 ]
 
 input_var_cat_float_permutations = input_var_cat_permutations + input_var_float_permutations
@@ -69,22 +69,22 @@ input_var_cat_float_permutations = input_var_cat_permutations + input_var_float_
 input_var_and_none_permutations = [] + input_var_cat_permutations
 
 result_var_permutations = [
-    [ExampleBenchCfgOut.param.out_sin],
-    [ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos],
+    [ExampleBenchCfg.param.out_sin],
+    [ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
 ]
 
 
 class TestBencher(unittest.TestCase):
     def create_bench(self) -> Bench:
-        return Bench("test_bencher", bench_function, ExampleBenchCfgIn)
+        return Bench("test_bencher", ExampleBenchCfg())
 
     @settings(deadline=10000)
     @given(
         input_vars=st.sampled_from(
             [
-                [ExampleBenchCfgIn.param.theta],
-                [ExampleBenchCfgIn.param.postprocess_fn],
-                [ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.postprocess_fn],
+                [ExampleBenchCfg.param.theta],
+                [ExampleBenchCfg.param.postprocess_fn],
+                [ExampleBenchCfg.param.theta, ExampleBenchCfg.param.postprocess_fn],
             ]
         ),
         result_vars=st.sampled_from(result_var_permutations),
@@ -130,7 +130,7 @@ class TestBencher(unittest.TestCase):
     @settings(deadline=30000)
     @given(
         input_vars=st.sampled_from(input_var_cat_permutations),
-        result_vars=st.sampled_from([[ExampleBenchCfgOut.param.out_sin]]),
+        result_vars=st.sampled_from([[ExampleBenchCfg.param.out_sin]]),
     )
     def test_combinations_over_time(self, input_vars, result_vars) -> None:
         """check that up to 3 categorical values over time can be plotted"""
@@ -156,7 +156,7 @@ class TestBencher(unittest.TestCase):
     @given(
         input_vars=st.sampled_from(input_var_cat_permutations),
         result_vars=st.sampled_from(
-            [[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos]]
+            [[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos]]
         ),
         repeats=st.sampled_from([20]),
         # repeats=st.sampled_from([1, 2]), #TODO this fails at the moment
@@ -179,11 +179,9 @@ class TestBencher(unittest.TestCase):
 
     @settings(deadline=10000)
     @given(
-        input_vars=st.sampled_from(
-            [[ExampleBenchCfgIn.param.theta, ExampleBenchCfgIn.param.offset]]
-        ),
+        input_vars=st.sampled_from([[ExampleBenchCfg.param.theta, ExampleBenchCfg.param.offset]]),
         result_vars=st.sampled_from(
-            [[ExampleBenchCfgOut.param.out_sin, ExampleBenchCfgOut.param.out_cos]]
+            [[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos]]
         ),
         repeats=st.sampled_from([2]),
     )
@@ -268,8 +266,8 @@ class TestBencher(unittest.TestCase):
 
         # set up inputs and results that are shared across runs
         title = "test_benching_cache"
-        iv = [ExampleBenchCfgIn.param.theta]
-        rv = [ExampleBenchCfgOut.param.out_sin]
+        iv = [ExampleBenchCfg.param.theta]
+        rv = [ExampleBenchCfg.param.out_sin]
 
         bench = self.create_bench()
 
@@ -284,7 +282,7 @@ class TestBencher(unittest.TestCase):
         )
 
         self.assertEqual(
-            bench.sample_cache.worker_wrapper_call_count, ExampleBenchCfgIn.param.theta.samples
+            bench.sample_cache.worker_wrapper_call_count, ExampleBenchCfg.param.theta.samples
         )
 
         bench2 = self.create_bench()
@@ -296,7 +294,7 @@ class TestBencher(unittest.TestCase):
             run_cfg=BenchRunCfg(over_time=over_time, cache_results=False, auto_plot=False),
         )
         self.assertEqual(
-            bench2.sample_cache.worker_wrapper_call_count, ExampleBenchCfgIn.param.theta.samples
+            bench2.sample_cache.worker_wrapper_call_count, ExampleBenchCfg.param.theta.samples
         )
 
         # bench3 = self.create_bench()
@@ -308,7 +306,7 @@ class TestBencher(unittest.TestCase):
             run_cfg=BenchRunCfg(over_time=over_time, cache_results=True, auto_plot=False),
         )
         self.assertEqual(
-            bench2.sample_cache.worker_wrapper_call_count, ExampleBenchCfgIn.param.theta.samples
+            bench2.sample_cache.worker_wrapper_call_count, ExampleBenchCfg.param.theta.samples
         )
 
     @settings(deadline=10000)
@@ -316,7 +314,7 @@ class TestBencher(unittest.TestCase):
     def test_const_hashing(self, noisy) -> None:
         """check that const variables are hashed correctly. This test was created because setting a const variable was resulting in a hash value that changed over time even though the inputs were not changing.  The source of the problem was that the input config had a native param instead of a paramSweep object.  The native param objects don't have a constant hash because they include the .name field which changes for every instance of the param.  the paramSweep objects have the .name field removed from the hash so that hashes for the same inputs remain constant"""
 
-        ExampleBenchCfgIn.param.theta.samples = 5
+        ExampleBenchCfg.param.theta.samples = 5
 
         logging.info(f"starting with const value noisy:{noisy}")
 
@@ -325,16 +323,16 @@ class TestBencher(unittest.TestCase):
         # run without caching and make sure any old caches are cleared
         bench.plot_sweep(
             title="test_const_hashing",
-            input_vars=[ExampleBenchCfgIn.param.theta],
-            result_vars=[ExampleBenchCfgOut.param.out_sin],
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
             const_vars=[
-                (ExampleBenchCfgIn.param.noisy, noisy),
+                (ExampleBenchCfg.param.noisy, noisy),
             ],
             run_cfg=BenchRunCfg(clear_cache=True, clear_history=True, auto_plot=False),
         )
         self.assertEqual(
             bench.sample_cache.worker_wrapper_call_count,
-            ExampleBenchCfgIn.param.theta.samples,
+            ExampleBenchCfg.param.theta.samples,
             "no cache used so the function should sample again",
         )
         logging.info("re-run and attempt to load from cache")
@@ -343,10 +341,10 @@ class TestBencher(unittest.TestCase):
         # run again without caching, the function should be called again
         bench2.plot_sweep(
             title="test_const_hashing",
-            input_vars=[ExampleBenchCfgIn.param.theta],
-            result_vars=[ExampleBenchCfgOut.param.out_sin],
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
             const_vars=[
-                (ExampleBenchCfgIn.param.noisy, noisy),
+                (ExampleBenchCfg.param.noisy, noisy),
             ],
             run_cfg=BenchRunCfg(cache_results=True, auto_plot=False),
         )
@@ -363,21 +361,21 @@ class TestBencher(unittest.TestCase):
         with self.assertRaises(TypeError):
             bench.plot_sweep(
                 title="test_param_usage",
-                input_vars=[ExampleBenchCfgIn.param.theta],
-                result_vars=[ExampleBenchCfgOut.out_sin],  # forgot to use param here
+                input_vars=[ExampleBenchCfg.param.theta],
+                result_vars=[ExampleBenchCfg.out_sin],  # forgot to use param here
             )
 
         with self.assertRaises(TypeError):
             bench.plot_sweep(
                 title="test_param_usage",
-                input_vars=[ExampleBenchCfgIn.theta],  # forgot to use param here
-                result_vars=[ExampleBenchCfgOut.param.out_sin],
+                input_vars=[ExampleBenchCfg.theta],  # forgot to use param here
+                result_vars=[ExampleBenchCfg.param.out_sin],
             )
 
         with self.assertRaises(TypeError):
             bench.plot_sweep(
                 title="test_param_usage",
-                input_vars=[ExampleBenchCfgIn.param.theta],
-                result_vars=[ExampleBenchCfgOut.param.out_sin],
-                const_vars=[(ExampleBenchCfgIn.offset, 0.1)],  # forgot to use param here
+                input_vars=[ExampleBenchCfg.param.theta],
+                result_vars=[ExampleBenchCfg.param.out_sin],
+                const_vars=[(ExampleBenchCfg.offset, 0.1)],  # forgot to use param here
             )

--- a/test/test_sample_order.py
+++ b/test/test_sample_order.py
@@ -25,14 +25,14 @@ class OrderExample(bch.ParametrizedSweep):
 class TestSampleOrder(unittest.TestCase):
     def test_sample_order_does_not_change_results_or_dims(self):
         # Use deterministic example worker (no noise by default)
-        bench1 = bch.Bench("sample_order_eq_1", bch.bench_function, bch.ExampleBenchCfgIn)
-        bench2 = bch.Bench("sample_order_eq_2", bch.bench_function, bch.ExampleBenchCfgIn)
+        bench1 = bch.Bench("sample_order_eq_1", bch.ExampleBenchCfg())
+        bench2 = bch.Bench("sample_order_eq_2", bch.ExampleBenchCfg())
 
         input_vars = [
-            bch.ExampleBenchCfgIn.param.theta,
-            bch.ExampleBenchCfgIn.param.postprocess_fn,
+            bch.ExampleBenchCfg.param.theta,
+            bch.ExampleBenchCfg.param.postprocess_fn,
         ]
-        result_vars = [bch.ExampleBenchCfgOut.param.out_sin]
+        result_vars = [bch.ExampleBenchCfg.param.out_sin]
         run_cfg = bch.BenchRunCfg(
             repeats=1,
             over_time=False,
@@ -65,7 +65,7 @@ class TestSampleOrder(unittest.TestCase):
         self.assertTrue(ds_in.equals(ds_rev))
 
         # Dimension order should match input_vars order and remain unchanged
-        var_name = bch.ExampleBenchCfgOut.param.out_sin.name
+        var_name = bch.ExampleBenchCfg.param.out_sin.name
         self.assertEqual(
             list(ds_in[var_name].dims)[:2],
             [v.name for v in input_vars],


### PR DESCRIPTION
## Summary by Sourcery

Simplify the example benchmarking API by removing the separate ExampleBenchCfgIn, ExampleBenchCfgOut and NoiseCfg classes and consolidating all parameters into a single ExampleBenchCfg; update tests and example scripts to use the new config and default bench_function behavior.

Enhancements:
- Remove ExampleBenchCfgIn, ExampleBenchCfgOut and NoiseCfg definitions and related calculate_noise/bench_function implementations
- Consolidate all input, constant, and result parameters into the unified ExampleBenchCfg class

Tests:
- Update tests to instantiate benches with ExampleBenchCfg, reference ExampleBenchCfg.param throughout, and adjust expected sample counts accordingly

Chores:
- Revise example scripts to use ExampleBenchCfg() and default bench_function returning dict outputs instead of the removed classes