### PR TITLE
remove obsolete non checks

### DIFF
--- a/bencher/example/example_cat2_scatter_jitter.py
+++ b/bencher/example/example_cat2_scatter_jitter.py
@@ -83,8 +83,6 @@ def example_2_cat_in_4_out_repeats(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 15  # Run multiple times to get statistical significance
     bench = ProgrammingBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep(

--- a/bencher/example/example_pareto.py
+++ b/bencher/example/example_pareto.py
@@ -96,10 +96,8 @@ def example_pareto(run_cfg: bch.BenchRunCfg = None, report: bch.BenchReport = No
     Returns:
         Bench: Benchmark object with results
     """
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-        run_cfg.repeats = 5  # Multiple repeats to demonstrate randomness effects
-        run_cfg.level = 4
+    run_cfg.repeats = 5  # Multiple repeats to demonstrate randomness effects
+    run_cfg.level = 4
 
     # Set up Optuna for multi-objective optimization
     run_cfg.use_optuna = True

--- a/bencher/example/inputs_0_float/example_1_cat_in_2_out.py
+++ b/bencher/example/inputs_0_float/example_1_cat_in_2_out.py
@@ -74,8 +74,6 @@ def example_1_cat_in_2_out(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     bench = PythonOperations1CatBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep(
         title="Python Data Structure Performance Benchmark (1 Variable)",

--- a/bencher/example/inputs_0_float/example_2_cat_in_2_out.py
+++ b/bencher/example/inputs_0_float/example_2_cat_in_2_out.py
@@ -83,8 +83,6 @@ def example_2_cat_in_2_out(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     bench = PythonOperations2CatBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep(
         title="Python Operations Performance Benchmark (2 Variables)",

--- a/bencher/example/inputs_0_float/example_3_cat_in_2_out.py
+++ b/bencher/example/inputs_0_float/example_3_cat_in_2_out.py
@@ -87,8 +87,6 @@ def example_3_cat_in_2_out(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     bench = PythonOperationsBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep(
         title="Python Operations Performance Benchmark",

--- a/bencher/example/inputs_1D/example_1_cat_in_2_out_repeats.py
+++ b/bencher/example/inputs_1D/example_1_cat_in_2_out_repeats.py
@@ -56,8 +56,6 @@ def example_1_cat_in_2_out_repeats(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 30  # Increased repeats for better statistical significance
     bench = DataStructureBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep()

--- a/bencher/example/inputs_1D/example_1_int_in_2_out_repeats.py
+++ b/bencher/example/inputs_1D/example_1_int_in_2_out_repeats.py
@@ -84,8 +84,6 @@ def example_1_int_in_2_out_repeats(
     from importlib.metadata import version
 
     print(version("holobench"))
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 4
     bench = Example1D().to_bench(run_cfg, report)
     bench.plot_sweep()

--- a/bencher/example/inputs_2D/example_2_cat_in_4_out_repeats.py
+++ b/bencher/example/inputs_2D/example_2_cat_in_4_out_repeats.py
@@ -89,8 +89,6 @@ def example_2_cat_in_4_out_repeats(
         bch.Bench: The benchmark object
     """
 
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 15  # Run multiple times to get statistical significance
     bench = ProgrammingBenchmark().to_bench(run_cfg, report)
     bench.plot_sweep(

--- a/bencher/example/inputs_2_float/example_2_float_0_cat_in_2_out.py
+++ b/bencher/example/inputs_2_float/example_2_float_0_cat_in_2_out.py
@@ -74,8 +74,6 @@ def example_2_float_0_cat_in_2_out(
     Returns:
         bch.Bench: The benchmark object
     """
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 3  # Fewer repeats for a quicker benchmark
 
     bench = Pattern0CatBenchmark().to_bench(run_cfg, report)

--- a/bencher/example/inputs_2_float/example_2_float_1_cat_in_2_out.py
+++ b/bencher/example/inputs_2_float/example_2_float_1_cat_in_2_out.py
@@ -89,8 +89,6 @@ def example_2_float_1_cat_in_2_out(
     Returns:
         bch.Bench: The benchmark object
     """
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 1  # Fewer repeats for a quicker benchmark
 
     bench = Pattern1CatBenchmark().to_bench(run_cfg, report)

--- a/bencher/example/inputs_2_float/example_2_float_2_cat_in_2_out.py
+++ b/bencher/example/inputs_2_float/example_2_float_2_cat_in_2_out.py
@@ -99,8 +99,6 @@ def example_2_float_2_cat_in_2_out(
     Returns:
         bch.Bench: The benchmark object
     """
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 3  # Fewer repeats for a quicker benchmark
 
     bench = Pattern2CatBenchmark().to_bench(run_cfg, report)

--- a/bencher/example/inputs_2_float/example_2_float_3_cat_in_2_out.py
+++ b/bencher/example/inputs_2_float/example_2_float_3_cat_in_2_out.py
@@ -114,8 +114,6 @@ def example_2_float_3_cat_in_2_out(
     Returns:
         bch.Bench: The benchmark object
     """
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     run_cfg.repeats = 3  # Fewer repeats for a quicker benchmark
 
     bench = PatternBenchmark().to_bench(run_cfg, report)


### PR DESCRIPTION
## Summary by Sourcery

Simplify example benchmark scripts by removing obsolete checks for a missing run_cfg and eliminating redundant default instantiation, directly setting run_cfg properties instead

Enhancements:
- Remove conditional instantiation of run_cfg across all example scripts
- Eliminate "if run_cfg is None" blocks and assume a valid BenchRunCfg is provided