### PR TITLE
Complete config migration: Remove backwards compatibility for flat parameter access

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -1,4 +1,5 @@
 from .bencher import Bench, BenchCfg, BenchRunCfg
+from .bench_cfg.server_cfg import BenchPlotSrvCfg
 from .bench_runner import BenchRunner
 from .example.benchmark_data import ExampleBenchCfg
 from .bench_plot_server import BenchPlotServer

--- a/bencher/bench_cfg/__init__.py
+++ b/bencher/bench_cfg/__init__.py
@@ -8,18 +8,22 @@ Configuration classes for benchmarking, organized by concern:
 - VisualizationCfg: Plotting (auto_plot, plot_size, use_holoview, ...)
 - TimeCfg: History (over_time, run_tag, run_date, ...)
 - BenchPlotSrvCfg: Server (port, show, allow_ws_origin)
-- BenchRunCfg: Composes all above with backward-compatible flat access
+- BenchRunCfg: Composes all above configurations
 - BenchCfg: Full benchmark config with variables and metadata
 - DimsCfg: Dimension info extraction
 
 Usage:
-    # Flat access (backward compatible)
-    cfg = BenchRunCfg(cache_results=True, repeats=5)
-    cfg.auto_plot = False
+    # Create with sub-config objects
+    cfg = BenchRunCfg(
+        cache=CacheCfg(cache_results=True),
+        execution=ExecutionCfg(repeats=5)
+    )
 
-    # Grouped access
+    # Or create with defaults and modify
+    cfg = BenchRunCfg()
     cfg.cache.cache_samples = True
     cfg.execution.level = 3
+    cfg.visualization.auto_plot = False
 """
 
 from bencher.bench_cfg.server_cfg import BenchPlotSrvCfg

--- a/bencher/bench_cfg/bench_cfg_class.py
+++ b/bencher/bench_cfg/bench_cfg_class.py
@@ -131,7 +131,7 @@ class BenchCfg(BenchRunCfg):
 
         if include_repeats:
             # needed so that the historical xarray arrays are the same size
-            repeats_hash = hash_sha1(self.repeats)
+            repeats_hash = hash_sha1(self.execution.repeats)
         else:
             repeats_hash = 0
 
@@ -139,7 +139,7 @@ class BenchCfg(BenchRunCfg):
             (
                 hash_sha1(str(self.bench_name)),
                 hash_sha1(str(self.title)),
-                hash_sha1(self.over_time),
+                hash_sha1(self.time.over_time),
                 repeats_hash,
                 hash_sha1(self.tag),
             )
@@ -234,15 +234,15 @@ class BenchCfg(BenchRunCfg):
             benchmark_sampling_str.extend(describe_variable(rv, False))
 
         benchmark_sampling_str.append("\nMeta Variables:")
-        benchmark_sampling_str.append(f"    run date: {self.run_date}")
-        if self.run_tag:
-            benchmark_sampling_str.append(f"    run tag: {self.run_tag}")
-        if self.level is not None:
-            benchmark_sampling_str.append(f"    bench level: {self.level}")
-        benchmark_sampling_str.append(f"    cache_results: {self.cache_results}")
-        benchmark_sampling_str.append(f"    cache_samples {self.cache_samples}")
-        benchmark_sampling_str.append(f"    only_hash_tag: {self.only_hash_tag}")
-        benchmark_sampling_str.append(f"    executor: {self.executor}")
+        benchmark_sampling_str.append(f"    run date: {self.time.run_date}")
+        if self.time.run_tag:
+            benchmark_sampling_str.append(f"    run tag: {self.time.run_tag}")
+        if self.execution.level is not None:
+            benchmark_sampling_str.append(f"    bench level: {self.execution.level}")
+        benchmark_sampling_str.append(f"    cache_results: {self.cache.cache_results}")
+        benchmark_sampling_str.append(f"    cache_samples {self.cache.cache_samples}")
+        benchmark_sampling_str.append(f"    only_hash_tag: {self.cache.only_hash_tag}")
+        benchmark_sampling_str.append(f"    executor: {self.execution.executor}")
 
         for mv in self.meta_vars:
             benchmark_sampling_str.extend(describe_variable(mv, True))

--- a/bencher/bench_cfg/bench_cfg_class.py
+++ b/bencher/bench_cfg/bench_cfg_class.py
@@ -224,7 +224,7 @@ class BenchCfg(BenchRunCfg):
         for iv in self.input_vars:
             benchmark_sampling_str.extend(describe_variable(iv, True))
 
-        if self.const_vars and (self.summarise_constant_inputs):
+        if self.const_vars and (self.display.summarise_constant_inputs):
             benchmark_sampling_str.append("\nConstants:")
             for cv in self.const_vars:
                 benchmark_sampling_str.extend(describe_variable(cv[0], False, cv[1]))

--- a/bencher/bench_cfg/bench_cfg_class.py
+++ b/bencher/bench_cfg/bench_cfg_class.py
@@ -240,7 +240,7 @@ class BenchCfg(BenchRunCfg):
         if self.execution.level is not None:
             benchmark_sampling_str.append(f"    bench level: {self.execution.level}")
         benchmark_sampling_str.append(f"    cache_results: {self.cache.cache_results}")
-        benchmark_sampling_str.append(f"    cache_samples {self.cache.cache_samples}")
+        benchmark_sampling_str.append(f"    cache_samples: {self.cache.cache_samples}")
         benchmark_sampling_str.append(f"    only_hash_tag: {self.cache.only_hash_tag}")
         benchmark_sampling_str.append(f"    executor: {self.execution.executor}")
 

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -76,7 +76,7 @@ class BenchRunner:
         self.run_cfg = BenchRunner.setup_run_cfg(run_cfg)
         # Override run_tag if provided as parameter
         if run_tag is not None:
-            self.run_cfg.run_tag = run_tag
+            self.run_cfg.time.run_tag = run_tag
         self.publisher = publisher
         if bench_class is not None:
             self.add_bench(bench_class)
@@ -123,9 +123,9 @@ class BenchRunner:
             BenchRunCfg: A new configuration object with the specified settings
         """
         run_cfg_out = BenchRunCfg() if run_cfg is None else deepcopy(run_cfg)
