### PR TITLE
Add gallery grid to section index pages

### DIFF
--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -1,6 +1,7 @@
 """Generate Python example files, run them, save HTML reports, and generate RST for docs."""
 
 import ast
+import html
 import importlib
 import os
 import shutil
@@ -157,31 +158,69 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path):
     }
 
 
-def generate_section_index(section_path: Path, section_title: str):
-    """Generate an index.rst for a docs section with a toctree."""
+def _render_gallery_cards(examples: list[dict], href_fn, report_src_fn) -> list[str]:
+    """Render gallery card HTML lines for a list of example metadata dicts."""
+    lines = []
+    for ex in sorted(examples, key=lambda e: e["stem"]):
+        href = href_fn(ex)
+        report_src = report_src_fn(ex)
+        title = html.escape(ex["title"])
+        lines.append(f'   <a class="gallery-card" href="{href}">')
+        lines.append('     <div class="gallery-thumb-wrap">')
+        lines.append(
+            f'       <iframe class="gallery-thumb" src="{report_src}"'
+            ' loading="lazy" tabindex="-1" scrolling="no"></iframe>'
+        )
+        lines.append("     </div>")
+        lines.append(f'     <div class="gallery-card-title">{title}</div>')
+        lines.append("   </a>")
+    return lines
+
+
+def generate_section_index(section_path: Path, section_title: str, section_metadata: list[dict]):
+    """Generate an index.rst for a docs section with a gallery grid and hidden toctree."""
     rst_files = sorted(section_path.rglob("*.rst"))
     rst_files = [f for f in rst_files if f.name != "index.rst"]
 
     if not rst_files:
         return
 
-    entries = []
-    for f in rst_files:
-        rel = f.relative_to(section_path).with_suffix("")
-        entries.append(f"   {rel}")
+    toc_entries = [f"   {f.relative_to(section_path).with_suffix('')}" for f in rst_files]
 
     underline = "=" * len(section_title)
-    entries_str = "\n".join(entries)
-    content = f"""{section_title}
-{underline}
 
-.. toctree::
-   :maxdepth: 1
+    lines = [
+        section_title,
+        underline,
+        "",
+        ".. toctree::",
+        "   :hidden:",
+        "   :maxdepth: 1",
+        "",
+        "\n".join(toc_entries),
+        "",
+    ]
 
-{entries_str}
-"""
+    if section_metadata:
+        lines += [
+            ".. raw:: html",
+            "",
+            '   <div class="gallery-container">',
+            '   <div class="gallery-grid">',
+        ]
+        lines += _render_gallery_cards(
+            section_metadata,
+            href_fn=lambda ex: f"{ex['stem']}.html",
+            report_src_fn=lambda ex: f"_reports/{ex['stem']}/{ex['bench_name']}.html",
+        )
+        lines += [
+            "   </div>",
+            "   </div>",
+            "",
+        ]
+
     index_path = section_path / "index.rst"
-    index_path.write_text(content, encoding="utf-8")
+    index_path.write_text("\n".join(lines), encoding="utf-8")
 
 
 SECTIONS = {
@@ -240,20 +279,15 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
     for section_title, info in grouped.items():
         if not info["examples"]:
             continue
-        lines.append(f'   <h3 class="gallery-section-title">{section_title}</h3>')
+        lines.append(f'   <h3 class="gallery-section-title">{html.escape(section_title)}</h3>')
         lines.append('   <div class="gallery-grid">')
-        for ex in info["examples"]:
-            href = f"{ex['rst_rel']}.html"
-            report_src = f"{ex['section_rel']}/_reports/{ex['stem']}/{ex['bench_name']}.html"
-            lines.append(f'   <a class="gallery-card" href="{href}">')
-            lines.append('     <div class="gallery-thumb-wrap">')
-            lines.append(
-                f'       <iframe class="gallery-thumb" src="{report_src}"'
-                ' loading="lazy" tabindex="-1" scrolling="no"></iframe>'
-            )
-            lines.append("     </div>")
-            lines.append(f'     <div class="gallery-card-title">{ex["title"]}</div>')
-            lines.append("   </a>")
+        lines += _render_gallery_cards(
+            info["examples"],
+            href_fn=lambda ex: f"{ex['rst_rel']}.html",
+            report_src_fn=lambda ex: (
+                f"{ex['section_rel']}/_reports/{ex['stem']}/{ex['bench_name']}.html"
+            ),
+        )
         lines.append("   </div>")
 
     lines.append("   </div>")
@@ -289,10 +323,14 @@ def generate_all() -> list[Path]:
             examples_metadata.append(meta)
 
     # Phase 3: Generate section index files
+    meta_by_section = {}
+    for meta in examples_metadata:
+        meta_by_section.setdefault(meta["section_rel"], []).append(meta)
+
     for title, rel_path in SECTIONS.items():
         section_dir = META_DOCS_DIR / rel_path
         if section_dir.exists():
-            generate_section_index(section_dir, title)
+            generate_section_index(section_dir, title, meta_by_section.get(rel_path, []))
 
     # Phase 4: Generate gallery overview page
     generate_gallery_page(examples_metadata, META_DOCS_DIR)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -210,8 +210,11 @@ def generate_section_index(section_path: Path, section_title: str, section_metad
         ]
         lines += _render_gallery_cards(
             section_metadata,
-            href_fn=lambda ex: f"{ex['stem']}.html",
-            report_src_fn=lambda ex: f"_reports/{ex['stem']}/{ex['bench_name']}.html",
+            href_fn=lambda ex: f"{Path(ex['rst_rel']).relative_to(ex['section_rel'])}.html",
+            report_src_fn=lambda ex: str(
+                Path(ex["rst_rel"]).relative_to(ex["section_rel"]).parent
+                / f"_reports/{ex['stem']}/{ex['bench_name']}.html"
+            ),
         )
         lines += [
             "   </div>",


### PR DESCRIPTION
## Summary

- Replace plain toctree text lists in section index pages with visual gallery grids showing iframe thumbnail previews
- Each section (e.g. "Plot Types", "0 Float Inputs") now shows the same card layout as the main gallery overview
- Extract shared `_render_gallery_cards()` helper used by both section indices and the main gallery page
- HTML-escape titles to prevent broken markup
- Sort cards by stem for stable ordering matching the toctree
- Toctree is kept as `:hidden:` so Sphinx navigation still works

## Test plan

- [ ] Run `pixi run generate-docs` to regenerate section index pages
- [ ] Build docs and navigate to a section (e.g. Plot Types)
- [ ] Verify visual gallery grid with iframe thumbnails instead of text list
- [ ] Verify clicking a card navigates to the full example page
- [ ] Verify height auto-cropping still works (gallery.js)
- [ ] `pixi run ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Render section index pages as gallery-style grids of example cards while keeping Sphinx toctrees hidden for navigation.

Enhancements:
- Extract a reusable helper to render gallery cards shared between the main gallery page and section index pages.
- HTML-escape gallery titles and section headings when emitting raw HTML to avoid broken markup or injection issues.
- Ensure consistent ordering of gallery cards by example stem to align with toctree ordering.

Documentation:
- Update generated section index documentation to show visual gallery grids with iframe thumbnails instead of plain toctree text lists.