### PR TITLE
Fix ty dependency categorization and update to v0.0.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,10 @@ updates:
           - "ruff"
           - "coverage"
           - "ty"
+          - "nbformat"
+          - "ipykernel"
+          - "pip"
+          - "jupyter_bokeh"
       lib-dependencies:
         #try to group all third party library updates into a single pr
         patterns:
@@ -35,6 +39,12 @@ updates:
           - "ruff"
           - "coverage"
           - "ty"
+          - "nbformat"
+          - "ipykernel"
+          - "pip"
+          - "jupyter_bokeh"
+          - "prek"
+          - "check-manifest"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
           - "hypothesis"
           - "ruff"
           - "coverage"
+          - "ty"
       lib-dependencies:
         #try to group all third party library updates into a single pr
         patterns:
@@ -29,10 +30,11 @@ updates:
           - "pre-commit"
           - "pylint"
           - "pytest"
-          - "pytest-cov"          
+          - "pytest-cov"
           - "hypothesis"
           - "ruff"
           - "coverage"
+          - "ty"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ test = [
     "pip",
     "jupyter_bokeh",
     "prek>=0.2.28,<0.4.0",
-    "ty>=0.0.12,<=0.0.13",
+    "ty>=0.0.13,<=0.0.13",
 ]
 
 #adds support for embedding rerun windows (alpha)


### PR DESCRIPTION
## Summary
- Update ty from v0.0.12 to v0.0.13 (latest version)
- Fix Dependabot configuration to properly categorize ty as a dev dependency
- Prevent future PRs from incorrectly grouping ty with library dependencies

## Problem
Dependabot was creating PRs (like #707) that incorrectly categorized `ty` as a library dependency in the "lib-dependencies" group, even though it's a development tool (type checker).

## Solution
1. Updated ty to the latest version (0.0.13)
2. Added ty to the dev-dependencies patterns in `.github/dependabot.yml`
3. Added ty to the exclude-patterns for lib-dependencies to ensure proper categorization

## Test plan
- [x] Updated ty version in pyproject.toml
- [x] Modified Dependabot configuration
- [ ] Future Dependabot PRs should group ty with dev dependencies, not library dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Update ty tooling dependency version and adjust Dependabot grouping configuration.

Enhancements:
- Bump ty development dependency from 0.0.12 to 0.0.13 in pyproject configuration.

Build:
- Update Dependabot configuration to include ty in the dev-dependencies and lib-dependencies groups for Python package updates.