### PR TITLE
Fix DTypePromotionError in load_history_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.66.1] - 2026-03-13
+
+### Fixed
+- Fix `DTypePromotionError` crash when `over_time` coordinate type changes between runs (e.g., `time_event=None` → `time_event="v1.0"`)
+- Check `over_time` dtype compatibility before concat, discarding incompatible history with a warning instead of crashing
+- Include old/new dtypes in the warning message for easier debugging
+
 ## [1.66.0] - 2026-03-12
 
 ### Added

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -310,7 +310,13 @@ class ResultCollector:
                 if bench_cfg_hash in c:
                     logger.info("loading historical data from cache")
                     ds_old = c[bench_cfg_hash]
-                    dataset = xr.concat([ds_old, dataset], "over_time")
+                    try:
+                        dataset = xr.concat([ds_old, dataset], "over_time")
+                    except (TypeError, np.exceptions.DTypePromotionError):
+                        logger.warning(
+                            "Discarding incompatible historical data "
+                            "(over_time dtype changed between runs)"
+                        )
                 else:
                     logger.info("did not detect any historical data")
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -317,7 +317,8 @@ class ResultCollector:
                     ):
                         logger.warning(
                             "Discarding incompatible historical data "
-                            "(over_time dtype changed between runs)"
+                            "(over_time dtype changed: "
+                            f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
                         )
                     else:
                         dataset = xr.concat([ds_old, dataset], "over_time")

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -310,13 +310,17 @@ class ResultCollector:
                 if bench_cfg_hash in c:
                     logger.info("loading historical data from cache")
                     ds_old = c[bench_cfg_hash]
-                    try:
-                        dataset = xr.concat([ds_old, dataset], "over_time")
-                    except (TypeError, np.exceptions.DTypePromotionError):
+                    if (
+                        "over_time" in ds_old.dims
+                        and "over_time" in dataset.dims
+                        and ds_old["over_time"].dtype != dataset["over_time"].dtype
+                    ):
                         logger.warning(
                             "Discarding incompatible historical data "
                             "(over_time dtype changed between runs)"
                         )
+                    else:
+                        dataset = xr.concat([ds_old, dataset], "over_time")
                 else:
                     logger.info("did not detect any historical data")
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.66.0
-  sha256: 501c5e9d15407e4a1c34e8910a95f9896526c0cdbe85ff71d3f9c3221b6b19f5
+  version: 1.66.1
+  sha256: 69b08df2effb2c23a19f527591b4250ebf41dac3eb88d30086a6c2713ee88506
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.66.0"
+version = "1.66.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -377,6 +377,36 @@ class TestMaxTimeEvents(unittest.TestCase):
         self.assertTrue(result.equals(dataset))
 
 
+class TestDTypeIncompatibleHistory(unittest.TestCase):
+    """Test that load_history_cache handles dtype changes in over_time coords."""
+
+    def setUp(self):
+        self.collector = ResultCollector()
+
+    def test_datetime_then_string_over_time_no_crash(self):
+        """Switching from datetime to string over_time coords should not crash."""
+        unique_hash = f"dtype-compat-{uuid.uuid4()}"
+
+        # First run: datetime over_time coord (TimeSnapshot style)
+        ds_datetime = xr.Dataset(
+            {"var": (["x", "over_time"], [[1.0]])},
+            coords={"over_time": [np.datetime64("2024-01-01")]},
+        )
+        self.collector.load_history_cache(ds_datetime, unique_hash, clear_history=False)
+
+        # Second run: string over_time coord (TimeEvent style)
+        ds_string = xr.Dataset(
+            {"var": (["x", "over_time"], [[2.0]])},
+            coords={"over_time": ["v1.0"]},
+        )
+        result = self.collector.load_history_cache(ds_string, unique_hash, clear_history=False)
+
+        # Should not crash; old datetime data discarded, only new string data remains
+        self.assertEqual(result.sizes["over_time"], 1)
+        self.assertEqual(result["var"].values[0, 0], 2.0)
+        self.assertEqual(str(result.coords["over_time"].values[0]), "v1.0")
+
+
 class TestSetXarrayMultidim(unittest.TestCase):
     """Tests for set_xarray_multidim utility function."""
 

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -399,12 +399,43 @@ class TestDTypeIncompatibleHistory(unittest.TestCase):
             {"var": (["x", "over_time"], [[2.0]])},
             coords={"over_time": ["v1.0"]},
         )
-        result = self.collector.load_history_cache(ds_string, unique_hash, clear_history=False)
+        with self.assertLogs(level="WARNING") as captured_logs:
+            result = self.collector.load_history_cache(
+                ds_string, unique_hash, clear_history=False
+            )
 
-        # Should not crash; old datetime data discarded, only new string data remains
-        self.assertEqual(result.sizes["over_time"], 1)
-        self.assertEqual(result["var"].values[0, 0], 2.0)
-        self.assertEqual(str(result.coords["over_time"].values[0]), "v1.0")
+        # Should warn about discarded history
+        self.assertTrue(
+            any("Discarding incompatible historical data" in msg for msg in captured_logs.output)
+        )
+        # Old data discarded, result matches the new dataset exactly
+        self.assertTrue(result.equals(ds_string))
+
+    def test_string_then_datetime_over_time_no_crash(self):
+        """Switching from string to datetime over_time coords should not crash."""
+        unique_hash = f"dtype-compat-reverse-{uuid.uuid4()}"
+
+        # First run: string over_time coord (TimeEvent style)
+        ds_string = xr.Dataset(
+            {"var": (["x", "over_time"], [[1.0]])},
+            coords={"over_time": ["v1.0"]},
+        )
+        self.collector.load_history_cache(ds_string, unique_hash, clear_history=False)
+
+        # Second run: datetime over_time coord (TimeSnapshot style)
+        ds_datetime = xr.Dataset(
+            {"var": (["x", "over_time"], [[2.0]])},
+            coords={"over_time": [np.datetime64("2024-06-15")]},
+        )
+        with self.assertLogs(level="WARNING") as captured_logs:
+            result = self.collector.load_history_cache(
+                ds_datetime, unique_hash, clear_history=False
+            )
+
+        self.assertTrue(
+            any("Discarding incompatible historical data" in msg for msg in captured_logs.output)
+        )
+        self.assertTrue(result.equals(ds_datetime))
 
 
 class TestSetXarrayMultidim(unittest.TestCase):

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -400,9 +400,7 @@ class TestDTypeIncompatibleHistory(unittest.TestCase):
             coords={"over_time": ["v1.0"]},
         )
         with self.assertLogs(level="WARNING") as captured_logs:
-            result = self.collector.load_history_cache(
-                ds_string, unique_hash, clear_history=False
-            )
+            result = self.collector.load_history_cache(ds_string, unique_hash, clear_history=False)
 
         # Should warn about discarded history
         self.assertTrue(


### PR DESCRIPTION
## Summary
- Fix crash when `over_time` coordinate type changes between runs (e.g., `time_event=None` → `time_event="v1.0"`)
- `xr.concat` throws `DTypePromotionError` when merging datetime64 and string coords from cache
- Handle at the cache layer: check `over_time` dtype compatibility **before** attempting concat, discarding incompatible history with a warning
- No reliance on catching specific numpy/xarray exception types

## Test plan
- [x] New test `test_datetime_then_string_over_time_no_crash` — saves datetime-coord history, loads with string-coord dataset, verifies no crash and only new data returned
- [x] All existing `test_result_collector.py` tests pass (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)