### PR TITLE
Reduce CI matrix to Python 3.10 and 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [py310, py311, py312,py313]
+        environment: [py310, py313]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Drop py311 and py312 from the CI matrix, keeping only py310 and py313
- Saves CI minutes by testing only the oldest and newest supported Python versions

## Test plan
- [ ] Verify CI passes on py310 and py313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update GitHub Actions CI matrix to run only on Python 3.10 and 3.13 to reduce build combinations and save CI time.