### PR TITLE
Reduce generated example boilerplate

### DIFF
--- a/bencher/example/generated/0_float/no_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/no_repeats/ex_0_float_0_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_0_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_0_float_0_cat(run_cfg=None):
     """0 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=[],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=[], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/0_float/no_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/no_repeats/ex_0_float_1_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_0_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_0_float_1_cat(run_cfg=None):
     """0 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["wave"],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=["wave"], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/0_float/no_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/no_repeats/ex_0_float_2_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_0_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_0_float_2_cat(run_cfg=None):
     """0 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["wave", "variant"],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=["wave", "variant"], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/0_float/no_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/no_repeats/ex_0_float_3_cat.py
@@ -4,15 +4,11 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_0_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_0_float_3_cat(run_cfg=None):
     """0 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["wave", "variant", "transform"],
-        result_vars=["distance", "sample_noise"],
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["wave", "variant", "transform"], result_vars=["distance", "sample_noise"]
     )
 
     return bench

--- a/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_0_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_0_float_0_cat(run_cfg=None):
     """0 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_0_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_0_float_1_cat(run_cfg=None):
     """0 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_0_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_0_float_2_cat(run_cfg=None):
     """0 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_0_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_0_float_3_cat(run_cfg=None):
     """0 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
@@ -4,21 +4,15 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_0_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_0_float_0_cat(run_cfg=None):
     """0 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=[],
-        result_vars=["distance", "sample_noise"],
-        const_vars=dict(noise_scale=0.15),
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[], result_vars=["distance", "sample_noise"], const_vars=dict(noise_scale=0.15)
     )
 
     return bench
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_0_float_0_cat, level=4)
+    bch.run(example_with_repeats_0_float_0_cat, level=4, repeats=10)

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_0_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_0_float_1_cat(run_cfg=None):
     """0 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["wave"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_0_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_0_float_1_cat, level=4)
+    bch.run(example_with_repeats_0_float_1_cat, level=4, repeats=10)

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_0_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_0_float_2_cat(run_cfg=None):
     """0 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["wave", "variant"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_0_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_0_float_2_cat, level=4)
+    bch.run(example_with_repeats_0_float_2_cat, level=4, repeats=10)

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_0_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_0_float_3_cat(run_cfg=None):
     """0 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["wave", "variant", "transform"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_0_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_0_float_3_cat, level=4)
+    bch.run(example_with_repeats_0_float_3_cat, level=4, repeats=10)

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_0_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_1_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_1_float_0_cat(run_cfg=None):
     """1 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1"],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=["float1"], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_1_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_1_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_1_float_1_cat(run_cfg=None):
     """1 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1", "wave"],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=["float1", "wave"], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_2_cat.py
@@ -4,15 +4,11 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_1_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_1_float_2_cat(run_cfg=None):
     """1 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1", "wave", "variant"],
-        result_vars=["distance", "sample_noise"],
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["float1", "wave", "variant"], result_vars=["distance", "sample_noise"]
     )
 
     return bench

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_3_cat.py
@@ -4,13 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_1_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_1_float_3_cat(run_cfg=None):
     """1 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "wave", "variant", "transform"],
         result_vars=["distance", "sample_noise"],
     )

--- a/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_1_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_1_float_0_cat(run_cfg=None):
     """1 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_1_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_1_float_1_cat(run_cfg=None):
     """1 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_1_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_1_float_2_cat(run_cfg=None):
     """1 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_1_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_1_float_3_cat(run_cfg=None):
     """1 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_1_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_1_float_0_cat(run_cfg=None):
     """1 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_1_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_1_float_0_cat, level=4)
+    bch.run(example_with_repeats_1_float_0_cat, level=4, repeats=10)

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_1_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_1_float_1_cat(run_cfg=None):
     """1 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "wave"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_1_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_1_float_1_cat, level=4)
+    bch.run(example_with_repeats_1_float_1_cat, level=4, repeats=10)

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_1_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_1_float_2_cat(run_cfg=None):
     """1 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "wave", "variant"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_1_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_1_float_2_cat, level=4)
+    bch.run(example_with_repeats_1_float_2_cat, level=4, repeats=10)

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_1_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_1_float_3_cat(run_cfg=None):
     """1 Float, 3 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "wave", "variant", "transform"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_1_float_3_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_1_float_3_cat, level=4)
+    bch.run(example_with_repeats_1_float_3_cat, level=4, repeats=10)

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_0_cat.py
@@ -4,16 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_2_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_2_float_0_cat(run_cfg=None):
     """2 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1", "float2"],
-        result_vars=["distance", "sample_noise"],
-    )
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=["float1", "float2"], result_vars=["distance", "sample_noise"])
 
     return bench
 

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_1_cat.py
@@ -4,15 +4,11 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_2_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_2_float_1_cat(run_cfg=None):
     """2 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1", "float2", "wave"],
-        result_vars=["distance", "sample_noise"],
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["float1", "float2", "wave"], result_vars=["distance", "sample_noise"]
     )
 
     return bench

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_2_cat.py
@@ -4,15 +4,11 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_2_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_2_float_2_cat(run_cfg=None):
     """2 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
-        input_vars=["float1", "float2", "wave", "variant"],
-        result_vars=["distance", "sample_noise"],
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["float1", "float2", "wave", "variant"], result_vars=["distance", "sample_noise"]
     )
 
     return bench

--- a/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_2_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_2_float_0_cat(run_cfg=None):
     """2 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_2_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_2_float_1_cat(run_cfg=None):
     """2 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_2_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_2_float_2_cat(run_cfg=None):
     """2 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_2_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_2_float_0_cat(run_cfg=None):
     """2 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "float2"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_2_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_2_float_0_cat, level=4)
+    bch.run(example_with_repeats_2_float_0_cat, level=4, repeats=3)

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_2_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_2_float_1_cat(run_cfg=None):
     """2 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "float2", "wave"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_2_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_2_float_1_cat, level=4)
