### PR TITLE
Claude/review and fix pr q2 dhn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.66.3] - 2026-03-14
+
+### Fixed
+- Force `DiscreteSlider` widget for the `over_time` dimension so string-based `TimeEvent` coordinates get a slider instead of a dropdown
+
 ## [1.66.2] - 2026-03-13
 
 ### Fixed

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -147,10 +147,15 @@ class HoloviewResult(VideoResult):
         produces a ``Row(plot, widget_box)``), then rearrange into a
         ``Column(plot, widget_box)`` so the slider sits underneath.
 
+        Force ``DiscreteSlider`` for the *over_time* dimension so that
+        string-based ``TimeEvent`` coordinates get a slider instead of
+        the default dropdown ``Select`` widget.
+
         Safe to call on any HoloViews object; if no widgets are produced
         the original object is returned unchanged.
         """
-        row = pn.panel(hvobj)
+        # Force a slider (not a dropdown) for the over_time dimension
+        row = pn.panel(hvobj, widgets={"over_time": pn.widgets.DiscreteSlider})
         if not isinstance(row, pn.Row) or len(row) < 2:
             return hvobj
         widget_box = row[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.66.2"
+version = "1.66.3"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -91,6 +91,22 @@ def _find_over_time_widget(obj, depth=0):
     return None
 
 
+def _find_all_over_time_widgets(obj, depth=0):
+    """Recursively collect *all* over_time widgets from a Panel layout."""
+    found = []
+    if isinstance(obj, pn.widgets.Widget) and getattr(obj, "name", None) == "over_time":
+        found.append(obj)
+        return found
+    if depth > 8:
+        return found
+    try:
+        for child in obj:
+            found.extend(_find_all_over_time_widgets(child, depth + 1))
+    except TypeError:
+        pass
+    return found
+
+
 class ZeroDimBench(bch.ParametrizedSweep):
     """Benchmark with no input vars — 0D numeric result for over_time regression test."""
 
@@ -183,12 +199,16 @@ class TestOverTimeWidgetIsDiscreteSlider:
     """Verify over_time uses DiscreteSlider, not a Select dropdown."""
 
     def test_bar_over_time_uses_discrete_slider(self):
-        """Bar chart over_time widget must be a DiscreteSlider."""
+        """All over_time widgets must be DiscreteSlider, none should be Select."""
         benchable = SimpleBench()
         res = _run_over_time(benchable, ["backend"], ["latency"], repeats=1, snapshots=3)
         plots = res.to_auto_plots()
-        widget = _find_over_time_widget(plots)
-        assert widget is not None, "Expected an over_time widget in the plots"
-        assert isinstance(widget, pn.widgets.DiscreteSlider), (
-            f"Expected DiscreteSlider, got {type(widget).__name__}"
-        )
+        widgets = _find_all_over_time_widgets(plots)
+        assert len(widgets) > 0, "Expected at least one over_time widget in the plots"
+        for widget in widgets:
+            assert isinstance(widget, pn.widgets.DiscreteSlider), (
+                f"Expected DiscreteSlider, got {type(widget).__name__}"
+            )
+            assert not isinstance(widget, pn.widgets.Select), (
+                "over_time widget must not be a Select dropdown"
+            )

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -75,6 +75,22 @@ def _has_holomap_column(plots):
     return False
 
 
+def _find_over_time_widget(obj, depth=0):
+    """Recursively find the over_time widget from a Panel layout, or None."""
+    if isinstance(obj, pn.widgets.Widget) and getattr(obj, "name", None) == "over_time":
+        return obj
+    if depth > 8:
+        return None
+    try:
+        for child in obj:
+            result = _find_over_time_widget(child, depth + 1)
+            if result is not None:
+                return result
+    except TypeError:
+        pass
+    return None
+
+
 class ZeroDimBench(bch.ParametrizedSweep):
     """Benchmark with no input vars — 0D numeric result for over_time regression test."""
 
@@ -161,3 +177,18 @@ class TestCurveResultOverTime:
         assert len(plots) > 0
         # Curve with over_time should produce a Column with slider
         assert any(isinstance(p, pn.Column) for p in plots)
+
+
+class TestOverTimeWidgetIsDiscreteSlider:
+    """Verify over_time uses DiscreteSlider, not a Select dropdown."""
+
+    def test_bar_over_time_uses_discrete_slider(self):
+        """Bar chart over_time widget must be a DiscreteSlider."""
+        benchable = SimpleBench()
+        res = _run_over_time(benchable, ["backend"], ["latency"], repeats=1, snapshots=3)
+        plots = res.to_auto_plots()
+        widget = _find_over_time_widget(plots)
+        assert widget is not None, "Expected an over_time widget in the plots"
+        assert isinstance(widget, pn.widgets.DiscreteSlider), (
+            f"Expected DiscreteSlider, got {type(widget).__name__}"
+        )


### PR DESCRIPTION
## Summary by Sourcery

Ensure over_time visualizations always use a discrete slider widget instead of a dropdown for their time dimension.

Enhancements:
- Force the over_time HoloViews dimension to render with a DiscreteSlider widget so string-based TimeEvent coordinates get a slider instead of a dropdown.

Tests:
- Add regression test verifying that over_time plots use a Panel DiscreteSlider widget rather than a Select dropdown.