### PR TITLE
Add max_over_time parameter to limit over_time event accumulation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,13 +49,10 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
   # Shell script linter
-  - repo: local
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
     hooks:
       - id: shellcheck
-        name: shellcheck
-        language: system
-        entry: shellcheck
-        types: [shell]
 
   # Checks for spelling mistakes
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,10 +49,13 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
   # Shell script linter
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  - repo: local
     hooks:
       - id: shellcheck
+        name: shellcheck
+        language: system
+        entry: shellcheck
+        types: [shell]
 
   # Checks for spelling mistakes
   - repo: https://github.com/codespell-project/codespell

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -60,7 +60,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
         print_bench_results (bool): Print the results of the benchmark function
                                    every time it is called
         clear_history (bool): Clear historical results
-        max_over_time (int): Maximum number of over_time events to retain. None means unlimited.
+        max_time_events (int): Maximum number of over_time events to retain. None means unlimited.
         print_pandas (bool): Print a pandas summary of the results to the console
         print_xarray (bool): Print an xarray summary of the results to the console
         serve_pandas (bool): Serve a pandas summary on the results webpage
@@ -220,7 +220,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     clear_history: bool = param.Boolean(False, doc="Clear historical results")
 
-    max_over_time: Optional[int] = param.Integer(
+    max_time_events: int | None = param.Integer(
         None,
         bounds=[1, None],
         allow_None=True,

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -60,6 +60,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
         print_bench_results (bool): Print the results of the benchmark function
                                    every time it is called
         clear_history (bool): Clear historical results
+        max_over_time (int): Maximum number of over_time events to retain. None means unlimited.
         print_pandas (bool): Print a pandas summary of the results to the console
         print_xarray (bool): Print an xarray summary of the results to the console
         serve_pandas (bool): Serve a pandas summary on the results webpage
@@ -218,6 +219,13 @@ class BenchRunCfg(BenchPlotSrvCfg):
     )
 
     clear_history: bool = param.Boolean(False, doc="Clear historical results")
+
+    max_over_time: Optional[int] = param.Integer(
+        None,
+        bounds=[1, None],
+        allow_None=True,
+        doc="Maximum number of over_time events to retain. Oldest events are trimmed. None means unlimited.",
+    )
 
     time_event: Optional[str] = param.String(
         None,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -565,7 +565,7 @@ class Bench(BenchPlotServer):
             # use the hash of the inputs to look up historical values in the cache
             if run_cfg.over_time:
                 bench_res.ds = self.load_history_cache(
-                    bench_res.ds, bench_cfg_hash, run_cfg.clear_history, run_cfg.max_over_time
+                    bench_res.ds, bench_cfg_hash, run_cfg.clear_history, run_cfg.max_time_events
                 )
                 # sync the over_time meta variable with the actual accumulated values
                 if bench_cfg.iv_time and "over_time" in bench_res.ds.coords:
@@ -631,11 +631,11 @@ class Bench(BenchPlotServer):
         dataset: xr.Dataset,
         bench_cfg_hash: str,
         clear_history: bool,
-        max_over_time: int | None = None,
+        max_time_events: int | None = None,
     ) -> xr.Dataset:
         """Load and concatenate historical benchmark data from cache."""
         return self._collector.load_history_cache(
-            dataset, bench_cfg_hash, clear_history, max_over_time
+            dataset, bench_cfg_hash, clear_history, max_time_events
         )
 
     def setup_dataset(

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -565,7 +565,7 @@ class Bench(BenchPlotServer):
             # use the hash of the inputs to look up historical values in the cache
             if run_cfg.over_time:
                 bench_res.ds = self.load_history_cache(
-                    bench_res.ds, bench_cfg_hash, run_cfg.clear_history
+                    bench_res.ds, bench_cfg_hash, run_cfg.clear_history, run_cfg.max_over_time
                 )
                 # sync the over_time meta variable with the actual accumulated values
                 if bench_cfg.iv_time and "over_time" in bench_res.ds.coords:
@@ -627,10 +627,16 @@ class Bench(BenchPlotServer):
     #     return BenchPlotServer().plot_server(self.bench_name, run_cfg, pane)
 
     def load_history_cache(
-        self, dataset: xr.Dataset, bench_cfg_hash: str, clear_history: bool
+        self,
+        dataset: xr.Dataset,
+        bench_cfg_hash: str,
+        clear_history: bool,
+        max_over_time: int | None = None,
     ) -> xr.Dataset:
         """Load and concatenate historical benchmark data from cache."""
-        return self._collector.load_history_cache(dataset, bench_cfg_hash, clear_history)
+        return self._collector.load_history_cache(
+            dataset, bench_cfg_hash, clear_history, max_over_time
+        )
 
     def setup_dataset(
         self, bench_cfg: BenchCfg, time_src: datetime | str

--- a/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -16,7 +17,7 @@ class BaselineCheck(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.baseline = 42.0
-        self.baseline += __import__("random").gauss(0, 0.1 * 5)
+        self.baseline += random.gauss(0, 0.1 * 5)
         self.baseline += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_1_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -18,7 +19,7 @@ class CacheBackend(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
-        self.latency = base + __import__("random").gauss(0, 0.1 * base)
+        self.latency = base + random.gauss(0, 0.1 * base)
         self.latency += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_2_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -20,7 +21,7 @@ class NetworkConfig(bch.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
-        self.throughput = region_base * proto_factor + __import__("random").gauss(0, 0.1 * 50)
+        self.throughput = region_base * proto_factor + random.gauss(0, 0.1 * 50)
         self.throughput += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/over_time/ex_0_float_3_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -22,9 +23,7 @@ class DeploymentConfig(bch.ParametrizedSweep):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
-        self.throughput = region_base * proto_factor * log_penalty + __import__("random").gauss(
-            0, 0.1 * 50
-        )
+        self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, 0.1 * 50)
         self.throughput += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_0_cat.py
@@ -1,9 +1,9 @@
 """Auto-generated example: 0 Float, 0 Categorical."""
 
-import random
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_1_cat.py
@@ -1,9 +1,9 @@
 """Auto-generated example: 0 Float, 1 Categorical."""
 
-import random
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_2_cat.py
@@ -1,9 +1,9 @@
 """Auto-generated example: 0 Float, 2 Categorical."""
 
-import random
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_3_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/over_time_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/over_time_repeats/ex_0_float_3_cat.py
@@ -1,9 +1,9 @@
 """Auto-generated example: 0 Float, 3 Categorical."""
 
-import random
 from typing import Any
 
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 
 
 class BaselineCheck(bch.ParametrizedSweep):
@@ -13,7 +14,7 @@ class BaselineCheck(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.baseline = 42.0
-        self.baseline += __import__("random").gauss(0, 0.15 * 5)
+        self.baseline += random.gauss(0, 0.15 * 5)
         return super().__call__()
 
 

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 
 
 class BaselineCheck(bch.ParametrizedSweep):

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 
 
 class CacheBackend(bch.ParametrizedSweep):
@@ -15,7 +16,7 @@ class CacheBackend(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
-        self.latency = base + __import__("random").gauss(0, 0.15 * base)
+        self.latency = base + random.gauss(0, 0.15 * base)
         return super().__call__()
 
 

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 
 
 class CacheBackend(bch.ParametrizedSweep):

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 
 
 class NetworkConfig(bch.ParametrizedSweep):

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_2_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 
 
 class NetworkConfig(bch.ParametrizedSweep):
@@ -17,7 +18,7 @@ class NetworkConfig(bch.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
-        self.throughput = region_base * proto_factor + __import__("random").gauss(0, 0.15 * 50)
+        self.throughput = region_base * proto_factor + random.gauss(0, 0.15 * 50)
         return super().__call__()
 
 

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import random
+import bencher as bch
 
 
 class DeploymentConfig(bch.ParametrizedSweep):

--- a/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
+++ b/bencher/example/generated/0_float/with_repeats/ex_0_float_3_cat.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import bencher as bch
+import random
 
 
 class DeploymentConfig(bch.ParametrizedSweep):
@@ -19,9 +20,7 @@ class DeploymentConfig(bch.ParametrizedSweep):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
-        self.throughput = region_base * proto_factor * log_penalty + __import__("random").gauss(
-            0, 0.15 * 50
-        )
+        self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, 0.15 * 50)
         return super().__call__()
 
 

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SortBenchmark(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SortComparison(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SortAnalysis(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/no_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/no_repeats/ex_1_float_3_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SortFullMatrix(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -19,7 +20,7 @@ class SortBenchmark(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
-        self.time += __import__("random").gauss(0, 0.1 * self.time)
+        self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -21,7 +22,7 @@ class SortComparison(bch.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
-        self.time += __import__("random").gauss(0, 0.1 * self.time)
+        self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -25,7 +26,7 @@ class SortAnalysis(bch.ParametrizedSweep):
         self.time = (
             algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         )
-        self.time += __import__("random").gauss(0, 0.1 * self.time)
+        self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -32,7 +33,7 @@ class SortFullMatrix(bch.ParametrizedSweep):
             * math.log2(self.array_size + 1)
             * 0.001
         )
-        self.time += __import__("random").gauss(0, 0.1 * self.time)
+        self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/over_time/ex_1_float_3_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_0_cat.py
@@ -3,9 +3,8 @@
 from typing import Any
 
 import math
-import random
-
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_1_cat.py
@@ -3,9 +3,8 @@
 from typing import Any
 
 import math
-import random
-
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_2_cat.py
@@ -3,9 +3,8 @@
 from typing import Any
 
 import math
-import random
-
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_3_cat.py
@@ -3,9 +3,8 @@
 from typing import Any
 
 import math
-import random
-
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/over_time_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/over_time_repeats/ex_1_float_3_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class SortBenchmark(bch.ParametrizedSweep):
@@ -16,7 +17,7 @@ class SortBenchmark(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
-        self.time += __import__("random").gauss(0, 0.15 * self.time)
+        self.time += random.gauss(0, 0.15 * self.time)
         return super().__call__()
 
 

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class SortBenchmark(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class SortComparison(bch.ParametrizedSweep):
@@ -18,7 +19,7 @@ class SortComparison(bch.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
-        self.time += __import__("random").gauss(0, 0.15 * self.time)
+        self.time += random.gauss(0, 0.15 * self.time)
         return super().__call__()
 
 

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class SortComparison(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class SortAnalysis(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class SortAnalysis(bch.ParametrizedSweep):
@@ -22,7 +23,7 @@ class SortAnalysis(bch.ParametrizedSweep):
         self.time = (
             algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         )
-        self.time += __import__("random").gauss(0, 0.15 * self.time)
+        self.time += random.gauss(0, 0.15 * self.time)
         return super().__call__()
 
 

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class SortFullMatrix(bch.ParametrizedSweep):

--- a/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
+++ b/bencher/example/generated/1_float/with_repeats/ex_1_float_3_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class SortFullMatrix(bch.ParametrizedSweep):
@@ -29,7 +30,7 @@ class SortFullMatrix(bch.ParametrizedSweep):
             * math.log2(self.array_size + 1)
             * 0.001
         )
-        self.time += __import__("random").gauss(0, 0.15 * self.time)
+        self.time += random.gauss(0, 0.15 * self.time)
         return super().__call__()
 
 

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class CompressionBench(bch.ParametrizedSweep):

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class CompressionCodec(bch.ParametrizedSweep):

--- a/bencher/example/generated/2_float/no_repeats/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/no_repeats/ex_2_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class CompressionSuite(bch.ParametrizedSweep):

--- a/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -20,7 +21,7 @@ class CompressionBench(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
-        self.ratio += __import__("random").gauss(0, 0.1 * 0.3)
+        self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -24,7 +25,7 @@ class CompressionCodec(bch.ParametrizedSweep):
         self.ratio = (
             codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        self.ratio += __import__("random").gauss(0, 0.1 * 0.3)
+        self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/over_time/ex_2_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -29,7 +30,7 @@ class CompressionSuite(bch.ParametrizedSweep):
             * (1.0 - 0.7 * self.entropy)
             * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        self.ratio += __import__("random").gauss(0, 0.1 * 0.3)
+        self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class CompressionBench(bch.ParametrizedSweep):

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class CompressionBench(bch.ParametrizedSweep):
@@ -17,7 +18,7 @@ class CompressionBench(bch.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
-        self.ratio += __import__("random").gauss(0, 0.15 * 0.3)
+        self.ratio += random.gauss(0, 0.15 * 0.3)
         return super().__call__()
 
 

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class CompressionCodec(bch.ParametrizedSweep):

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class CompressionCodec(bch.ParametrizedSweep):
@@ -21,7 +22,7 @@ class CompressionCodec(bch.ParametrizedSweep):
         self.ratio = (
             codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        self.ratio += __import__("random").gauss(0, 0.15 * 0.3)
+        self.ratio += random.gauss(0, 0.15 * 0.3)
         return super().__call__()
 
 

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class CompressionSuite(bch.ParametrizedSweep):
@@ -26,7 +27,7 @@ class CompressionSuite(bch.ParametrizedSweep):
             * (1.0 - 0.7 * self.entropy)
             * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        self.ratio += __import__("random").gauss(0, 0.15 * 0.3)
+        self.ratio += random.gauss(0, 0.15 * 0.3)
         return super().__call__()
 
 

--- a/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
+++ b/bencher/example/generated/2_float/with_repeats/ex_2_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class CompressionSuite(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_0_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HashBenchmark(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_1_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HashComparison(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/no_repeats/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/no_repeats/ex_3_float_2_cat.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HashAnalysis(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -26,7 +27,7 @@ class HashBenchmark(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.1 * 30)
+        self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -29,7 +30,7 @@ class HashComparison(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.1 * 30)
+        self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import math
 import bencher as bch
+import random
 from datetime import datetime, timedelta
 
 
@@ -32,7 +33,7 @@ class HashAnalysis(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.1 * 30)
+        self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
         return super().__call__()
 

--- a/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/over_time/ex_3_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
+import random
 import math
 import bencher as bch
-import random
 from datetime import datetime, timedelta
 
 

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class HashBenchmark(bch.ParametrizedSweep):
@@ -23,7 +24,7 @@ class HashBenchmark(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.15 * 30)
+        self.throughput += random.gauss(0, 0.15 * 30)
         return super().__call__()
 
 

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_0_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class HashBenchmark(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class HashComparison(bch.ParametrizedSweep):
@@ -26,7 +27,7 @@ class HashComparison(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.15 * 30)
+        self.throughput += random.gauss(0, 0.15 * 30)
         return super().__call__()
 
 

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_1_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class HashComparison(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
-import math
 import random
+import math
+import bencher as bch
 
 
 class HashAnalysis(bch.ParametrizedSweep):

--- a/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
+++ b/bencher/example/generated/3_float/with_repeats/ex_3_float_2_cat.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import bencher as bch
 import math
+import random
 
 
 class HashAnalysis(bch.ParametrizedSweep):
@@ -29,7 +30,7 @@ class HashAnalysis(bch.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        self.throughput += __import__("random").gauss(0, 0.15 * 30)
+        self.throughput += random.gauss(0, 0.15 * 30)
         return super().__call__()
 
 

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -41,8 +41,10 @@ def example_advanced_max_time_events(run_cfg: bch.BenchRunCfg | None = None) -> 
     benchable = LatencyMonitor()
     bench = benchable.to_bench(run_cfg)
 
+    # Run 5 iterations but only keep the 3 most recent thanks to max_time_events.
+    # Without the cap, all 5 time slices would accumulate in the cache.
     base_time = datetime(2024, 6, 1)
-    for i in range(3):
+    for i in range(5):
         benchable._drift = i * 3.0  # simulate gradual degradation
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
@@ -50,8 +52,8 @@ def example_advanced_max_time_events(run_cfg: bch.BenchRunCfg | None = None) -> 
             title="Service Latency",
             input_vars=["endpoint"],
             result_vars=["latency"],
-            description="max_time_events caps over_time history so only the N most "
-            "recent snapshots are retained, preventing unbounded cache growth.",
+            description="5 snapshots are recorded but max_time_events=3 trims the oldest, "
+            "so only the 3 most recent are retained.",
             run_cfg=run_cfg,
             time_src=base_time + timedelta(hours=i),
         )

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -1,0 +1,64 @@
+"""Auto-generated example: Max Time Events — cap over_time history."""
+
+from typing import Any
+
+import random
+import bencher as bch
+from datetime import datetime, timedelta
+
+
+class LatencyMonitor(bch.ParametrizedSweep):
+    """Simulates a service latency monitor that drifts over time.
+
+    When tracking metrics over_time, history grows without bound by default.
+    Setting max_time_events on BenchRunCfg caps the number of retained
+    time slices, keeping only the most recent ones.
+    """
+
+    endpoint = bch.StringSweep(["/api/users", "/api/orders"], doc="API endpoint")
+
+    latency = bch.ResultVar(units="ms", doc="Response latency")
+
+    _drift = 0.0  # set externally per snapshot
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        base = {"/api/users": 45, "/api/orders": 120}[self.endpoint]
+        self.latency = base + self._drift + random.gauss(0, 5)
+        return super().__call__()
+
+
+def example_advanced_max_time_events(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Max Time Events — cap over_time history."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+
+    # Keep only the 4 most recent time slices in the cache.
+    # Without this, every call to plot_sweep appends a new slice and the
+    # cache grows without bound.
+    run_cfg.max_time_events = 4
+
+    benchable = LatencyMonitor()
+    bench = benchable.to_bench(run_cfg)
+
+    base_time = datetime(2024, 6, 1)
+    for i in range(6):
+        benchable._drift = i * 3.0  # simulate gradual degradation
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        bench.plot_sweep(
+            title="Service Latency",
+            input_vars=["endpoint"],
+            result_vars=["latency"],
+            description="max_time_events caps over_time history so only the N most "
+            "recent snapshots are retained. Here 6 snapshots are recorded but only "
+            "the last 4 are kept, preventing unbounded cache growth.",
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(hours=i),
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_advanced_max_time_events, level=3)

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -33,16 +33,16 @@ def example_advanced_max_time_events(run_cfg: bch.BenchRunCfg | None = None) -> 
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
 
-    # Keep only the 4 most recent time slices in the cache.
+    # Keep only the 3 most recent time slices in the cache.
     # Without this, every call to plot_sweep appends a new slice and the
     # cache grows without bound.
-    run_cfg.max_time_events = 4
+    run_cfg.max_time_events = 3
 
     benchable = LatencyMonitor()
     bench = benchable.to_bench(run_cfg)
 
     base_time = datetime(2024, 6, 1)
-    for i in range(6):
+    for i in range(3):
         benchable._drift = i * 3.0  # simulate gradual degradation
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
@@ -51,8 +51,7 @@ def example_advanced_max_time_events(run_cfg: bch.BenchRunCfg | None = None) -> 
             input_vars=["endpoint"],
             result_vars=["latency"],
             description="max_time_events caps over_time history so only the N most "
-            "recent snapshots are retained. Here 6 snapshots are recorded but only "
-            "the last 4 are kept, preventing unbounded cache growth.",
+            "recent snapshots are retained, preventing unbounded cache growth.",
             run_cfg=run_cfg,
             time_src=base_time + timedelta(hours=i),
         )

--- a/bencher/example/generated/optimization/optim_1obj_1d.py
+++ b/bencher/example/generated/optimization/optim_1obj_1d.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import random
+import bencher as bch
 
 
 class ServerOptimizer(bch.ParametrizedSweep):

--- a/bencher/example/generated/optimization/optim_1obj_2d.py
+++ b/bencher/example/generated/optimization/optim_1obj_2d.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import random
+import bencher as bch
 
 
 class ServerOptimizer(bch.ParametrizedSweep):

--- a/bencher/example/generated/optimization/optim_2obj_1d.py
+++ b/bencher/example/generated/optimization/optim_2obj_1d.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import random
+import bencher as bch
 
 
 class ServerOptimizer(bch.ParametrizedSweep):

--- a/bencher/example/generated/optimization/optim_2obj_2d.py
+++ b/bencher/example/generated/optimization/optim_2obj_2d.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import random
+import bencher as bch
 
 
 class ServerOptimizer(bch.ParametrizedSweep):

--- a/bencher/example/generated/plot_types/plot_box_whisker.py
+++ b/bencher/example/generated/plot_types/plot_box_whisker.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 from bencher.results.holoview_results.distribution_result.box_whisker_result import BoxWhiskerResult
+import bencher as bch
 
 import random
 

--- a/bencher/example/generated/plot_types/plot_scatter_jitter.py
+++ b/bencher/example/generated/plot_types/plot_scatter_jitter.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 from bencher.results.holoview_results.distribution_result.scatter_jitter_result import (
     ScatterJitterResult,
 )
+import bencher as bch
 
 import random
 

--- a/bencher/example/generated/result_types/result_bool/result_bool_0d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_0d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HealthChecker(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_bool/result_bool_1d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HealthChecker(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_bool/result_bool_2d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_2d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class HealthChecker(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class TimeseriesCollector(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class TimeseriesCollector(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_image/result_image_0d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_0d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/result_types/result_image/result_image_1d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_1d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/result_types/result_image/result_image_2d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_2d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/result_types/result_path/result_path_0d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_0d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class ReportExporter(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_path/result_path_1d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class ReportExporter(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_string/result_string_0d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_0d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class LogFormatter(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_string/result_string_1d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class LogFormatter(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_var/result_var_0d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_0d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class ResponseTimer(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_var/result_var_1d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class ResponseTimer(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_var/result_var_2d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_2d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class ResponseTimer(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_vec/result_vec_1d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_1d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SystemMetrics(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_vec/result_vec_2d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_2d.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class SystemMetrics(bch.ParametrizedSweep):

--- a/bencher/example/generated/result_types/result_video/result_video_0d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_0d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/result_types/result_video/result_video_1d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_1d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/result_types/result_video/result_video_2d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_2d.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
-import bencher as bch
 import math
 import numpy as np
 from PIL import Image, ImageDraw
+import bencher as bch
 
 
 def _polygon_points(radius, sides, start_angle=0.0):

--- a/bencher/example/generated/sampling/sampling_int_vs_float.py
+++ b/bencher/example/generated/sampling/sampling_int_vs_float.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class IntFloatCompare(bch.ParametrizedSweep):

--- a/bencher/example/generated/sampling/sampling_uniform.py
+++ b/bencher/example/generated/sampling/sampling_uniform.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-import bencher as bch
 import math
+import bencher as bch
 
 
 class UniformSampler(bch.ParametrizedSweep):

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -17,7 +17,7 @@ INLINE_CLASSES = {
         "call_body": ["self.baseline = 42.0"],
         "noise_body": [
             "self.baseline = 42.0",
-            "self.baseline += __import__('random').gauss(0, {noise} * 5)",
+            "self.baseline += random.gauss(0, {noise} * 5)",
         ],
     },
     (0, 1): {
@@ -36,7 +36,7 @@ INLINE_CLASSES = {
         ],
         "noise_body": [
             'base = {{"redis": 1.2, "memcached": 1.5, "local": 0.3}}[self.backend]',
-            "self.latency = base + __import__('random').gauss(0, {noise} * base)",
+            "self.latency = base + random.gauss(0, {noise} * base)",
         ],
     },
     (0, 2): {
@@ -58,7 +58,7 @@ INLINE_CLASSES = {
         "noise_body": [
             'proto_factor = {{"http": 1.0, "grpc": 1.8}}[self.protocol]',
             'region_base = {{"us-east": 500, "eu-west": 420, "ap-south": 350}}[self.region]',
-            "self.throughput = region_base * proto_factor + __import__('random').gauss(0, {noise} * 50)",
+            "self.throughput = region_base * proto_factor + random.gauss(0, {noise} * 50)",
         ],
     },
     (0, 3): {
@@ -83,7 +83,7 @@ INLINE_CLASSES = {
             'proto_factor = {{"http": 1.0, "grpc": 1.8}}[self.protocol]',
             'region_base = {{"us-east": 500, "eu-west": 420, "ap-south": 350}}[self.region]',
             'log_penalty = {{"debug": 0.7, "info": 1.0, "warn": 1.0}}[self.log_level]',
-            "self.throughput = region_base * proto_factor * log_penalty + __import__('random').gauss(0, {noise} * 50)",
+            "self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, {noise} * 50)",
         ],
     },
     (1, 0): {
@@ -101,7 +101,7 @@ INLINE_CLASSES = {
         ],
         "noise_body": [
             "self.time = self.array_size * math.log2(self.array_size + 1) * 0.001",
-            "self.time += __import__('random').gauss(0, {noise} * self.time)",
+            "self.time += random.gauss(0, {noise} * self.time)",
         ],
     },
     (1, 1): {
@@ -122,7 +122,7 @@ INLINE_CLASSES = {
         "noise_body": [
             'algo_factor = {{"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}}[self.algorithm]',
             "self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001",
-            "self.time += __import__('random').gauss(0, {noise} * self.time)",
+            "self.time += random.gauss(0, {noise} * self.time)",
         ],
     },
     (1, 2): {
@@ -146,7 +146,7 @@ INLINE_CLASSES = {
             'algo_factor = {{"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}}[self.algorithm]',
             'dist_factor = {{"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}}[self.distribution]',
             "self.time = algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001",
-            "self.time += __import__('random').gauss(0, {noise} * self.time)",
+            "self.time += random.gauss(0, {noise} * self.time)",
         ],
     },
     (1, 3): {
@@ -173,7 +173,7 @@ INLINE_CLASSES = {
             'dist_factor = {{"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}}[self.distribution]',
             'stab_factor = {{"stable": 1.1, "unstable": 1.0}}[self.stability]',
             "self.time = algo_factor * dist_factor * stab_factor * self.array_size * math.log2(self.array_size + 1) * 0.001",
-            "self.time += __import__('random').gauss(0, {noise} * self.time)",
+            "self.time += random.gauss(0, {noise} * self.time)",
         ],
     },
     (2, 0): {
@@ -192,7 +192,7 @@ INLINE_CLASSES = {
         ],
         "noise_body": [
             "self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))",
-            "self.ratio += __import__('random').gauss(0, {noise} * 0.3)",
+            "self.ratio += random.gauss(0, {noise} * 0.3)",
         ],
     },
     (2, 1): {
@@ -214,7 +214,7 @@ INLINE_CLASSES = {
         "noise_body": [
             'codec_eff = {{"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}}[self.codec]',
             "self.ratio = codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))",
-            "self.ratio += __import__('random').gauss(0, {noise} * 0.3)",
+            "self.ratio += random.gauss(0, {noise} * 0.3)",
         ],
     },
     (2, 2): {
@@ -239,7 +239,7 @@ INLINE_CLASSES = {
             'codec_eff = {{"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}}[self.codec]',
             'effort_mult = {{"fast": 0.8, "balanced": 1.0, "max": 1.15}}[self.effort]',
             "self.ratio = codec_eff * effort_mult * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))",
-            "self.ratio += __import__('random').gauss(0, {noise} * 0.3)",
+            "self.ratio += random.gauss(0, {noise} * 0.3)",
         ],
     },
     (3, 0): {
@@ -259,7 +259,7 @@ INLINE_CLASSES = {
         ],
         "noise_body": [
             "self.throughput = 500.0 / (1.0 + 0.5 * math.log2(self.key_size / 8)) / (1.0 + 0.3 * math.log2(self.payload_size / 64)) * (self.iterations / 100)",
-            "self.throughput += __import__('random').gauss(0, {noise} * 30)",
+            "self.throughput += random.gauss(0, {noise} * 30)",
         ],
     },
     (3, 1): {
@@ -282,7 +282,7 @@ INLINE_CLASSES = {
         "noise_body": [
             'algo_speed = {{"sha256": 1.0, "blake2": 1.4, "md5": 1.8}}[self.algorithm]',
             "self.throughput = algo_speed * 500.0 / (1.0 + 0.5 * math.log2(self.key_size / 8)) / (1.0 + 0.3 * math.log2(self.payload_size / 64)) * (self.iterations / 100)",
-            "self.throughput += __import__('random').gauss(0, {noise} * 30)",
+            "self.throughput += random.gauss(0, {noise} * 30)",
         ],
     },
     (3, 2): {
@@ -308,7 +308,7 @@ INLINE_CLASSES = {
             'algo_speed = {{"sha256": 1.0, "blake2": 1.4, "md5": 1.8}}[self.algorithm]',
             'mode_factor = {{"stream": 1.0, "block": 0.85}}[self.mode]',
             "self.throughput = algo_speed * mode_factor * 500.0 / (1.0 + 0.5 * math.log2(self.key_size / 8)) / (1.0 + 0.3 * math.log2(self.payload_size / 64)) * (self.iterations / 100)",
-            "self.throughput += __import__('random').gauss(0, {noise} * 30)",
+            "self.throughput += random.gauss(0, {noise} * 30)",
         ],
     },
 }
@@ -442,7 +442,8 @@ class BenchMetaGen(bch.ParametrizedSweep):
                 f"        time_src=_base_time + timedelta(seconds=i),\n"
                 f"    )\n"
             )
-            imports = f"{info['imports']}\nfrom datetime import datetime, timedelta"
+            noise_imports = "\nimport random" if noise_val > 0 else ""
+            imports = f"{info['imports']}{noise_imports}\nfrom datetime import datetime, timedelta"
             gen.generate_example(
                 title=title,
                 output_dir=f"{self.float_vars_count}_float/{variant}",
@@ -463,6 +464,10 @@ class BenchMetaGen(bch.ParametrizedSweep):
             if self.sample_with_repeats > 1:
                 run_kwargs["repeats"] = self.sample_with_repeats
 
+            sweep_extra_imports = list(extra_imports)
+            if noise_val > 0:
+                sweep_extra_imports.append("import random")
+
             gen.generate_sweep_example(
                 title=title,
                 output_dir=f"{self.float_vars_count}_float/{variant}",
@@ -473,7 +478,7 @@ class BenchMetaGen(bch.ParametrizedSweep):
                 input_vars=repr(input_var_names),
                 result_vars=repr(result_var_names),
                 class_code=class_code,
-                extra_imports=extra_imports or None,
+                extra_imports=sweep_extra_imports or None,
                 run_kwargs=run_kwargs,
             )
 

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -442,8 +442,8 @@ class BenchMetaGen(bch.ParametrizedSweep):
                 f"        time_src=_base_time + timedelta(seconds=i),\n"
                 f"    )\n"
             )
-            noise_imports = "\nimport random" if noise_val > 0 else ""
-            imports = f"{info['imports']}{noise_imports}\nfrom datetime import datetime, timedelta"
+            noise_imports = "import random\n" if noise_val > 0 else ""
+            imports = f"{noise_imports}{info['imports']}\nfrom datetime import datetime, timedelta"
             gen.generate_example(
                 title=title,
                 output_dir=f"{self.float_vars_count}_float/{variant}",
@@ -466,7 +466,7 @@ class BenchMetaGen(bch.ParametrizedSweep):
 
             sweep_extra_imports = list(extra_imports)
             if noise_val > 0:
-                sweep_extra_imports.append("import random")
+                sweep_extra_imports.insert(0, "import random")
 
             gen.generate_sweep_example(
                 title=title,

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -197,8 +197,10 @@ run_cfg.max_time_events = 3
 benchable = LatencyMonitor()
 bench = benchable.to_bench(run_cfg)
 
+# Run 5 iterations but only keep the 3 most recent thanks to max_time_events.
+# Without the cap, all 5 time slices would accumulate in the cache.
 base_time = datetime(2024, 6, 1)
-for i in range(3):
+for i in range(5):
     benchable._drift = i * 3.0  # simulate gradual degradation
     run_cfg.clear_cache = True
     run_cfg.clear_history = i == 0
@@ -206,8 +208,8 @@ for i in range(3):
         title="Service Latency",
         input_vars=["endpoint"],
         result_vars=["latency"],
-        description="max_time_events caps over_time history so only the N most "
-        "recent snapshots are retained, preventing unbounded cache growth.",
+        description="5 snapshots are recorded but max_time_events=3 trims the oldest, "
+        "so only the 3 most recent are retained.",
         run_cfg=run_cfg,
         time_src=base_time + timedelta(hours=i),
     )

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -189,16 +189,16 @@ class LatencyMonitor(bch.ParametrizedSweep):
 run_cfg = run_cfg or bch.BenchRunCfg()
 run_cfg.over_time = True
 
-# Keep only the 4 most recent time slices in the cache.
+# Keep only the 3 most recent time slices in the cache.
 # Without this, every call to plot_sweep appends a new slice and the
 # cache grows without bound.
-run_cfg.max_time_events = 4
+run_cfg.max_time_events = 3
 
 benchable = LatencyMonitor()
 bench = benchable.to_bench(run_cfg)
 
 base_time = datetime(2024, 6, 1)
-for i in range(6):
+for i in range(3):
     benchable._drift = i * 3.0  # simulate gradual degradation
     run_cfg.clear_cache = True
     run_cfg.clear_history = i == 0
@@ -207,8 +207,7 @@ for i in range(6):
         input_vars=["endpoint"],
         result_vars=["latency"],
         description="max_time_events caps over_time history so only the N most "
-        "recent snapshots are retained. Here 6 snapshots are recorded but only "
-        "the last 4 are kept, preventing unbounded cache growth.",
+        "recent snapshots are retained, preventing unbounded cache growth.",
         run_cfg=run_cfg,
         time_src=base_time + timedelta(hours=i),
     )

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -14,6 +14,7 @@ OUTPUT_DIR = "advanced"
 ADVANCED_EXAMPLES = [
     "cache_patterns",
     "time_event",
+    "max_time_events",
     "report_save",
 ]
 
@@ -30,6 +31,8 @@ class MetaAdvanced(MetaGeneratorBase):
             self._generate_cache_patterns()
         elif self.example == "time_event":
             self._generate_time_event()
+        elif self.example == "max_time_events":
+            self._generate_max_time_events()
         elif self.example == "report_save":
             self._generate_report_save()
 
@@ -151,6 +154,70 @@ for i, event_name in enumerate(events):
             output_dir=OUTPUT_DIR,
             filename="advanced_time_event",
             function_name="example_advanced_time_event",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"level": 3},
+        )
+
+    def _generate_max_time_events(self):
+        """Demonstrate max_time_events to cap over_time history."""
+        imports = "import random\nimport bencher as bch\nfrom datetime import datetime, timedelta"
+        class_code = '''\
+class LatencyMonitor(bch.ParametrizedSweep):
+    """Simulates a service latency monitor that drifts over time.
+
+    When tracking metrics over_time, history grows without bound by default.
+    Setting max_time_events on BenchRunCfg caps the number of retained
+    time slices, keeping only the most recent ones.
+    """
+
+    endpoint = bch.StringSweep(
+        ["/api/users", "/api/orders"], doc="API endpoint"
+    )
+
+    latency = bch.ResultVar(units="ms", doc="Response latency")
+
+    _drift = 0.0  # set externally per snapshot
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        base = {"/api/users": 45, "/api/orders": 120}[self.endpoint]
+        self.latency = base + self._drift + random.gauss(0, 5)
+        return super().__call__()'''
+        body = """\
+run_cfg = run_cfg or bch.BenchRunCfg()
+run_cfg.over_time = True
+
+# Keep only the 4 most recent time slices in the cache.
+# Without this, every call to plot_sweep appends a new slice and the
+# cache grows without bound.
+run_cfg.max_time_events = 4
+
+benchable = LatencyMonitor()
+bench = benchable.to_bench(run_cfg)
+
+base_time = datetime(2024, 6, 1)
+for i in range(6):
+    benchable._drift = i * 3.0  # simulate gradual degradation
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    bench.plot_sweep(
+        title="Service Latency",
+        input_vars=["endpoint"],
+        result_vars=["latency"],
+        description="max_time_events caps over_time history so only the N most "
+        "recent snapshots are retained. Here 6 snapshots are recorded but only "
+        "the last 4 are kept, preventing unbounded cache growth.",
+        run_cfg=run_cfg,
+        time_src=base_time + timedelta(hours=i),
+    )
+"""
+        self.generate_example(
+            title="Max Time Events — cap over_time history",
+            output_dir=OUTPUT_DIR,
+            filename="advanced_max_time_events",
+            function_name="example_advanced_max_time_events",
             imports=imports,
             body=body,
             class_code=class_code,

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -109,11 +109,12 @@ if __name__ == "__main__":
             run_kwargs: Dict of kwargs for bch.run() (e.g. {"level": 4, "repeats": 10}).
             module_docstring: Optional override for the module-level docstring.
         """
-        import_lines = ["import bencher as bch"]
-        if benchable_module is not None:
-            import_lines.append(f"from {benchable_module} import {benchable_class}")
+        import_lines = []
         if extra_imports:
             import_lines.extend(extra_imports)
+        import_lines.append("import bencher as bch")
+        if benchable_module is not None:
+            import_lines.append(f"from {benchable_module} import {benchable_class}")
         imports = "\n".join(import_lines)
 
         body_lines = []

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -314,7 +314,7 @@ class ResultCollector:
                 else:
                     logger.info("did not detect any historical data")
 
-            if max_time_events is not None and max_time_events >= 1 and "over_time" in dataset.dims:
+            if max_time_events is not None and "over_time" in dataset.dims:
                 if dataset.sizes["over_time"] > max_time_events:
                     dataset = dataset.isel(over_time=slice(-max_time_events, None))
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -283,7 +283,7 @@ class ResultCollector:
         dataset: xr.Dataset,
         bench_cfg_hash: str,
         clear_history: bool,
-        max_over_time: int | None = None,
+        max_time_events: int | None = None,
     ) -> xr.Dataset:
         """Load historical data from a cache if over_time is enabled.
 
@@ -295,7 +295,7 @@ class ResultCollector:
             dataset (xr.Dataset): Freshly calculated benchmark data for the current run
             bench_cfg_hash (str): Hash of the input variables used to identify cached data
             clear_history (bool): If True, clears historical data instead of loading it
-            max_over_time (int | None): Maximum number of over_time events to retain.
+            max_time_events (int | None): Maximum number of over_time events to retain.
                 Oldest events are trimmed. None means unlimited.
 
         Returns:
@@ -314,9 +314,9 @@ class ResultCollector:
                 else:
                     logger.info("did not detect any historical data")
 
-            if max_over_time is not None and "over_time" in dataset.dims:
-                if dataset.sizes["over_time"] > max_over_time:
-                    dataset = dataset.isel(over_time=slice(-max_over_time, None))
+            if max_time_events is not None and "over_time" in dataset.dims:
+                if dataset.sizes["over_time"] > max_time_events:
+                    dataset = dataset.isel(over_time=slice(-max_time_events, None))
 
             logger.info("saving data to history cache")
             c[bench_cfg_hash] = dataset

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -314,7 +314,7 @@ class ResultCollector:
                 else:
                     logger.info("did not detect any historical data")
 
-            if max_time_events is not None and "over_time" in dataset.dims:
+            if max_time_events is not None and max_time_events >= 1 and "over_time" in dataset.dims:
                 if dataset.sizes["over_time"] > max_time_events:
                     dataset = dataset.isel(over_time=slice(-max_time_events, None))
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -279,7 +279,11 @@ class ResultCollector:
             c[bench_res.bench_cfg.bench_name] = bench_cfg_hashes
 
     def load_history_cache(
-        self, dataset: xr.Dataset, bench_cfg_hash: str, clear_history: bool
+        self,
+        dataset: xr.Dataset,
+        bench_cfg_hash: str,
+        clear_history: bool,
+        max_over_time: int | None = None,
     ) -> xr.Dataset:
         """Load historical data from a cache if over_time is enabled.
 
@@ -291,6 +295,8 @@ class ResultCollector:
             dataset (xr.Dataset): Freshly calculated benchmark data for the current run
             bench_cfg_hash (str): Hash of the input variables used to identify cached data
             clear_history (bool): If True, clears historical data instead of loading it
+            max_over_time (int | None): Maximum number of over_time events to retain.
+                Oldest events are trimmed. None means unlimited.
 
         Returns:
             xr.Dataset: Combined dataset with both historical and current benchmark data,
@@ -307,6 +313,10 @@ class ResultCollector:
                     dataset = xr.concat([ds_old, dataset], "over_time")
                 else:
                     logger.info("did not detect any historical data")
+
+            if max_over_time is not None and "over_time" in dataset.dims:
+                if dataset.sizes["over_time"] > max_over_time:
+                    dataset = dataset.isel(over_time=slice(-max_over_time, None))
 
             logger.info("saving data to history cache")
             c[bench_cfg_hash] = dataset

--- a/bencher/results/holoview_results/bar_result.py
+++ b/bencher/results/holoview_results/bar_result.py
@@ -144,9 +144,7 @@ class BarResult(HoloviewResult):
             holomap = hv.HoloMap(kdims=self._over_time_kdims())
             for t in da.coords["over_time"].values:
                 da_t = da.sel(over_time=t)
-                plot_t = da_t.hvplot.bar(
-                    x=x_dim, y=da.name, by=by, title=title, **kwargs
-                )
+                plot_t = da_t.hvplot.bar(x=x_dim, y=da.name, by=by, title=title, **kwargs)
                 if hasattr(plot_t, "opts"):
                     plot_t = plot_t.opts(**opts_kwargs)
                 holomap[t] = plot_t

--- a/bencher/results/holoview_results/bar_result.py
+++ b/bencher/results/holoview_results/bar_result.py
@@ -145,7 +145,7 @@ class BarResult(HoloviewResult):
             for t in da.coords["over_time"].values:
                 da_t = da.sel(over_time=t)
                 plot_t = da_t.hvplot.bar(
-                    x=x_dim, y=da.name, by=by, title=title, widget_location="bottom", **kwargs
+                    x=x_dim, y=da.name, by=by, title=title, **kwargs
                 )
                 if hasattr(plot_t, "opts"):
                     plot_t = plot_t.opts(**opts_kwargs)

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,7 +14,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -176,7 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -341,7 +341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -504,7 +504,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -667,7 +667,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -1213,16 +1213,16 @@ packages:
   - flask>=0.9
   - werkzeug>=0.7
   requires_python: '>=3.9,<4.0'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
-  sha256: c814583e79310022c6a7347b37591cb0a1b780d5f0e8684d2904a6495302eb33
-  md5: 859ccdb2889ba7eacbccf8d3bed02f8c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.1-h76a2195_0.conda
+  sha256: 78f9fbbf18272e92e62bc1672d34178760ced73edc1e818ebd5fd00296b5df88
+  md5: 0290cdefa20d98adb936c465ccb76ad6
   depends:
   - __glibc >=2.17,<3.0.a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 22877535
-  timestamp: 1773186836540
+  size: 22875681
+  timestamp: 1773332470542
 - pypi: https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
   version: 3.3.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,7 +14,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -70,7 +70,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
@@ -99,7 +99,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -116,7 +116,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -135,8 +135,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -148,7 +148,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -176,7 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -233,7 +233,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
@@ -261,7 +261,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -278,7 +278,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -298,8 +298,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -312,7 +312,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -341,7 +341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -398,7 +398,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
@@ -427,7 +427,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -444,7 +444,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -463,8 +463,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -476,7 +476,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -504,7 +504,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -561,7 +561,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
@@ -590,7 +590,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -607,7 +607,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -626,8 +626,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -639,7 +639,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -667,7 +667,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
@@ -723,7 +723,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
@@ -752,7 +752,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -769,7 +769,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -788,8 +788,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -801,7 +801,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/f9/3bbfbbe35478de9bcd63848f4bc9bffda72278dd9732dbad3efc3978432e/ty-0.0.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -1213,16 +1213,16 @@ packages:
   - flask>=0.9
   - werkzeug>=0.7
   requires_python: '>=3.9,<4.0'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.87.3-h76a2195_0.conda
-  sha256: d11ce5465c6d9dda9e139eb01c71574cd694fdf8a02ad3dd65f919cfc99a6f7e
-  md5: b9e1e9e61748f2983917459b4ca56398
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.88.0-h76a2195_0.conda
+  sha256: c814583e79310022c6a7347b37591cb0a1b780d5f0e8684d2904a6495302eb33
+  md5: 859ccdb2889ba7eacbccf8d3bed02f8c
   depends:
   - __glibc >=2.17,<3.0.a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 22811233
-  timestamp: 1771994966015
+  size: 22877535
+  timestamp: 1773186836540
 - pypi: https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
   version: 3.3.2
@@ -1567,10 +1567,10 @@ packages:
   - pytest>=8.3.2 ; extra == 'all'
   - flake8>=7.1.1 ; extra == 'all'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/fb/fe/301e0936b79bcab4cacc7548bf2853fc28dced0a578bab1f7ef53c9aa75b/imageio-2.37.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
   name: imageio
-  version: 2.37.2
-  sha256: ad9adfb20335d718c03de457358ed69f141021a333c40a53e57273d8a5bd0b9b
+  version: 2.37.3
+  sha256: 46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0
   requires_dist:
   - numpy
   - pillow>=8.3.2
@@ -1628,7 +1628,7 @@ packages:
   - rawpy ; extra == 'full'
   - sphinx<6 ; extra == 'full'
   - tifffile ; extra == 'full'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
   name: imageio-ffmpeg
   version: 0.6.0
@@ -2360,10 +2360,10 @@ packages:
   - flake8-implicit-str-concat==0.4.0 ; extra == 'lint'
   - isort>=5.12 ; extra == 'lint'
   - pre-commit>=3.3 ; extra == 'lint'
-- pypi: https://files.pythonhosted.org/packages/4b/27/20770bd6bf8fbe1e16f848ba21da9df061f38d2e6483952c29d2bb5d1d8b/narwhals-2.17.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fe/75/0b4a10da17a44cf13567d08a9c7632a285297e46253263f1ae119129d10a/narwhals-2.18.0-py3-none-any.whl
   name: narwhals
-  version: 2.17.0
-  sha256: 2ac5307b7c2b275a7d66eeda906b8605e3d7a760951e188dcfff86e8ebe083dd
+  version: 2.18.0
+  sha256: 68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d
   requires_dist:
   - cudf-cu12>=24.10.0 ; extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'
@@ -3248,10 +3248,10 @@ packages:
   - pytest-benchmark ; extra == 'testing'
   - coverage ; extra == 'testing'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/05/c5/98a73fec052059c3ae06ce105bef67caca42334c56d84e9ef75df72ba152/prek-0.3.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek
-  version: 0.3.4
-  sha256: 10a621a690d9c127afc3d21c275030d364d1fbef3296c095068d3ae80a59546e
+  version: 0.3.5
+  sha256: 45ee84199bb48e013bdfde0c84352c17a44cc42d5792681b86d94e9474aab6f8
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
   name: proglog
@@ -3670,10 +3670,10 @@ packages:
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
   - chardet>=3.0.2,<6 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/7b/ce/df39e5a2c0547bbafdeb629f3fd2ef16079b8b3519d3cd1969f9eb6d5691/rerun_notebook-0.30.1-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
   name: rerun-notebook
-  version: 0.30.1
-  sha256: c0041b934764d9a52bb9eb2d7924fd9d2eca577af9c2bedf8e89e17a6d389bc5
+  version: 0.30.2
+  sha256: ce4e7e40c7972b0000c8254dc280c3d997a7c95afdd384bd22f84d4d492e7b62
   requires_dist:
   - anywidget
   - ipykernel<7.0.0
@@ -3681,10 +3681,10 @@ packages:
   - hatch ; extra == 'dev'
   - jupyterlab ; extra == 'dev'
   - watchfiles ; extra == 'dev'
-- pypi: https://files.pythonhosted.org/packages/48/66/27ba6f49022f14b983637fbc108f2eb81a2d9c8b7b9d0457273106166b55/rerun_sdk-0.30.1-cp310-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
   name: rerun-sdk
-  version: 0.30.1
-  sha256: 79028f4ad22162f1cee103ea4974d13a69a623125f975a7d52dbbaa2f6484886
+  version: 0.30.2
+  sha256: f3480847f124894d1c9bcbbdb4182a4c64986bf9d0d669e10752f0738ecac359
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2
@@ -3701,14 +3701,14 @@ packages:
   - tomli==2.0.1 ; extra == 'tests'
   - torch>=2.5 ; extra == 'tests'
   - datafusion==50.1.0 ; extra == 'tests'
-  - rerun-notebook==0.30.1 ; extra == 'notebook'
+  - rerun-notebook==0.30.2 ; extra == 'notebook'
   - datafusion==50.1.0 ; extra == 'datafusion'
   - pandas>=2 ; extra == 'datafusion'
   - datafusion==50.1.0 ; extra == 'dataplatform'
   - pandas>=2 ; extra == 'dataplatform'
   - datafusion==50.1.0 ; extra == 'all'
   - pandas>=2 ; extra == 'all'
-  - rerun-notebook==0.30.1 ; extra == 'all'
+  - rerun-notebook==0.30.2 ; extra == 'all'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: rpds-py
@@ -4393,10 +4393,10 @@ packages:
   version: 0.14.0
   sha256: 592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
   name: tornado
-  version: 6.5.4
-  sha256: e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f
+  version: 6.5.5
+  sha256: e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
   name: tqdm

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -280,8 +280,8 @@ class TestCacheOperations(unittest.TestCase):
         self.assertEqual(bench_res.ds["theta"].attrs.get("units"), "rad")
 
 
-class TestMaxOverTime(unittest.TestCase):
-    """Tests for max_over_time trimming in load_history_cache."""
+class TestMaxTimeEvents(unittest.TestCase):
+    """Tests for max_time_events trimming in load_history_cache."""
 
     def setUp(self):
         self.collector = ResultCollector()
@@ -294,13 +294,13 @@ class TestMaxOverTime(unittest.TestCase):
             slices.append(ds)
         return xr.concat(slices, "over_time")
 
-    def test_max_over_time_trims_oldest(self):
-        """max_over_time should keep only the N most recent slices."""
+    def test_max_time_events_trims_oldest(self):
+        """max_time_events should keep only the N most recent slices."""
         dataset = self._make_over_time_dataset(5)
         unique_hash = f"trim-test-{uuid.uuid4()}"
 
         result = self.collector.load_history_cache(
-            dataset, unique_hash, clear_history=False, max_over_time=3
+            dataset, unique_hash, clear_history=False, max_time_events=3
         )
 
         self.assertEqual(result.sizes["over_time"], 3)
@@ -309,24 +309,24 @@ class TestMaxOverTime(unittest.TestCase):
         actual = list(result["var"].values[0])
         self.assertEqual(actual, expected)
 
-    def test_max_over_time_none_unlimited(self):
-        """max_over_time=None should not trim anything."""
+    def test_max_time_events_none_unlimited(self):
+        """max_time_events=None should not trim anything."""
         dataset = self._make_over_time_dataset(5)
         unique_hash = f"unlimited-test-{uuid.uuid4()}"
 
         result = self.collector.load_history_cache(
-            dataset, unique_hash, clear_history=False, max_over_time=None
+            dataset, unique_hash, clear_history=False, max_time_events=None
         )
 
         self.assertEqual(result.sizes["over_time"], 5)
 
-    def test_max_over_time_exact_count_no_trim(self):
-        """When over_time count equals max_over_time, no trimming occurs."""
+    def test_max_time_events_exact_count_no_trim(self):
+        """When over_time count equals max_time_events, no trimming occurs."""
         dataset = self._make_over_time_dataset(3)
         unique_hash = f"exact-test-{uuid.uuid4()}"
 
         result = self.collector.load_history_cache(
-            dataset, unique_hash, clear_history=False, max_over_time=3
+            dataset, unique_hash, clear_history=False, max_time_events=3
         )
 
         self.assertEqual(result.sizes["over_time"], 3)
@@ -334,13 +334,14 @@ class TestMaxOverTime(unittest.TestCase):
         actual = list(result["var"].values[0])
         self.assertEqual(actual, expected)
 
-    def test_max_over_time_with_clear_history(self):
-        """clear_history + max_over_time: trimming still applies to new data."""
+    def test_max_time_events_with_clear_history(self):
+        """clear_history + max_time_events: in practice clear_history yields a single slice,
+        but trimming is still correct if the incoming dataset has multiple over_time slices."""
         dataset = self._make_over_time_dataset(5)
         unique_hash = f"clear-trim-test-{uuid.uuid4()}"
 
         result = self.collector.load_history_cache(
-            dataset, unique_hash, clear_history=True, max_over_time=2
+            dataset, unique_hash, clear_history=True, max_time_events=2
         )
 
         self.assertEqual(result.sizes["over_time"], 2)
@@ -348,13 +349,29 @@ class TestMaxOverTime(unittest.TestCase):
         actual = list(result["var"].values[0])
         self.assertEqual(actual, expected)
 
-    def test_max_over_time_no_over_time_dim(self):
-        """max_over_time should be a no-op when dataset has no over_time dim."""
+    def test_max_time_events_incremental_accumulation(self):
+        """Simulates repeated plot_sweep() calls: cache should stay bounded."""
+        unique_hash = f"incremental-test-{uuid.uuid4()}"
+
+        for i in range(10):
+            single_slice = xr.Dataset({"var": (["x", "over_time"], [[float(i)]])})
+            result = self.collector.load_history_cache(
+                single_slice, unique_hash, clear_history=False, max_time_events=3
+            )
+
+        # After 10 incremental calls with max_time_events=3, only the last 3 should remain
+        self.assertEqual(result.sizes["over_time"], 3)
+        expected = [7.0, 8.0, 9.0]
+        actual = list(result["var"].values[0])
+        self.assertEqual(actual, expected)
+
+    def test_max_time_events_no_over_time_dim(self):
+        """max_time_events should be a no-op when dataset has no over_time dim."""
         dataset = xr.Dataset({"var": (["x"], [1, 2, 3])})
         unique_hash = f"nodim-test-{uuid.uuid4()}"
 
         result = self.collector.load_history_cache(
-            dataset, unique_hash, clear_history=False, max_over_time=2
+            dataset, unique_hash, clear_history=False, max_time_events=2
         )
 
         self.assertTrue(result.equals(dataset))

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -280,6 +280,86 @@ class TestCacheOperations(unittest.TestCase):
         self.assertEqual(bench_res.ds["theta"].attrs.get("units"), "rad")
 
 
+class TestMaxOverTime(unittest.TestCase):
+    """Tests for max_over_time trimming in load_history_cache."""
+
+    def setUp(self):
+        self.collector = ResultCollector()
+
+    def _make_over_time_dataset(self, n_slices):
+        """Create a dataset with n over_time slices."""
+        slices = []
+        for i in range(n_slices):
+            ds = xr.Dataset({"var": (["x", "over_time"], [[float(i)]])})
+            slices.append(ds)
+        return xr.concat(slices, "over_time")
+
+    def test_max_over_time_trims_oldest(self):
+        """max_over_time should keep only the N most recent slices."""
+        dataset = self._make_over_time_dataset(5)
+        unique_hash = f"trim-test-{uuid.uuid4()}"
+
+        result = self.collector.load_history_cache(
+            dataset, unique_hash, clear_history=False, max_over_time=3
+        )
+
+        self.assertEqual(result.sizes["over_time"], 3)
+        # Should keep the last 3 slices (values 2, 3, 4)
+        expected = [2.0, 3.0, 4.0]
+        actual = list(result["var"].values[0])
+        self.assertEqual(actual, expected)
+
+    def test_max_over_time_none_unlimited(self):
+        """max_over_time=None should not trim anything."""
+        dataset = self._make_over_time_dataset(5)
+        unique_hash = f"unlimited-test-{uuid.uuid4()}"
+
+        result = self.collector.load_history_cache(
+            dataset, unique_hash, clear_history=False, max_over_time=None
+        )
+
+        self.assertEqual(result.sizes["over_time"], 5)
+
+    def test_max_over_time_exact_count_no_trim(self):
+        """When over_time count equals max_over_time, no trimming occurs."""
+        dataset = self._make_over_time_dataset(3)
+        unique_hash = f"exact-test-{uuid.uuid4()}"
+
+        result = self.collector.load_history_cache(
+            dataset, unique_hash, clear_history=False, max_over_time=3
+        )
+
+        self.assertEqual(result.sizes["over_time"], 3)
+        expected = [0.0, 1.0, 2.0]
+        actual = list(result["var"].values[0])
+        self.assertEqual(actual, expected)
+
+    def test_max_over_time_with_clear_history(self):
+        """clear_history + max_over_time: trimming still applies to new data."""
+        dataset = self._make_over_time_dataset(5)
+        unique_hash = f"clear-trim-test-{uuid.uuid4()}"
+
+        result = self.collector.load_history_cache(
+            dataset, unique_hash, clear_history=True, max_over_time=2
+        )
+
+        self.assertEqual(result.sizes["over_time"], 2)
+        expected = [3.0, 4.0]
+        actual = list(result["var"].values[0])
+        self.assertEqual(actual, expected)
+
+    def test_max_over_time_no_over_time_dim(self):
+        """max_over_time should be a no-op when dataset has no over_time dim."""
+        dataset = xr.Dataset({"var": (["x"], [1, 2, 3])})
+        unique_hash = f"nodim-test-{uuid.uuid4()}"
+
+        result = self.collector.load_history_cache(
+            dataset, unique_hash, clear_history=False, max_over_time=2
+        )
+
+        self.assertTrue(result.equals(dataset))
+
+
 class TestSetXarrayMultidim(unittest.TestCase):
     """Tests for set_xarray_multidim utility function."""
 


### PR DESCRIPTION
## Summary
- Adds `max_over_time` parameter to `BenchRunCfg` (`param.Integer(None, bounds=[1, None], allow_None=True)`) to cap the number of retained time slices when `over_time=True`
- Trims oldest slices in `load_history_cache()` after concatenation but before saving to cache, so the cache itself stays bounded
- Default `None` preserves full backward compatibility (unlimited accumulation)

## Test plan
- [x] Unit tests in `TestMaxOverTime`: trims oldest, None = unlimited, exact count = no trim, interaction with clear_history, no-op without over_time dim
- [x] Full CI passes (`pixi run ci` — 547 tests pass, 90% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable cap on accumulated over_time history in benchmark runs.

New Features:
- Add a max_over_time parameter to BenchRunCfg to limit the number of retained over_time events when accumulating history.

Enhancements:
- Apply max_over_time trimming in ResultCollector/load_history_cache so only the most recent over_time slices are kept and the cache remains bounded.

Tests:
- Add TestMaxOverTime test suite covering trimming behavior, unlimited mode, interaction with clear_history, and datasets without an over_time dimension.