### PR TITLE
Make init_singleton() auto-reset on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.63.1] - 2026-03-11
+
+### Added
+- `init_singleton()` now returns a context manager that auto-resets singleton state when first-time init raises, eliminating manual `_seen`/`_instances` cleanup boilerplate
+- `reset_singleton()` public classmethod for explicitly clearing singleton state
+- Full backward compatibility preserved — `if self.init_singleton():` works identically
+
 ## [1.63.0] - 2026-03-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.63.1] - 2026-03-11
+## [1.64.0] - 2026-03-11
 
 ### Added
 - `init_singleton()` now returns a context manager that auto-resets singleton state when first-time init raises, eliminating manual `_seen`/`_instances` cleanup boilerplate
 - `reset_singleton()` public classmethod for explicitly clearing singleton state
+- Thread-safe singleton operations via internal `threading.Lock`
 - Full backward compatibility preserved — `if self.init_singleton():` works identically
 
 ## [1.63.0] - 2026-03-09

--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -4,18 +4,61 @@ Provides a per-subclass singleton with the smallest useful surface:
 
 - One instance per subclass via ``__new__``.
 - Base ``__init__`` calls the Parametrized chain exactly once.
-- A simple classmethod ``first_time()`` you can call to know if this
-  is the first time the class has been created in this process.
+- ``init_singleton()`` returns a result that is **truthy on first call**
+  (backward-compatible with ``if self.init_singleton():``) and also
+  works as a **context manager** that auto-resets singleton state when
+  the ``with`` block raises during first-time init.
+- ``reset_singleton()`` classmethod to manually clear singleton state.
 
-Example
+Example (boolean style — unchanged from before)::
+
     class MySweep(ParametrizedSweepSingleton):
         def __init__(self, value=0):
-            if self.first_time():
+            if self.init_singleton():
                 self.value = value  # only set once
             super().__init__()  # safe no-op after the first call
+
+Example (context-manager style — auto-resets on failure)::
+
+    class MySweep(ParametrizedSweepSingleton):
+        def __init__(self, **kwargs):
+            with self.init_singleton() as is_first:
+                if is_first:
+                    self._do_fallible_setup(**kwargs)
+            super().__init__()
 """
 
 from .parametrised_sweep import ParametrizedSweep
+
+
+class _SingletonInitResult:
+    """Ephemeral result from ``init_singleton()``.
+
+    * **Bool** — ``bool(result)`` is ``True`` when this is the first init.
+    * **Context manager** — on ``__exit__``, if the block raised *and* this
+      was the first init, singleton bookkeeping (``_seen`` / ``_instances``)
+      is rolled back so a subsequent construction can retry.
+    """
+
+    __slots__ = ("_cls", "_is_first")
+
+    def __init__(self, cls, is_first: bool):
+        self._cls = cls
+        self._is_first = is_first
+
+    # -- boolean protocol (backward compat) ----------------------------------
+    def __bool__(self) -> bool:
+        return self._is_first
+
+    # -- context-manager protocol ---------------------------------------------
+    def __enter__(self):
+        return self._is_first
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None and self._is_first:
+            self._cls._seen.discard(self._cls)
+            self._cls._instances.pop(self._cls, None)
+        return False  # never swallow exceptions
 
 
 class ParametrizedSweepSingleton(ParametrizedSweep):
@@ -23,7 +66,9 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
 
     - Repeated construction returns the same instance for each subclass.
     - Ensures the Parametrized ``__init__`` chain runs only once.
-    - ``first_time()`` returns True once per subclass to gate one-time setup.
+    - ``init_singleton()`` returns a result that is truthy once per subclass
+      and doubles as a context manager for automatic rollback on failure.
+    - ``reset_singleton()`` explicitly clears singleton state for a subclass.
     """
 
     _instances = {}
@@ -42,9 +87,28 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
         self._singleton_inited = True
 
     @classmethod
-    def init_singleton(cls) -> bool:
-        """Return True the first time a subclass is constructed in this process."""
-        if cls in cls._seen:
-            return False
+    def init_singleton(cls) -> _SingletonInitResult:
+        """Mark *cls* as seen and return a ``_SingletonInitResult``.
+
+        The result is **truthy** the first time a subclass calls this and
+        **falsy** on every subsequent call — identical to the previous boolean
+        return value.
+
+        It can also be used as a **context manager**::
+
+            with self.init_singleton() as is_first:
+                if is_first:
+                    self._fallible_setup()
+
+        If the ``with`` block raises during a first-time init, the singleton
+        bookkeeping is rolled back so the next construction can retry cleanly.
+        """
+        is_first = cls not in cls._seen
         cls._seen.add(cls)