+    bch.run(example_with_repeats_2_float_1_cat, level=4, repeats=3)

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_2_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_2_float_2_cat(run_cfg=None):
     """2 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=["float1", "float2", "wave", "variant"],
         result_vars=["distance", "sample_noise"],
         const_vars=dict(noise_scale=0.15),
@@ -21,4 +17,4 @@ def example_with_repeats_2_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_2_float_2_cat, level=4)
+    bch.run(example_with_repeats_2_float_2_cat, level=4, repeats=3)

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_0_cat.py
@@ -4,13 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_3_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_3_float_0_cat(run_cfg=None):
     """3 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_1_cat.py
@@ -4,13 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_3_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_3_float_1_cat(run_cfg=None):
     """3 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_2_cat.py
@@ -4,13 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_no_repeats_3_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_no_repeats_3_float_2_cat(run_cfg=None):
     """3 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",

--- a/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_3_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_3_float_0_cat(run_cfg=None):
     """3 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_3_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_3_float_1_cat(run_cfg=None):
     """3 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
@@ -5,10 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from datetime import datetime, timedelta
 
 
-def example_over_time_3_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_over_time_3_float_2_cat(run_cfg=None):
     """3 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_3_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_3_float_0_cat(run_cfg=None):
     """3 Float, 0 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",
@@ -25,4 +21,4 @@ def example_with_repeats_3_float_0_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_3_float_0_cat, level=4)
+    bch.run(example_with_repeats_3_float_0_cat, level=4, repeats=3)

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_3_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_3_float_1_cat(run_cfg=None):
     """3 Float, 1 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",
@@ -26,4 +22,4 @@ def example_with_repeats_3_float_1_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_3_float_1_cat, level=4)
+    bch.run(example_with_repeats_3_float_1_cat, level=4, repeats=3)

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
@@ -4,14 +4,10 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_with_repeats_3_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_with_repeats_3_float_2_cat(run_cfg=None):
     """3 Float, 2 Categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench = BenchableObject().to_bench(run_cfg)
+    bench.plot_sweep(
         input_vars=[
             "float1",
             "float2",
@@ -27,4 +23,4 @@ def example_with_repeats_3_float_2_cat(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_with_repeats_3_float_2_cat, level=4)
+    bch.run(example_with_repeats_3_float_2_cat, level=4, repeats=3)

--- a/bencher/example/generated/const_vars/const_vars_0.py
+++ b/bencher/example/generated/const_vars/const_vars_0.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_const_vars_0(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_const_vars_0(run_cfg=None):
     """Constant Variables: 0 fixed parameter(s)."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["float1", "float2", "float3"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/const_vars/const_vars_1.py
+++ b/bencher/example/generated/const_vars/const_vars_1.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_const_vars_1(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_const_vars_1(run_cfg=None):
     """Constant Variables: 1 fixed parameter(s)."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["float1", "float2"], result_vars=["distance"], const_vars=dict(float3=0.5)
     )

--- a/bencher/example/generated/const_vars/const_vars_2.py
+++ b/bencher/example/generated/const_vars/const_vars_2.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_const_vars_2(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_const_vars_2(run_cfg=None):
     """Constant Variables: 2 fixed parameter(s)."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["float1"], result_vars=["distance"], const_vars=dict(float2=0.5, float3=0.5)
     )

--- a/bencher/example/generated/optimization/optim_1obj_1d.py
+++ b/bencher/example/generated/optimization/optim_1obj_1d.py
@@ -4,14 +4,11 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableMultiObjective
 
 
-def example_optim_1obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_optim_1obj_1d(run_cfg=None):
     """Optimization: 1 objective(s), 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
-    benchable = BenchableMultiObjective()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableMultiObjective().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["x"], result_vars=["performance"], const_vars=dict(noise_scale=0.1)
     )
@@ -21,4 +18,4 @@ def example_optim_1obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_1obj_1d, level=3)
+    bch.run(example_optim_1obj_1d, level=3, repeats=3)

--- a/bencher/example/generated/optimization/optim_1obj_2d.py
+++ b/bencher/example/generated/optimization/optim_1obj_2d.py
@@ -4,14 +4,11 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableMultiObjective
 
 
-def example_optim_1obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_optim_1obj_2d(run_cfg=None):
     """Optimization: 1 objective(s), 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
-    benchable = BenchableMultiObjective()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableMultiObjective().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["x", "y"], result_vars=["performance"], const_vars=dict(noise_scale=0.1)
     )
@@ -21,4 +18,4 @@ def example_optim_1obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_1obj_2d, level=2)
+    bch.run(example_optim_1obj_2d, level=2, repeats=3)

--- a/bencher/example/generated/optimization/optim_2obj_1d.py
+++ b/bencher/example/generated/optimization/optim_2obj_1d.py
@@ -4,14 +4,11 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableMultiObjective
 
 
-def example_optim_2obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_optim_2obj_1d(run_cfg=None):
     """Optimization: 2 objective(s), 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
-    benchable = BenchableMultiObjective()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableMultiObjective().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["x"], result_vars=["performance", "cost"], const_vars=dict(noise_scale=0.1)
     )
@@ -21,4 +18,4 @@ def example_optim_2obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_2obj_1d, level=3)
+    bch.run(example_optim_2obj_1d, level=3, repeats=3)

--- a/bencher/example/generated/optimization/optim_2obj_2d.py
+++ b/bencher/example/generated/optimization/optim_2obj_2d.py
@@ -4,14 +4,11 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableMultiObjective
 
 
-def example_optim_2obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_optim_2obj_2d(run_cfg=None):
     """Optimization: 2 objective(s), 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 3
+    run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
-    benchable = BenchableMultiObjective()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableMultiObjective().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["x", "y"], result_vars=["performance", "cost"], const_vars=dict(noise_scale=0.1)
     )
@@ -21,4 +18,4 @@ def example_optim_2obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_2obj_2d, level=2)
+    bch.run(example_optim_2obj_2d, level=2, repeats=3)

--- a/bencher/example/generated/plot_types/plot_bar.py
+++ b/bencher/example/generated/plot_types/plot_bar.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_bar(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_bar(run_cfg=None):
     """Plot Type: Bar."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(input_vars=["wave"], result_vars=["distance"])
     res.to_bar()
 

