### PR TITLE
Force DiscreteSlider widget for over_time dimension

### DIFF
--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -147,10 +147,15 @@ class HoloviewResult(VideoResult):
         produces a ``Row(plot, widget_box)``), then rearrange into a
         ``Column(plot, widget_box)`` so the slider sits underneath.
 
+        Force ``DiscreteSlider`` for the *over_time* dimension so that
+        string-based ``TimeEvent`` coordinates get a slider instead of
+        the default dropdown ``Select`` widget.
+
         Safe to call on any HoloViews object; if no widgets are produced
         the original object is returned unchanged.
         """
-        row = pn.panel(hvobj)
+        # Force a slider (not a dropdown) for the over_time dimension
+        row = pn.panel(hvobj, widgets={"over_time": pn.widgets.DiscreteSlider})
         if not isinstance(row, pn.Row) or len(row) < 2:
             return hvobj
         widget_box = row[1]


### PR DESCRIPTION
When using TimeEvent (string-based time labels), Panel auto-detects the
coordinate dtype and renders a Select dropdown. This change forces
pn.widgets.DiscreteSlider for the over_time dimension so both TimeEvent
and TimeSnapshot get a consistent slider widget.

https://claude.ai/code/session_017V3s3rvB4T4ndUNBup59Km

## Summary by Sourcery

Enhancements:
- Configure Panel to always use a DiscreteSlider for the over_time dimension instead of allowing a Select dropdown based on coordinate type.