### PR TITLE
Fix non-deterministic hash_persistent() in result variable classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.65.0] - 2026-03-11
+
+### Fixed
+- Fix non-deterministic `hash_persistent()` in 9 result variable classes that broke `over_time` history cache lookups across process invocations
+- Fix `ResultVec.hash_persistent()` not including `size` in hash, causing cache key collisions for vectors of different sizes
+- Add `_hash_slots()` helper that hashes all `__slots__` by default, with explicit `_hash_exclude` for non-deterministic runtime attributes (`obj`, `container`)
+- Add comprehensive auto-discovery tests that will catch any future Result class missing deterministic hashing
+
 ## [1.64.0] - 2026-03-11
 
 ### Added

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -1,3 +1,31 @@
+"""Result variable classes for benchmark outputs.
+
+IMPORTANT — hash_persistent() contract:
+    Every Result* class MUST implement hash_persistent() using _hash_slots() which hashes
+    ALL __slots__ by default. This is critical for the over_time history cache:
+    BenchCfg.hash_persistent() includes result variable hashes in the cache key, so a
+    non-deterministic hash means historical data can never be found.
+
+    The default behavior hashes every slot. If a slot holds a non-deterministic value
+    (runtime objects, callbacks, etc.), add it to _hash_exclude on the class:
+
+        class MyResult(param.Parameter):
+            __slots__ = ["units", "obj"]
+            _hash_exclude = ("obj",)  # runtime object, not deterministic
+
+            def hash_persistent(self) -> str:
+                return _hash_slots(self)
+
+    WRONG — never do this (str(self) includes the memory address for param.Parameter):
+        def hash_persistent(self) -> str:
+            return hash_sha1(self)
+
+    Tests in test/test_hash_persistent.py auto-discover all Result* classes and verify:
+    - Determinism: two equivalent instances produce the same hash
+    - Slot coverage: every __slots__ entry is either hashed or in _hash_exclude
+    Adding a new class without proper hashing will fail CI.
+"""
+
 from enum import auto
 from typing import List, Callable, Any, Optional
 from functools import partial
@@ -9,6 +37,21 @@ import holoviews as hv
 from bencher.utils import hash_sha1
 
 # from bencher.variables.parametrised_sweep import ParametrizedSweep
+
+
+def _hash_slots(instance):
+    """Hash all __slots__ on the result class, excluding non-deterministic attributes.
+
+    Reads __slots__ directly from the class (not inherited) and hashes all values except
+    those listed in the class-level _hash_exclude tuple. If the class has no hashable
+    slots (e.g. ResultHmap), falls back to the class name.
+    """
+    exclude = getattr(type(instance), "_hash_exclude", ())
+    slots = type(instance).__dict__.get("__slots__", ())
+    values = tuple(getattr(instance, slot) for slot in slots if slot not in exclude)
+    if not values:
+        return hash_sha1((type(instance).__name__,))
+    return hash_sha1(values)
 
 
 class OptDir(StrEnum):
@@ -34,7 +77,7 @@ class ResultVar(Number):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1((self.units, self.direction))
+        return _hash_slots(self)
 
 
 class ResultBool(Number):
@@ -55,7 +98,7 @@ class ResultBool(Number):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1((self.units, self.direction))
+        return _hash_slots(self)
 
 
 class ResultVec(param.List):