-        return True
+        return _SingletonInitResult(cls, is_first)
+
+    @classmethod
+    def reset_singleton(cls) -> None:
+        """Clear singleton state for *cls*, allowing re-initialisation."""
+        cls._seen.discard(cls)
+        cls._instances.pop(cls, None)

--- a/bencher/variables/singleton_parametrized_sweep.py
+++ b/bencher/variables/singleton_parametrized_sweep.py
@@ -1,4 +1,4 @@
-"""Singleton variant of ParametrizedSweep (minimal).
+"""Singleton variant of ParametrizedSweep (thread-safe).
 
 Provides a per-subclass singleton with the smallest useful surface:
 
@@ -9,6 +9,7 @@ Provides a per-subclass singleton with the smallest useful surface:
   works as a **context manager** that auto-resets singleton state when
   the ``with`` block raises during first-time init.
 - ``reset_singleton()`` classmethod to manually clear singleton state.
+- All operations are **thread-safe** via an internal lock.
 
 Example (boolean style — unchanged from before)::
 
@@ -28,6 +29,8 @@ Example (context-manager style — auto-resets on failure)::
             super().__init__()
 """
 
+import threading
+
 from .parametrised_sweep import ParametrizedSweep
 
 
@@ -36,8 +39,8 @@ class _SingletonInitResult:
 
     * **Bool** — ``bool(result)`` is ``True`` when this is the first init.
     * **Context manager** — on ``__exit__``, if the block raised *and* this
-      was the first init, singleton bookkeeping (``_seen`` / ``_instances``)
-      is rolled back so a subsequent construction can retry.
+      was the first init, singleton bookkeeping is rolled back via
+      ``reset_singleton()`` so a subsequent construction can retry.
     """
 
     __slots__ = ("_cls", "_is_first")
@@ -56,8 +59,7 @@ class _SingletonInitResult:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None and self._is_first:
-            self._cls._seen.discard(self._cls)
-            self._cls._instances.pop(self._cls, None)
+            self._cls.reset_singleton()
         return False  # never swallow exceptions
 
 
@@ -69,15 +71,18 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
     - ``init_singleton()`` returns a result that is truthy once per subclass
       and doubles as a context manager for automatic rollback on failure.
     - ``reset_singleton()`` explicitly clears singleton state for a subclass.
+    - Thread-safe: all shared state is protected by ``_lock``.
     """
 
     _instances = {}
     _seen = set()
+    _lock = threading.Lock()
 
     def __new__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__new__(cls)
-        return cls._instances[cls]
+        with cls._lock:
+            if cls not in cls._instances:
+                cls._instances[cls] = super().__new__(cls)
+            return cls._instances[cls]
 
     def __init__(self, **params):
         # Only run the Parametrized init chain once
@@ -103,12 +108,14 @@ class ParametrizedSweepSingleton(ParametrizedSweep):
         If the ``with`` block raises during a first-time init, the singleton
         bookkeeping is rolled back so the next construction can retry cleanly.
         """
-        is_first = cls not in cls._seen
-        cls._seen.add(cls)
+        with cls._lock:
+            is_first = cls not in cls._seen
+            cls._seen.add(cls)
         return _SingletonInitResult(cls, is_first)
 
     @classmethod
     def reset_singleton(cls) -> None:
         """Clear singleton state for *cls*, allowing re-initialisation."""
-        cls._seen.discard(cls)
-        cls._instances.pop(cls, None)
+        with cls._lock:
+            cls._seen.discard(cls)
+            cls._instances.pop(cls, None)

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.62.0
-  sha256: 337eaaa11168aa4dcbe1de518ba8c88f21b907d719cfd5f03fed9c77e90da176
+  version: 1.63.1
+  sha256: 0bde13fe1fb30b3e8754b2e300c166b38e98f019c1310ced9926a4ec88160636
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.63.1
-  sha256: 0bde13fe1fb30b3e8754b2e300c166b38e98f019c1310ced9926a4ec88160636
+  version: 1.64.0
+  sha256: 03917ba297134229d4996122a1f94d06087e38d19ed31d166234653087dc80b2
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.63.1"
+version = "1.64.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.63.0"
+version = "1.63.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -170,3 +170,112 @@ def test_single_argument_benchable_supported():
 
     results = br.run(level=1, repeats=1, cache_results=False)
     assert len(results) == 1
