### PR TITLE
Fix plotly backend contaminating subsequent holoviews plots

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -78,7 +78,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
         nightly (bool): Run a more extensive set of tests for a nightly benchmark
         time_event (str): String representation of a sequence over time
         headless (bool): Run the benchmarks headlessly
-        render_plotly (bool): Controls plotly rendering behavior with bokeh
         level (int): Method of defining the number of samples to sweep over
         run_tag (str): Tag for isolating cached results
         run_date (datetime): Date the benchmark run was performed
@@ -194,11 +193,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
     use_holoview: bool = param.Boolean(False, doc="Use holoview for plotting")
 
     use_optuna: bool = param.Boolean(False, doc="show optuna plots")
-
-    render_plotly: bool = param.Boolean(
-        True,
-        doc="Plotly and Bokeh don't play nicely together, so by default pre-render plotly figures to a non dynamic version so that bokeh plots correctly.  If you want interactive 3D graphs, set this to true but be aware that your 2D interactive graphs will probably stop working.",
-    )
 
     plot_size: Optional[int] = param.Integer(
         default=None, doc="Sets the width and height of the plot"

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -152,12 +152,10 @@ class SurfaceResult(HoloviewResult):
                 **kwargs,
             )
 
-            if self.bench_cfg.render_plotly:
-                hv.extension("plotly")
-                out = surface
-            else:
-                # using render disabled the holoviews sliders :(
-                out = hv.render(surface, backend="plotly")
+            # Always pre-render to plotly to avoid hv.extension("plotly") polluting
+            # the global backend (which would make all subsequent plots use plotly).
+            # Note: pre-rendering disables holoviews sliders for surface plots.
+            out = pn.pane.Plotly(hv.render(surface, backend="plotly"))
             return pn.Column(out, name="surface_hv")
 
         return matches_res.to_panel()


### PR DESCRIPTION
## Summary
- `hv.extension("plotly")` in `SurfaceResult.to_surface_ds()` globally changed the holoviews backend, causing all subsequent plots to render with plotly instead of bokeh
- Replace with `hv.render(surface, backend="plotly")` wrapped in `pn.pane.Plotly()` which renders the surface using plotly without changing global state
- Remove the now-unused `render_plotly` config parameter from `BenchRunCfg`

## Test plan
- [ ] All tests pass
- [ ] Verify surface plots still render correctly with plotly
- [ ] Verify subsequent bokeh plots are no longer affected by surface/volume plot rendering

Replaces #740 (was based on wrong branch with notebook noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent holoviews surface plotting from changing the global backend while simplifying plotly rendering configuration.

Bug Fixes:
- Ensure surface plots rendered with plotly no longer change the global holoviews backend and affect subsequent plots.

Enhancements:
- Always pre-render surface plots to plotly via a dedicated pane to keep backend handling explicit and localized.

Chores:
- Remove the unused render_plotly configuration option from BenchRunCfg to reflect the new fixed rendering behavior.