@@ -72,7 +115,7 @@ class ResultVec(param.List):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1((self.units, self.direction))
+        return _hash_slots(self)
 
     def index_name(self, idx: int) -> str:
         """given the index of the vector, return the column name that
@@ -105,7 +148,7 @@ class ResultHmap(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 def curve(
@@ -129,7 +172,7 @@ class ResultPath(param.Filename):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
     def to_container(self):
         """Returns a partial function for creating a FileDownload widget with embedding enabled.  This function is used to create a panel container to represent the ResultPath object"""
@@ -145,7 +188,7 @@ class ResultVideo(param.Filename):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultImage(param.Filename):
@@ -157,7 +200,7 @@ class ResultImage(param.Filename):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultString(param.String):
@@ -169,7 +212,7 @@ class ResultString(param.String):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultContainer(param.Parameter):
@@ -181,13 +224,14 @@ class ResultContainer(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultReference(param.Parameter):
     """Use this class to save arbitrary objects that are not picklable or native to panel.  You can pass a container callback that takes the object and returns a panel pane to be displayed"""
 
     __slots__ = ["units", "obj", "container"]
+    _hash_exclude = ("obj", "container")  # runtime state, not deterministic config
 
     def __init__(
         self,
@@ -204,11 +248,12 @@ class ResultReference(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultDataSet(param.Parameter):
     __slots__ = ["units", "obj"]
+    _hash_exclude = ("obj",)  # runtime state, not deterministic config
 
     def __init__(
         self,
@@ -223,11 +268,12 @@ class ResultDataSet(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 class ResultVolume(param.Parameter):
     __slots__ = ["units", "obj"]
+    _hash_exclude = ("obj",)  # runtime state, not deterministic config
 
     def __init__(self, obj=None, default=None, units="container", **params):
         super().__init__(default=default, **params)
@@ -236,7 +282,7 @@ class ResultVolume(param.Parameter):
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1(self)
+        return _hash_slots(self)
 
 
 PANEL_TYPES = (

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -42,16 +42,23 @@ from bencher.utils import hash_sha1
 def _hash_slots(instance):
     """Hash all __slots__ on the result class, excluding non-deterministic attributes.
 
-    Reads __slots__ directly from the class (not inherited) and hashes all values except
-    those listed in the class-level _hash_exclude tuple. If the class has no hashable
-    slots (e.g. ResultHmap), falls back to the class name.
+    Reads __slots__ directly from the immediate class (not inherited via MRO) and hashes
+    all values except those listed in the class-level _hash_exclude tuple. This is
+    intentional: each Result* class defines its own __slots__ and is responsible for its
+    own hash. If shared slots are ever introduced via a base class, this helper would
+    need to walk the MRO to aggregate them.
+
+    The class name is always included in the hash to prevent collisions between different
+    Result* classes that share the same slot layout and values (e.g. ResultPath,
+    ResultVideo, and ResultImage all have __slots__ = ["units"] with default units="path").
     """
-    exclude = getattr(type(instance), "_hash_exclude", ())
-    slots = type(instance).__dict__.get("__slots__", ())
+    cls = type(instance)
+    exclude = getattr(cls, "_hash_exclude", ())
+    slots = cls.__dict__.get("__slots__", ())
+    if isinstance(slots, str):
+        slots = (slots,)
     values = tuple(getattr(instance, slot) for slot in slots if slot not in exclude)
-    if not values:
-        return hash_sha1((type(instance).__name__,))
-    return hash_sha1(values)
+    return hash_sha1((cls.__name__,) + values)
 
 
 class OptDir(StrEnum):

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -39,20 +39,38 @@ from bencher.utils import hash_sha1
 # from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 
+_PARAM_MODULES = frozenset({"param", "param.parameters", "param.parameterized"})
+
+
 def _hash_slots(instance):
     """Hash all __slots__ on the result class, excluding non-deterministic attributes.
 
     Reads __slots__ directly from the immediate class (not inherited via MRO) and hashes
     all values except those listed in the class-level _hash_exclude tuple. This is
     intentional: each Result* class defines its own __slots__ and is responsible for its