-        run_cfg_out.cache_samples = cache_results
-        run_cfg_out.only_hash_tag = cache_results
-        run_cfg_out.level = level
+        run_cfg_out.cache.cache_samples = cache_results
+        run_cfg_out.cache.only_hash_tag = cache_results
+        run_cfg_out.execution.level = level
         return run_cfg_out
 
     @staticmethod
@@ -317,11 +317,11 @@ class BenchRunner:
             for lvl in range(min_level, final_max_level + 1):
                 report_level = None
                 if grouped:
-                    report_level = BenchReport(f"{run_cfg.run_tag}_{self.name}")
+                    report_level = BenchReport(f"{run_cfg.time.run_tag}_{self.name}")
                 for bch_fn in self.bench_fns:
                     run_lvl = deepcopy(run_cfg)
-                    run_lvl.level = lvl
-                    run_lvl.repeats = r
+                    run_lvl.execution.level = lvl
+                    run_lvl.execution.repeats = r
                     logging.info(f"Running {bch_fn} at level: {lvl} with repeats:{r}")
                     res, active_report = self._execute_bench_fn(bch_fn, run_lvl, report_level)
                     if grouped:
@@ -336,8 +336,8 @@ class BenchRunner:
                         report_to_publish = active_report or BenchReport()
                         if active_report is None:
                             res.report = report_to_publish
-                        if run_cfg.run_tag:
-                            tag_suffix = f"_{run_cfg.run_tag}"
+                        if run_cfg.time.run_tag:
+                            tag_suffix = f"_{run_cfg.time.run_tag}"
                         else:
                             current_date = datetime.now().strftime("%Y-%m-%d")
                             tag_suffix = f"_{current_date}"

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -535,7 +535,7 @@ class Bench(BenchPlotServer):
 
         if self.sample_cache is None:
             self.sample_cache = self.init_sample_cache(run_cfg)
-        if bench_cfg.clear_sample_cache:
+        if bench_cfg.cache.clear_sample_cache:
             self.clear_tag_from_sample_cache(bench_cfg.tag, run_cfg)
 
         calculate_results = True

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -570,7 +570,9 @@ class Bench(BenchPlotServer):
                     bench_res.ds, bench_cfg_hash, run_cfg.time.clear_history
                 )
 
-            self.report_results(bench_res, run_cfg.display.print_xarray, run_cfg.display.print_pandas)
+            self.report_results(
+                bench_res, run_cfg.display.print_xarray, run_cfg.display.print_pandas
+            )
             self.cache_results(bench_res, bench_cfg_hash)
 
         logging.info(self.sample_cache.stats())

