### PR TITLE
Default over_time slider to most recent time point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.62.1] - 2026-03-09
+
+### Fixed
+- Over-time slider now correctly defaults to the most recent time point instead of the first (#756)
+- Fixed `DiscreteSlider` dict options handling — `list(w.options)` returned string keys instead of actual values, causing the slider to silently fall back to the first time point
+- Added guard against empty widget options to prevent `IndexError`
+- Narrowed slider default logic to only target the `over_time` widget, avoiding unintended side effects on other widgets
+
 ## [1.62.0] - 2026-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.62.1] - 2026-03-09
+## [1.63.0] - 2026-03-09
 
 ### Fixed
 - Over-time slider now correctly defaults to the most recent time point instead of the first (#756)

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -152,7 +152,7 @@ class HoloviewResult(VideoResult):
         widget_box.align = ("start", "start")
         # Default slider to the most recent (last) time point
         for w in widget_box:
-            if hasattr(w, "value") and hasattr(w, "options"):
+            if hasattr(w, "value") and hasattr(w, "options") and w.options:
                 w.value = list(w.options)[-1]
         return pn.Column(row[0], widget_box)
 

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -150,6 +150,10 @@ class HoloviewResult(VideoResult):
         row = pn.panel(holomap)
         widget_box = row[1]
         widget_box.align = ("start", "start")
+        # Default slider to the most recent (last) time point
+        for w in widget_box:
+            if hasattr(w, "value") and hasattr(w, "options"):
+                w.value = list(w.options)[-1]
         return pn.Column(row[0], widget_box)
 
     def hv_container_ds(

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -153,7 +153,8 @@ class HoloviewResult(VideoResult):
         # Default slider to the most recent (last) time point
         for w in widget_box:
             if hasattr(w, "name") and w.name == "over_time" and hasattr(w, "options") and w.options:
-                w.value = list(w.options)[-1]
+                opts = w.options.values() if isinstance(w.options, dict) else w.options
+                w.value = list(opts)[-1]
         return pn.Column(row[0], widget_box)
 
     def hv_container_ds(

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -152,7 +152,7 @@ class HoloviewResult(VideoResult):
         widget_box.align = ("start", "start")
         # Default slider to the most recent (last) time point
         for w in widget_box:
-            if hasattr(w, "value") and hasattr(w, "options") and w.options:
+            if hasattr(w, "name") and w.name == "over_time" and hasattr(w, "options") and w.options:
                 w.value = list(w.options)[-1]
         return pn.Column(row[0], widget_box)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.62.0"
+version = "1.62.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.62.1"
+version = "1.63.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- When `over_time=True`, the HoloMap slider now defaults to the last (most recent) time point instead of the first
- Users immediately see the latest benchmark result without needing to scrub the slider
- Applies to all three over_time plot types: line plots, heatmaps, and curve plots

## Test plan
- [x] `pixi run ci` passes (all 441 tests, linting, formatting)
- [ ] Manually verify with `python bencher/example/example_over_time.py` that slider starts at latest time point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Set over-time HoloMap sliders to initialize at the last available time point so users see the latest results by default.