### PR TITLE
Fix flaky hypothesis tests in test_job.py

### DIFF
--- a/test/test_job.py
+++ b/test/test_job.py
@@ -19,7 +19,7 @@ class CachedParamExample(bch.CachedParams):
 
 
 class TestJob(unittest.TestCase):
-    @settings(deadline=2000)  # Increased from 500ms to 2000ms
+    @settings(deadline=5000)  # Increased deadline for multiprocessing startup overhead
     @given(st.sampled_from([bch.Executors.SERIAL, bch.Executors.MULTIPROCESSING]))
     def test_basic(self, executor):
         cp = CachedParamExample()  # clears cache by default
@@ -49,7 +49,7 @@ class TestJob(unittest.TestCase):
         res1cp3 = jc3.call(var1=1).result()
         self.assertNotEqual(res1["result"], res1cp3["result"])
 
-    @settings(deadline=500)
+    @settings(deadline=5000)  # Increased deadline for multiprocessing startup overhead
     @given(st.sampled_from([bch.Executors.SERIAL, bch.Executors.MULTIPROCESSING]))
     def test_overwrite(self, executor):
         cp = CachedParamExample()  # clears cache by default
@@ -81,7 +81,7 @@ class TestJob(unittest.TestCase):
 
         self.assertNotEqual(res1["result"], res3["result"], f"{res1}")
 
-    @settings(deadline=2000)  # Increased from 1000ms to 2000ms
+    @settings(deadline=5000)  # Increased deadline for multiprocessing startup overhead
     @given(st.sampled_from([bch.Executors.SERIAL, bch.Executors.MULTIPROCESSING]))
     def test_bench_runner_parallel(self, executor):
         run_cfg = bch.BenchRunCfg()


### PR DESCRIPTION
## Summary

- Increased hypothesis test deadlines from 500-2000ms to 5000ms for all tests in test_job.py
- The multiprocessing executor has significant startup overhead that was causing intermittent deadline failures

## Summary by Sourcery

Introduce a structured benchmark configuration system with composable sub-config classes and update tests and configuration access accordingly.

Bug Fixes:
- Relax Hypothesis deadlines in job tests to avoid flaky failures caused by multiprocessing startup overhead.

Enhancements:
- Add BenchRunCfg as a composable run-configuration that delegates parameters to sub-config objects while preserving flat, backward-compatible access.
- Add BenchCfg as a higher-level benchmark configuration encapsulating variables, metadata, hashing, and sweep description utilities.
- Provide dedicated cache, execution, display, visualization, time, server, and dims configuration classes to better organize benchmark settings.
- Refactor the bench_cfg package into a proper subpackage with explicit exports and improve LaTeX/markdown description helpers for sweeps and results.

Tests:
- Add comprehensive tests for sub-config defaults, BenchRunCfg composition/delegation, BenchCfg behavior, and backward-compatible imports.