--- a/bencher/example/example_sample_cache_context.py
+++ b/bencher/example/example_sample_cache_context.py
@@ -35,26 +35,26 @@ def assert_call_counts(bencher, run_cfg, wrapper_calls=-1, fn_calls=-1, cache_ca
     print_assert_equal(
         "worker wrapper call count",
         bencher.sample_cache.worker_wrapper_call_count,
-        wrapper_calls * run_cfg.repeats,
+        wrapper_calls * run_cfg.execution.repeats,
     )
     print_assert_equal(
         "worker fn call count",
         bencher.sample_cache.worker_fn_call_count,
-        fn_calls * run_cfg.repeats,
+        fn_calls * run_cfg.execution.repeats,
     )
     print_assert_equal(
         "worker cache call count",
         bencher.sample_cache.worker_cache_call_count,
-        cache_calls * run_cfg.repeats,
+        cache_calls * run_cfg.execution.repeats,
     )
 
 
 def example_cache_context() -> bch.Bench:
     run_cfg = bch.BenchRunCfg()
-    run_cfg.cache_samples = True
-    run_cfg.only_hash_tag = True
-    run_cfg.repeats = 2
-    run_cfg.parallel = False
+    run_cfg.cache.cache_samples = True
+    run_cfg.cache.only_hash_tag = True
+    run_cfg.execution.repeats = 2
+    # run_cfg.parallel = False  # Deprecated - parallel execution is now controlled via executor parameter
 
     bencher = bch.Bench("bench_context", bench_function, Cfg, run_cfg=run_cfg)
 

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -75,7 +75,7 @@ class PltCntCfg(param.Parameterized):
         plt_cnt_cfg.float_cnt = len(plt_cnt_cfg.float_vars)
         plt_cnt_cfg.cat_cnt = len(plt_cnt_cfg.cat_vars)
         plt_cnt_cfg.panel_cnt = len(plt_cnt_cfg.panel_vars)
-        plt_cnt_cfg.repeats = bench_cfg.repeats
+        plt_cnt_cfg.repeats = bench_cfg.execution.repeats
         plt_cnt_cfg.inputs_cnt = len(bench_cfg.input_vars)
         return plt_cnt_cfg
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -101,7 +101,7 @@ class ResultCollector:
         """
         if time_src is None:
             time_src = datetime.now()
-        bench_cfg.meta_vars = self.define_extra_vars(bench_cfg, bench_cfg.repeats, time_src)
+        bench_cfg.meta_vars = self.define_extra_vars(bench_cfg, bench_cfg.execution.repeats, time_src)
 
         bench_cfg.all_vars = bench_cfg.input_vars + bench_cfg.meta_vars
 
@@ -171,7 +171,7 @@ class ResultCollector:
         bench_cfg.iv_repeat.name = "repeat"
         extra_vars = [bench_cfg.iv_repeat]
 
-        if bench_cfg.over_time:
+        if bench_cfg.time.over_time:
             if isinstance(time_src, str):
                 iv_over_time = TimeEvent(time_src)
             else:
@@ -206,7 +206,7 @@ class ResultCollector:
         result = job_result.result()
         if result is not None:
             logger.info(f"{job_result.job.job_id}:")
-            if bench_res.bench_cfg.print_bench_inputs:
+            if bench_res.bench_cfg.display.print_bench_inputs:
                 for k, v in worker_job.function_input.items():
                     logger.info(f"\t {k}:{v}")
 
@@ -214,7 +214,7 @@ class ResultCollector:
 
             for rv in bench_res.bench_cfg.result_vars:
                 result_value = result_dict[rv.name]
-                if bench_run_cfg.print_bench_results:
+                if bench_run_cfg.display.print_bench_results:
                     logger.info(f"{rv.name}: {result_value}")
 
                 if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -101,7 +101,9 @@ class ResultCollector:
         """
         if time_src is None:
             time_src = datetime.now()
-        bench_cfg.meta_vars = self.define_extra_vars(bench_cfg, bench_cfg.execution.repeats, time_src)
+        bench_cfg.meta_vars = self.define_extra_vars(
+            bench_cfg, bench_cfg.execution.repeats, time_src
+        )
 
         bench_cfg.all_vars = bench_cfg.input_vars + bench_cfg.meta_vars
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -201,7 +201,9 @@ class BenchResultBase:
             xr.Dataset: results in the form of an xarray dataset
         """
         if reduce == ReduceType.AUTO:
-            reduce = ReduceType.REDUCE if self.bench_cfg.execution.repeats > 1 else ReduceType.SQUEEZE
+            reduce = (
+                ReduceType.REDUCE if self.bench_cfg.execution.repeats > 1 else ReduceType.SQUEEZE
+            )
 
         ds_out = self.ds.copy()
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -122,7 +122,7 @@ class BenchResultBase:
         Returns:
             BenchCfg: updated config with wrapped labels
         """
-        if bench_cfg.over_time:
+        if bench_cfg.time.over_time:
             if self.ds.coords["over_time"].dtype == np.datetime64:
                 # plotly catastrophically fails to plot anything with the default long string representation of time, so convert to a shorter time representation
                 self.ds.coords["over_time"] = [
@@ -130,7 +130,7 @@ class BenchResultBase:
                     for t in self.ds.coords["over_time"].values
                 ]
                 # wrap very long time event labels because otherwise the graphs are unreadable
-            if bench_cfg.time_event is not None:
+            if bench_cfg.time.time_event is not None:
                 self.ds.coords["over_time"] = [
                     "\n".join(wrap(t, 20)) for t in self.ds.coords["over_time"].values
                 ]
@@ -201,7 +201,7 @@ class BenchResultBase:
             xr.Dataset: results in the form of an xarray dataset
         """
         if reduce == ReduceType.AUTO:
-            reduce = ReduceType.REDUCE if self.bench_cfg.repeats > 1 else ReduceType.SQUEEZE
+            reduce = ReduceType.REDUCE if self.bench_cfg.execution.repeats > 1 else ReduceType.SQUEEZE
 
         ds_out = self.ds.copy()
 
@@ -600,7 +600,7 @@ class BenchResultBase:
         dims = list(d for d in dataset.sizes)
 
         time_dim_delta = 0
-        if self.bench_cfg.over_time:
+        if self.bench_cfg.time.over_time:
             time_dim_delta = 0
 
         if num_dims > (target_dimension + time_dim_delta) and num_dims != 0:
@@ -737,16 +737,16 @@ class BenchResultBase:
 
     def set_plot_size(self, **kwargs) -> dict:
         if "width" not in kwargs:
-            if self.bench_cfg.plot_size is not None:
-                kwargs["width"] = self.bench_cfg.plot_size
+            if self.bench_cfg.visualization.plot_size is not None:
+                kwargs["width"] = self.bench_cfg.visualization.plot_size
             # specific width overrides general size
-            if self.bench_cfg.plot_width is not None:
-                kwargs["width"] = self.bench_cfg.plot_width
+            if self.bench_cfg.visualization.plot_width is not None:
+                kwargs["width"] = self.bench_cfg.visualization.plot_width
 
         if "height" not in kwargs:
-            if self.bench_cfg.plot_size is not None:
-                kwargs["height"] = self.bench_cfg.plot_size
+            if self.bench_cfg.visualization.plot_size is not None:
+                kwargs["height"] = self.bench_cfg.visualization.plot_size
             # specific height overrides general size
-            if self.bench_cfg.plot_height is not None:
-                kwargs["height"] = self.bench_cfg.plot_height
+            if self.bench_cfg.visualization.plot_height is not None:
+                kwargs["height"] = self.bench_cfg.visualization.plot_height
         return kwargs

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -125,7 +125,7 @@ class SurfaceResult(HoloviewResult):
             except Exception as e:  # pylint: disable=broad-except
                 logging.warning(e)
 
-            if self.bench_cfg.repeats > 1:
+            if self.bench_cfg.execution.repeats > 1:
                 std_dev = dataset[f"{result_var.name}_std"]
 
                 upper = mean + std_dev

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -152,7 +152,7 @@ class SurfaceResult(HoloviewResult):
                 **kwargs,
             )
 
-            if self.bench_cfg.render_plotly:
+            if self.bench_cfg.visualization.render_plotly:
                 hv.extension("plotly")
                 out = surface
             else:

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -190,7 +190,7 @@ class OptunaResult(BenchResultBase):
 
         self.studies = [self.bench_result_to_study(True)]
         titles = ["# Analysis"]
-        if self.bench_cfg.repeats > 1:
+        if self.bench_cfg.execution.repeats > 1:
             self.studies.append(self.bench_result_to_study(False))
             titles = [
                 "# Parameter Importance With Repeats",

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -114,7 +114,7 @@ class SweepExecutor:
                 param_var = param_var.with_samples(variable["samples"])
             if variable.get("max_level"):
                 if run_cfg is not None:
-                    param_var = param_var.with_level(run_cfg.level, variable["max_level"])
+                    param_var = param_var.with_level(run_cfg.execution.level, variable["max_level"])
             variable = param_var
         if not isinstance(variable, param.Parameter):
             raise TypeError(
@@ -159,12 +159,12 @@ class SweepExecutor:
             FutureCache: A configured cache for storing benchmark results
         """
         self.sample_cache = FutureCache(
-            overwrite=run_cfg.overwrite_sample_cache,
-            executor=run_cfg.executor,
+            overwrite=run_cfg.cache.overwrite_sample_cache,
+            executor=run_cfg.execution.executor,
             cache_name="sample_cache",
             tag_index=True,
             size_limit=self.cache_size,
-            cache_results=run_cfg.cache_samples,
+            cache_results=run_cfg.cache.cache_samples,
         )
         return self.sample_cache
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -44,7 +44,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py313h7037e92_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -124,7 +124,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/7b/e9a6fa461ef266c5a23485004934b8f08a2a8ddc447802161ea56d9837dd/psygnal-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -156,7 +156,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl
@@ -212,7 +212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py310h03d9f68_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -292,7 +292,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/4c/42e597b47e64f4e87f5b70f03e027d0d535b1f302897d4409d774d6859fa/psygnal-0.15.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -325,7 +325,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl
@@ -382,7 +382,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311hdf67eae_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -462,7 +462,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/17/44/744374443b6e30f2ede11eb182d698d97c0bd021d59e472a0f0a4ddccf8e/psygnal-0.15.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -494,7 +494,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl
@@ -551,7 +551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -631,7 +631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/ce/ad35c19f489c563e6655a6ee9509e1af7ee864ae8fe95f04f851a47e141a/psygnal-0.15.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -663,7 +663,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl
@@ -718,7 +718,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py313h7037e92_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
@@ -798,7 +798,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/7b/e9a6fa461ef266c5a23485004934b8f08a2a8ddc447802161ea56d9837dd/psygnal-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -830,7 +830,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl
@@ -3289,11 +3289,12 @@ packages:
   requires_dist:
   - wcwidth
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/12/ff/e93136587c00a543f4bc768b157fac2c47cd77b180d4f4e5c6efb6ea53a2/psutil-7.2.0-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/29/f8/40e01c350ad9a2b3cb4e6adbcc8a83b17ee50dd5792102b6142385937db5/psutil-7.2.1-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
   name: psutil
-  version: 7.2.0
-  sha256: 91f211ba9279e7c61d9d8f84b713cfc38fa161cb0597d5cb3f1ca742f6848254
+  version: 7.2.1
+  sha256: 5e38404ca2bb30ed7267a46c02f06ff842e92da3bb8c5bfdadbd35a5722314d8
   requires_dist:
+  - psleak ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-instafail ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
@@ -3318,6 +3319,7 @@ packages:
   - virtualenv ; extra == 'dev'
   - vulture ; extra == 'dev'
   - wheel ; extra == 'dev'
+  - psleak ; extra == 'test'
   - pytest ; extra == 'test'
   - pytest-instafail ; extra == 'test'
   - pytest-xdist ; extra == 'test'
@@ -4519,10 +4521,10 @@ packages:
   - pytest-mypy-testing ; extra == 'test'
   - pytest>=7.0,<8.2 ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/ad/09/d1858c66620d8ae566e021ad0d7168914b1568841f8fe9e439116ce6b440/ty-0.0.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0e/8d/8667c7e0ac9f13c461ded487c8d7350f440cd39ba866d0160a8e1b1efd6c/ty-0.0.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.7
-  sha256: f56a5a0c1c045863b1b70c358a392b3f73b8528c5c571d409f19dd465525e116
+  version: 0.0.8
+  sha256: b558a647a073d0c25540aaa10f8947de826cb8757d034dd61ecf50ab8dbd77bf
   requires_python: '>=3.8'
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
@@ -4541,13 +4543,13 @@ packages:
   version: '2025.3'
   sha256: 06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1
   requires_python: '>=2'
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-h8577fbf_0.conda
-  sha256: 50fad5db6734d1bb73df1cf5db73215e326413d4b2137933f70708aa1840e25b
-  md5: 338201218b54cadff2e774ac27733990
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
   license: LicenseRef-Public-Domain
   purls: []
-  size: 119204
-  timestamp: 1765745742795
+  size: 119135
+  timestamp: 1767016325805
 - pypi: https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl
   name: uc-micro-py
   version: 1.0.3

--- a/test/test_bench_cfg.py
+++ b/test/test_bench_cfg.py
@@ -81,13 +81,13 @@ class TestBenchRunCfgComposition(unittest.TestCase):
         """Flat attribute access is no longer supported and raises AttributeError."""
         cfg = BenchRunCfg()
         with self.assertRaises(AttributeError):
-            _ = cfg.cache_results
+            _ = cfg.cache_results  # pylint: disable=no-member
         with self.assertRaises(AttributeError):
-            _ = cfg.repeats
+            _ = cfg.repeats  # pylint: disable=no-member
         with self.assertRaises(AttributeError):
-            _ = cfg.auto_plot
+            _ = cfg.auto_plot  # pylint: disable=no-member
         with self.assertRaises(AttributeError):
-            _ = cfg.over_time
+            _ = cfg.over_time  # pylint: disable=no-member
 
     def test_sub_config_init(self):
         """Sub-config parameters can be set via constructor."""

--- a/test/test_bench_cfg.py
+++ b/test/test_bench_cfg.py
@@ -211,7 +211,7 @@ class TestBenchCfgInheritance(unittest.TestCase):
         # Check sub-config fields appear in output
         self.assertIn("bench level: 5", description)
         self.assertIn("cache_results: True", description)
-        self.assertIn("cache_samples True", description)
+        self.assertIn("cache_samples: True", description)
 
 
 class TestBackwardCompatibility(unittest.TestCase):

--- a/test/test_bench_cfg.py
+++ b/test/test_bench_cfg.py
@@ -77,6 +77,18 @@ class TestBenchRunCfgComposition(unittest.TestCase):
         _ = cfg.time.over_time
         _ = cfg.server.port
 
+    def test_flat_attribute_access_raises(self):
+        """Flat attribute access is no longer supported and raises AttributeError."""
+        cfg = BenchRunCfg()
+        with self.assertRaises(AttributeError):
+            _ = cfg.cache_results
+        with self.assertRaises(AttributeError):
+            _ = cfg.repeats
+        with self.assertRaises(AttributeError):
+            _ = cfg.auto_plot
+        with self.assertRaises(AttributeError):
+            _ = cfg.over_time
+
     def test_sub_config_init(self):
         """Sub-config parameters can be set via constructor."""
         cfg = BenchRunCfg(

--- a/test/test_bench_examples.py
+++ b/test/test_bench_examples.py
@@ -55,9 +55,9 @@ class TestBenchExamples(unittest.TestCase):
     def create_run_cfg(self) -> bch.BenchRunCfg:
         cfg = bch.BenchRunCfg()
         if not self.generate_all:
-            cfg.repeats = 2  # low number of repeats to reduce test time, but also test averaging and variance code
-            cfg.level = 2  # reduce size of param sweep so tests are faster
-        cfg.clear_cache = True
+            cfg.execution.repeats = 2  # low number of repeats to reduce test time, but also test averaging and variance code
+            cfg.execution.level = 2  # reduce size of param sweep so tests are faster
+        cfg.cache.clear_cache = True
         return cfg
 
     def examples_asserts(self, example_result, save=False) -> None:

--- a/test/test_bench_runner.py
+++ b/test/test_bench_runner.py
@@ -9,9 +9,9 @@ class TestBenchRunner(unittest.TestCase):
     # Tests that bch.BenchRunner can be created with default configuration and the import statement in the bch.BenchRunner class is fixed
     def test_benchrunner_default_configuration_fixed(self):
         bench_runner = bch.BenchRunner("bench_runner_test")
-        self.assertEqual(bench_runner.run_cfg.cache_samples, True)
-        self.assertEqual(bench_runner.run_cfg.only_hash_tag, True)
-        self.assertEqual(bench_runner.run_cfg.level, 2)
+        self.assertEqual(bench_runner.run_cfg.cache.cache_samples, True)
+        self.assertEqual(bench_runner.run_cfg.cache.only_hash_tag, True)
+        self.assertEqual(bench_runner.run_cfg.execution.level, 2)
         self.assertEqual(bench_runner.publisher, None)
         self.assertEqual(bench_runner.bench_fns, [])
 
@@ -36,7 +36,7 @@ class TestBenchRunner(unittest.TestCase):
         bench_runner.add_bench(SimpleBenchClass())
         results = bench_runner.run(run_cfg=bch.BenchRunCfg(run_tag="1"))
 
-        self.assertEqual(results[0].bench_cfg.run_tag, "1")
+        self.assertEqual(results[0].bench_cfg.time.run_tag, "1")
 
     def test_benchrunner_cache(self):
         from datetime import datetime
@@ -62,27 +62,27 @@ class TestBenchRunner(unittest.TestCase):
         self.assertEqual(results[0].sample_cache.worker_wrapper_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_fn_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_cache_call_count, 0)
-        self.assertEqual(results[0].run_cfg.run_tag, run_tag)
+        self.assertEqual(results[0].run_cfg.time.run_tag, run_tag)
 
         # run again with the same tag, should hit cache because it was already run
         results = bench_runner.run()
         self.assertEqual(results[0].sample_cache.worker_wrapper_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_fn_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_cache_call_count, 0)
-        self.assertEqual(results[0].run_cfg.run_tag, run_tag)
+        self.assertEqual(results[0].run_cfg.time.run_tag, run_tag)
 
         # run with the same tag but set use cache to false, should not hit cache because even tho the tag is the same, cache_results=false
         results = bench_runner.run(cache_results=False)
         self.assertEqual(results[0].sample_cache.worker_wrapper_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_fn_call_count, 2)
         self.assertEqual(results[0].sample_cache.worker_cache_call_count, 0)
-        self.assertEqual(results[0].run_cfg.run_tag, run_tag)
+        self.assertEqual(results[0].run_cfg.time.run_tag, run_tag)
 
     def test_benchrunner_benchable_class_run_constructor(self):
         bench_runner = bch.BenchRunner("bench_runner_test", run_cfg=bch.BenchRunCfg(run_tag="1"))
         bench_runner.add_bench(SimpleBenchClass())
         results = bench_runner.run()
-        self.assertEqual(results[0].bench_cfg.run_tag, "1")
+        self.assertEqual(results[0].bench_cfg.time.run_tag, "1")
 
     # def test_benchrunner_level_1(self):
     #     results = bch.BenchRunner("bench_runner_test", AllSweepVars()).run(min_level=1)
@@ -109,7 +109,7 @@ class TestBenchRunner(unittest.TestCase):
         executed_configs = []
 
         def simple_benchmark(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) -> bch.BenchCfg:
-            executed_configs.append((run_cfg.level, run_cfg.repeats))
+            executed_configs.append((run_cfg.execution.level, run_cfg.execution.repeats))
             bench = bch.Bench("test", SimpleBenchClassFloat(), run_cfg=run_cfg, report=report)
             return bench.plot_sweep("test")
 

--- a/test/test_plot_server.py
+++ b/test/test_plot_server.py
@@ -21,7 +21,7 @@ class TestBenchPlotServer(unittest.TestCase):
 
         bps = bch.BenchPlotServer()
 
-        server_cfg = bch.BenchRunCfg()
+        server_cfg = bch.BenchPlotSrvCfg()
         server_cfg.show = False
 
         server = bps.plot_server(bench.bench_name, server_cfg)
@@ -48,7 +48,7 @@ class TestBenchPlotServer(unittest.TestCase):
 
     def test_plot_server_port(self):
         bps = bch.BenchPlotServer()
-        server_cfg = bch.BenchRunCfg()
+        server_cfg = bch.BenchPlotSrvCfg()
         server_cfg.port = 34343
         server_cfg.show = False
         srv = bps.plot_server("test_bench_server", server_cfg)

--- a/test/test_sample_cache.py
+++ b/test/test_sample_cache.py
@@ -26,12 +26,14 @@ class TestSampleCache(unittest.TestCase):
 
     def sample_cache(self):
         run_cfg = bch.BenchRunCfg()
-        run_cfg.repeats = 1
-        run_cfg.executor = bch.Executors.SERIAL  # THE ASSERTS WILL ONLY WORK IF RUN SERIALLY!!!
+        run_cfg.execution.repeats = 1
+        run_cfg.execution.executor = (
+            bch.Executors.SERIAL
+        )  # THE ASSERTS WILL ONLY WORK IF RUN SERIALLY!!!
 
-        run_cfg.cache_samples = True  # this will store the result of every call
-        run_cfg.only_hash_tag = True
-        run_cfg.auto_plot = False
+        run_cfg.cache.cache_samples = True  # this will store the result of every call
+        run_cfg.cache.only_hash_tag = True
+        run_cfg.visualization.auto_plot = False
 
         instance = UnreliableClass()
         instance.trigger_crash = True
@@ -66,7 +68,7 @@ class TestSampleCache(unittest.TestCase):
         self.assertEqual(bencher.sample_cache.worker_cache_call_count, 2)
 
         # now increase the number of repeats to 2.  This will use the previously calculated values for repeat 1 and only calculate the new values for repeat=2
-        run_cfg.repeats = 2
+        run_cfg.execution.repeats = 2
         bencher.clear_call_counts()
         self.call_bencher(bencher, run_cfg)
 
@@ -78,7 +80,7 @@ class TestSampleCache(unittest.TestCase):
         self.assertEqual(bencher.sample_cache.worker_cache_call_count, 4)
 
         # create a new benchmark and clear the cache (for this new benchmark only)
-        run_cfg.clear_sample_cache = True
+        run_cfg.cache.clear_sample_cache = True
         bencher.clear_call_counts()
         bencher.plot_sweep(
             title="new benchmark", result_vars=[UnreliableClass.param.return_value], run_cfg=run_cfg
@@ -93,7 +95,7 @@ class TestSampleCache(unittest.TestCase):
 
         # check that the previous benchmark still has the cached values, and that they were not removed by clearing the sample cache of an unrelated benchmark
 
-        run_cfg.clear_sample_cache = False
+        run_cfg.cache.clear_sample_cache = False
         bencher.clear_call_counts()
         self.call_bencher(bencher, run_cfg)
 

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -133,7 +133,7 @@ def test_singleton_report_save_and_pickling():
     # Run and save report; also exercises diskcache pickling of results
     br.run(level=1, repeats=1, cache_results=False, save=True)
 
-    expected_filename = f"MySingletonSweep_benchable_singleton_fn_{run_cfg.run_tag}.html"
+    expected_filename = f"MySingletonSweep_benchable_singleton_fn_{run_cfg.time.run_tag}.html"
     expected_path = Path("reports") / expected_filename
     assert expected_path.exists(), f"Report not saved at {expected_path}"
     # Cleanup saved report to avoid polluting workspace

--- a/test/test_sweep_executor.py
+++ b/test/test_sweep_executor.py
@@ -90,8 +90,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_init_sample_cache(self):
         """Test FutureCache initialization with config."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = True
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = True
+        run_cfg.execution.executor = Executors.SERIAL
 
         cache = self.executor.init_sample_cache(run_cfg)
 
@@ -101,8 +101,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_init_sample_cache_with_caching_disabled(self):
         """Test FutureCache when cache_samples=False."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = False
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = False
+        run_cfg.execution.executor = Executors.SERIAL
 
         cache = self.executor.init_sample_cache(run_cfg)
 
@@ -113,8 +113,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_clear_call_counts(self):
         """Test clearing call counts."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = True
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = True
+        run_cfg.execution.executor = Executors.SERIAL
 
         self.executor.init_sample_cache(run_cfg)
         self.executor.sample_cache.worker_wrapper_call_count = 5
@@ -131,8 +131,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_close_cache(self):
         """Test closing the cache."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = True
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = True
+        run_cfg.execution.executor = Executors.SERIAL
 
         self.executor.init_sample_cache(run_cfg)
         self.executor.close_cache()
@@ -150,8 +150,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_get_cache_stats_with_cache(self):
         """Test getting stats when cache is present."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = True
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = True
+        run_cfg.execution.executor = Executors.SERIAL
 
         self.executor.init_sample_cache(run_cfg)
         result = self.executor.get_cache_stats()
@@ -162,7 +162,7 @@ class TestSweepExecutor(unittest.TestCase):
     def test_convert_vars_to_params_with_max_level(self):
         """Test max_level handling when run_cfg.level is set."""
         run_cfg = BenchRunCfg()
-        run_cfg.level = 2
+        run_cfg.execution.level = 2
 
         result = self.executor.convert_vars_to_params(
             {"name": "theta", "max_level": 3},
@@ -181,8 +181,8 @@ class TestSweepExecutor(unittest.TestCase):
         self.assertIsNone(self.executor.sample_cache)
 
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = True
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = True
+        run_cfg.execution.executor = Executors.SERIAL
 
         # This should initialize the cache lazily
         self.executor.clear_tag_from_sample_cache("test_tag", run_cfg)
@@ -198,8 +198,8 @@ class TestSweepExecutor(unittest.TestCase):
     def test_init_sample_cache_configs(self, cache_samples):
         """Property: cache initializes correctly with various configs."""
         run_cfg = BenchRunCfg()
-        run_cfg.cache_samples = cache_samples
-        run_cfg.executor = Executors.SERIAL
+        run_cfg.cache.cache_samples = cache_samples
+        run_cfg.execution.executor = Executors.SERIAL
 
         cache = self.executor.init_sample_cache(run_cfg)
 


### PR DESCRIPTION
This commit completes the config migration started in PR #688 by fully converting
to the new grouped config structure and removing backwards compatibility infrastructure.

Key changes:
- Converted all flat parameter accesses (e.g., cfg.cache_results) to grouped structure (e.g., cfg.cache.cache_results)
- Removed __getattr__ and __setattr__ delegation methods from BenchRunCfg
- Removed _build_delegation_map and _DELEGATION_MAP
- Simplified BenchRunCfg.__init__ by removing legacy flat parameter routing
- Updated all core files: bencher.py, bench_runner.py, sweep_executor.py, result_collector.py
- Updated result and plotting files: bench_result_base.py, optuna_result.py, surface_result.py, plt_cnt_cfg.py
- Updated bench_cfg_class.py to use grouped access in hash_persistent() and describe_benchmark()
- Updated from_cmd_line() to create sub-config objects
- Updated documentation to reflect new structure
- Updated tests to use new config structure

All config parameters now accessed via sub-configs:
- cfg.cache.cache_results, cfg.cache.cache_samples, cfg.cache.only_plot
- cfg.execution.repeats, cfg.execution.level, cfg.execution.executor
- cfg.display.print_bench_inputs, cfg.display.print_pandas
- cfg.visualization.auto_plot, cfg.visualization.plot_size
- cfg.time.over_time, cfg.time.run_tag, cfg.time.run_date
- cfg.server.port, cfg.server.show

This simplifies the codebase by removing the complexity of maintaining dual access patterns.

## Summary by Sourcery

Complete the migration to grouped configuration objects by removing legacy flat access patterns and delegation from benchmark run configuration.

Enhancements:
- Simplify BenchRunCfg initialization to only accept and manage sub-config objects for cache, execution, display, visualization, time, and server settings.
- Update benchmark execution, result handling, plotting, and runner logic to reference configuration values exclusively through their respective sub-configs.
- Adjust BenchCfg metadata description and persistent hashing to rely on grouped execution, cache, and time configuration fields.

Tests:
- Rewrite configuration tests to validate only grouped sub-config access, constructor behavior, deep-copy semantics, and inheritance of sub-config-based configuration.