### PR TITLE
Fix input validation and clean up minor code issues

### DIFF
--- a/bencher/utils_rerun.py
+++ b/bencher/utils_rerun.py
@@ -1,5 +1,5 @@
 import logging
-from importlib.metadata import version as get_package_version
+from importlib.metadata import version as get_package_version, PackageNotFoundError
 from rerun.legacy_notebook import as_html
 import rerun as rr
 import panel as pn
@@ -10,7 +10,7 @@ def _get_rerun_version() -> str:
     """Get the installed rerun package version."""
     try:
         return get_package_version("rerun-sdk")
-    except Exception:
+    except PackageNotFoundError:
         return "0.20.1"  # Fallback version
 
 

--- a/bencher/utils_rerun.py
+++ b/bencher/utils_rerun.py
@@ -1,15 +1,24 @@
 import logging
+from importlib.metadata import version as get_package_version
 from rerun.legacy_notebook import as_html
 import rerun as rr
 import panel as pn
 from .utils import publish_file, gen_rerun_data_path
 
 
+def _get_rerun_version() -> str:
+    """Get the installed rerun package version."""
+    try:
+        return get_package_version("rerun-sdk")
+    except Exception:
+        return "0.20.1"  # Fallback version
+
+
 def rrd_to_pane(
     url: str, width: int = 500, height: int = 600, version: str = None
 ):  # pragma: no cover
     if version is None:
-        version = "0.20.1"  # TODO find a better way of doing this
+        version = _get_rerun_version()
     return pn.pane.HTML(
         f'<iframe src="https://app.rerun.io/version/{version}/?url={url}" width={width} height={height}></iframe>'
     )


### PR DESCRIPTION
Fixes a few small code issues:

- **Input validation**: Changed `assert` statements to raise `TypeError`/`ValueError` with descriptive messages. Assertions can be disabled with `-O`, so they shouldn't  be used for input validation.

- **Dead code**: Removed duplicate `self.worker_class_instance = None` assignment.

- **Magic number**: Extracted the 100GB cache size to `DEFAULT_CACHE_SIZE_BYTES` constant.

- **Hardcoded version**: The rerun viewer URL now uses the installed package version  via `importlib.metadata` instead of a hardcoded string (resolves the TODO).

## Summary by Sourcery

Improve input validation and configuration around benchmarking cache and rerun viewer integration.

Bug Fixes:
- Replace assertion-based input validation with explicit TypeError/ValueError exceptions for benchmark names and input variable lists.
- Remove duplicate worker_class_instance initialization in the benchmark setup.

Enhancements:
- Introduce a DEFAULT_CACHE_SIZE_BYTES constant for the default 100GB benchmark result cache size.
- Derive the rerun viewer URL version from the installed rerun package via importlib.metadata with a safe fallback.