+
+
+def test_context_manager_resets_on_first_init_failure():
+    """with init_singleton() auto-resets _seen/_instances when first init raises."""
+
+    class FailCM(ParametrizedSweepSingleton):
+        def __init__(self, fail=True):
+            with self.init_singleton() as is_first:
+                if is_first:
+                    if fail:
+                        raise RuntimeError("boom")
+                    self.value = 42
+            super().__init__()
+
+    # First attempt — should fail and reset singleton state
+    with pytest.raises(RuntimeError, match="boom"):
+        FailCM(fail=True)
+
+    # Retry — singleton was rolled back, so init_singleton() is truthy again
+    obj = FailCM(fail=False)
+    assert obj.value == 42
+
+    # Third call — singleton is now established
+    obj2 = FailCM(fail=False)
+    assert obj2 is obj
+
+
+def test_context_manager_no_reset_on_success():
+    """Successful first init must NOT be rolled back."""
+
+    class SuccessCM(ParametrizedSweepSingleton):
+        def __init__(self):
+            with self.init_singleton() as is_first:
+                if is_first:
+                    self.value = 99
+            super().__init__()
+
+    obj = SuccessCM()
+    assert obj.value == 99
+
+    obj2 = SuccessCM()
+    assert obj2 is obj
+    assert obj2.value == 99
+
+
+def test_context_manager_no_reset_on_non_first_error():
+    """Error inside `with` on a non-first call must NOT reset the singleton."""
+
+    class NonFirstCM(ParametrizedSweepSingleton):
+        call_count = 0
+
+        def __init__(self):
+            with self.init_singleton() as is_first:
+                NonFirstCM.call_count += 1
+                if is_first:
+                    self.value = 7
+                elif NonFirstCM.call_count == 2:
+                    raise RuntimeError("second-call error")
+            super().__init__()
+
+    obj = NonFirstCM()
+    assert obj.value == 7
+
+    # Second construction — raises inside `with` but is_first is False
+    with pytest.raises(RuntimeError, match="second-call error"):
+        NonFirstCM()
+
+    # Singleton must still be intact
+    obj3 = NonFirstCM()
+    assert obj3 is obj
+    assert obj3.value == 7
+
+
+def test_reset_singleton_public_api():
+    """reset_singleton() clears state so the next construction re-inits."""
+
+    class Resettable(ParametrizedSweepSingleton):
+        def __init__(self, val=1):
+            if self.init_singleton():
+                self.val = val
+            super().__init__()
+
+    obj1 = Resettable(val=10)
+    assert obj1.val == 10
+
+    Resettable.reset_singleton()
+
+    obj2 = Resettable(val=20)
+    assert obj2.val == 20
+    assert obj2 is not obj1
+
+
+def test_init_singleton_boolean_backward_compat():
+    """init_singleton() result works in boolean context (if/elif/not/and/or)."""
+
+    class BoolCompat(ParametrizedSweepSingleton):
+        def __init__(self):
+            result = self.init_singleton()
+            if result:
+                self.init_count = 1
+            super().__init__()
+
+    obj = BoolCompat()
+    assert obj.init_count == 1
+
+    # Second call — init_singleton() is falsy, init_count stays 1
+    obj2 = BoolCompat()
+    assert obj2 is obj
+    assert obj.init_count == 1


### PR DESCRIPTION
## Summary
- `init_singleton()` now returns a `_SingletonInitResult` object that is **truthy/falsy** (fully backward-compatible with `if self.init_singleton():`) and also works as a **context manager** that auto-resets `_seen`/`_instances` when the `with` block raises during first-time init
- Adds `reset_singleton()` public classmethod for explicitly clearing singleton state


**Before** (downstream boilerplate):
```python
if self.init_singleton():
    try:
        self._init_planning(...)
    except Exception:
        type(self)._seen.discard(type(self))
        type(self)._instances.pop(type(self), None)
        raise
```

**After**:
```python
with self.init_singleton() as is_first:
    if is_first:
        self._init_planning(...)
```

## Test plan
- [x] Context manager auto-resets on first-time init failure
- [x] Context manager does NOT reset on success
- [x] Context manager does NOT reset on non-first-time errors
- [x] `reset_singleton()` public API works
- [x] Boolean backward compatibility preserved
- [x] All existing singleton tests pass unchanged
- [x] `pixi run ci` passes (format, lint, 446 tests, 90% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make ParametrizedSweepSingleton initialisation more robust by adding a context-manager capable init result and explicit reset API while preserving existing boolean semantics.

New Features:
- Extend init_singleton() to return an object that is truthy on first use and can be used as a context manager that auto-rolls back singleton state on first-time init failure.
- Add reset_singleton() classmethod to clear singleton state for a given subclass.

Enhancements:
- Document the new init_singleton() behavior and context-manager usage pattern in the ParametrizedSweepSingleton docstring and module-level docs.

Build:
- Bump project version from 1.63.0 to 1.63.1 in pyproject.toml.

Documentation:
- Update CHANGELOG with the new init_singleton() context manager behavior, reset_singleton() API, and note backward compatibility.

Tests:
- Add tests covering context-manager auto-reset behavior on first-time failures, no reset on success or non-first errors, the reset_singleton() API, and boolean backward compatibility of init_singleton().