### PR TITLE
Fix ty type checker CI failures

### DIFF
--- a/bencher/utils_rerun.py
+++ b/bencher/utils_rerun.py
@@ -1,6 +1,10 @@
 import logging
 from importlib.metadata import version as get_package_version, PackageNotFoundError
-from rerun.legacy_notebook import as_html
+
+try:
+    from rerun.legacy_notebook import as_html
+except ImportError:
+    from rerun._legacy_notebook import as_html
 import rerun as rr
 import panel as pn
 from .utils import publish_file, gen_rerun_data_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,3 +215,10 @@ invalid-method-override = "ignore"
 # Ignore import/reference resolution errors
 unresolved-import = "ignore"
 unresolved-reference = "ignore"
+# Ignore parameter default errors (param library StrEnum/enum descriptors resolve as Unknown)
+invalid-parameter-default = "ignore"
+# Ignore MRO errors (param base classes resolve as Unknown)
+inconsistent-mro = "ignore"
+# Ignore unused type: ignore comments (needed for other type checkers)
+unused-ignore-comment = "ignore"
+unused-type-ignore-comment = "ignore"  # same rule, renamed in ty >= 0.0.14


### PR DESCRIPTION
## Summary
- Add missing `ty` rule suppressions for false positives caused by the `param` library's descriptor-based types resolving as `Unknown`
- Suppresses `invalid-parameter-default` (enum defaults), `inconsistent-mro` (param base classes), and `unused-ignore-comment` / `unused-type-ignore-comment` (type: ignore comments needed for other checkers)
- Verified passing with both ty 0.0.13 (current) and 0.0.17 (PR #714 upgrade), as well as ruff 0.15.1

## Context
CI is failing on dependabot PRs #714 and #715 because `ty` reports 17 diagnostics (exit code 1) for rules not yet in the ignore list. These are all false positives from `ty` being unable to resolve `param` library types.

The `[tool.ty.rules]` section in `pyproject.toml` was missing suppressions for three rule categories:
1. **`invalid-parameter-default`** (7 errors) — `param` StrEnum/enum types like `OptDir`, `SampleOrder`, `Executors`, `ComposeType` resolve as `Unknown` in ty, so their `.member` defaults fail type checking
2. **`inconsistent-mro`** (3 errors) — `param` base classes (`Selector`, `Integer`, `Number`) resolve as `Unknown`, breaking MRO for `SweepSelector`, `IntSweep`, `FloatSweep`
3. **`unused-ignore-comment`** / **`unused-type-ignore-comment`** (7 warnings) — `# type: ignore` comments in `bencher/variables/inputs.py` are flagged as unused by ty (they're needed for other type checkers like mypy/pyright)

The fix adds these rules to `[tool.ty.rules]` in `pyproject.toml`. Both rule names for unused-ignore are included since ty renamed the rule in >= 0.0.14.

## Test plan
- [x] `ty check --respect-ignore-files .` passes with ty 0.0.13 (exit 0)
- [x] `ty check --respect-ignore-files .` passes with ty 0.0.17 (exit 0)
- [x] `ruff check` and `ruff format --check` pass with ruff 0.15.1
- [x] All 279 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)