### PR TITLE
Optimize gallery page with deferred iframe loading

### DIFF
--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -248,8 +248,8 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
             lines.append(f'   <a class="gallery-card" href="{href}">')
             lines.append('     <div class="gallery-thumb-wrap">')
             lines.append(
-                f'       <iframe class="gallery-thumb" src="{report_src}"'
-                ' loading="lazy" tabindex="-1" scrolling="no"></iframe>'
+                f'       <iframe class="gallery-thumb" data-src="{report_src}"'
+                ' tabindex="-1" scrolling="no"></iframe>'
             )
             lines.append("     </div>")
             lines.append(f'     <div class="gallery-card-title">{ex["title"]}</div>')

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -56,9 +56,14 @@
     height: 600px;
     overflow: hidden;
     position: relative;
-    background: #fafafa;
+    background: #f5f5f5;
     border-bottom: 1px solid #eee;
     transition: height 0.3s ease;
+}
+
+/* Hide iframe until src is set by IntersectionObserver */
+.gallery-thumb[data-src] {
+    visibility: hidden;
 }
 
 .gallery-thumb {

--- a/docs/_static/gallery.js
+++ b/docs/_static/gallery.js
@@ -8,8 +8,6 @@
   var MIN_CONTENT_HEIGHT = 100;
   var MAX_WRAPPER_HEIGHT = 600;
   var MAX_CONCURRENT = 4;
-  var loading = 0;
-  var queue = [];
 
   function applyHeight(iframe, h) {
     if (h > MIN_CONTENT_HEIGHT) {
@@ -43,32 +41,50 @@
     } catch (e) {}
   }
 
-  function loadNext() {
-    while (loading < MAX_CONCURRENT && queue.length) {
-      var iframe = queue.shift();
-      var src = iframe.getAttribute("data-src");
-      if (!src) continue;
-      loading++;
-      iframe.addEventListener("load", function handler() {
-        iframe.removeEventListener("load", handler);
-        loading--;
-        observeIframe(iframe);
-        loadNext();
+  function withConcurrencyLimit(max, worker) {
+    var active = 0;
+    var queue = [];
+
+    function runNext() {
+      if (active >= max || !queue.length) return;
+      active++;
+      var item = queue.shift();
+      worker(item, function done() {
+        active--;
+        runNext();
       });
-      iframe.src = src;
-      iframe.removeAttribute("data-src");
     }
+
+    return function enqueue(item) {
+      queue.push(item);
+      runNext();
+    };
   }
 
-  function enqueueIframe(iframe) {
-    if (!iframe.getAttribute("data-src")) return;
-    queue.push(iframe);
-    loadNext();
-  }
+  var enqueueIframe = withConcurrencyLimit(MAX_CONCURRENT, function (iframe, done) {
+    var src = iframe.getAttribute("data-src");
+    if (!src) {
+      done();
+      return;
+    }
 
-  function setupIntersectionObserver() {
+    iframe.addEventListener("load", function () {
+      observeIframe(iframe);
+      done();
+    }, { once: true });
+
+    iframe.src = src;
+    iframe.removeAttribute("data-src");
+  });
+
+  function setupDeferredLoading() {
     var iframes = document.querySelectorAll(".gallery-thumb[data-src]");
     if (!iframes.length) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      iframes.forEach(enqueueIframe);
+      return;
+    }
 
     var observer = new IntersectionObserver(function (entries) {
       entries.forEach(function (entry) {
@@ -85,8 +101,8 @@
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", setupIntersectionObserver);
+    document.addEventListener("DOMContentLoaded", setupDeferredLoading);
   } else {
-    setupIntersectionObserver();
+    setupDeferredLoading();
   }
 })();

--- a/docs/_static/gallery.js
+++ b/docs/_static/gallery.js
@@ -1,11 +1,15 @@
-/* Auto-crop gallery thumbnails to actual content height.
-   Panel/Bokeh reports set html,body{height:100%} which makes scrollHeight
-   return the iframe's CSS height, not the content height. We override that
-   to auto, then use ResizeObserver to detect when Bokeh finishes rendering. */
+/* Deferred iframe loading with IntersectionObserver + concurrency limiter.
+   Gallery iframes start with data-src instead of src. When an iframe enters
+   the viewport (with 200px margin), its src is set and loading begins.
+   At most MAX_CONCURRENT iframes load simultaneously to avoid browser thrash.
+   Once loaded, ResizeObserver auto-crops each thumbnail to its content height. */
 (function () {
   var SCALE = 0.2;
   var MIN_CONTENT_HEIGHT = 100;
-  var MAX_WRAPPER_HEIGHT = 600; /* never grow beyond the CSS default */
+  var MAX_WRAPPER_HEIGHT = 600;
+  var MAX_CONCURRENT = 4;
+  var loading = 0;
+  var queue = [];
 
   function applyHeight(iframe, h) {
     if (h > MIN_CONTENT_HEIGHT) {
@@ -19,50 +23,70 @@
     try {
       doc.documentElement.style.setProperty("height", "auto", "important");
       doc.body.style.setProperty("height", "auto", "important");
-    } catch (e) { /* cross-origin */ }
+    } catch (e) {}
   }
 
   function observeIframe(iframe) {
     try {
       var doc = iframe.contentDocument || iframe.contentWindow.document;
       if (!doc || !doc.body) return;
-
       fixBodyHeight(doc);
-
-      /* Use ResizeObserver on the body to react to Bokeh rendering */
       if (typeof ResizeObserver !== "undefined") {
         var observer = new ResizeObserver(function () {
           fixBodyHeight(doc);
-          var h = doc.body.scrollHeight;
-          applyHeight(iframe, h);
+          applyHeight(iframe, doc.body.scrollHeight);
         });
         observer.observe(doc.body);
-        /* Also observe documentElement for layout changes */
         observer.observe(doc.documentElement);
       }
+      applyHeight(iframe, doc.body.scrollHeight);
+    } catch (e) {}
+  }
 
-      /* Immediate attempt as well */
-      var h = doc.body.scrollHeight;
-      applyHeight(iframe, h);
-    } catch (e) {
-      console.log("gallery.js: cannot access iframe", e.message);
+  function loadNext() {
+    while (loading < MAX_CONCURRENT && queue.length) {
+      var iframe = queue.shift();
+      var src = iframe.getAttribute("data-src");
+      if (!src) continue;
+      loading++;
+      iframe.addEventListener("load", function handler() {
+        iframe.removeEventListener("load", handler);
+        loading--;
+        observeIframe(iframe);
+        loadNext();
+      });
+      iframe.src = src;
+      iframe.removeAttribute("data-src");
     }
   }
 
-  function attachListeners() {
-    var iframes = document.querySelectorAll(".gallery-thumb");
-    for (var i = 0; i < iframes.length; i++) {
-      (function (iframe) {
-        iframe.addEventListener("load", function () {
-          observeIframe(iframe);
-        });
-      })(iframes[i]);
-    }
+  function enqueueIframe(iframe) {
+    if (!iframe.getAttribute("data-src")) return;
+    queue.push(iframe);
+    loadNext();
+  }
+
+  function setupIntersectionObserver() {
+    var iframes = document.querySelectorAll(".gallery-thumb[data-src]");
+    if (!iframes.length) return;
+
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          observer.unobserve(entry.target);
+          enqueueIframe(entry.target);
+        }
+      });
+    }, { rootMargin: "200px" });
+
+    iframes.forEach(function (iframe) {
+      observer.observe(iframe);
+    });
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", attachListeners);
+    document.addEventListener("DOMContentLoaded", setupIntersectionObserver);
   } else {
-    attachListeners();
+    setupIntersectionObserver();
   }
 })();


### PR DESCRIPTION
## Summary

- Replace `loading="lazy"` with IntersectionObserver + concurrency queue in `gallery.js` so gallery iframes only load when approaching the viewport (200px margin), with at most 4 loading simultaneously
- Change iframe `src` to `data-src` in the gallery generator so iframes don't trigger HTTP requests on page open
- Add CSS placeholder style for unloaded iframes (`visibility: hidden` while `data-src` is present)

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Initial HTTP requests | ~110 iframes | ~4-8 visible |
| Initial data transfer | ~9.5 MB | ~0.3-0.6 MB |
| Bokeh JS initializations | ~110 simultaneous | ~4 concurrent, rest on scroll |

## Test plan

- [ ] Run `pixi run generate-docs` to regenerate gallery with `data-src`
- [ ] Build docs and open gallery page in browser
- [ ] Verify only visible iframes load initially (check Network tab)
- [ ] Scroll down and verify more iframes load as they approach viewport
- [ ] Verify height auto-cropping still works after iframe loads
- [ ] `pixi run ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Defer loading of gallery iframes and limit concurrent loads to improve initial page performance and keep thumbnail auto-cropping behavior.

New Features:
- Add deferred loading of gallery iframes using IntersectionObserver with a 200px viewport margin and a concurrency limiter.
- Render gallery iframes initially with data-src attributes instead of src to prevent HTTP requests until needed.
- Hide unloaded gallery iframes via CSS while data-src is present to act as a placeholder state.