-    own hash. If shared slots are ever introduced via a base class, this helper would
-    need to walk the MRO to aggregate them.
+    own hash.
+
+    A defensive check ensures no intermediate base class (between the concrete Result*
+    class and the param framework) defines __slots__ that would be silently missed.
 
     The class name is always included in the hash to prevent collisions between different
     Result* classes that share the same slot layout and values (e.g. ResultPath,
     ResultVideo, and ResultImage all have __slots__ = ["units"] with default units="path").
     """
     cls = type(instance)
+
+    # Guard: ensure no intermediate bencher base class has __slots__ we'd miss.
+    for ancestor in cls.__mro__[1:]:
+        if getattr(ancestor, "__module__", "") in _PARAM_MODULES or ancestor is object:
+            break
+        ancestor_slots = ancestor.__dict__.get("__slots__", ())
+        if ancestor_slots:
+            raise TypeError(
+                f"_hash_slots({cls.__name__}): intermediate base class {ancestor.__name__} "
+                f"defines __slots__ = {ancestor_slots} which would be silently ignored. "
+                "Update _hash_slots to walk the MRO or move slots to the leaf class."
+            )
+
     exclude = getattr(cls, "_hash_exclude", ())
     slots = cls.__dict__.get("__slots__", ())
     if isinstance(slots, str):
@@ -151,7 +169,13 @@ class ResultVec(param.List):
 
 
 class ResultHmap(param.Parameter):
-    """A class to represent a holomap return type"""
+    """A class to represent a holomap return type.
+
+    Note: this class has no __slots__, so _hash_slots hashes only the class name.
+    Every ResultHmap instance produces the same hash. This is intentional — there are
+    no configuration attributes that would differentiate instances. If a slot is added
+    in the future, _hash_slots will automatically include it.
+    """
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
@@ -325,4 +349,5 @@ ALL_RESULT_TYPES = (
     ResultContainer,
     ResultDataSet,
     ResultReference,
+    ResultVolume,
 )

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.64.0
-  sha256: 03917ba297134229d4996122a1f94d06087e38d19ed31d166234653087dc80b2
+  version: 1.65.0
+  sha256: 9f8c939b8faaef457cee02ff91fa073f3dff6656e236a9a6b80508d82f1773f0
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.64.0"
+version = "1.65.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -78,7 +78,6 @@ class TestSlotCoverage:
     def test_all_slots_accounted_for(self, cls):
         slots = set(cls.__dict__.get("__slots__", ()))
         exclude = set(getattr(cls, "_hash_exclude", ()))
-        hashed = slots - exclude
         # _hash_exclude entries must actually be slots
         extra_excludes = exclude - slots
         assert not extra_excludes, (
@@ -307,6 +306,7 @@ def _hash_in_subprocess(cls_name, args="doc='test'", extra=""):
         capture_output=True,
         text=True,
         timeout=30,
+        check=False,
     )
     assert result.returncode == 0, f"Subprocess failed for {cls_name}:\n{result.stderr}"
     return result.stdout.strip()
@@ -368,6 +368,7 @@ class TestCrossProcessDeterminism:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                check=False,
             )
             assert result.returncode == 0, f"Subprocess failed:\n{result.stderr}"
             hashes.append(result.stdout.strip())

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -24,7 +24,6 @@ import pytest
 
 import bencher.variables.results as results_module
 from bencher.variables.results import (
-    ALL_RESULT_TYPES,
     ResultContainer,
     ResultDataSet,
     ResultImage,
@@ -61,9 +60,6 @@ def _make_instance(cls):
 
 # Auto-discovered list — any new Result* class will appear here automatically
 ALL_DISCOVERED_CLASSES = _discover_all_result_classes()
-
-# Manually curated list for cross-checking
-ALL_HASHABLE_CLASSES = list(ALL_RESULT_TYPES) + [ResultVolume]
 
 
 class TestSlotCoverage:
@@ -117,22 +113,10 @@ class TestSlotCoverage:
             )
 
 
-class TestHashPersistentDeterminism:
-    """Two independently constructed instances with the same parameters must hash identically."""
-
-    @pytest.mark.parametrize("cls", ALL_HASHABLE_CLASSES, ids=lambda c: c.__name__)
-    def test_same_hash_for_identical_instances(self, cls):
-        r1 = _make_instance(cls)
-        r2 = _make_instance(cls)
-        assert r1.hash_persistent() == r2.hash_persistent(), (
-            f"{cls.__name__}.hash_persistent() differs between two identical instances"
-        )
-
-
 class TestHashPersistentDeepcopy:
     """hash_persistent() must be stable across deepcopy."""
 
-    @pytest.mark.parametrize("cls", ALL_HASHABLE_CLASSES, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("cls", ALL_DISCOVERED_CLASSES, ids=lambda c: c.__name__)
     def test_deepcopy_stability(self, cls):
         r1 = _make_instance(cls)
         r2 = deepcopy(r1)
@@ -171,19 +155,6 @@ class TestHashPersistentDifferentiation:
         assert r1.hash_persistent() != r2.hash_persistent(), (
             "ResultVec hashes should differ for size=3 vs size=5"
         )
-
-
-class TestHashPersistentCompleteness:
-    """Every type in ALL_RESULT_TYPES must have a hash_persistent method."""
-
-    @pytest.mark.parametrize("cls", list(ALL_RESULT_TYPES), ids=lambda c: c.__name__)
-    def test_has_hash_persistent(self, cls):
-        assert hasattr(cls, "hash_persistent"), (
-            f"{cls.__name__} in ALL_RESULT_TYPES is missing hash_persistent()"
-        )
-        instance = _make_instance(cls)
-        h = instance.hash_persistent()
-        assert isinstance(h, str) and len(h) > 0
 
 
 class TestAutoDiscoverAllResultClasses:
@@ -293,28 +264,6 @@ class TestBenchCfgHashStability:
         assert cfg1.hash_persistent(include_repeats=True) == cfg3.hash_persistent(
             include_repeats=True
         ), "BenchCfg hash should not change when only excluded obj fields differ"
-
-
-class TestSpecificVerification:
-    """Explicit verification from the task description."""
-
-    def test_result_image_triple_equality(self):
-        r1 = ResultImage(doc="test")
-        r2 = ResultImage(doc="test")
-        r3 = deepcopy(r1)
-        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
-
-    def test_result_string_triple_equality(self):
-        r1 = ResultString(doc="test")
-        r2 = ResultString(doc="test")
-        r3 = deepcopy(r1)
-        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
-
-    def test_result_video_triple_equality(self):
-        r1 = ResultVideo(doc="test")
-        r2 = ResultVideo(doc="test")
-        r3 = deepcopy(r1)
-        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
 
 
 # Script template for cross-process tests. Each subprocess imports the class,

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -1,0 +1,280 @@
+"""Tests for hash_persistent() determinism across all result variable classes.
+
+These tests ensure that hash_persistent() is deterministic (same result for equivalent
+instances) for every Result* class. This is critical for the over_time cache: if a hash
+changes across process invocations, historical data can never be found.
+
+Key guarantees enforced by these tests:
+- Auto-discovery: any new Result* class is automatically tested (no manual updates needed)
+- Slot coverage: every __slots__ entry is either hashed or explicitly in _hash_exclude
+- Determinism: two equivalent instances produce the same hash
+- Deepcopy stability: hash survives deepcopy
+- Differentiation: different config values produce different hashes
+"""
+
+import inspect
+from copy import deepcopy
+
+import param
+import pytest
+
+import bencher.variables.results as results_module
+from bencher.variables.results import (
+    ALL_RESULT_TYPES,
+    ResultContainer,
+    ResultDataSet,
+    ResultImage,
+    ResultPath,
+    ResultReference,
+    ResultString,
+    ResultVar,
+    ResultVec,
+    ResultVideo,
+    ResultVolume,
+)
+from bencher.bench_cfg import BenchCfg
+
+
+def _discover_all_result_classes():
+    """Auto-discover all Result* classes in the results module."""
+    classes = []
+    for name, obj in inspect.getmembers(results_module, inspect.isclass):
+        if (
+            name.startswith("Result")
+            and issubclass(obj, param.Parameter)
+            and obj.__module__ == results_module.__name__
+        ):
+            classes.append(obj)
+    return classes
+
+
+def _make_instance(cls):
+    """Create an instance of a result class with sensible defaults."""
+    if cls is ResultVec:
+        return cls(size=3, units="ul", doc="test")
+    return cls(doc="test")
+
+
+# Auto-discovered list — any new Result* class will appear here automatically
+ALL_DISCOVERED_CLASSES = _discover_all_result_classes()
+
+# Manually curated list for cross-checking
+ALL_HASHABLE_CLASSES = list(ALL_RESULT_TYPES) + [ResultVolume]
+
+
+class TestSlotCoverage:
+    """Verify every __slots__ entry is either hashed or explicitly excluded.
+
+    This catches the case where someone adds a new slot to a class but forgets to
+    include it in the hash or _hash_exclude. Without this, the new config attribute
+    would be silently ignored by the cache key.
+    """
+
+    @pytest.mark.parametrize("cls", ALL_DISCOVERED_CLASSES, ids=lambda c: c.__name__)
+    def test_all_slots_accounted_for(self, cls):
+        slots = set(cls.__dict__.get("__slots__", ()))
+        exclude = set(getattr(cls, "_hash_exclude", ()))
+        hashed = slots - exclude
+        # _hash_exclude entries must actually be slots
+        extra_excludes = exclude - slots
+        assert not extra_excludes, (
+            f"{cls.__name__}._hash_exclude contains {extra_excludes} "
+            f"which are not in __slots__ = {slots}"
+        )
+        # Verify excluded slots are non-deterministic by checking that instances with
+        # different excluded values still produce the same hash
+        if exclude:
+            r1 = _make_instance(cls)
+            r2 = _make_instance(cls)
+            for slot in exclude:
+                # Set excluded slot to a different value on r2
+                setattr(r2, slot, "DIFFERENT_VALUE")
+            assert r1.hash_persistent() == r2.hash_persistent(), (
+                f"{cls.__name__}: excluded slots {exclude} affected the hash. "
+                "If a slot affects the hash, remove it from _hash_exclude."
+            )
+
+    @pytest.mark.parametrize("cls", ALL_DISCOVERED_CLASSES, ids=lambda c: c.__name__)
+    def test_hashed_slots_affect_hash(self, cls):
+        """Every non-excluded slot must actually affect the hash value."""
+        slots = list(cls.__dict__.get("__slots__", ()))
+        exclude = set(getattr(cls, "_hash_exclude", ()))
+        hashed_slots = [s for s in slots if s not in exclude]
+        if not hashed_slots:
+            pytest.skip(f"{cls.__name__} has no hashed slots (uses class name fallback)")
+        r1 = _make_instance(cls)
+        for slot in hashed_slots:
+            r2 = _make_instance(cls)
+            original = getattr(r2, slot)
+            setattr(r2, slot, "CHANGED_VALUE_FOR_TEST")
+            assert r1.hash_persistent() != r2.hash_persistent(), (
+                f"{cls.__name__}: changing slot '{slot}' from {original!r} to "
+                "'CHANGED_VALUE_FOR_TEST' did not change the hash. "
+                "Either add it to _hash_exclude or fix _hash_slots."
+            )
+
+
+class TestHashPersistentDeterminism:
+    """Two independently constructed instances with the same parameters must hash identically."""
+
+    @pytest.mark.parametrize("cls", ALL_HASHABLE_CLASSES, ids=lambda c: c.__name__)
+    def test_same_hash_for_identical_instances(self, cls):
+        r1 = _make_instance(cls)
+        r2 = _make_instance(cls)
+        assert r1.hash_persistent() == r2.hash_persistent(), (
+            f"{cls.__name__}.hash_persistent() differs between two identical instances"
+        )
+
+
+class TestHashPersistentDeepcopy:
+    """hash_persistent() must be stable across deepcopy."""
+
+    @pytest.mark.parametrize("cls", ALL_HASHABLE_CLASSES, ids=lambda c: c.__name__)
+    def test_deepcopy_stability(self, cls):
+        r1 = _make_instance(cls)
+        r2 = deepcopy(r1)
+        assert r1.hash_persistent() == r2.hash_persistent(), (
+            f"{cls.__name__}.hash_persistent() changed after deepcopy"
+        )
+
+
+class TestHashPersistentDifferentiation:
+    """Classes with different units values must produce different hashes."""
+
+    @pytest.mark.parametrize(
+        "cls,units_a,units_b",
+        [
+            (ResultImage, "path", "custom"),
+            (ResultVideo, "path", "custom"),
+            (ResultPath, "path", "custom"),
+            (ResultString, "str", "custom"),
+            (ResultContainer, "container", "custom"),
+            (ResultReference, "container", "custom"),
+            (ResultDataSet, "dataset", "custom"),
+            (ResultVolume, "container", "custom"),
+        ],
+        ids=lambda x: x.__name__ if isinstance(x, type) else x,
+    )
+    def test_different_units_different_hash(self, cls, units_a, units_b):
+        r1 = cls(units=units_a, doc="test")
+        r2 = cls(units=units_b, doc="test")
+        assert r1.hash_persistent() != r2.hash_persistent(), (
+            f"{cls.__name__} hashes should differ for units={units_a!r} vs {units_b!r}"
+        )
+
+    def test_result_vec_different_size_different_hash(self):
+        r1 = ResultVec(size=3, doc="test")
+        r2 = ResultVec(size=5, doc="test")
+        assert r1.hash_persistent() != r2.hash_persistent(), (
+            "ResultVec hashes should differ for size=3 vs size=5"
+        )
+
+
+class TestHashPersistentCompleteness:
+    """Every type in ALL_RESULT_TYPES must have a hash_persistent method."""
+
+    @pytest.mark.parametrize("cls", list(ALL_RESULT_TYPES), ids=lambda c: c.__name__)
+    def test_has_hash_persistent(self, cls):
+        assert hasattr(cls, "hash_persistent"), (
+            f"{cls.__name__} in ALL_RESULT_TYPES is missing hash_persistent()"
+        )
+        instance = _make_instance(cls)
+        h = instance.hash_persistent()
+        assert isinstance(h, str) and len(h) > 0
+
+
+class TestAutoDiscoverAllResultClasses:
+    """Auto-discover all Result* classes and verify they have deterministic hashing.
+
+    This test will AUTOMATICALLY FAIL if a new Result* class is added to
+    bencher/variables/results.py without a proper hash_persistent() method.
+    No manual test updates are needed — just adding the class triggers the check.
+    """
+
+    @pytest.mark.parametrize("cls", ALL_DISCOVERED_CLASSES, ids=lambda c: c.__name__)
+    def test_discovered_class_has_hash_persistent(self, cls):
+        assert hasattr(cls, "hash_persistent"), (
+            f"{cls.__name__} is missing hash_persistent(). "
+            "All Result* classes MUST implement hash_persistent() using _hash_slots(self). "
+            "See the module docstring in bencher/variables/results.py for the pattern."
+        )
+
+    @pytest.mark.parametrize("cls", ALL_DISCOVERED_CLASSES, ids=lambda c: c.__name__)
+    def test_discovered_class_hash_is_deterministic(self, cls):
+        r1 = _make_instance(cls)
+        r2 = _make_instance(cls)
+        assert r1.hash_persistent() == r2.hash_persistent(), (
+            f"{cls.__name__}.hash_persistent() is non-deterministic! "
+            "Two independently constructed instances returned different hashes. "
+            "This breaks over_time cache lookups. "
+            "Fix: use _hash_slots(self) and add non-deterministic slots to _hash_exclude."
+        )
+
+
+class TestBenchCfgHashStability:
+    """BenchCfg.hash_persistent() must be stable when result_vars include previously-buggy types."""
+
+    def test_bench_cfg_with_result_image_stable(self):
+        def make_cfg():
+            cfg = BenchCfg()
+            cfg.bench_name = "test_bench"
+            cfg.title = "Test Title"
+            cfg.over_time = False
+            cfg.repeats = 1
+            cfg.tag = ""
+            cfg.input_vars = []
+            cfg.result_vars = [ResultImage(doc="img")]
+            cfg.const_vars = []
+            return cfg
+
+        cfg1 = make_cfg()
+        cfg2 = make_cfg()
+        assert cfg1.hash_persistent(include_repeats=True) == cfg2.hash_persistent(
+            include_repeats=True
+        ), "BenchCfg hash should be stable across two separate constructions"
+
+    def test_bench_cfg_with_multiple_result_types_stable(self):
+        def make_cfg():
+            cfg = BenchCfg()
+            cfg.bench_name = "multi_bench"
+            cfg.title = "Multi"
+            cfg.over_time = False
+            cfg.repeats = 1
+            cfg.tag = ""
+            cfg.input_vars = []
+            cfg.result_vars = [
+                ResultVar(units="m/s", doc="speed"),
+                ResultImage(doc="img"),
+                ResultString(doc="label"),
+                ResultContainer(doc="cont"),
+            ]
+            cfg.const_vars = []
+            return cfg
+
+        cfg1 = make_cfg()
+        cfg2 = make_cfg()
+        assert cfg1.hash_persistent(include_repeats=True) == cfg2.hash_persistent(
+            include_repeats=True
+        )
+
+
+class TestSpecificVerification:
+    """Explicit verification from the task description."""
+
+    def test_result_image_triple_equality(self):
+        r1 = ResultImage(doc="test")
+        r2 = ResultImage(doc="test")
+        r3 = deepcopy(r1)
+        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
+
+    def test_result_string_triple_equality(self):
+        r1 = ResultString(doc="test")
+        r2 = ResultString(doc="test")
+        r3 = deepcopy(r1)
+        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
+
+    def test_result_video_triple_equality(self):
+        r1 = ResultVideo(doc="test")
+        r2 = ResultVideo(doc="test")
+        r3 = deepcopy(r1)
+        assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -260,6 +260,40 @@ class TestBenchCfgHashStability:
             include_repeats=True
         )
 
+    def test_bench_cfg_with_object_carrying_result_types_stable(self):
+        """Ensure BenchCfg.hash_persistent ignores runtime-only obj fields."""
+
+        def make_cfg(obj_payload):
+            cfg = BenchCfg()
+            cfg.bench_name = "obj_bench"
+            cfg.title = "Object-carrying result types"
+            cfg.over_time = False
+            cfg.repeats = 1
+            cfg.tag = ""
+            cfg.input_vars = []
+            cfg.result_vars = [
+                ResultReference(obj=obj_payload, doc="ref"),
+                ResultDataSet(obj=obj_payload, doc="ds"),
+                ResultVolume(obj=obj_payload, doc="vol"),
+            ]
+            cfg.const_vars = []
+            return cfg
+
+        # Two separately constructed BenchCfgs with equivalent config but
+        # different runtime obj instances should produce the same hash.
+        cfg1 = make_cfg({"value": 1})
+        cfg2 = make_cfg({"value": 1})
+        assert cfg1.hash_persistent(include_repeats=True) == cfg2.hash_persistent(
+            include_repeats=True
+        ), "BenchCfg hash should be stable with object-carrying result types"
+
+        # Changing the underlying runtime object while keeping the hashed
+        # configuration fields the same should not affect the hash.
+        cfg3 = make_cfg({"value": 999})
+        assert cfg1.hash_persistent(include_repeats=True) == cfg3.hash_persistent(
+            include_repeats=True
+        ), "BenchCfg hash should not change when only excluded obj fields differ"
+
 
 class TestSpecificVerification:
     """Explicit verification from the task description."""

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -8,11 +8,15 @@ Key guarantees enforced by these tests:
 - Auto-discovery: any new Result* class is automatically tested (no manual updates needed)
 - Slot coverage: every __slots__ entry is either hashed or explicitly in _hash_exclude
 - Determinism: two equivalent instances produce the same hash
+- Cross-process stability: hash is identical across separate Python processes
 - Deepcopy stability: hash survives deepcopy
 - Differentiation: different config values produce different hashes
 """
 
 import inspect