--- a/bencher/example/generated/plot_types/plot_box_whisker.py
+++ b/bencher/example/generated/plot_types/plot_box_whisker.py
@@ -5,13 +5,9 @@ from bencher.example.meta.example_meta import BenchableObject
 from bencher.results.holoview_results.distribution_result.box_whisker_result import BoxWhiskerResult
 
 
-def example_plot_box_whisker(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_box_whisker(run_cfg=None):
     """Plot Type: Box Whisker."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["wave"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -21,4 +17,4 @@ def example_plot_box_whisker(run_cfg: bch.BenchRunCfg | None = None) -> bch.Benc
 
 
 if __name__ == "__main__":
-    bch.run(example_plot_box_whisker, level=3)
+    bch.run(example_plot_box_whisker, level=3, repeats=10)

--- a/bencher/example/generated/plot_types/plot_curve.py
+++ b/bencher/example/generated/plot_types/plot_curve.py
@@ -4,13 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_curve(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_curve(run_cfg=None):
     """Plot Type: Curve."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 5
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["float1"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -20,4 +16,4 @@ def example_plot_curve(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_plot_curve, level=3)
+    bch.run(example_plot_curve, level=3, repeats=5)

--- a/bencher/example/generated/plot_types/plot_heatmap.py
+++ b/bencher/example/generated/plot_types/plot_heatmap.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_heatmap(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_heatmap(run_cfg=None):
     """Plot Type: Heatmap."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(input_vars=["float1", "float2"], result_vars=["distance"])
     res.to_heatmap()
 

--- a/bencher/example/generated/plot_types/plot_line.py
+++ b/bencher/example/generated/plot_types/plot_line.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_line(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_line(run_cfg=None):
     """Plot Type: Line."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(input_vars=["float1"], result_vars=["distance"])
     res.to_line()
 

--- a/bencher/example/generated/plot_types/plot_scatter.py
+++ b/bencher/example/generated/plot_types/plot_scatter.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_scatter(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_scatter(run_cfg=None):
     """Plot Type: Scatter."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(input_vars=["wave"], result_vars=["distance"])
     res.to_scatter()
 

--- a/bencher/example/generated/plot_types/plot_scatter_jitter.py
+++ b/bencher/example/generated/plot_types/plot_scatter_jitter.py
@@ -7,13 +7,9 @@ from bencher.results.holoview_results.distribution_result.scatter_jitter_result 
 )
 
 
-def example_plot_scatter_jitter(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_scatter_jitter(run_cfg=None):
     """Plot Type: Scatter Jitter."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 10
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["wave"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -23,4 +19,4 @@ def example_plot_scatter_jitter(run_cfg: bch.BenchRunCfg | None = None) -> bch.B
 
 
 if __name__ == "__main__":
-    bch.run(example_plot_scatter_jitter, level=3)
+    bch.run(example_plot_scatter_jitter, level=3, repeats=10)

--- a/bencher/example/generated/plot_types/plot_surface.py
+++ b/bencher/example/generated/plot_types/plot_surface.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_plot_surface(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_plot_surface(run_cfg=None):
     """Plot Type: Surface."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     res = bench.plot_sweep(input_vars=["float1", "float2"], result_vars=["distance"])
     res.to_surface()
 

--- a/bencher/example/generated/result_types/result_bool/result_bool_0d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_0d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableBoolResult
 
 
-def example_result_bool_0d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_bool_0d(run_cfg=None):
     """Result Bool: 0D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableBoolResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableBoolResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["difficulty"], result_vars=["pass_rate"])
 
     return bench

--- a/bencher/example/generated/result_types/result_bool/result_bool_1d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableBoolResult
 
 
-def example_result_bool_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_bool_1d(run_cfg=None):
     """Result Bool: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableBoolResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableBoolResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["threshold"], result_vars=["pass_rate"])
 
     return bench

--- a/bencher/example/generated/result_types/result_bool/result_bool_2d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_2d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableBoolResult
 
 
-def example_result_bool_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_bool_2d(run_cfg=None):
     """Result Bool: 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableBoolResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableBoolResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["threshold", "difficulty"], result_vars=["pass_rate"])
 
     return bench

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableDataSetResult
 
 
-def example_result_dataset_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_dataset_1d(run_cfg=None):
     """Result Dataset: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableDataSetResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableDataSetResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["value"], result_vars=["result_ds"])
 
     return bench

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableDataSetResult
 
 
-def example_result_dataset_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_dataset_2d(run_cfg=None):
     """Result Dataset: 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableDataSetResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableDataSetResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["value", "scale"], result_vars=["result_ds"])
 
     return bench

--- a/bencher/example/generated/result_types/result_path/result_path_0d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_0d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchablePathResult
 
 
-def example_result_path_0d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_path_0d(run_cfg=None):
     """Result Path: 0D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchablePathResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchablePathResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["content"], result_vars=["file_result"])
 
     return bench

--- a/bencher/example/generated/result_types/result_path/result_path_1d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchablePathResult
 
 
-def example_result_path_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_path_1d(run_cfg=None):
     """Result Path: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchablePathResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchablePathResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["content"], result_vars=["file_result"])
 
     return bench

--- a/bencher/example/generated/result_types/result_string/result_string_0d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_0d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableStringResult
 
 
-def example_result_string_0d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_string_0d(run_cfg=None):
     """Result String: 0D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableStringResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableStringResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["label"], result_vars=["report"])
 
     return bench

--- a/bencher/example/generated/result_types/result_string/result_string_1d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableStringResult
 
 
-def example_result_string_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_string_1d(run_cfg=None):
     """Result String: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableStringResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableStringResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["label", "value"], result_vars=["report"])
 
     return bench

--- a/bencher/example/generated/result_types/result_var/result_var_0d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_0d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_result_var_0d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_var_0d(run_cfg=None):
     """Result Var: 0D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["wave"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/result_types/result_var/result_var_1d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_result_var_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_var_1d(run_cfg=None):
     """Result Var: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["float1"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/result_types/result_var/result_var_2d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_2d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_result_var_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_var_2d(run_cfg=None):
     """Result Var: 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["float1", "float2"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/result_types/result_vec/result_vec_1d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_1d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableVecResult
 
 
-def example_result_vec_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_vec_1d(run_cfg=None):
     """Result Vec: 1D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableVecResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableVecResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["x"], result_vars=["position"])
 
     return bench

--- a/bencher/example/generated/result_types/result_vec/result_vec_2d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_2d.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableVecResult
 
 
-def example_result_vec_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_result_vec_2d(run_cfg=None):
     """Result Vec: 2D input."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableVecResult()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableVecResult().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["x", "y"], result_vars=["position"])
 
     return bench

--- a/bencher/example/generated/sampling/sampling_custom_values.py
+++ b/bencher/example/generated/sampling/sampling_custom_values.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_sampling_custom_values(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_sampling_custom_values(run_cfg=None):
     """Sampling: Custom Values."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=[bch.p("float1", [0.0, 0.1, 0.3, 0.7, 0.9, 1.0])],
         result_vars=["distance"],

--- a/bencher/example/generated/sampling/sampling_int_vs_float.py
+++ b/bencher/example/generated/sampling/sampling_int_vs_float.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.benchable_objects import BenchableIntFloat
 
 
-def example_sampling_int_vs_float(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_sampling_int_vs_float(run_cfg=None):
     """Sampling: Int Vs Float."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableIntFloat()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableIntFloat().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["int_input", "float_input"], result_vars=["output"])
 
     return bench

--- a/bencher/example/generated/sampling/sampling_levels.py
+++ b/bencher/example/generated/sampling/sampling_levels.py
@@ -4,10 +4,8 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchMeta
 
 
-def example_sampling_levels(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_sampling_levels(run_cfg=None):
     """Sampling: Levels."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
     bench = BenchMeta().to_bench(run_cfg)
     bench.plot_sweep(
         title="Level-based sampling resolution",

--- a/bencher/example/generated/sampling/sampling_uniform.py
+++ b/bencher/example/generated/sampling/sampling_uniform.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_sampling_uniform(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_sampling_uniform(run_cfg=None):
     """Sampling: Uniform."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["float1"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/statistics/stats_0d_categorical_repeats_1.py
+++ b/bencher/example/generated/statistics/stats_0d_categorical_repeats_1.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_0d_categorical_repeats_1(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_0d_categorical_repeats_1(run_cfg=None):
     """Statistics: 1 repeat(s), categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["wave"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/statistics/stats_0d_categorical_repeats_20.py
+++ b/bencher/example/generated/statistics/stats_0d_categorical_repeats_20.py
@@ -4,13 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_0d_categorical_repeats_20(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_0d_categorical_repeats_20(run_cfg=None):
     """Statistics: 20 repeat(s), categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 20
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["wave"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -19,4 +15,4 @@ def example_stats_0d_categorical_repeats_20(run_cfg: bch.BenchRunCfg | None = No
 
 
 if __name__ == "__main__":
-    bch.run(example_stats_0d_categorical_repeats_20, level=3)
+    bch.run(example_stats_0d_categorical_repeats_20, level=3, repeats=20)

--- a/bencher/example/generated/statistics/stats_0d_categorical_repeats_5.py
+++ b/bencher/example/generated/statistics/stats_0d_categorical_repeats_5.py
@@ -4,13 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_0d_categorical_repeats_5(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_0d_categorical_repeats_5(run_cfg=None):
     """Statistics: 5 repeat(s), categorical."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 5
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["wave"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -19,4 +15,4 @@ def example_stats_0d_categorical_repeats_5(run_cfg: bch.BenchRunCfg | None = Non
 
 
 if __name__ == "__main__":
-    bch.run(example_stats_0d_categorical_repeats_5, level=3)
+    bch.run(example_stats_0d_categorical_repeats_5, level=3, repeats=5)

--- a/bencher/example/generated/statistics/stats_1d_float_repeats_1.py
+++ b/bencher/example/generated/statistics/stats_1d_float_repeats_1.py
@@ -4,12 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_1d_float_repeats_1(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_1d_float_repeats_1(run_cfg=None):
     """Statistics: 1 repeat(s), 1D float."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(input_vars=["float1"], result_vars=["distance"])
 
     return bench

--- a/bencher/example/generated/statistics/stats_1d_float_repeats_20.py
+++ b/bencher/example/generated/statistics/stats_1d_float_repeats_20.py
@@ -4,13 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_1d_float_repeats_20(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_1d_float_repeats_20(run_cfg=None):
     """Statistics: 20 repeat(s), 1D float."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 20
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["float1"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -19,4 +15,4 @@ def example_stats_1d_float_repeats_20(run_cfg: bch.BenchRunCfg | None = None) ->
 
 
 if __name__ == "__main__":
-    bch.run(example_stats_1d_float_repeats_20, level=3)
+    bch.run(example_stats_1d_float_repeats_20, level=3, repeats=20)

--- a/bencher/example/generated/statistics/stats_1d_float_repeats_5.py
+++ b/bencher/example/generated/statistics/stats_1d_float_repeats_5.py
@@ -4,13 +4,9 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def example_stats_1d_float_repeats_5(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def example_stats_1d_float_repeats_5(run_cfg=None):
     """Statistics: 5 repeat(s), 1D float."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
-    run_cfg.repeats = 5
-    benchable = BenchableObject()
-    bench = benchable.to_bench(run_cfg)
+    bench = BenchableObject().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["float1"], result_vars=["distance"], const_vars=dict(noise_scale=0.15)
     )
@@ -19,4 +15,4 @@ def example_stats_1d_float_repeats_5(run_cfg: bch.BenchRunCfg | None = None) -> 
 
 
 if __name__ == "__main__":
-    bch.run(example_stats_1d_float_repeats_5, level=3)
+    bch.run(example_stats_1d_float_repeats_5, level=3, repeats=5)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -1,5 +1,6 @@
 """Generate Python example files, run them, save HTML reports, and generate RST for docs."""
 
+import ast
 import importlib
 import os
 import shutil
@@ -10,6 +11,25 @@ import bencher as bch
 
 
 GENERATED_DIR = Path("bencher/example/generated")
+
+
+def _extract_run_kwargs(py_file: Path) -> dict:
+    """Extract kwargs from bch.run() call in __main__ block."""
+    source = py_file.read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "run"
+        ):
+            kwargs = {}
+            for kw in node.keywords:
+                kwargs[kw.arg] = ast.literal_eval(kw.value)
+            return kwargs
+    return {}
+
+
 META_DOCS_DIR = Path("docs/reference/meta")
 # Reports go under docs/_extra/ so html_extra_path copies them to match the built output structure
 REPORTS_EXTRA_DIR = Path("docs/_extra/reference/meta")
@@ -83,8 +103,12 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path):
         print(f"WARNING: No example_* function found in {py_file}, skipping")
         return None
 
+    run_kwargs = _extract_run_kwargs(py_file)
     run_cfg = bch.BenchRunCfg()
-    run_cfg.level = 4
+    run_cfg.level = run_kwargs.get("level", 4)
+    run_cfg.repeats = run_kwargs.get("repeats", 1)
+    if "use_optuna" in run_kwargs:
+        run_cfg.use_optuna = run_kwargs["use_optuna"]
     print(f"Running {py_file}...")
     bench = example_fn(run_cfg)
 

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -22,10 +22,15 @@ def _extract_run_kwargs(py_file: Path) -> dict:
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "run"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "bch"
         ):
             kwargs = {}
             for kw in node.keywords:
-                kwargs[kw.arg] = ast.literal_eval(kw.value)
+                try:
+                    kwargs[kw.arg] = ast.literal_eval(kw.value)
+                except (ValueError, TypeError):
+                    continue
             return kwargs
     return {}
 

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -98,16 +98,16 @@ class BenchMetaGen(bch.ParametrizedSweep):
         function_name = f"example_{variant}_{base_title}"
         filename = f"ex_{base_title}"
 
+        gen = MetaGeneratorBase()
+
         if self.sample_over_time:
             noise_val = max(0.1, 0.15 if self.sample_with_repeats > 1 else 0.0)
-            repeat_lines = (
-                f"run_cfg.repeats = {self.sample_with_repeats}\n"
-                if self.sample_with_repeats > 1
-                else ""
-            )
+            run_cfg_lines = ["run_cfg.over_time = True"]
+            if self.sample_with_repeats > 1:
+                run_cfg_lines.append(f"run_cfg.repeats = {self.sample_with_repeats}")
+
             body = (
-                f"{repeat_lines}"
-                f"run_cfg.over_time = True\n"
+                "run_cfg = run_cfg or bch.BenchRunCfg()\n" + "\n".join(run_cfg_lines) + "\n"
                 f"benchable = {obj_class}()\n"
                 f"bench = benchable.to_bench(run_cfg)\n"
                 f"time_offsets = [0.0, 0.5, 1.0]\n"
@@ -125,39 +125,38 @@ class BenchMetaGen(bch.ParametrizedSweep):
                 f"        time_src=_base_time + timedelta(seconds=i),\n"
                 f"    )\n"
             )
-            extra_imports = "\nfrom datetime import datetime, timedelta"
+            imports = f"import bencher as bch\n{benchmark_import}\nfrom datetime import datetime, timedelta"
+            gen.generate_example(
+                title=title,
+                output_dir=f"{self.float_vars_count}_float/{variant}",
+                filename=filename,
+                function_name=function_name,
+                imports=imports,
+                body=body,
+                run_kwargs={"level": 4},
+            )
         else:
-            noise_const = (
-                ", const_vars=dict(noise_scale=0.15)" if self.sample_with_repeats > 1 else ""
-            )
-            lines = []
+            noise_const = "dict(noise_scale=0.15)" if self.sample_with_repeats > 1 else None
+            run_kwargs = {"level": 4}
             if self.sample_with_repeats > 1:
-                lines.append(f"run_cfg.repeats = {self.sample_with_repeats}")
-            lines.append(f"benchable = {obj_class}()")
-            lines.extend(
-                [
-                    "bench = benchable.to_bench(run_cfg)",
-                    "res = bench.plot_sweep(",
-                    f"    input_vars={input_vars},",
-                    f"    result_vars={self.result_var_names}{noise_const},",
-                    ")",
-                ]
+                run_kwargs["repeats"] = self.sample_with_repeats
+
+            gen.generate_sweep_example(
+                title=title,
+                output_dir=f"{self.float_vars_count}_float/{variant}",
+                filename=filename,
+                function_name=function_name,
+                benchable_class=obj_class,
+                benchable_module=(
+                    self.benchable_obj.__class__.__module__
+                    if self.benchable_obj.__class__.__module__ != "__main__"
+                    else "bencher.example.meta.example_meta"
+                ),
+                input_vars=repr(input_vars),
+                result_vars=repr(self.result_var_names),
+                const_vars=noise_const,
+                run_kwargs=run_kwargs,
             )
-            body = "\n".join(lines) + "\n"
-            extra_imports = ""
-
-        imports = f"import bencher as bch\n{benchmark_import}{extra_imports}"
-
-        gen = MetaGeneratorBase()
-        gen.generate_example(
-            title=title,
-            output_dir=f"{self.float_vars_count}_float/{variant}",
-            filename=filename,
-            function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=", level=4",
-        )
 
         return super().__call__()
 

--- a/bencher/example/meta/generate_meta_const_vars.py
+++ b/bencher/example/meta/generate_meta_const_vars.py
@@ -25,33 +25,25 @@ class MetaConstVars(MetaGeneratorBase):
 
         if self.n_const == 0:
             input_vars_code = '["float1", "float2", "float3"]'
-            const_vars_code = ""
+            const_vars = None
         elif self.n_const == 1:
             input_vars_code = '["float1", "float2"]'
-            const_vars_code = ", const_vars=dict(float3=0.5)"
+            const_vars = "dict(float3=0.5)"
         else:
             input_vars_code = '["float1"]'
-            const_vars_code = ", const_vars=dict(float2=0.5, float3=0.5)"
+            const_vars = "dict(float2=0.5, float3=0.5)"
 
-        imports = (
-            "import bencher as bch\nfrom bencher.example.meta.example_meta import BenchableObject"
-        )
-
-        body = (
-            f"benchable = BenchableObject()\n"
-            f"bench = benchable.to_bench(run_cfg)\n"
-            f"bench.plot_sweep(input_vars={input_vars_code}, "
-            f'result_vars=["distance"]{const_vars_code})\n'
-        )
-
-        self.generate_example(
+        self.generate_sweep_example(
             title=title,
             output_dir=OUTPUT_DIR,
             filename=filename,
             function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=", level=3",
+            benchable_class="BenchableObject",
+            benchable_module="bencher.example.meta.example_meta",
+            input_vars=input_vars_code,
+            result_vars='["distance"]',
+            const_vars=const_vars,
+            run_kwargs={"level": 3},
         )
 
         return super().__call__()

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -34,30 +34,20 @@ class MetaOptimization(MetaGeneratorBase):
         else:
             input_vars_code = '["x", "y"]'
 
-        imports = (
-            "import bencher as bch\n"
-            "from bencher.example.meta.benchable_objects import BenchableMultiObjective"
-        )
-
-        body = (
-            f"run_cfg.repeats = 3\n"
-            f"run_cfg.use_optuna = True\n"
-            f"benchable = BenchableMultiObjective()\n"
-            f"bench = benchable.to_bench(run_cfg)\n"
-            f"res = bench.plot_sweep(input_vars={input_vars_code}, "
-            f"result_vars={result_vars_code}, const_vars=dict(noise_scale=0.1))\n"
-            f"res.to_optuna_plots()\n"
-        )
-
         level = 2 if self.input_dims >= 2 else 3
-        self.generate_example(
+        self.generate_sweep_example(
             title=title,
             output_dir=OUTPUT_DIR,
             filename=filename,
             function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=f", level={level}",
+            benchable_class="BenchableMultiObjective",
+            benchable_module="bencher.example.meta.benchable_objects",
+            input_vars=input_vars_code,
+            result_vars=result_vars_code,
+            const_vars="dict(noise_scale=0.1)",
+            post_sweep_line="res.to_optuna_plots()",
+            run_cfg_lines=["run_cfg.use_optuna = True"],
+            run_kwargs={"level": level, "repeats": 3},
         )
 
         return super().__call__()

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -93,40 +93,27 @@ class MetaPlotTypes(MetaGeneratorBase):
         function_name = f"example_plot_{self.plot_type}"
         title = f"Plot Type: {self.plot_type.replace('_', ' ').title()}"
 
-        import_lines = [
-            "import bencher as bch",
-            "from bencher.example.meta.example_meta import BenchableObject",
-        ]
-        if cfg.get("extra_import"):
-            import_lines.append(cfg["extra_import"])
-        imports = "\n".join(import_lines)
-
-        noise_const = ", const_vars=dict(noise_scale=0.15)" if cfg["repeats"] > 1 else ""
-        body_lines = []
-        if cfg["repeats"] > 1:
-            body_lines.append(f"run_cfg.repeats = {cfg['repeats']}")
-        body_lines.extend(
-            [
-                "benchable = BenchableObject()",
-                "bench = benchable.to_bench(run_cfg)",
-                (
-                    f"res = bench.plot_sweep(input_vars={cfg['input_vars']},"
-                    f' result_vars=["distance"]{noise_const})'
-                ),
-                cfg["plot_call"],
-            ]
-        )
-        body = "\n".join(body_lines) + "\n"
+        const_vars = "dict(noise_scale=0.15)" if cfg["repeats"] > 1 else None
+        extra_imports = [cfg["extra_import"]] if cfg.get("extra_import") else None
 
         level = 2 if cfg["float_dims"] >= 2 else 3
-        self.generate_example(
+        run_kwargs = {"level": level}
+        if cfg["repeats"] > 1:
+            run_kwargs["repeats"] = cfg["repeats"]
+
+        self.generate_sweep_example(
             title=title,
             output_dir=OUTPUT_DIR,
             filename=filename,
             function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=f", level={level}",
+            benchable_class="BenchableObject",
+            benchable_module="bencher.example.meta.example_meta",
+            input_vars=cfg["input_vars"],
+            result_vars='["distance"]',
+            const_vars=const_vars,
+            post_sweep_line=cfg["plot_call"],
+            extra_imports=extra_imports,
+            run_kwargs=run_kwargs,
         )
 
         return super().__call__()

--- a/bencher/example/meta/generate_meta_result_types.py
+++ b/bencher/example/meta/generate_meta_result_types.py
@@ -91,24 +91,17 @@ class MetaResultTypes(MetaGeneratorBase):
         function_name = f"example_{self.result_type}_{self.input_dims}d"
         title = f"{self.result_type.replace('_', ' ').title()}: {self.input_dims}D input"
 
-        imports = f"import bencher as bch\nfrom {info['module']} import {info['class']}"
-
-        body = (
-            f"benchable = {info['class']}()\n"
-            f"bench = benchable.to_bench(run_cfg)\n"
-            f"bench.plot_sweep(input_vars={input_vars_code}, "
-            f"result_vars={info['result_vars']})\n"
-        )
-
         level = 2 if self.input_dims >= 2 else 3
-        self.generate_example(
+        self.generate_sweep_example(
             title=title,
             output_dir=sub_dir,
             filename=filename,
             function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=f", level={level}",
+            benchable_class=info["class"],
+            benchable_module=info["module"],
+            input_vars=input_vars_code,
+            result_vars=info["result_vars"],
+            run_kwargs={"level": level},
         )
 
         return super().__call__()

--- a/bencher/example/meta/generate_meta_sampling.py
+++ b/bencher/example/meta/generate_meta_sampling.py
@@ -25,26 +25,38 @@ class MetaSampling(MetaGeneratorBase):
         function_name = f"example_sampling_{self.strategy}"
         title = f"Sampling: {self.strategy.replace('_', ' ').title()}"
 
-        common_imports = (
-            "import bencher as bch\nfrom bencher.example.meta.example_meta import BenchableObject"
-        )
-
         if self.strategy == "uniform":
-            imports = common_imports
-            body = (
-                "benchable = BenchableObject()\n"
-                "bench = benchable.to_bench(run_cfg)\n"
-                'bench.plot_sweep(input_vars=["float1"], result_vars=["distance"])\n'
+            self.generate_sweep_example(
+                title=title,
+                output_dir=OUTPUT_DIR,
+                filename=filename,
+                function_name=function_name,
+                benchable_class="BenchableObject",
+                benchable_module="bencher.example.meta.example_meta",
+                input_vars='["float1"]',
+                result_vars='["distance"]',
+                run_kwargs={"level": 4},
             )
         elif self.strategy == "custom_values":
-            imports = common_imports
+            imports = (
+                "import bencher as bch\n"
+                "from bencher.example.meta.example_meta import BenchableObject"
+            )
             body = (
-                "benchable = BenchableObject()\n"
-                "bench = benchable.to_bench(run_cfg)\n"
+                "bench = BenchableObject().to_bench(run_cfg)\n"
                 "bench.plot_sweep(\n"
                 '    input_vars=[bch.p("float1", [0.0, 0.1, 0.3, 0.7, 0.9, 1.0])],\n'
                 '    result_vars=["distance"],\n'
                 ")\n"
+            )
+            self.generate_example(
+                title=title,
+                output_dir=OUTPUT_DIR,
+                filename=filename,
+                function_name=function_name,
+                imports=imports,
+                body=body,
+                run_kwargs={"level": 3},
             )
         elif self.strategy == "levels":
             imports = (
@@ -61,28 +73,27 @@ class MetaSampling(MetaGeneratorBase):
                 "    const_vars=dict(categorical_vars=0),\n"
                 ")\n"
             )
+            self.generate_example(
+                title=title,
+                output_dir=OUTPUT_DIR,
+                filename=filename,
+                function_name=function_name,
+                imports=imports,
+                body=body,
+                run_kwargs={"level": 3},
+            )
         else:  # int_vs_float
-            imports = (
-                "import bencher as bch\n"
-                "from bencher.example.meta.benchable_objects import BenchableIntFloat"
+            self.generate_sweep_example(
+                title=title,
+                output_dir=OUTPUT_DIR,
+                filename=filename,
+                function_name=function_name,
+                benchable_class="BenchableIntFloat",
+                benchable_module="bencher.example.meta.benchable_objects",
+                input_vars='["int_input", "float_input"]',
+                result_vars='["output"]',
+                run_kwargs={"level": 3},
             )
-            body = (
-                "benchable = BenchableIntFloat()\n"
-                "bench = benchable.to_bench(run_cfg)\n"
-                'bench.plot_sweep(input_vars=["int_input", "float_input"], '
-                'result_vars=["output"])\n'
-            )
-
-        level = 4 if self.strategy == "uniform" else 3
-        self.generate_example(
-            title=title,
-            output_dir=OUTPUT_DIR,
-            filename=filename,
-            function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=f", level={level}",
-        )
 
         return super().__call__()
 

--- a/bencher/example/meta/generate_meta_statistics.py
+++ b/bencher/example/meta/generate_meta_statistics.py
@@ -17,23 +17,6 @@ class MetaStatistics(MetaGeneratorBase):
     repeats = bch.IntSweep(default=1, bounds=(1, 100), doc="Number of repeats")
     input_dims = bch.IntSweep(default=0, bounds=(0, 1), doc="0 = categorical only, 1 = float sweep")
 
-    def _build_body(self, input_vars_code: str) -> str:
-        noise_const = ", const_vars=dict(noise_scale=0.15)" if self.repeats > 1 else ""
-        lines = []
-        if self.repeats > 1:
-            lines.append(f"run_cfg.repeats = {self.repeats}")
-        lines.extend(
-            [
-                "benchable = BenchableObject()",
-                "bench = benchable.to_bench(run_cfg)",
-                (
-                    f"bench.plot_sweep(input_vars={input_vars_code},"
-                    f' result_vars=["distance"]{noise_const})'
-                ),
-            ]
-        )
-        return "\n".join(lines) + "\n"
-
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
 
@@ -45,25 +28,24 @@ class MetaStatistics(MetaGeneratorBase):
             f"{'categorical' if self.input_dims == 0 else '1D float'}"
         )
 
-        if self.input_dims == 0:
-            input_vars_code = '["wave"]'
-        else:
-            input_vars_code = '["float1"]'
+        input_vars_code = '["wave"]' if self.input_dims == 0 else '["float1"]'
+        const_vars = "dict(noise_scale=0.15)" if self.repeats > 1 else None
 
-        imports = (
-            "import bencher as bch\nfrom bencher.example.meta.example_meta import BenchableObject"
-        )
+        run_kwargs = {"level": 3}
+        if self.repeats > 1:
+            run_kwargs["repeats"] = self.repeats
 
-        body = self._build_body(input_vars_code)
-
-        self.generate_example(
+        self.generate_sweep_example(
             title=title,
             output_dir=OUTPUT_DIR,
             filename=filename,
             function_name=function_name,
-            imports=imports,
-            body=body,
-            main_extra=", level=3",
+            benchable_class="BenchableObject",
+            benchable_module="bencher.example.meta.example_meta",
+            input_vars=input_vars_code,
+            result_vars='["distance"]',
+            const_vars=const_vars,
+            run_kwargs=run_kwargs,
         )
 
         return super().__call__()

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -19,7 +19,7 @@ class MetaGeneratorBase(bch.ParametrizedSweep):
         function_name,
         imports,
         body,
-        main_extra="",
+        run_kwargs=None,
     ):
         """Write a runnable Python example file.
 
@@ -29,29 +29,100 @@ class MetaGeneratorBase(bch.ParametrizedSweep):
             filename: Python file stem (e.g. ``result_var_1d``).
             function_name: Name of the example function (e.g. ``example_result_var_1d``).
             imports: Import lines placed at the top of the file.
-            body: Unindented function body lines (after ``run_cfg`` guard).
-                  Indentation is applied automatically.
-            main_extra: Extra keyword args for the ``bch.run()`` call in ``__main__``
-                        (e.g. ``", level=4"``).
+            body: Unindented function body lines. Indentation is applied automatically.
+            run_kwargs: Dict of keyword args for ``bch.run()`` in ``__main__``
+                        (e.g. ``{"level": 4, "repeats": 10}``).
         """
+        if run_kwargs is None:
+            run_kwargs = {}
         indented_body = textwrap.indent(body, "    ")
+        kwargs_str = "".join(f", {k}={v!r}" for k, v in run_kwargs.items())
         content = f'''"""Auto-generated example: {title}."""
 
 {imports}
 
 
-def {function_name}(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+def {function_name}(run_cfg=None):
     """{title}."""
-    if run_cfg is None:
-        run_cfg = bch.BenchRunCfg()
 {indented_body}
     return bench
 
 
 if __name__ == "__main__":
-    bch.run({function_name}{main_extra})
+    bch.run({function_name}{kwargs_str})
 '''
         fpath = GENERATED_DIR / output_dir / f"{filename}.py"
         fpath.parent.mkdir(parents=True, exist_ok=True)
         fpath.write_text(content, encoding="utf-8")
         return fpath
+
+    def generate_sweep_example(
+        self,
+        *,
+        title,
+        output_dir,
+        filename,
+        function_name,
+        benchable_class,
+        benchable_module,
+        input_vars,
+        result_vars,
+        const_vars=None,
+        post_sweep_line=None,
+        run_cfg_lines=None,
+        extra_imports=None,
+        run_kwargs=None,
+    ):
+        """Build imports + body and call generate_example() for a standard sweep.
+
+        Args:
+            benchable_class: Class name to instantiate (e.g. "BenchableObject").
+            benchable_module: Module to import from (e.g. "bencher.example.meta.example_meta").
+            input_vars: Code string for input_vars (e.g. '["float1"]').
+            result_vars: Code string for result_vars (e.g. '["distance"]').
+            const_vars: Optional code string for const_vars (e.g. 'dict(noise_scale=0.15)').
+            post_sweep_line: Optional line after plot_sweep (e.g. 'res.to_bar()').
+            run_cfg_lines: Optional list of lines like 'run_cfg.use_optuna = True'.
+            extra_imports: Optional list of additional import lines.
+            run_kwargs: Dict of kwargs for bch.run() (e.g. {"level": 4, "repeats": 10}).
+        """
+        import_lines = [
+            "import bencher as bch",
+            f"from {benchable_module} import {benchable_class}",
+        ]
+        if extra_imports:
+            import_lines.extend(extra_imports)
+        imports = "\n".join(import_lines)
+
+        body_lines = []
+        if run_cfg_lines:
+            body_lines.append("run_cfg = run_cfg or bch.BenchRunCfg()")
+            body_lines.extend(run_cfg_lines)
+
+        body_lines.append(f"bench = {benchable_class}().to_bench(run_cfg)")
+
+        # Build plot_sweep call
+        sweep_parts = [f"input_vars={input_vars}"]
+        sweep_parts.append(f"result_vars={result_vars}")
+        if const_vars:
+            sweep_parts.append(f"const_vars={const_vars}")
+        sweep_args = ", ".join(sweep_parts)
+
+        use_res = post_sweep_line is not None
+        prefix = "res = " if use_res else ""
+        body_lines.append(f"{prefix}bench.plot_sweep({sweep_args})")
+
+        if post_sweep_line:
+            body_lines.append(post_sweep_line)
+
+        body = "\n".join(body_lines) + "\n"
+
+        return self.generate_example(
+            title=title,
+            output_dir=output_dir,
+            filename=filename,
+            function_name=function_name,
+            imports=imports,
+            body=body,
+            run_kwargs=run_kwargs or {},
+        )


### PR DESCRIPTION
## Summary

- **Simplify generated example template**: drop type hints, drop `if run_cfg is None` guard, inline `benchable = X(); bench = benchable.to_bench()` → `bench = X().to_bench(run_cfg)`. Generated function bodies go from ~7 lines to ~3 lines.
- **Move `repeats` to `bch.run()` kwargs**: execution settings like `repeats` now live in the `__main__` block (`bch.run(fn, level=4, repeats=10)`) instead of being hardcoded in the function body.
- **Add `generate_sweep_example()` helper** to `MetaGeneratorBase`: builds imports + body from parameters, eliminating manual string building in each meta-generator.
- **Extract run kwargs via AST** in `generate_examples.py`: `run_example_and_save` now parses the `bch.run()` call to configure `run_cfg` (level, repeats, use_optuna) for doc generation.
- **Convert all 7 meta-generators** to use the new helper where applicable, reducing code duplication.

## Test plan

- [x] `pixi run ci` passes — format, lint (pylint 10/10), and all 356 tests pass
- [x] Generated examples regenerated and verified (80+ files)
- [x] Spot-checked output for each example category (no_repeats, with_repeats, over_time, plot_types, optimization, sampling, statistics, const_vars, result_types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify generated example functions and centralize configuration of benchmark run parameters while reducing duplication in meta-generator code.

Enhancements:
- Add a MetaGeneratorBase.generate_sweep_example helper to construct standard sweep example imports and bodies from parameters, and use it across the various meta-generators to reduce repeated string-building logic.
- Simplify the generated example function template by removing type hints and run_cfg guards, and constructing benches via inline Benchable().to_bench(run_cfg) calls.
- Change example generation to pass run-specific settings (e.g., level, repeats, use_optuna) as kwargs to bch.run() in __main__ blocks rather than hardcoding them in function bodies.
- Update all meta-generators (sampling, general meta, plot types, statistics, const vars, optimization, result types) to use the new helper and run-kwargs pattern, streamlining configuration of repeats, levels, const vars, and optional behavior like Optuna plots.
- Adjust example-doc generation to parse bch.run() calls via AST and derive BenchRunCfg settings (level, repeats, use_optuna) dynamically from generated examples.

Tests:
- Regenerate and update all affected auto-generated example files to reflect the simplified function structure and new run-configuration pattern.