### PR TITLE
Fix over_time bar chart broken by unconditional image slider routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.66.2] - 2026-03-13
+
+### Fixed
+- Fix over_time bar chart broken by unconditional image slider routing — numeric `ResultVar` types were incorrectly routed to `_pane_over_time_slider`, causing `FileNotFoundError` and `ValueError`
+
 ## [1.66.1] - 2026-03-13
 
 ### Fixed

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -20,7 +20,7 @@ from bencher.variables.results import ResultVar
 from bencher.plotting.plot_filter import VarRange, PlotFilter
 from bencher.utils import listify
 
-from bencher.variables.results import ResultReference, ResultDataSet, ResultVideo
+from bencher.variables.results import ResultReference, ResultDataSet, ResultVideo, ResultImage
 
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
@@ -677,6 +677,7 @@ class BenchResultBase:
                 self.bench_cfg.over_time
                 and "over_time" in list(dataset.sizes)
                 and dataset.sizes["over_time"] > 1
+                and isinstance(result_var, (ResultVideo, ResultImage))
             ):
                 return self._pane_over_time_slider(dataset, result_var)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.66.1"
+version = "1.66.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -75,6 +75,44 @@ def _has_holomap_column(plots):
     return False
 
 
+class ZeroDimBench(bch.ParametrizedSweep):
+    """Benchmark with no input vars — 0D numeric result for over_time regression test."""
+
+    value = bch.ResultVar(units="m", doc="Value")
+
+    offset = 0.0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self.value = 2.844 + self.offset
+        return super().__call__()
+
+
+class TestNumericOverTimeNotRoutedToImageSlider:
+    """Regression tests: numeric ResultVar must not be routed to _pane_over_time_slider.
+
+    Commit 9279dd32 unconditionally routed all result types through the image/video
+    slider when over_time was active.  Numeric values (e.g. 2.844) were then treated
+    as file paths, causing FileNotFoundError and ValueError.
+    """
+
+    def test_0d_numeric_over_time_no_file_error(self):
+        """0 input + numeric result + over_time must not raise FileNotFoundError."""
+        benchable = ZeroDimBench()
+        res = _run_over_time(benchable, [], ["value"], repeats=1, snapshots=3)
+        plots = res.to_auto_plots()
+        assert plots is not None
+        assert len(plots) > 0
+
+    def test_0d_numeric_over_time_with_repeats(self):
+        """0 input + numeric result + repeats + over_time must not raise ValueError."""
+        benchable = ZeroDimBench()
+        res = _run_over_time(benchable, [], ["value"], repeats=2, snapshots=3)
+        plots = res.to_auto_plots()
+        assert plots is not None
+        assert len(plots) > 0
+
+
 class TestBarResultOverTime:
     """Test BarResult with over_time slider."""
 


### PR DESCRIPTION
## Summary
- Guard `_pane_over_time_slider` routing with `isinstance(result_var, (ResultVideo, ResultImage))` so numeric `ResultVar` types (bar charts, line plots) fall through to their normal `plot_callback` instead of being treated as image file paths
- Add regression tests for 0D numeric results with `over_time` (with and without repeats)
- Bump version to 1.66.2

## Test plan
- [x] New regression tests pass: `test_0d_numeric_over_time_no_file_error`, `test_0d_numeric_over_time_with_repeats`
- [x] `example_over_time_0D` runs without `FileNotFoundError` or `ValueError`
- [ ] Full test suite passes (`pixi run test`)
- [ ] Image over_time examples still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix incorrect routing of numeric over_time results through the image/video slider and add regression coverage for 0D numeric benchmarks.

Bug Fixes:
- Guard over_time image/video slider routing so only ResultVideo and ResultImage types use it, preventing numeric ResultVar values from being treated as file paths.

Build:
- Bump project version to 1.66.2 in pyproject and changelog.

Documentation:
- Update changelog with a 1.66.2 entry describing the over_time routing fix.

Tests:
- Add regression tests ensuring 0D numeric over_time results, with and without repeats, produce plots without file-related errors.