+import subprocess
+import sys
+import textwrap
 from copy import deepcopy
 
 import param
@@ -278,3 +282,95 @@ class TestSpecificVerification:
         r2 = ResultVideo(doc="test")
         r3 = deepcopy(r1)
         assert r1.hash_persistent() == r2.hash_persistent() == r3.hash_persistent()
+
+
+# Script template for cross-process tests. Each subprocess imports the class,
+# constructs an instance, and prints its hash. The parent compares hashes from
+# two independent processes to verify they match.
+_SUBPROCESS_HASH_SCRIPT = textwrap.dedent("""\
+    from bencher.variables.results import {cls_name}
+    {extra}
+    r = {cls_name}({args})
+    print(r.hash_persistent())
+""")
+
+
+def _hash_in_subprocess(cls_name, args="doc='test'", extra=""):
+    """Spawn a fresh Python process and return the hash_persistent() value."""
+    script = _SUBPROCESS_HASH_SCRIPT.format(
+        cls_name=cls_name,
+        args=args,
+        extra=extra,
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Subprocess failed for {cls_name}:\n{result.stderr}"
+    return result.stdout.strip()
+
+
+class TestCrossProcessDeterminism:
+    """Verify hash_persistent() produces identical values across separate processes.
+
+    This is the ultimate test for the over_time cache: process A writes cache with
+    a key, process B must compute the same key to find it. In-process tests cannot
+    catch bugs where str(obj) includes the memory address, because the address is
+    stable within a single process.
+    """
+
+    @pytest.mark.parametrize(
+        "cls_name,args",
+        [
+            ("ResultVar", "units='ul', doc='test'"),
+            ("ResultBool", "units='ratio', doc='test'"),
+            ("ResultVec", "size=3, units='ul', doc='test'"),
+            ("ResultHmap", "doc='test'"),
+            ("ResultPath", "doc='test'"),
+            ("ResultVideo", "doc='test'"),
+            ("ResultImage", "doc='test'"),
+            ("ResultString", "doc='test'"),
+            ("ResultContainer", "doc='test'"),
+            ("ResultReference", "doc='test'"),
+            ("ResultDataSet", "doc='test'"),
+            ("ResultVolume", "doc='test'"),
+        ],
+    )
+    def test_hash_stable_across_two_processes(self, cls_name, args):
+        hash_a = _hash_in_subprocess(cls_name, args)
+        hash_b = _hash_in_subprocess(cls_name, args)
+        assert hash_a == hash_b, (
+            f"{cls_name}.hash_persistent() differs across processes: {hash_a!r} != {hash_b!r}"
+        )
+
+    def test_bench_cfg_hash_stable_across_processes(self):
+        """End-to-end: BenchCfg cache key must be identical across processes."""
+        script = textwrap.dedent("""\
+            from bencher.variables.results import ResultImage, ResultVar
+            from bencher.bench_cfg import BenchCfg
+            cfg = BenchCfg()
+            cfg.bench_name = "test_bench"
+            cfg.title = "Test"
+            cfg.over_time = False
+            cfg.repeats = 1
+            cfg.tag = ""
+            cfg.input_vars = []
+            cfg.result_vars = [ResultVar(units="m/s", doc="speed"), ResultImage(doc="img")]
+            cfg.const_vars = []
+            print(cfg.hash_persistent(include_repeats=True))
+        """)
+        hashes = []
+        for _ in range(2):
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, f"Subprocess failed:\n{result.stderr}"
+            hashes.append(result.stdout.strip())
+        assert hashes[0] == hashes[1], (
+            f"BenchCfg.hash_persistent() differs across processes: {hashes[0]!r} != {hashes[1]!r}"
+        )


### PR DESCRIPTION
## Summary
- Fix `hash_persistent()` on 9 result variable classes (`ResultHmap`, `ResultPath`, `ResultVideo`, `ResultImage`, `ResultString`, `ResultContainer`, `ResultReference`, `ResultDataSet`, `ResultVolume`) that used `hash_sha1(self)` — which includes the Python memory address via `str()`, producing different hashes every process invocation. This broke `over_time` history cache lookups since `BenchCfg` cache keys changed every run.
- Fix `ResultVec.hash_persistent()` not including `size` in its hash, causing cache key collisions for vectors of different sizes.
- Introduce `_hash_slots()` helper that hashes **all** `__slots__` by default, with explicit `_hash_exclude` for non-deterministic runtime attributes (`obj`, `container`). This "hash everything, exclude what's non-deterministic" approach ensures new slots are automatically included.
- Add comprehensive auto-discovery tests (97 tests) that will **automatically fail CI** if a new `Result*` class is added without deterministic hashing — no manual test updates needed.

## What was broken

`BenchCfg.hash_persistent()` feeds every result variable's hash into the cache key. Since `str()` on a `param.Parameter` includes the object's memory address, the cache key was different every process invocation. `load_history_cache()` could never find prior entries, silently breaking the `over_time` history accumulation feature.

## Design

Instead of manually choosing which attributes to hash per class, `_hash_slots()` hashes all `__slots__` by default. Non-deterministic slots (runtime objects, callbacks) must be explicitly listed in `_hash_exclude`:

```python
class ResultReference(param.Parameter):
    __slots__ = ["units", "obj", "container"]
    _hash_exclude = ("obj", "container")  # runtime state, not deterministic config
```

Tests enforce:
- **Slot coverage**: every `__slots__` entry is either hashed or in `_hash_exclude`
- **Hashed slots affect hash**: changing any non-excluded slot changes the hash
- **Excluded slots don't affect hash**: changing excluded slots leaves hash unchanged
- **Determinism**: two equivalent instances always produce the same hash
- **Deepcopy stability**: hash survives `deepcopy()`

## Test plan
- [x] 96 passed, 1 skipped in `test/test_hash_persistent.py`
- [x] Full CI passes (the 1 `test_yaml_sweep_hash_includes_value` failure is pre-existing and also fails on `main`)
- [x] Lint: 10.00/10, format: no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure deterministic persistent hashing for result variable classes and protect it with automated tests.

Bug Fixes:
- Make hash_persistent() deterministic for result variable classes that previously included process-specific state in their hashes.
- Include ResultVec size in its persistent hash to avoid collisions between vectors of different lengths.

Enhancements:
- Introduce a shared _hash_slots() helper that hashes all slot attributes by default while allowing explicit exclusion of non-deterministic fields.

Build:
- Bump the project version to 1.65.0 in pyproject.toml.

Documentation:
- Update the changelog with the new version and details of the hashing fixes.

Tests:
- Add comprehensive auto-discovery tests that enforce deterministic hashing behavior and slot coverage for all Result* classes, including BenchCfg integration scenarios.