### PR TITLE
Modernize type hints to Python 3.10+ syntax

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -470,7 +470,7 @@ class BenchCfg(BenchRunCfg):
         """Get a list of input variable names.
 
         Returns:
-            list[str]: list of the names of input variables
+            list[str]: List of the names of input variables
         """
         return [i.name for i in self.input_vars]
 
@@ -644,7 +644,7 @@ class BenchCfg(BenchRunCfg):
                           Defaults to False.
 
         Returns:
-            list[Any]: list of result variable names or objects that are optimization targets
+            list[Any]: List of result variable names or objects that are optimization targets
         """
         targets = []
         for rv in self.result_vars:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 
-from typing import List, Optional, Dict, Any, Union, TypeVar
+from typing import Any, TypeVar
 
 import param
 import panel as pn
@@ -32,7 +32,7 @@ class BenchPlotSrvCfg(param.Parameterized):
         show (bool): Open the served page in a web browser
     """
 
-    port: Optional[int] = param.Integer(None, doc="The port to launch panel with")
+    port: int | None = param.Integer(None, doc="The port to launch panel with")
     allow_ws_origin: bool = param.Boolean(
         False,
         doc="Add the port to the whitelist, (warning will disable remote access if set to true)",
@@ -195,16 +195,14 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     use_optuna: bool = param.Boolean(False, doc="show optuna plots")
 
-    plot_size: Optional[int] = param.Integer(
-        default=None, doc="Sets the width and height of the plot"
-    )
+    plot_size: int | None = param.Integer(default=None, doc="Sets the width and height of the plot")
 
-    plot_width: Optional[int] = param.Integer(
+    plot_width: int | None = param.Integer(
         default=None,
         doc="Sets with width of the plots, this will override the plot_size parameter",
     )
 
-    plot_height: Optional[int] = param.Integer(
+    plot_height: int | None = param.Integer(
         default=None, doc="Sets the height of the plot, this will override the plot_size parameter"
     )
 
@@ -227,7 +225,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
         doc="Maximum number of over_time events to retain. Oldest events are trimmed. None means unlimited.",
     )
 
-    time_event: Optional[str] = param.String(
+    time_event: str | None = param.String(
         None,
         doc="A string representation of a sequence over time, i.e. datetime, pull request number, or run number",
     )
@@ -317,14 +315,14 @@ class BenchCfg(BenchRunCfg):
     descriptive summaries and visualizations of the benchmark configuration.
 
     Attributes:
-        input_vars (List): A list of ParameterizedSweep variables to perform a parameter sweep over
-        result_vars (List): A list of ParameterizedSweep results to collect and plot
-        const_vars (List): Variables to keep constant but are different from the default value
-        result_hmaps (List): A list of holomap results
-        meta_vars (List): Meta variables such as recording time and repeat id
-        all_vars (List): Stores a list of both the input_vars and meta_vars
-        iv_time (List[TimeSnapshot | TimeEvent]): Parameter for sampling the same inputs over time
-        iv_time_event (List[TimeEvent]): Parameter for sampling inputs over time as a discrete type
+        input_vars (list): A list of ParameterizedSweep variables to perform a parameter sweep over
+        result_vars (list): A list of ParameterizedSweep results to collect and plot
+        const_vars (list): Variables to keep constant but are different from the default value
+        result_hmaps (list): A list of holomap results
+        meta_vars (list): Meta variables such as recording time and repeat id
+        all_vars (list): Stores a list of both the input_vars and meta_vars
+        iv_time (list[TimeSnapshot | TimeEvent]): Parameter for sampling the same inputs over time
+        iv_time_event (list[TimeEvent]): Parameter for sampling inputs over time as a discrete type
         over_time (bool): Controls whether the function is sampled over time
         name (str): The name of the benchmarkCfg
         title (str): The title of the benchmark
@@ -336,7 +334,7 @@ class BenchCfg(BenchRunCfg):
         pass_repeat (bool): Whether to pass the 'repeat' kwarg to the benchmark function
         tag (str): Tags for grouping different benchmarks
         hash_value (str): Stored hash value of the config
-        plot_callbacks (List): Callables that take a BenchResult and return panel representation
+        plot_callbacks (list): Callables that take a BenchResult and return panel representation
     """
 
     input_vars = param.List(
@@ -365,7 +363,7 @@ class BenchCfg(BenchRunCfg):
     )
     iv_time = param.List(
         default=[],
-        item_type=Union[TimeSnapshot, TimeEvent],
+        item_type=TimeSnapshot | TimeEvent,
         doc="A parameter to represent the sampling the same inputs over time as a scalar type",
     )
 
@@ -376,19 +374,19 @@ class BenchCfg(BenchRunCfg):
     )
 
     # Note: over_time is already inherited from BenchRunCfg
-    name: Optional[str] = param.String(None, doc="The name of the benchmarkCfg")
-    title: Optional[str] = param.String(None, doc="The title of the benchmark")
+    name: str | None = param.String(None, doc="The name of the benchmarkCfg")
+    title: str | None = param.String(None, doc="The title of the benchmark")
     raise_duplicate_exception: bool = param.Boolean(
         False, doc="Use this while debugging if filename generation is unique"
     )
-    bench_name: Optional[str] = param.String(
+    bench_name: str | None = param.String(
         None, doc="The name of the benchmark and the name of the save folder"
     )
-    description: Optional[str] = param.String(
+    description: str | None = param.String(
         None,
         doc="A place to store a longer description of the function of the benchmark",
     )
-    post_description: Optional[str] = param.String(
+    post_description: str | None = param.String(
         None, doc="A place to comment on the output of the graphs"
     )
 
@@ -468,25 +466,25 @@ class BenchCfg(BenchRunCfg):
 
         return hash_val
 
-    def inputs_as_str(self) -> List[str]:
+    def inputs_as_str(self) -> list[str]:
         """Get a list of input variable names.
 
         Returns:
-            List[str]: List of the names of input variables
+            list[str]: list of the names of input variables
         """
         return [i.name for i in self.input_vars]
 
-    def to_latex(self) -> Optional[pn.pane.LaTeX]:
+    def to_latex(self) -> pn.pane.LaTeX | None:
         """Convert benchmark configuration to LaTeX representation.
 
         Returns:
-            Optional[pn.pane.LaTeX]: LaTeX representation of the benchmark configuration
+            pn.pane.LaTeX | None: LaTeX representation of the benchmark configuration
         """
         return to_latex(self)
 
     def describe_sweep(
         self, width: int = 800, accordion: bool = True
-    ) -> Union[pn.pane.Markdown, pn.Column]:
+    ) -> pn.pane.Markdown | pn.Column:
         """Produce a markdown summary of the sweep settings.
 
         Args:
@@ -494,7 +492,7 @@ class BenchCfg(BenchRunCfg):
             accordion (bool): Whether to wrap the description in an accordion. Defaults to True.
 
         Returns:
-            Union[pn.pane.Markdown, pn.Column]: Panel containing the sweep description
+            pn.pane.Markdown | pn.Column: Panel containing the sweep description
         """
 
         latex = self.to_latex()
@@ -566,11 +564,11 @@ class BenchCfg(BenchRunCfg):
         benchmark_sampling_str = "\n".join(benchmark_sampling_str)
         return benchmark_sampling_str
 
-    def to_title(self, panel_name: Optional[str] = None) -> pn.pane.Markdown:
+    def to_title(self, panel_name: str | None = None) -> pn.pane.Markdown:
         """Create a markdown panel with the benchmark title.
 
         Args:
-            panel_name (Optional[str]): The name for the panel. Defaults to the benchmark title.
+            panel_name (str | None): The name for the panel. Defaults to the benchmark title.
 
         Returns:
             pn.pane.Markdown: A panel with the benchmark title as a heading
@@ -603,7 +601,7 @@ class BenchCfg(BenchRunCfg):
 
     def to_sweep_summary(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         description: bool = True,
         describe_sweep: bool = True,
         results_suffix: bool = True,
@@ -612,7 +610,7 @@ class BenchCfg(BenchRunCfg):
         """Produce panel output summarising the title, description and sweep setting.
 
         Args:
-            name (Optional[str]): Name for the panel. Defaults to benchmark title or
+            name (str | None): Name for the panel. Defaults to benchmark title or
                                  "Data Collection Parameters" if title is False.
             description (bool): Whether to include the benchmark description. Defaults to True.
             describe_sweep (bool): Whether to include the sweep description. Defaults to True.
@@ -638,7 +636,7 @@ class BenchCfg(BenchRunCfg):
             col.append(pn.pane.Markdown("## Results:"))
         return col
 
-    def optuna_targets(self, as_var: bool = False) -> List[Any]:
+    def optuna_targets(self, as_var: bool = False) -> list[Any]:
         """Get the list of result variables that are optimization targets.
 
         Args:
@@ -646,7 +644,7 @@ class BenchCfg(BenchRunCfg):
                           Defaults to False.
 
         Returns:
-            List[Any]: List of result variable names or objects that are optimization targets
+            list[Any]: list of result variable names or objects that are optimization targets
         """
         targets = []
         for rv in self.result_vars:
@@ -666,12 +664,12 @@ class DimsCfg:
     It is used to set up the structure for analyzing and visualizing benchmark results.
 
     Attributes:
-        dims_name (List[str]): Names of the benchmark dimensions
-        dim_ranges (List[List[Any]]): Values for each dimension
-        dims_size (List[int]): Size (number of values) for each dimension
-        dim_ranges_index (List[List[int]]): Indices for each dimension value
-        dim_ranges_str (List[str]): String representation of dimension ranges
-        coords (Dict[str, List[Any]]): Mapping of dimension names to their values
+        dims_name (list[str]): Names of the benchmark dimensions
+        dim_ranges (list[list[Any]]): Values for each dimension
+        dims_size (list[int]): Size (number of values) for each dimension
+        dim_ranges_index (list[list[int]]): Indices for each dimension value
+        dim_ranges_str (list[str]): String representation of dimension ranges
+        coords (dict[str, list[Any]]): Mapping of dimension names to their values
     """
 
     def __init__(self, bench_cfg: BenchCfg) -> None:
@@ -683,13 +681,13 @@ class DimsCfg:
         Args:
             bench_cfg (BenchCfg): The benchmark configuration containing dimension information
         """
-        self.dims_name: List[str] = [i.name for i in bench_cfg.all_vars]
+        self.dims_name: list[str] = [i.name for i in bench_cfg.all_vars]
 
-        self.dim_ranges: List[List[Any]] = [i.values() for i in bench_cfg.all_vars]
-        self.dims_size: List[int] = [len(p) for p in self.dim_ranges]
-        self.dim_ranges_index: List[List[int]] = [list(range(i)) for i in self.dims_size]
-        self.dim_ranges_str: List[str] = [f"{s}\n" for s in self.dim_ranges]
-        self.coords: Dict[str, List[Any]] = dict(zip(self.dims_name, self.dim_ranges))
+        self.dim_ranges: list[list[Any]] = [i.values() for i in bench_cfg.all_vars]
+        self.dims_size: list[int] = [len(p) for p in self.dim_ranges]
+        self.dim_ranges_index: list[list[int]] = [list(range(i)) for i in self.dims_size]
+        self.dim_ranges_str: list[str] = [f"{s}\n" for s in self.dim_ranges]
+        self.coords: dict[str, list[Any]] = dict(zip(self.dims_name, self.dim_ranges))
 
         logging.debug(f"dims_name: {self.dims_name}")
         logging.debug(f"dim_ranges {self.dim_ranges_str}")

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -1,8 +1,9 @@
 """A server for display plots of benchmark results"""
 
+from __future__ import annotations
+
 import logging
 import os
-from typing import List, Tuple
 from threading import Thread
 
 import panel as pn
@@ -42,14 +43,14 @@ class BenchPlotServer:
 
         return self.serve(bench_name, plots_instance, port=plot_cfg.port, show=plot_cfg.show)
 
-    def load_data_from_cache(self, bench_name: str) -> Tuple[BenchCfg, List[pn.panel]] | None:
+    def load_data_from_cache(self, bench_name: str) -> tuple[BenchCfg, list[pn.panel]] | None:
         """Load previously calculated benchmark data from the database and start a plot server to display it
 
         Args:
             bench_name (str): The name of the benchmark and output folder for the figures
 
         Returns:
-            Tuple[BenchCfg, List[pn.panel]] | None: benchmark result data and any additional panels
+            tuple[BenchCfg, list[pn.panel]] | None: benchmark result data and any additional panels
 
         Raises:
             FileNotFoundError: No data found was found in the database to plot
@@ -81,7 +82,7 @@ class BenchPlotServer:
     def serve(
         self,
         bench_name: str,
-        plots_instance: List[pn.panel],
+        plots_instance: list[pn.panel],
         port: int | None = None,
         show: bool = True,
     ) -> Thread:
@@ -90,7 +91,7 @@ class BenchPlotServer:
 
         Args:
             bench_cfg (BenchCfg): benchmark results
-            plots_instance (List[pn.panel]): list of panel objects to display
+            plots_instance (list[pn.panel]): list of panel objects to display
             port (int): use a fixed port to launch the server
         """
 

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import logging
 from typing import Callable
@@ -233,14 +235,14 @@ resizeIframe();
 
         .. code-block:: python
 
-            def publish_args(branch_name) -> Tuple[str, str]:
+            def publish_args(branch_name) -> tuple[str, str]:
                 return (
                     "https://github.com/blooop/bencher.git",
                     f"https://github.com/blooop/bencher/blob/{branch_name}")
 
 
         Args:
-            remote (Callable): A function the returns a tuple of the publishing urls. It must follow the signature def publish_args(branch_name) -> Tuple[str, str].  The first url is the git repo name, the second url needs to match the format for viewable html pages on your git provider.  The second url can use the argument branch_name to point to the report on a specified branch.
+            remote (Callable): A function the returns a tuple of the publishing urls. It must follow the signature def publish_args(branch_name) -> tuple[str, str].  The first url is the git repo name, the second url needs to match the format for viewable html pages on your git provider.  The second url can use the argument branch_name to point to the report on a specified branch.
 
         Returns:
             str: the url of the published report

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Protocol, Union, runtime_checkable
+from __future__ import annotations
+
+from typing import Callable, Protocol, runtime_checkable
 import logging
 import warnings
 import inspect
@@ -29,7 +31,7 @@ class BenchableV2(Protocol):
 
 
 # Accept both versions during transition
-Benchable = Union[BenchableV1, BenchableV2]
+Benchable = BenchableV1 | BenchableV2
 
 
 class BenchRunner:
@@ -263,7 +265,7 @@ class BenchRunner:
         save: bool = False,
         grouped: bool = False,
         cache_results: bool = True,
-    ) -> List[BenchCfg]:
+    ) -> list[BenchCfg]:
         """Unified interface for running benchmarks.
 
         This function provides a single entry point for benchmark runs:
@@ -290,7 +292,7 @@ class BenchRunner:
             cache_results (bool, optional): Use the sample cache to reused previous results. Defaults to True.
 
         Returns:
-            List[BenchCfg]: A list of benchmark configuration objects with results
+            list[BenchCfg]: A list of benchmark configuration objects with results
         """
         # Handle deprecation warnings for legacy parameters
         if min_level is not None:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from itertools import product, combinations
 
 from param import Parameter
-from typing import Callable, List, Optional, Tuple, Any
+from typing import Callable, Any
 from copy import deepcopy
 import param
 import xarray as xr
@@ -176,16 +178,16 @@ class Bench(BenchPlotServer):
     def sweep_sequential(
         self,
         title: str = "",
-        input_vars: List[ParametrizedSweep] | None = None,
-        result_vars: List[ParametrizedSweep] | None = None,
-        const_vars: List[ParametrizedSweep] | None = None,
+        input_vars: list[ParametrizedSweep] | None = None,
+        result_vars: list[ParametrizedSweep] | None = None,
+        const_vars: list[ParametrizedSweep] | None = None,
         optimise_var: ParametrizedSweep | None = None,
         run_cfg: BenchRunCfg | None = None,
         group_size: int = 1,
         iterations: int = 1,
         relationship_cb: Callable | None = None,
-        plot_callbacks: List[Callable] | bool | None = None,
-    ) -> List[BenchResult]:
+        plot_callbacks: list[Callable] | bool | None = None,
+    ) -> list[BenchResult]:
         """Run a sequence of benchmarks by sweeping through groups of input variables.
 
         This method performs sweeps on combinations of input variables, potentially
@@ -193,10 +195,10 @@ class Bench(BenchPlotServer):
 
         Args:
             title (str, optional): Base title for all the benchmark sweeps. Defaults to "".
-            input_vars (List[ParametrizedSweep], optional): Input variables to sweep through.
+            input_vars (list[ParametrizedSweep], optional): Input variables to sweep through.
                 If None, defaults to all input variables from the worker class instance.
-            result_vars (List[ParametrizedSweep], optional): Result variables to collect. Defaults to None.
-            const_vars (List[ParametrizedSweep], optional): Variables to keep constant. Defaults to None.
+            result_vars (list[ParametrizedSweep], optional): Result variables to collect. Defaults to None.
+            const_vars (list[ParametrizedSweep], optional): Variables to keep constant. Defaults to None.
             optimise_var (ParametrizedSweep, optional): Variable to optimize on each sweep iteration.
                 The optimal value will be used as constant input for subsequent sweeps. Defaults to None.
             run_cfg (BenchRunCfg, optional): Run configuration. Defaults to None.
@@ -204,11 +206,11 @@ class Bench(BenchPlotServer):
             iterations (int, optional): Number of optimization iterations to perform. Defaults to 1.
             relationship_cb (Callable, optional): Function to determine how to group variables for sweeping.
                 Defaults to itertools.combinations if None.
-            plot_callbacks (List[Callable] | bool, optional): Callbacks for plotting or bool to enable/disable.
+            plot_callbacks (list[Callable] | bool, optional): Callbacks for plotting or bool to enable/disable.
                 Defaults to None.
 
         Returns:
-            List[BenchResult]: A list of results from all the sweep runs
+            list[BenchResult]: A list of results from all the sweep runs
         """
         if relationship_cb is None:
             relationship_cb = combinations
@@ -237,16 +239,16 @@ class Bench(BenchPlotServer):
     def plot_sweep(
         self,
         title: str | None = None,
-        input_vars: List[ParametrizedSweep] | None = None,
-        result_vars: List[ParametrizedSweep] | None = None,
-        const_vars: List[ParametrizedSweep] | None = None,
+        input_vars: list[ParametrizedSweep] | None = None,
+        result_vars: list[ParametrizedSweep] | None = None,
+        const_vars: list[ParametrizedSweep] | None = None,
         time_src: datetime | None = None,
         description: str | None = None,
         post_description: str | None = None,
         pass_repeat: bool = False,
         tag: str = "",
         run_cfg: BenchRunCfg | None = None,
-        plot_callbacks: List[Callable] | bool | None = None,
+        plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
@@ -257,11 +259,11 @@ class Bench(BenchPlotServer):
         Args:
             title (str, optional): The title of the benchmark. If None, a title will be
                 generated based on the input variables. Defaults to None.
-            input_vars (List[ParametrizedSweep], optional): Variables to sweep through in the benchmark.
+            input_vars (list[ParametrizedSweep], optional): Variables to sweep through in the benchmark.
                 If None and worker_class_instance exists, uses input variables from it. Defaults to None.
-            result_vars (List[ParametrizedSweep], optional): Variables to collect results for.
+            result_vars (list[ParametrizedSweep], optional): Variables to collect results for.
                 If None and worker_class_instance exists, uses result variables from it. Defaults to None.
-            const_vars (List[ParametrizedSweep], optional): Variables to keep constant with specified values.
+            const_vars (list[ParametrizedSweep], optional): Variables to keep constant with specified values.
                 If None and worker_class_instance exists, uses default input values. Defaults to None.
             time_src (datetime, optional): The timestamp for the benchmark. Used for time-series benchmarks.
                 Defaults to None, which will use the current time.
@@ -273,7 +275,7 @@ class Bench(BenchPlotServer):
             tag (str, optional): Tag to group different benchmarks together. Defaults to "".
             run_cfg (BenchRunCfg, optional): Configuration for how the benchmarks are run.
                 If None, uses the instance's run_cfg or creates a default one. Defaults to None.
-            plot_callbacks (List[Callable] | bool, optional): Callbacks for plotting results.
+            plot_callbacks (list[Callable] | bool, optional): Callbacks for plotting results.
                 If True, uses default plotting. If False, disables plotting.
                 If a list, uses the provided callbacks. Defaults to None.
             sample_order (SampleOrder, optional): Controls the traversal order of sampling only.
@@ -440,7 +442,7 @@ class Bench(BenchPlotServer):
     @staticmethod
     def filter_overridable_params(
         bench_cfg: BenchCfg, run_cfg: BenchRunCfg
-    ) -> Tuple[dict, List[str], List[str]]:
+    ) -> tuple[dict, list[str], list[str]]:
         """Filter run_cfg parameters to only those that can override bench_cfg.
 
         Param 2.3 enforces constant Parameters (e.g. the implicit `name`), which cannot
@@ -591,7 +593,7 @@ class Bench(BenchPlotServer):
         self,
         variable: param.Parameter | str | dict | tuple,
         var_type: str,
-        run_cfg: Optional[BenchRunCfg],
+        run_cfg: BenchRunCfg | None,
     ) -> param.Parameter:
         """Convert various input formats (str, dict, tuple) to param.Parameter objects."""
         return self._executor.convert_vars_to_params(
@@ -640,17 +642,17 @@ class Bench(BenchPlotServer):
 
     def setup_dataset(
         self, bench_cfg: BenchCfg, time_src: datetime | str
-    ) -> tuple[BenchResult, List[tuple], List[str]]:
+    ) -> tuple[BenchResult, list[tuple], list[str]]:
         """Initialize n-dimensional xarray dataset for storing benchmark results."""
         return self._collector.setup_dataset(bench_cfg, time_src)
 
-    def define_const_inputs(self, const_vars: List[Tuple[param.Parameter, Any]]) -> Optional[dict]:
+    def define_const_inputs(self, const_vars: list[tuple[param.Parameter, Any]]) -> dict | None:
         """Convert constant variable tuples into a name-value dictionary."""
         return self._executor.define_const_inputs(const_vars)
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> List[IntSweep]:
+    ) -> list[IntSweep]:
         """Define meta variables (repeat count, timestamps) for benchmark tracking."""
         return self._collector.define_extra_vars(bench_cfg, repeats, time_src)
 
@@ -822,7 +824,7 @@ class Bench(BenchPlotServer):
         branch_name = f"{self.bench_name}_{self.run_cfg.run_tag}"
         return self.report.publish(remote_callback, branch_name=branch_name)
 
-    def get_result_vars(self, as_str: bool = True) -> List[str | ParametrizedSweep]:
+    def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
         """
         Retrieve the result variables from the worker class instance.
 
@@ -832,7 +834,7 @@ class Bench(BenchPlotServer):
                            Default is True.
 
         Returns:
-            List[str | ParametrizedSweep]: A list of result variables, either as strings or in their original form.
+            list[str | ParametrizedSweep]: A list of result variables, either as strings or in their original form.
 
         Raises:
             RuntimeError: If the worker class instance is not set.
@@ -846,7 +848,7 @@ class Bench(BenchPlotServer):
     def to(
         self,
         result_type: BenchResult,
-        result_var: Optional[Parameter] = None,
+        result_var: Parameter | None = None,
         override: bool = True,
         **kwargs: Any,
     ) -> BenchResult:
@@ -863,7 +865,7 @@ class Bench(BenchPlotServer):
     def add(
         self,
         result_type: BenchResult,
-        result_var: Optional[Parameter] = None,
+        result_var: Parameter | None = None,
         override: bool = True,
         **kwargs: Any,
     ):

--- a/bencher/example/generated/result_types/result_image/result_image_over_time.py
+++ b/bencher/example/generated/result_types/result_image/result_image_over_time.py
@@ -17,11 +17,10 @@ def _polygon_points(radius, sides, start_angle=0.0):
     return points
 
 
-def _draw_polygon_image(points, color, linewidth, size=200, offset=(0, 0)):
+def _draw_polygon_image(points, color, linewidth, size=200):
     img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
-    ox, oy = offset
-    scaled = [((p[0] + 1) * size / 2 + ox, (1 - p[1]) * size / 2 + oy) for p in points]
+    scaled = [((p[0] + 1) * size / 2, (1 - p[1]) * size / 2) for p in points]
     draw.line(scaled, fill=color, width=int(linewidth))
     return img
 
@@ -35,13 +34,10 @@ class PolygonRenderer(bch.ParametrizedSweep):
     polygon = bch.ResultImage(doc="Rendered polygon image")
     area = bch.ResultVar("u^2", doc="Polygon area")
 
-    _start_angle = 0.0
-    _offset = (0, 0)
-
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
-        points = _polygon_points(self.radius, self.sides, start_angle=self._start_angle)
-        img = _draw_polygon_image(points, self.color, linewidth=3, offset=self._offset)
+        points = _polygon_points(self.radius, self.sides)
+        img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bch.gen_image_path("polygon")
         img.save(filepath, "PNG")
         self.polygon = str(filepath)
@@ -58,13 +54,8 @@ def example_result_image_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bc
     benchable = PolygonRenderer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
-    colors = ["red", "green", "blue"]
-    offsets = [(0, 0), (15, -10), (-10, 15)]
     for i, radius in enumerate([0.3, 0.6, 0.9]):
         benchable.radius = radius
-        benchable.color = colors[i]
-        benchable._start_angle = i * 30.0
-        benchable._offset = offsets[i]
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
         bench.plot_sweep(
@@ -79,4 +70,4 @@ def example_result_image_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bc
 
 
 if __name__ == "__main__":
-    bch.run(example_result_image_over_time, save=True, level=3)
+    bch.run(example_result_image_over_time, level=3)

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -1,4 +1,5 @@
-from typing import List
+from __future__ import annotations
+
 import logging
 
 import optuna
@@ -58,7 +59,7 @@ def param_importance(bench_cfg: BenchCfg, study: optuna.Study) -> pn.Row:
 
 
 # BENCH_CFG
-def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> List[str]:
+def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> list[str]:
     """Given a trial produce a string summary of the best results
 
     Args:
@@ -66,7 +67,7 @@ def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> List[str]:
         bench_cfg (BenchCfg): info about the trial
 
     Returns:
-        List[str]: Summary of trial
+        list[str]: Summary of trial
     """
     sep = "    "
     output = []

--- a/bencher/plotting/plot_filter.py
+++ b/bencher/plotting/plot_filter.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 from dataclasses import dataclass, field
 from bencher.plotting.plt_cnt_cfg import PltCntCfg
 import logging
@@ -141,14 +140,14 @@ class PlotMatchesResult:
         # if self.plt_cnt_cfg.print_debug:
         logging.info(self.matches_info)
 
-    def to_panel(self, **kwargs) -> Optional[pn.pane.Markdown]:
+    def to_panel(self, **kwargs) -> pn.pane.Markdown | None:
         """Convert match information to a Panel Markdown pane if debug mode is enabled.
 
         Args:
             **kwargs: Additional keyword arguments to pass to the Panel Markdown constructor
 
         Returns:
-            Optional[pn.pane.Markdown]: A Markdown pane containing match information if in debug mode,
+            pn.pane.Markdown | None: A Markdown pane containing match information if in debug mode,
                                         None otherwise
         """
         if self.plt_cnt_cfg.print_debug:

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -263,7 +263,7 @@ class ResultCollector:
         Args:
             bench_res (BenchResult): The benchmark result to cache
             bench_cfg_hash (str): The hash value to use as the cache key
-            bench_cfg_hashes (list[str]): list to append the hash to (modified in place)
+            bench_cfg_hashes (list[str]): List to append the hash to (modified in place)
         """
         with Cache("cachedir/benchmark_inputs", size_limit=self.cache_size) as c:
             logger.info(f"saving results with key: {bench_cfg_hash}")

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -4,10 +4,12 @@ This module provides the ResultCollector class for managing benchmark results,
 including xarray dataset operations, caching, and metadata management.
 """
 
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from itertools import product
-from typing import Any, List, Tuple
+from typing import Any
 
 import numpy as np
 import xarray as xr
@@ -40,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 def set_xarray_multidim(
-    data_array: xr.DataArray, index_tuple: Tuple[int, ...], value: Any
+    data_array: xr.DataArray, index_tuple: tuple[int, ...], value: Any
 ) -> xr.DataArray:
     """Set a value in a multi-dimensional xarray at the specified index position.
 
@@ -49,7 +51,7 @@ def set_xarray_multidim(
 
     Args:
         data_array (xr.DataArray): The data array to modify
-        index_tuple (Tuple[int, ...]): The index coordinates as a tuple
+        index_tuple (tuple[int, ...]): The index coordinates as a tuple
         value (Any): The value to set at the specified position
 
     Returns:
@@ -81,7 +83,7 @@ class ResultCollector:
 
     def setup_dataset(
         self, bench_cfg: BenchCfg, time_src: datetime | str
-    ) -> Tuple[BenchResult, List[Tuple], List[str]]:
+    ) -> tuple[BenchResult, list[tuple], list[str]]:
         """Initialize an n-dimensional xarray dataset from benchmark configuration parameters.
 
         This function creates the data structures needed to store benchmark results based on
@@ -94,7 +96,7 @@ class ResultCollector:
             time_src (datetime | str): Timestamp or event name for the benchmark run
 
         Returns:
-            Tuple[BenchResult, List[Tuple], List[str]]:
+            tuple[BenchResult, list[tuple], list[str]]:
                 - A BenchResult object with the initialized dataset
                 - A list of function input tuples (index, value pairs)
                 - A list of dimension names for the dataset
@@ -145,7 +147,7 @@ class ResultCollector:
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> List[IntSweep]:
+    ) -> list[IntSweep]:
         """Define extra meta variables for tracking benchmark execution details.
 
         This function creates variables that aren't passed to the worker function but are stored
@@ -159,7 +161,7 @@ class ResultCollector:
                 tracking
 
         Returns:
-            List[IntSweep]: A list of additional parameter variables to include in the benchmark
+            list[IntSweep]: A list of additional parameter variables to include in the benchmark
         """
         bench_cfg.iv_repeat = IntSweep(
             default=repeats,
@@ -250,7 +252,7 @@ class ResultCollector:
                 bench_res.hmaps[rv.name][worker_job.canonical_input] = result_dict[rv.name]
 
     def cache_results(
-        self, bench_res: BenchResult, bench_cfg_hash: str, bench_cfg_hashes: List[str]
+        self, bench_res: BenchResult, bench_cfg_hash: str, bench_cfg_hashes: list[str]
     ) -> None:
         """Cache benchmark results for future retrieval.
 
@@ -261,7 +263,7 @@ class ResultCollector:
         Args:
             bench_res (BenchResult): The benchmark result to cache
             bench_cfg_hash (str): The hash value to use as the cache key
-            bench_cfg_hashes (List[str]): List to append the hash to (modified in place)
+            bench_cfg_hashes (list[str]): list to append the hash to (modified in place)
         """
         with Cache("cachedir/benchmark_inputs", size_limit=self.cache_size) as c:
             logger.info(f"saving results with key: {bench_cfg_hash}")

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -155,8 +155,8 @@ class BenchResult(
         """Automatically generate plots based on the provided plot callbacks.
 
         Args:
-            plot_list (list[callable], optional): list of plot callback functions to use. Defaults to None.
-            remove_plots (list[callable], optional): list of plot callback functions to exclude. Defaults to None.
+            plot_list (list[callable], optional): List of plot callback functions to use. Defaults to None.
+            remove_plots (list[callable], optional): List of plot callback functions to exclude. Defaults to None.
             default_container (type, optional): Default container type for the plots. Defaults to pn.Column.
             override (bool, optional): Whether to override unsupported plots. Defaults to False.
             **kwargs: Additional keyword arguments for plot configuration.

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Optional, Any, Literal
+from typing import Any, Literal
 import logging
 import panel as pn
 from param import Parameter
@@ -68,7 +68,7 @@ class BenchResult(
     def to(
         self,
         result_type: BenchResult,
-        result_var: Optional[Parameter] = None,
+        result_var: Parameter | None = None,
         override: bool = True,
         reduce: ReduceType | None = None,
         # Aggregation controls (applied in filter())
@@ -98,14 +98,14 @@ class BenchResult(
         return result_instance.to_plot(**plot_kwargs)
 
     @staticmethod
-    def default_plot_callbacks() -> List[callable]:
+    def default_plot_callbacks() -> list[callable]:
         """Get the default list of plot callback functions.
 
         These callbacks are used by default in the to_auto method if no specific
         plot list is provided.
 
         Returns:
-            List[callable]: A list of plotting callback functions
+            list[callable]: A list of plotting callback functions
         """
         return [
             # VideoSummaryResult.to_video_summary, #quite expensive so not turned on by default
@@ -123,11 +123,11 @@ class BenchResult(
         ]
 
     @staticmethod
-    def plotly_callbacks() -> List[callable]:
+    def plotly_callbacks() -> list[callable]:
         """Get the list of Plotly-specific callback functions.
 
         Returns:
-            List[callable]: A list of Plotly-based visualization callback functions
+            list[callable]: A list of Plotly-based visualization callback functions
         """
         return [SurfaceResult.to_surface, VolumeResult.to_volume]
 
@@ -146,23 +146,23 @@ class BenchResult(
 
     def to_auto(
         self,
-        plot_list: List[callable] | None = None,
-        remove_plots: List[callable] | None = None,
+        plot_list: list[callable] | None = None,
+        remove_plots: list[callable] | None = None,
         default_container=pn.Column,
         override: bool = False,  # false so that plots that are not supported are not shown
         **kwargs,
-    ) -> List[pn.panel]:
+    ) -> list[pn.panel]:
         """Automatically generate plots based on the provided plot callbacks.
 
         Args:
-            plot_list (List[callable], optional): List of plot callback functions to use. Defaults to None.
-            remove_plots (List[callable], optional): List of plot callback functions to exclude. Defaults to None.
+            plot_list (list[callable], optional): list of plot callback functions to use. Defaults to None.
+            remove_plots (list[callable], optional): list of plot callback functions to exclude. Defaults to None.
             default_container (type, optional): Default container type for the plots. Defaults to pn.Column.
             override (bool, optional): Whether to override unsupported plots. Defaults to False.
             **kwargs: Additional keyword arguments for plot configuration.
 
         Returns:
-            List[pn.panel]: A list of panel objects containing the generated plots.
+            list[pn.panel]: A list of panel objects containing the generated plots.
         """
         self.plt_cnt_cfg.print_debug = False
         plot_list = listify(plot_list)

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import List, Any, Tuple, Optional, Literal, Callable
+from typing import Any, Literal, Callable
 from enum import Enum, auto
 import numpy as np
 import xarray as xr
@@ -313,16 +315,16 @@ class BenchResultBase:
     def get_optimal_vec(
         self,
         result_var: ParametrizedSweep,
-        input_vars: List[ParametrizedSweep],
-    ) -> List[Any]:
+        input_vars: list[ParametrizedSweep],
+    ) -> list[Any]:
         """Get the optimal values from the sweep as a vector.
 
         Args:
             result_var (bch.ParametrizedSweep): Optimal values of this result variable
-            input_vars (List[bch.ParametrizedSweep]): Define which input vars values are returned in the vector
+            input_vars (list[bch.ParametrizedSweep]): Define which input vars values are returned in the vector
 
         Returns:
-            List[Any]: A vector of optimal values for the desired input vector
+            list[Any]: A vector of optimal values for the desired input vector
         """
 
         da = self.get_optimal_value_indices(result_var)
@@ -361,7 +363,7 @@ class BenchResultBase:
         result_var: ParametrizedSweep,
         keep_existing_consts: bool = True,
         as_dict: bool = False,
-    ) -> Tuple[ParametrizedSweep, Any] | dict[ParametrizedSweep, Any]:
+    ) -> tuple[ParametrizedSweep, Any] | dict[ParametrizedSweep, Any]:
         """Get a list of tuples of optimal variable names and value pairs, that can be fed in as constant values to subsequent parameter sweeps
 
         Args:
@@ -370,7 +372,7 @@ class BenchResultBase:
             as_dict (bool): return value as a dictionary
 
         Returns:
-            Tuple[bch.ParametrizedSweep, Any]|[ParametrizedSweep, Any]: Tuples of variable name and optimal values
+            tuple[bch.ParametrizedSweep, Any]|[ParametrizedSweep, Any]: Tuples of variable name and optimal values
         """
         da = self.get_optimal_value_indices(result_var)
         if keep_existing_consts:
@@ -427,7 +429,7 @@ class BenchResultBase:
 
         return " vs ".join(tit)
 
-    def get_results_var_list(self, result_var: ParametrizedSweep | None = None) -> List[ResultVar]:
+    def get_results_var_list(self, result_var: ParametrizedSweep | None = None) -> list[ResultVar]:
         return self.bench_cfg.result_vars if result_var is None else listify(result_var)
 
     def map_plots(
@@ -435,7 +437,7 @@ class BenchResultBase:
         plot_callback: Callable,
         result_var: ParametrizedSweep | None = None,
         row: EmptyContainer | None = None,
-    ) -> Optional[pn.Row]:
+    ) -> pn.Row | None:
         if row is None:
             row = EmptyContainer(pn.Row(name=self.to_plot_title()))
         for rv in self.get_results_var_list(result_var):
@@ -493,7 +495,7 @@ class BenchResultBase:
         zip_results=False,
         reduce: ReduceType | None = None,
         **kwargs,
-    ) -> Optional[pn.Row]:
+    ) -> pn.Row | None:
         if hv_dataset is None:
             hv_dataset = self.to_hv_dataset(reduce=reduce)
 
@@ -539,7 +541,7 @@ class BenchResultBase:
         agg_over_dims: list[str] | None = None,
         agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         # Initialize default filters if not provided to avoid shared mutable defaults
         if float_range is None:
             float_range = VarRange(0, None)
@@ -794,15 +796,15 @@ class BenchResultBase:
     def select_level(
         dataset: xr.Dataset,
         level: int,
-        include_types: List[type] | None = None,
-        exclude_names: List[str] | None = None,
+        include_types: list[type] | None = None,
+        exclude_names: list[str] | None = None,
     ) -> xr.Dataset:
         """Given a dataset, return a reduced dataset that only contains data from a specified level.  By default all types of variables are filtered at the specified level.  If you only want to get a reduced level for some types of data you can pass in a list of types to get filtered, You can also pass a list of variables names to exclude from getting filtered
         Args:
             dataset (xr.Dataset): dataset to filter
             level (int): desired data resolution level
-            include_types (List[type], optional): Only filter data of these types. Defaults to None.
-            exclude_names (List[str], optional): Only filter data with these variable names. Defaults to None.
+            include_types (list[type], optional): Only filter data of these types. Defaults to None.
+            exclude_names (list[str], optional): Only filter data with these variable names. Defaults to None.
 
         Returns:
             xr.Dataset: A reduced dataset at the specified level

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from enum import auto
-from typing import Any, List
+from typing import Any
 from dataclasses import dataclass, field
 from strenum import StrEnum
 from bencher.results.float_formatter import FormatFloat
@@ -31,7 +33,7 @@ class ComposableContainerBase:
     """A base class for renderer backends.  A composable renderer"""
 
     compose_method: ComposeType = ComposeType.right
-    container: List[Any] = field(default_factory=list)
+    container: list[Any] = field(default_factory=list)
     label_len: int = 0
 
     @staticmethod

--- a/bencher/results/dataset_result.py
+++ b/bencher/results/dataset_result.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+
 from functools import partial
 
 import panel as pn
@@ -18,7 +19,7 @@ class DataSetResult(BenchResultBase):
         container=None,
         level: int | None = None,
         **kwargs,
-    ) -> Optional[pn.pane.panel]:
+    ) -> pn.pane.panel | None:
         if hv_dataset is None:
             hv_dataset = self.to_hv_dataset(ReduceType.SQUEEZE, level=level)
         elif not isinstance(hv_dataset, hv.Dataset):

--- a/bencher/results/histogram_result.py
+++ b/bencher/results/histogram_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 import panel as pn
 from param import Parameter
 import hvplot.xarray  # noqa pylint: disable=duplicate-code,unused-import
@@ -16,7 +15,7 @@ from bencher.variables.results import ResultVar
 class HistogramResult(VideoResult):
     def to_plot(
         self, result_var: Parameter | None = None, target_dimension: int = 2, **kwargs
-    ) -> Optional[pn.pane.Pane]:
+    ) -> pn.pane.Pane | None:
         """Generates a histogram plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a histogram
@@ -28,7 +27,7 @@ class HistogramResult(VideoResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.pane.Pane]: A panel containing the histogram if data is appropriate,
+            pn.pane.Pane | None: A panel containing the histogram if data is appropriate,
                                   otherwise returns filter match results.
         """
         return self.filter(

--- a/bencher/results/holoview_results/bar_result.py
+++ b/bencher/results/holoview_results/bar_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -23,7 +22,7 @@ class BarResult(HoloviewResult):
 
     def to_plot(
         self, result_var: Parameter | None = None, override: bool = True, **kwargs
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         return self.to_bar(result_var, override, **kwargs)
 
     def to_bar(
@@ -32,7 +31,7 @@ class BarResult(HoloviewResult):
         override: bool = True,
         target_dimension: int = 2,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a bar chart from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a bar chart
@@ -45,7 +44,7 @@ class BarResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the bar chart if data is appropriate,
+            pn.panel | None: A panel containing the bar chart if data is appropriate,
                               otherwise returns filter match results.
         """
         # When over_time is active, allow 0 inputs so 0D+0cat+over_time can produce

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 import holoviews as hv
 from param import Parameter
 import hvplot.xarray  # noqa pylint: disable=duplicate-code,unused-import
@@ -22,7 +21,7 @@ class CurveResult(HoloviewResult):
 
     def to_plot(
         self, result_var: Parameter | None = None, override: bool = True, **kwargs
-    ) -> Optional[hv.Curve]:
+    ) -> hv.Curve | None:
         """Generates a curve plot from benchmark data.
 
         This is a convenience method that calls to_curve() with the same parameters.
@@ -33,7 +32,7 @@ class CurveResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[hv.Curve]: A curve plot if data is appropriate,
+            hv.Curve | None: A curve plot if data is appropriate,
                               otherwise returns filter match results.
         """
         return self.to_curve(result_var=result_var, override=override, **kwargs)
@@ -57,7 +56,7 @@ class CurveResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[hv.Curve]: A curve plot if data is appropriate,
+            hv.Curve | None: A curve plot if data is appropriate,
                               otherwise returns filter match results.
         """
         return self.filter(
@@ -73,9 +72,7 @@ class CurveResult(HoloviewResult):
             **kwargs,
         )
 
-    def to_curve_ds(
-        self, dataset: xr.Dataset, result_var: Parameter, **kwargs
-    ) -> Optional[hv.Curve]:
+    def to_curve_ds(self, dataset: xr.Dataset, result_var: Parameter, **kwargs) -> hv.Curve | None:
         """Creates a curve plot from the provided dataset.
 
         Given a filtered dataset, this method generates a curve visualization showing
@@ -89,7 +86,7 @@ class CurveResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the curve plot options.
 
         Returns:
-            Optional[hv.Curve]: A curve plot with optional standard deviation spread.
+            hv.Curve | None: A curve plot with optional standard deviation spread.
         """
         var = result_var.name
         std_var = f"{var}_std"

--- a/bencher/results/holoview_results/distribution_result/box_whisker_result.py
+++ b/bencher/results/holoview_results/distribution_result/box_whisker_result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Any
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -27,20 +27,20 @@ class BoxWhiskerResult(DistributionResult):
     """
 
     def to_plot(
-        self, result_var: Optional[Parameter] = None, override: bool = True, **kwargs: Any
-    ) -> Optional[pn.panel]:
+        self, result_var: Parameter | None = None, override: bool = True, **kwargs: Any
+    ) -> pn.panel | None:
         """Generates a box and whisker plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a box plot
         and then passes the filtered data to to_boxplot_ds for rendering.
 
         Args:
-            result_var (Optional[Parameter]): The result variable to plot. If None, uses the default.
+            result_var (Parameter | None): The result variable to plot. If None, uses the default.
             override (bool): Whether to override filter restrictions. Defaults to True.
             **kwargs (Any): Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the box plot if data is appropriate,
+            pn.panel | None: A panel containing the box plot if data is appropriate,
             otherwise returns filter match results.
         """
         return self.to_distribution_plot(

--- a/bencher/results/holoview_results/distribution_result/distribution_result.py
+++ b/bencher/results/holoview_results/distribution_result/distribution_result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Callable, Any, Type
+from typing import Callable, Any
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -27,10 +27,10 @@ class DistributionResult(HoloviewResult):
     def to_distribution_plot(
         self,
         plot_method: Callable[[xr.Dataset, Parameter, Any], hv.Element],
-        result_var: Optional[Parameter] = None,
+        result_var: Parameter | None = None,
         override: bool = True,
         **kwargs: Any,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a distribution plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for distribution plots
@@ -80,7 +80,7 @@ class DistributionResult(HoloviewResult):
         self,
         dataset: xr.Dataset,
         result_var: Parameter,
-        plot_class: Type[hv.Selection1DExpr],
+        plot_class: type[hv.Selection1DExpr],
         **kwargs: Any,
     ) -> hv.Element:
         """Prepares data for distribution plots and creates the plot.

--- a/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
+++ b/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Any
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -32,12 +32,12 @@ class ScatterJitterResult(DistributionResult):
 
     def to_plot(
         self,
-        result_var: Optional[Parameter] = None,
+        result_var: Parameter | None = None,
         override: bool = True,
         jitter: float = 0.1,
-        target_dimension: Optional[int] = None,
+        target_dimension: int | None = None,
         **kwargs: Any,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a scatter jitter plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a scatter plot

--- a/bencher/results/holoview_results/distribution_result/violin_result.py
+++ b/bencher/results/holoview_results/distribution_result/violin_result.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Any
+from typing import Any
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -26,20 +26,20 @@ class ViolinResult(DistributionResult):
     """
 
     def to_plot(
-        self, result_var: Optional[Parameter] = None, override: bool = True, **kwargs: Any
-    ) -> Optional[pn.panel]:
+        self, result_var: Parameter | None = None, override: bool = True, **kwargs: Any
+    ) -> pn.panel | None:
         """Generates a violin plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a violin plot
         and then passes the filtered data to to_violin_ds for rendering.
 
         Args:
-            result_var (Optional[Parameter]): The result variable to plot. If None, uses the default.
+            result_var (Parameter | None): The result variable to plot. If None, uses the default.
             override (bool): Whether to override filter restrictions. Defaults to True.
             **kwargs (Any): Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the violin plot if data is appropriate,
+            pn.panel | None: A panel containing the violin plot if data is appropriate,
             otherwise returns filter match results.
         """
         return self.to_distribution_plot(

--- a/bencher/results/holoview_results/heatmap_result.py
+++ b/bencher/results/holoview_results/heatmap_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Optional
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -35,7 +34,7 @@ class HeatmapResult(HoloviewResult):
         override: bool = True,
         use_tap: bool | None = None,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a heatmap visualization from benchmark data.
 
         This is a convenience method that calls to_heatmap() with the same parameters.
@@ -51,7 +50,7 @@ class HeatmapResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the heatmap if data is appropriate,
+            pn.panel | None: A panel containing the heatmap if data is appropriate,
                               otherwise returns filter match results.
         """
         return self.to_heatmap(
@@ -75,7 +74,7 @@ class HeatmapResult(HoloviewResult):
         override: bool = True,
         use_tap: bool | None = None,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a heatmap visualization from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a heatmap
@@ -94,7 +93,7 @@ class HeatmapResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the heatmap if data is appropriate,
+            pn.panel | None: A panel containing the heatmap if data is appropriate,
                               otherwise returns filter match results.
         """
         if tap_var is None:
@@ -127,7 +126,7 @@ class HeatmapResult(HoloviewResult):
 
     def to_heatmap_ds(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs
-    ) -> Optional[hv.HeatMap | hv.HoloMap]:
+    ) -> hv.HeatMap | hv.HoloMap | None:
         """Creates a basic heatmap from the provided dataset.
 
         Given a filtered dataset, this method generates a heatmap visualization showing
@@ -141,7 +140,7 @@ class HeatmapResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the heatmap options.
 
         Returns:
-            Optional[hv.HeatMap | hv.HoloMap]: A heatmap visualization if the dataset has
+            hv.HeatMap | hv.HoloMap | None: A heatmap visualization if the dataset has
                 at least 2 dimensions, otherwise returns None.
         """
         if len(dataset.dims) >= 2:
@@ -175,7 +174,7 @@ class HeatmapResult(HoloviewResult):
         self,
         dataset: xr.Dataset,
         result_var: Parameter,
-        result_var_plots: List[Parameter] | None = None,
+        result_var_plots: list[Parameter] | None = None,
         container: pn.pane.panel = None,
         tap_container_direction: pn.Column | pn.Row | None = None,
         **kwargs,
@@ -188,7 +187,7 @@ class HeatmapResult(HoloviewResult):
         Args:
             dataset (xr.Dataset): The dataset containing benchmark results.
             result_var (Parameter): The primary result variable to plot in the heatmap.
-            result_var_plots (List[Parameter], optional): Additional result variables to display when a point is tapped.
+            result_var_plots (list[Parameter], optional): Additional result variables to display when a point is tapped.
             container (pn.pane.panel, optional): Container to display tapped information.
             tap_container_direction (pn.Column | pn.Row, optional): Layout direction for the tap containers.
             **kwargs: Additional keyword arguments passed to the heatmap options.

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -244,9 +244,9 @@ class HoloviewResult(VideoResult):
             **kwargs: Additional options to pass to the container constructors.
 
         Returns:
-            tuple[list[Parameter], list[pn.pane.panel]]: tuple containing:
-                - list of result variables
-                - list of initialized container instances
+            tuple[list[Parameter], list[pn.pane.panel]]: Tuple containing:
+                - List of result variables
+                - List of initialized container instances
         """
         result_var_plots = listify(result_var_plots)
         if container is None:

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Optional
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -63,14 +62,14 @@ class HoloviewResult(VideoResult):
         """
         return self.to_hv_dataset(reduce).to(hv_type, **kwargs)
 
-    def overlay_plots(self, plot_callback: callable) -> Optional[hv.Overlay | pn.Row]:
+    def overlay_plots(self, plot_callback: callable) -> hv.Overlay | pn.Row | None:
         """Create an overlay of plots by applying a callback to each result variable.
 
         Args:
             plot_callback (callable): Function to apply to each result variable to create a plot.
 
         Returns:
-            Optional[hv.Overlay | pn.Row]: An overlay of plots or Row of plots, or None if no results.
+            hv.Overlay | pn.Row | None: An overlay of plots or Row of plots, or None if no results.
         """
         results = []
         markdown_results = pn.Row()
@@ -90,14 +89,14 @@ class HoloviewResult(VideoResult):
             return markdown_results
         return None
 
-    def layout_plots(self, plot_callback: callable) -> Optional[hv.Layout]:
+    def layout_plots(self, plot_callback: callable) -> hv.Layout | None:
         """Create a layout of plots by applying a callback to each result variable.
 
         Args:
             plot_callback (callable): Function to apply to each result variable to create a plot.
 
         Returns:
-            Optional[hv.Layout]: A layout of plots or None if no results.
+            hv.Layout | None: A layout of plots or None if no results.
         """
         if len(self.bench_cfg.result_vars) > 0:
             pt = hv.Layout()
@@ -195,7 +194,7 @@ class HoloviewResult(VideoResult):
         result_var: Parameter | None = None,
         result_types: tuple | None = (ResultVar,),
         **kwargs,
-    ) -> Optional[pn.pane.panel]:
+    ) -> pn.pane.panel | None:
         """Convert the data to a HoloViews container with specified dimensions and options.
 
         Args:
@@ -207,7 +206,7 @@ class HoloviewResult(VideoResult):
             **kwargs: Additional visualization options.
 
         Returns:
-            Optional[pn.pane.panel]: A panel containing the visualization, or None if no valid results.
+            pn.pane.panel | None: A panel containing the visualization, or None if no valid results.
         """
         return self.map_plot_panes(
             partial(self.hv_container_ds, container=container),
@@ -233,21 +232,21 @@ class HoloviewResult(VideoResult):
 
     def setup_results_and_containers(
         self,
-        result_var_plots: Parameter | List[Parameter],
-        container: type | List[type] | None = None,
+        result_var_plots: Parameter | list[Parameter],
+        container: type | list[type] | None = None,
         **kwargs,
-    ) -> tuple[List[Parameter], List[pn.pane.panel]]:
+    ) -> tuple[list[Parameter], list[pn.pane.panel]]:
         """Set up appropriate containers for result variables.
 
         Args:
-            result_var_plots (Parameter | List[Parameter]): Result variables to visualize.
-            container (type | List[type], optional): Container types to use. Defaults to None.
+            result_var_plots (Parameter | list[Parameter]): Result variables to visualize.
+            container (type | list[type], optional): Container types to use. Defaults to None.
             **kwargs: Additional options to pass to the container constructors.
 
         Returns:
-            tuple[List[Parameter], List[pn.pane.panel]]: Tuple containing:
-                - List of result variables
-                - List of initialized container instances
+            tuple[list[Parameter], list[pn.pane.panel]]: tuple containing:
+                - list of result variables
+                - list of initialized container instances
         """
         result_var_plots = listify(result_var_plots)
         if container is None:
@@ -311,11 +310,11 @@ class HoloviewResult(VideoResult):
         """
         return hv.HoloMap(self.to_nd_layout(name)).opts(shared_axes=False)
 
-    def to_holomap_list(self, hmap_names: List[str] | None = None) -> pn.Column:
+    def to_holomap_list(self, hmap_names: list[str] | None = None) -> pn.Column:
         """Create a column of HoloMaps from multiple named maps.
 
         Args:
-            hmap_names (List[str], optional): List of HoloMap names to include.
+            hmap_names (list[str], optional): list of HoloMap names to include.
                 If None, uses all result_hmaps. Defaults to None.
 
         Returns:
@@ -368,11 +367,11 @@ class HoloviewResult(VideoResult):
 
         return hv.DynamicMap(cb, kdims=kdims)
 
-    def to_grid(self, inputs: List[str] | None = None) -> hv.GridSpace:
+    def to_grid(self, inputs: list[str] | None = None) -> hv.GridSpace:
         """Create a grid visualization from a HoloMap.
 
         Args:
-            inputs (List[str], optional): Input variable names to use for the grid dimensions.
+            inputs (list[str], optional): Input variable names to use for the grid dimensions.
                 If None, uses bench_cfg.inputs_as_str(). Defaults to None.
 
         Returns:

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Optional
 import panel as pn
 import holoviews as hv
 from param import Parameter
@@ -34,7 +33,7 @@ class LineResult(HoloviewResult):
         override: bool = True,
         use_tap: bool | None = None,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a line plot from benchmark data.
 
         This is a convenience method that calls to_line() with the same parameters.
@@ -49,7 +48,7 @@ class LineResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the line plot if data is appropriate,
+            pn.panel | None: A panel containing the line plot if data is appropriate,
                               otherwise returns filter match results.
         """
         return self.to_line(
@@ -71,7 +70,7 @@ class LineResult(HoloviewResult):
         override: bool = True,
         use_tap: bool | None = None,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Generates a line plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a line plot
@@ -89,7 +88,7 @@ class LineResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the line plot if data is appropriate,
+            pn.panel | None: A panel containing the line plot if data is appropriate,
                               otherwise returns filter match results.
         """
         if tap_var is None:
@@ -159,7 +158,7 @@ class LineResult(HoloviewResult):
         self,
         dataset: xr.Dataset,
         result_var: Parameter,
-        result_var_plots: List[Parameter] | None = None,
+        result_var_plots: list[Parameter] | None = None,
         container: pn.pane.panel = pn.pane.panel,
         **kwargs,
     ) -> pn.Row:
@@ -171,7 +170,7 @@ class LineResult(HoloviewResult):
         Args:
             dataset (xr.Dataset): The dataset containing benchmark results.
             result_var (Parameter): The primary result variable to plot in the line plot.
-            result_var_plots (List[Parameter], optional): Additional result variables to display when a point is tapped.
+            result_var_plots (list[Parameter], optional): Additional result variables to display when a point is tapped.
             container (pn.pane.panel, optional): Container to display tapped information.
             **kwargs: Additional keyword arguments passed to the line plot options.
 

--- a/bencher/results/holoview_results/scatter_result.py
+++ b/bencher/results/holoview_results/scatter_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 import panel as pn
 
 import hvplot.xarray  # noqa pylint: disable=duplicate-code,unused-import
@@ -25,7 +24,7 @@ class ScatterResult(HoloviewResult):
     - to_scatter: Creates standard scatter plots that can be grouped by categorical variables
     """
 
-    def to_plot(self, override: bool = True, **kwargs) -> Optional[pn.panel]:
+    def to_plot(self, override: bool = True, **kwargs) -> pn.panel | None:
         """Creates a standard scatter plot from benchmark data.
 
         This is a convenience method that calls to_scatter() with the same parameters.
@@ -35,12 +34,12 @@ class ScatterResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the scatter plot options.
 
         Returns:
-            Optional[pn.panel]: A panel containing the scatter plot if data is appropriate,
+            pn.panel | None: A panel containing the scatter plot if data is appropriate,
                               otherwise returns filter match results.
         """
         return self.to_scatter(override=override, **kwargs)
 
-    def to_scatter(self, override: bool = True, **kwargs) -> Optional[pn.panel]:
+    def to_scatter(self, override: bool = True, **kwargs) -> pn.panel | None:
         """Creates a standard scatter plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a scatter plot
@@ -52,7 +51,7 @@ class ScatterResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the scatter plot options.
 
         Returns:
-            Optional[pn.panel]: A panel containing the scatter plot if data is appropriate,
+            pn.panel | None: A panel containing the scatter plot if data is appropriate,
                               otherwise returns filter match results.
         """
         match_res = PlotFilter(
@@ -78,7 +77,7 @@ class ScatterResult(HoloviewResult):
 
     # def to_scatter_jitter(
     #     self, result_var: Parameter | None = None, override: bool = True, **kwargs
-    # ) -> Optional[pn.panel]:
+    # ) -> pn.panel | None:
     #     return self.filter(
     #         self.to_scatter_ds,
     #         float_range=VarRange(0, 0),

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 import panel as pn
 from param import Parameter
 import plotly.graph_objs as go
@@ -36,7 +35,7 @@ class SurfaceResult(HoloviewResult):
 
     def to_plot(
         self, result_var: Parameter | None = None, override: bool = True, **kwargs
-    ) -> Optional[pn.pane.Pane]:
+    ) -> pn.pane.Pane | None:
         """Generates a 3D surface plot from benchmark data.
 
         This is a convenience method that calls to_surface() with the same parameters.
@@ -47,7 +46,7 @@ class SurfaceResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.pane.Pane]: A panel containing the surface plot if data is appropriate,
+            pn.pane.Pane | None: A panel containing the surface plot if data is appropriate,
                                    otherwise returns filter match results.
         """
         return self.to_surface(result_var=result_var, override=override, **kwargs)
@@ -58,7 +57,7 @@ class SurfaceResult(HoloviewResult):
         override: bool = True,
         target_dimension: int = 2,
         **kwargs,
-    ) -> Optional[pn.pane.Pane]:
+    ) -> pn.pane.Pane | None:
         """Generates a 3D surface plot from benchmark data.
 
         This method applies filters to ensure the data is appropriate for a surface plot
@@ -71,7 +70,7 @@ class SurfaceResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.pane.Pane]: A panel containing the surface plot if data is appropriate,
+            pn.pane.Pane | None: A panel containing the surface plot if data is appropriate,
                                    otherwise returns filter match results.
         """
         return self.filter(
@@ -95,7 +94,7 @@ class SurfaceResult(HoloviewResult):
         alpha: float = 0.3,
         width: int = 600,
         height: int = 600,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Creates a 3D surface plot from the provided dataset.
 
         Uses plotly directly (like VolumeResult) to avoid HoloViews backend
@@ -111,7 +110,7 @@ class SurfaceResult(HoloviewResult):
             height (int, optional): Plot height in pixels. Defaults to 600.
 
         Returns:
-            Optional[pn.panel]: A panel containing the surface plot if data matches criteria,
+            pn.panel | None: A panel containing the surface plot if data matches criteria,
                                otherwise returns filter match results.
         """
         matches_res = PlotFilter(

--- a/bencher/results/laxtex_result.py
+++ b/bencher/results/laxtex_result.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import panel as pn
 from panel.pane import LaTeX
-from typing import Optional, List, Any
+from typing import Any
 
 pn.extension("mathjax")
 
@@ -10,14 +12,14 @@ def latex_text(text: str) -> str:
     return r"\text{" + text.replace("_", " ") + r"} \\"
 
 
-def format_values_list(values: List[Any], max_display: int = 5) -> List[Any]:
+def format_values_list(values: list[Any], max_display: int = 5) -> list[Any]:
     """Format a list of values, showing ellipsis if too long."""
     if len(values) <= max_display:
         return values
     return [values[i] for i in [0, 1, 0, -2, -1]]
 
 
-def create_matrix_array(values: List[Any]) -> str:
+def create_matrix_array(values: list[Any]) -> str:
     """Create a LaTeX matrix array from values."""
     displayed_vals = format_values_list(values)
     if len(values) > 5:
@@ -51,7 +53,7 @@ def result_var_to_latex(bench_cfg) -> str:
     return latex_str
 
 
-def to_latex(bench_cfg) -> Optional[pn.pane.LaTeX]:
+def to_latex(bench_cfg) -> pn.pane.LaTeX | None:
     """Convert benchmark configuration to LaTeX visualization.
 
     Returns None if there are no variables to display.

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List
 from copy import deepcopy
 
 import numpy as np
@@ -28,11 +27,11 @@ from bencher.optuna_conversions import (
 
 
 class OptunaResult(BenchResultBase):
-    def to_optuna_plots(self, **kwargs) -> List[pn.pane.panel]:
+    def to_optuna_plots(self, **kwargs) -> list[pn.pane.panel]:
         """Create an optuna summary from the benchmark results
 
         Returns:
-            List[pn.pane.panel]: A list of optuna plot summarising the benchmark process
+            list[pn.pane.panel]: A list of optuna plot summarising the benchmark process
         """
 
         return self.collect_optuna_plots(**kwargs)
@@ -47,7 +46,7 @@ class OptunaResult(BenchResultBase):
         self,
         worker,
         n_trials=100,
-        extra_results: List[OptunaResult] | None = None,
+        extra_results: list[OptunaResult] | None = None,
         sampler=None,
     ):
         directions = []
@@ -177,7 +176,7 @@ class OptunaResult(BenchResultBase):
 
     def collect_optuna_plots(
         self, pareto_width: float | None = None, pareto_height: float | None = None
-    ) -> List[pn.pane.panel]:
+    ) -> list[pn.pane.panel]:
         """Use optuna to plot various summaries of the optimisation
 
         Args:
@@ -185,7 +184,7 @@ class OptunaResult(BenchResultBase):
             bench_cfg (BenchCfg): Benchmark config with options used to generate the study
 
         Returns:
-            List[pn.pane.Pane]: A list of plots
+            list[pn.pane.Pane]: A list of plots
         """
 
         self.studies = [self.bench_result_to_study(True)]

--- a/bencher/results/video_controls.py
+++ b/bencher/results/video_controls.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+
 from pathlib import Path
 import panel as pn
 
@@ -15,7 +16,7 @@ class VideoControls:
             return vid
         return pn.pane.Markdown(f"video does not exist {path}")
 
-    def video_controls(self) -> Optional[pn.Column]:
+    def video_controls(self) -> pn.Column | None:
         def play_vid(_):  # pragma: no cover
             for r in self.vid_p:
                 r.paused = False

--- a/bencher/results/video_result.py
+++ b/bencher/results/video_result.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+
 from functools import partial
 import panel as pn
 from param import Parameter
@@ -26,7 +27,7 @@ class VideoResult(BenchResultBase):
         container=None,
         level: int | None = None,
         **kwargs,
-    ) -> Optional[pn.pane.panel]:
+    ) -> pn.pane.panel | None:
         if hv_dataset is None:
             hv_dataset = self.to_hv_dataset(ReduceType.SQUEEZE, level=level)
         elif not isinstance(hv_dataset, hv.Dataset):

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -1,4 +1,6 @@
-from typing import Optional, List, Callable
+from __future__ import annotations
+
+from typing import Callable
 from copy import deepcopy
 import panel as pn
 import xarray as xr
@@ -23,7 +25,7 @@ class VideoSummaryResult(BenchResultBase):
         reverse: bool = True,
         result_types=(ResultImage,),
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         return self.to_video_grid(
             result_var=result_var,
             result_types=result_types,
@@ -39,19 +41,19 @@ class VideoSummaryResult(BenchResultBase):
         pane_collection: pn.pane = None,
         time_sequence_dimension=0,
         target_duration: float | None = None,
-        compose_method_list: List | None = None,
+        compose_method_list: list | None = None,
         **kwargs,
-    ) -> Optional[pn.panel]:
+    ) -> pn.panel | None:
         """Returns the results compiled into a video
 
         Args:
             result_var (Parameter, optional): The result var to plot. Defaults to None.
             result_types (tuple, optional): The types of result var to convert to video. Defaults to (ResultImage,).
             collection (pn.pane, optional): If there are multiple results, use this collection to stack them. Defaults to pn.Row().
-            compose_method_list (List: optional): Defines how each of the dimensions is composed in the video. ie, concatenate the videos horizontally, vertically, sequentially or alpha overlay. Seee bch.ComposeType for the options.
+            compose_method_list (list: optional): Defines how each of the dimensions is composed in the video. ie, concatenate the videos horizontally, vertically, sequentially or alpha overlay. Seee bch.ComposeType for the options.
 
         Returns:
-            Optional[pn.panel]: a panel pane with a video of all results concatenated together
+            pn.panel | None: a panel pane with a video of all results concatenated together
         """
         plot_filter = PlotFilter(
             float_range=VarRange(0, None),
@@ -91,7 +93,7 @@ class VideoSummaryResult(BenchResultBase):
         time_sequence_dimension=0,
         video_controls: VideoControls | None = None,
         target_duration: float | None = None,
-        compose_method_list: List | None = None,
+        compose_method_list: list | None = None,
         target_dimension: int = 0,
         **kwargs,
     ):
@@ -107,12 +109,12 @@ class VideoSummaryResult(BenchResultBase):
             time_sequence_dimension (int, optional): The dimension to use for time sequencing. Defaults to 0.
             video_controls (VideoControls, optional): Controls for video playback. If None, creates default controls.
             target_duration (float, optional): Target duration for the video in seconds.
-            compose_method_list (List, optional): List of composition methods for combining panes.
+            compose_method_list (list, optional): list of composition methods for combining panes.
             target_dimension (int, optional): The target dimensionality for data filtering. Defaults to 0.
             **kwargs: Additional keyword arguments passed to video rendering.
 
         Returns:
-            Optional[pn.pane.HTML]: A video container with playback controls if successful, None otherwise.
+            pn.pane.HTML | None: A video container with playback controls if successful, None otherwise.
         """
         cvc = self._to_video_panes_ds(
             dataset,
@@ -148,7 +150,7 @@ class VideoSummaryResult(BenchResultBase):
         dataset: xr.Dataset,
         first_compose_method: ComposeType = ComposeType.down,
         time_sequence_dimension: int = 0,
-    ) -> List[ComposeType]:
+    ) -> list[ComposeType]:
         """ "Given a dataset, chose an order for composing the results.  By default will flip between right and down and the last dimension will be a time sequence.
 
         Args:
@@ -157,7 +159,7 @@ class VideoSummaryResult(BenchResultBase):
             time_sequence_dimension (int, optional): The dimension to start time sequencing instead of composing in space. Defaults to 0.
 
         Returns:
-            List[ComposeType]: A list of composition methods for composing the dataset result
+            list[ComposeType]: A list of composition methods for composing the dataset result
         """
 
         num_dims = len(dataset.sizes)

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -109,7 +109,7 @@ class VideoSummaryResult(BenchResultBase):
             time_sequence_dimension (int, optional): The dimension to use for time sequencing. Defaults to 0.
             video_controls (VideoControls, optional): Controls for video playback. If None, creates default controls.
             target_duration (float, optional): Target duration for the video in seconds.
-            compose_method_list (list, optional): list of composition methods for combining panes.
+            compose_method_list (list, optional): List of composition methods for combining panes.
             target_dimension (int, optional): The target dimensionality for data filtering. Defaults to 0.
             **kwargs: Additional keyword arguments passed to video rendering.
 

--- a/bencher/results/volume_result.py
+++ b/bencher/results/volume_result.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional, Any
+from typing import Any
 
 import xarray as xr
 from param import Parameter
@@ -13,17 +15,17 @@ from bencher.variables.results import ResultVar
 
 class VolumeResult(BenchResultBase):
     def to_plot(
-        self, result_var: Optional[Parameter] = None, override: bool = True, **kwargs: Any
-    ) -> Optional[pn.panel]:
+        self, result_var: Parameter | None = None, override: bool = True, **kwargs: Any
+    ) -> pn.panel | None:
         """Generates a 3d volume plot from benchmark data.
 
         Args:
-            result_var (Optional[Parameter]): The result variable to plot. If None, uses the default.
+            result_var (Parameter | None): The result variable to plot. If None, uses the default.
             override (bool): Whether to override filter restrictions. Defaults to True.
             **kwargs (Any): Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.panel]: A panel containing the volume plot if data is appropriate,
+            pn.panel | None: A panel containing the volume plot if data is appropriate,
             otherwise returns filter match results.
         """
         return self.to_volume(
@@ -51,7 +53,7 @@ class VolumeResult(BenchResultBase):
             **kwargs: Additional keyword arguments passed to the plot rendering.
 
         Returns:
-            Optional[pn.pane.Plotly]: A panel containing the volume plot if data is appropriate,
+            pn.pane.Plotly | None: A panel containing the volume plot if data is appropriate,
                                     otherwise returns filter match results.
         """
         if self.bench_cfg.over_time:
@@ -71,7 +73,7 @@ class VolumeResult(BenchResultBase):
 
     def to_volume_ds(
         self, dataset: xr.Dataset, result_var: Parameter, width=600, height=600
-    ) -> Optional[pn.pane.Plotly]:
+    ) -> pn.pane.Plotly | None:
         """Given a benchCfg generate a 3D surface plot
         Returns:
             pn.pane.Plotly: A 3d volume plot as a holoview in a pane

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, List, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 
 from bencher.bench_cfg import BenchRunCfg, BenchCfg
 from bencher.variables.parametrised_sweep import ParametrizedSweep
@@ -28,7 +28,7 @@ def run(
     publish: bool = False,
     grouped: bool = False,
     cache_results: bool = True,
-) -> List[BenchCfg]:
+) -> list[BenchCfg]:
     """Run a benchmark target with sensible defaults.
 
     Handles three cases:
@@ -52,7 +52,7 @@ def run(
         cache_results: Use sample cache for previous results. Defaults to True.
 
     Returns:
-        List[BenchCfg]: A list of benchmark configuration objects with results.
+        list[BenchCfg]: A list of benchmark configuration objects with results.
     """
     from bencher.bench_runner import BenchRunner
 

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -86,8 +86,8 @@ class SweepExecutor:
                 - param.Parameter: Already a parameter object
                 - str: Name of a parameter in the worker_class_instance
                 - dict: Configuration with 'name' and optional 'values', 'samples', 'max_level'
-                - tuple: tuple that can be converted to a parameter
-            var_type (str): type of variable ('input', 'result', or 'const') for error messages
+                - tuple: Tuple that can be converted to a parameter
+            var_type (str): Type of variable ('input', 'result', or 'const') for error messages
             run_cfg (BenchRunCfg | None): Run configuration for level settings
             worker_class_instance (ParametrizedSweep | None): The worker class instance for
                 looking up parameters by name
@@ -129,7 +129,7 @@ class SweepExecutor:
         """Convert constant variable tuples into a dictionary of name-value pairs.
 
         Args:
-            const_vars (list[tuple[param.Parameter, Any]]): list of (parameter, value) tuples
+            const_vars (list[tuple[param.Parameter, Any]]): List of (parameter, value) tuples
                 representing constant parameters and their values
 
         Returns:

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -4,9 +4,11 @@ This module provides the SweepExecutor class for managing parameter sweep execut
 job creation, and cache management in benchmark runs.
 """
 
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable
 
 import param
 
@@ -62,15 +64,15 @@ class SweepExecutor:
             cache_size (int): Maximum cache size in bytes. Defaults to 100 GB.
         """
         self.cache_size = cache_size
-        self.sample_cache: Optional[FutureCache] = None
+        self.sample_cache: FutureCache | None = None
 
     def convert_vars_to_params(
         self,
         variable: param.Parameter | str | dict | tuple,
         var_type: str,
-        run_cfg: Optional[BenchRunCfg],
-        worker_class_instance: Optional[ParametrizedSweep] = None,
-        worker_input_cfg: Optional[ParametrizedSweep] = None,
+        run_cfg: BenchRunCfg | None,
+        worker_class_instance: ParametrizedSweep | None = None,
+        worker_input_cfg: ParametrizedSweep | None = None,
     ) -> param.Parameter:
         """Convert various input formats to param.Parameter objects.
 
@@ -84,12 +86,12 @@ class SweepExecutor:
                 - param.Parameter: Already a parameter object
                 - str: Name of a parameter in the worker_class_instance
                 - dict: Configuration with 'name' and optional 'values', 'samples', 'max_level'
-                - tuple: Tuple that can be converted to a parameter
-            var_type (str): Type of variable ('input', 'result', or 'const') for error messages
-            run_cfg (Optional[BenchRunCfg]): Run configuration for level settings
-            worker_class_instance (Optional[ParametrizedSweep]): The worker class instance for
+                - tuple: tuple that can be converted to a parameter
+            var_type (str): type of variable ('input', 'result', or 'const') for error messages
+            run_cfg (BenchRunCfg | None): Run configuration for level settings
+            worker_class_instance (ParametrizedSweep | None): The worker class instance for
                 looking up parameters by name
-            worker_input_cfg (Optional[ParametrizedSweep]): The worker input configuration class
+            worker_input_cfg (ParametrizedSweep | None): The worker input configuration class
 
         Returns:
             param.Parameter: The converted parameter object
@@ -123,15 +125,15 @@ class SweepExecutor:
             )
         return variable
 
-    def define_const_inputs(self, const_vars: List[Tuple[param.Parameter, Any]]) -> Optional[dict]:
+    def define_const_inputs(self, const_vars: list[tuple[param.Parameter, Any]]) -> dict | None:
         """Convert constant variable tuples into a dictionary of name-value pairs.
 
         Args:
-            const_vars (List[Tuple[param.Parameter, Any]]): List of (parameter, value) tuples
+            const_vars (list[tuple[param.Parameter, Any]]): list of (parameter, value) tuples
                 representing constant parameters and their values
 
         Returns:
-            Optional[dict]: Dictionary mapping parameter names to their constant values,
+            dict | None: Dictionary mapping parameter names to their constant values,
                 or None if const_vars is None
         """
         constant_inputs = None

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import namedtuple
 import xarray as xr
 import hashlib
@@ -7,7 +9,7 @@ from colorsys import hsv_to_rgb
 from pathlib import Path
 from uuid import uuid4
 from functools import partial
-from typing import Callable, Any, List, Tuple
+from typing import Callable, Any
 import logging
 import os
 import tempfile
@@ -67,7 +69,7 @@ def get_nearest_coords(dataset: xr.Dataset, collapse_list: bool = False, **kwarg
     return cd2
 
 
-def get_nearest_coords1D(val: Any, coords: List[Any]) -> Any:
+def get_nearest_coords1D(val: Any, coords: list[Any]) -> Any:
     """Find the closest coordinate to a given value in a list of coordinates.
 
     For numeric values, finds the value in coords that is closest to val.
@@ -75,7 +77,7 @@ def get_nearest_coords1D(val: Any, coords: List[Any]) -> Any:
 
     Args:
         val (Any): The value to find the closest coordinate for
-        coords (List[Any]): The list of coordinates to search in
+        coords (list[Any]): The list of coordinates to search in
 
     Returns:
         Any: The closest coordinate value from the list
@@ -130,15 +132,15 @@ def un_camel(camel: str) -> str:
     return capitalise_words(re.sub("([a-z])([A-Z])", r"\g<1> \g<2>", camel.replace("_", " ")))
 
 
-def mult_tuple(inp: Tuple[float, ...], val: float) -> Tuple[float, ...]:
+def mult_tuple(inp: tuple[float, ...], val: float) -> tuple[float, ...]:
     """Multiply each element in a tuple by a scalar value.
 
     Args:
-        inp (Tuple[float, ...]): The input tuple of floats to multiply
+        inp (tuple[float, ...]): The input tuple of floats to multiply
         val (float): The scalar value to multiply each element by
 
     Returns:
-        Tuple[float, ...]: A new tuple with each element multiplied by val
+        tuple[float, ...]: A new tuple with each element multiplied by val
     """
     return tuple(np.array(inp) * val)
 
@@ -307,7 +309,7 @@ def callable_name(any_callable: Callable[..., Any]) -> str:
         return str(any_callable)
 
 
-def listify(obj: Any) -> List[Any] | None:
+def listify(obj: Any) -> list[Any] | None:
     """Convert an object to a list if it's not already a list.
 
     This function handles conversion of various object types to lists, with special
@@ -317,7 +319,7 @@ def listify(obj: Any) -> List[Any] | None:
         obj (Any): The object to convert to a list
 
     Returns:
-        List[Any] | None: A list containing the object, the object itself if it was
+        list[Any] | None: A list containing the object, the object itself if it was
             already a list, a list from the tuple if it was a tuple, or None if the
             input was None
     """
@@ -344,14 +346,14 @@ def get_name(var: Any) -> str:
     return var
 
 
-def params_to_str(param_list: List[param.Parameter]) -> List[str]:
+def params_to_str(param_list: list[param.Parameter]) -> list[str]:
     """Convert a list of param.Parameter objects to a list of their names.
 
     Args:
-        param_list (List[param.Parameter]): List of parameter objects
+        param_list (list[param.Parameter]): list of parameter objects
 
     Returns:
-        List[str]: List of parameter names
+        list[str]: list of parameter names
     """
     return [get_name(i) for i in param_list]
 
@@ -361,14 +363,14 @@ def publish_file(filepath: str, remote: str, branch_name: str) -> str:  # pragma
 
     .. code-block:: python
 
-        def publish_args(branch_name) -> Tuple[str, str]:
+        def publish_args(branch_name) -> tuple[str, str]:
             return (
                 "https://github.com/blooop/bencher.git",
                 f"https://github.com/blooop/bencher/blob/{branch_name}")
 
 
     Args:
-        remote (Callable): A function the returns a tuple of the publishing urls. It must follow the signature def publish_args(branch_name) -> Tuple[str, str].  The first url is the git repo name, the second url needs to match the format for viewable html pages on your git provider.  The second url can use the argument branch_name to point to the file on a specified branch.
+        remote (Callable): A function the returns a tuple of the publishing urls. It must follow the signature def publish_args(branch_name) -> tuple[str, str].  The first url is the git repo name, the second url needs to match the format for viewable html pages on your git provider.  The second url can use the argument branch_name to point to the file on a specified branch.
 
     Returns:
         str: the url of the published file

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -350,10 +350,10 @@ def params_to_str(param_list: list[param.Parameter]) -> list[str]:
     """Convert a list of param.Parameter objects to a list of their names.
 
     Args:
-        param_list (list[param.Parameter]): list of parameter objects
+        param_list (list[param.Parameter]): List of parameter objects
 
     Returns:
-        list[str]: list of parameter names
+        list[str]: List of parameter names
     """
     return [get_name(i) for i in param_list]
 

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Any, Dict
+from typing import Any
 
 import numpy as np
 from param import Integer, Number, Selector
@@ -47,11 +49,11 @@ class SweepSelector(Selector, SweepBase):
         else:
             self.samples = samples
 
-    def values(self) -> List[Any]:
+    def values(self) -> list[Any]:
         """Return all the values for the parameter sweep.
 
         Returns:
-            List[Any]: A list of parameter values to sweep through
+            list[Any]: A list of parameter values to sweep through
         """
         return self.indices_to_samples(self.samples, self.objects)
 
@@ -187,7 +189,7 @@ class StringSweep(SweepSelector):
 
     def __init__(
         self,
-        string_list: List[str],
+        string_list: list[str],
         units: str = "ul",
         samples: int | None = None,
         **params,
@@ -252,7 +254,7 @@ class EnumSweep(SweepSelector):
     __slots__ = shared_slots
 
     def __init__(
-        self, enum_type: Enum | List[Enum], units: str = "ul", samples: int | None = None, **params
+        self, enum_type: Enum | list[Enum], units: str = "ul", samples: int | None = None, **params
     ):
         # The enum can either be an Enum type or a list of enums
         list_of_enums = isinstance(enum_type, list)
@@ -402,15 +404,15 @@ class YamlSweep(SweepSelector):
         with Path(path_str).open("r", encoding="utf-8") as stream:
             return yaml.safe_load(stream)
 
-    def keys(self) -> List[str]:
+    def keys(self) -> list[str]:
         key_list = list(self._entries.keys())
         return self.indices_to_samples(self.samples, key_list)
 
-    def items(self) -> List[tuple[str, Any]]:
+    def items(self) -> list[tuple[str, Any]]:
         selected_keys = self.keys()
         return [(key, self._entries[key].value()) for key in selected_keys]
 
-    def values(self) -> List[Any]:
+    def values(self) -> list[Any]:
         selected_keys = self.keys()
         return [self._entries[key] for key in selected_keys]
 
@@ -437,7 +439,7 @@ class IntSweep(Integer, SweepBase):
     Attributes:
         units (str): The units of measurement for the parameter
         samples (int): The number of samples to take from the range
-        sample_values (List[int], optional): Specific integer values to use as samples instead of
+        sample_values (list[int], optional): Specific integer values to use as samples instead of
             generating them from bounds. If provided, overrides the samples parameter.
     """
 
@@ -447,7 +449,7 @@ class IntSweep(Integer, SweepBase):
         self,
         units: str = "ul",
         samples: int | None = None,
-        sample_values: List[int] | None = None,
+        sample_values: list[int] | None = None,
         **params,
     ):
         SweepBase.__init__(self)
@@ -469,14 +471,14 @@ class IntSweep(Integer, SweepBase):
             if "default" not in params:
                 self.default = sample_values[0]
 
-    def values(self) -> List[int]:
+    def values(self) -> list[int]:
         """Return all the values for the parameter sweep.
 
         If sample_values is provided, returns those values. Otherwise generates values
         within the specified bounds.
 
         Returns:
-            List[int]: A list of integer values to sweep through
+            list[int]: A list of integer values to sweep through
         """
         sample_values = (
             self.sample_values
@@ -514,7 +516,7 @@ class FloatSweep(Number, SweepBase):
     Attributes:
         units (str): The units of measurement for the parameter
         samples (int): The number of samples to take from the range
-        sample_values (List[float], optional): Specific float values to use as samples instead of
+        sample_values (list[float], optional): Specific float values to use as samples instead of
             generating them from bounds. If provided, overrides the samples parameter.
         step (float, optional): Step size between samples when generating values from bounds
     """
@@ -525,7 +527,7 @@ class FloatSweep(Number, SweepBase):
         self,
         units: str = "ul",
         samples: int = 10,
-        sample_values: List[float] | None = None,
+        sample_values: list[float] | None = None,
         step: float | None = None,
         **params,
     ):
@@ -543,14 +545,14 @@ class FloatSweep(Number, SweepBase):
             if "default" not in params:
                 self.default = sample_values[0]
 
-    def values(self) -> List[float]:
+    def values(self) -> list[float]:
         """Return all the values for the parameter sweep.
 
         If sample_values is provided, returns those values. Otherwise generates values
         within the specified bounds, either using linspace (when step is None) or arange.
 
         Returns:
-            List[float]: A list of float values to sweep through
+            list[float]: A list of float values to sweep through
         """
         samps = self.samples
         if self.sample_values is None:
@@ -582,21 +584,21 @@ def box(name: str, center: float, width: float) -> FloatSweep:
 
 def p(
     name: str,
-    values: List[Any] | None = None,
+    values: list[Any] | None = None,
     samples: int | None = None,
     max_level: int | None = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a parameter dictionary with optional values, samples, and max_level.
 
     Args:
         name (str): The name of the parameter.
-        values (List[Any], optional): A list of values for the parameter. Defaults to None.
+        values (list[Any], optional): A list of values for the parameter. Defaults to None.
         samples (int, optional): The number of samples. Must be greater than 0 if provided. Defaults to None.
         max_level (int, optional): The maximum level. Must be greater than 0 if provided. Defaults to None.
 
     Returns:
-        Dict[str, Any]: A dictionary containing the parameter details.
+        dict[str, Any]: A dictionary containing the parameter details.
     """
     if max_level is not None and max_level <= 0:
         raise ValueError("max_level must be greater than 0")
@@ -613,7 +615,7 @@ def with_level(arr: list, level: int) -> list:
     sampling to it, returning the resulting values.
 
     Args:
-        arr (list): List of values to sample from
+        arr (list): list of values to sample from
         level (int): The sampling level to apply (higher levels provide more samples)
 
     Returns:

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from functools import partial
-from typing import List, Tuple, Any
+from typing import Any
 from param import Parameter, Parameterized
 import holoviews as hv
 import panel as pn
@@ -55,7 +57,7 @@ class ParametrizedSweep(Parameterized):
         self.param.update(**used_params)
 
     @classmethod
-    def get_input_and_results(cls, include_name: bool = False) -> Tuple[dict, dict]:
+    def get_input_and_results(cls, include_name: bool = False) -> tuple[dict, dict]:
         """Get dictionaries of input parameters and result parameters
 
         Args:
@@ -63,7 +65,7 @@ class ParametrizedSweep(Parameterized):
             include_name (bool): Include the name parameter that all parametrised classes have. Default False
 
         Returns:
-            Tuple[dict, dict]: a tuple containing the inputs and result parameters as dictionaries
+            tuple[dict, dict]: a tuple containing the inputs and result parameters as dictionaries
         """
         inputs = {}
         results = {}
@@ -95,11 +97,11 @@ class ParametrizedSweep(Parameterized):
         return output
 
     @classmethod
-    def get_inputs_only(cls) -> List[Parameter]:
+    def get_inputs_only(cls) -> list[Parameter]:
         """Return a list of input parameters
 
         Returns:
-            List[param.Parameter]: A list of input parameters
+            list[param.Parameter]: A list of input parameters
         """
         return list(cls.get_input_and_results().inputs.values())
 
@@ -110,8 +112,8 @@ class ParametrizedSweep(Parameterized):
     @classmethod
     def get_input_defaults(
         cls,
-        override_defaults: List | None = None,
-    ) -> List[Tuple[Parameter, Any]]:
+        override_defaults: list | None = None,
+    ) -> list[tuple[Parameter, Any]]:
         inp = cls.get_inputs_only()
         if override_defaults is None:
             override_defaults = []
@@ -135,18 +137,18 @@ class ParametrizedSweep(Parameterized):
         return defaults
 
     @classmethod
-    def get_results_only(cls) -> List[Parameter]:
+    def get_results_only(cls) -> list[Parameter]:
         """Return a list of result parameters
 
         Returns:
-            List[param.Parameter]: A list of result parameters
+            list[param.Parameter]: A list of result parameters
         """
         return list(cls.get_input_and_results().results.values())
 
     @classmethod
     def get_inputs_as_dims(
-        self, compute_values=False, remove_dims: str | List[str] | None = None
-    ) -> List[hv.Dimension]:
+        self, compute_values=False, remove_dims: str | list[str] | None = None
+    ) -> list[hv.Dimension]:
         inputs = self.get_inputs_only()
 
         if remove_dims is not None:
@@ -161,7 +163,7 @@ class ParametrizedSweep(Parameterized):
         self,
         callback=None,
         name=None,
-        remove_dims: str | List[str] | None = None,
+        remove_dims: str | list[str] | None = None,
         result_var: str | None = None,
     ) -> hv.DynamicMap:
         if callback is None:
@@ -188,7 +190,7 @@ class ParametrizedSweep(Parameterized):
         )
         main.show()
 
-    def to_holomap(self, callback, remove_dims: str | List[str] | None = None) -> hv.DynamicMap:
+    def to_holomap(self, callback, remove_dims: str | list[str] | None = None) -> hv.DynamicMap:
         return hv.HoloMap(
             hv.DynamicMap(
                 callback=callback,

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -65,7 +65,7 @@ class ParametrizedSweep(Parameterized):
             include_name (bool): Include the name parameter that all parametrised classes have. Default False
 
         Returns:
-            tuple[dict, dict]: a tuple containing the inputs and result parameters as dictionaries
+            tuple[dict, dict]: A tuple containing the inputs and result parameters as dictionaries
         """
         inputs = {}
         results = {}

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -26,8 +26,10 @@ IMPORTANT — hash_persistent() contract:
     Adding a new class without proper hashing will fail CI.
 """
 
+from __future__ import annotations
+
 from enum import auto
-from typing import List, Callable, Any, Optional
+from typing import Callable, Any
 from functools import partial
 import panel as pn
 import param
@@ -159,7 +161,7 @@ class ResultVec(param.List):
             index = idx
         return f"{self.name}_{index}"
 
-    def index_names(self) -> List[str]:
+    def index_names(self) -> list[str]:
         """Returns a list of all the xarray column names for the result vector
 
         Returns:
@@ -183,11 +185,11 @@ class ResultHmap(param.Parameter):
 
 
 def curve(
-    x_vals: List[float],
-    y_vals: List[float],
+    x_vals: list[float],
+    y_vals: list[float],
     x_name: str,
     y_name: str,
-    label: Optional[str] = None,
+    label: str | None = None,
     **kwargs,
 ) -> hv.Curve:
     label = label or y_name

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Any, Tuple
+from typing import Any
 from copy import deepcopy
 
 import numpy as np
@@ -16,7 +16,7 @@ shared_slots = ["units", "samples"]
 
 def describe_variable(
     v: Parameterized, include_samples: bool, value: Any | None = None
-) -> List[str]:
+) -> list[str]:
     """Generate a string description of a variable
 
     Args:
@@ -56,11 +56,11 @@ class SweepBase(param.Parameter):
 
     def values(
         self,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """All sweep classes must implement this method. This generates sample values from based on the parameters bounds and sample number.
 
         Returns:
-            List[Any]: A list of samples from the variable
+            list[Any]: A list of samples from the variable
         """
         raise NotImplementedError
 
@@ -145,14 +145,14 @@ class SweepBase(param.Parameter):
         output.samples = len(sample_values)  # pylint: disable = attribute-defined-outside-init
         return output
 
-    def with_const(self, const_value: Any) -> Tuple[SweepBase, Any]:
+    def with_const(self, const_value: Any) -> tuple[SweepBase, Any]:
         """Create a new instance of SweepBase with a constant value.
 
         Args:
             const_value (Any): The constant value to be associated with the new instance.
 
         Returns:
-            Tuple[SweepBase, Any]: A tuple containing the new instance of SweepBase and the constant value.
+            tuple[SweepBase, Any]: A tuple containing the new instance of SweepBase and the constant value.
         """
         return (deepcopy(self), const_value)
 

--- a/bencher/variables/time.py
+++ b/bencher/variables/time.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import List
 
 from pandas import Timestamp
 from param import Selector
@@ -33,7 +34,7 @@ class TimeBase(SweepBase, Selector):
 
     __slots__ = shared_slots
 
-    def values(self) -> List[str]:
+    def values(self) -> list[str]:
         """return all the values for a parameter sweep.  If debug is true return a reduced list"""
         # print(self.sampling_str(debug))
         return self.objects

--- a/bencher/worker_job.py
+++ b/bencher/worker_job.py
@@ -1,4 +1,6 @@
-from typing import List, Tuple, Any
+from __future__ import annotations
+
+from typing import Any
 from dataclasses import dataclass, field
 from .utils import hash_sha1
 from bencher.utils import hmap_canonical_input
@@ -13,35 +15,35 @@ class WorkerJob:
     the preparation of function inputs and calculation of hash signatures for caching.
 
     Attributes:
-        function_input_vars (List): The values of the input variables to pass to the function
-        index_tuple (Tuple[int]): The indices of these values in the N-dimensional result array
-        dims_name (List[str]): The names of the input dimensions
+        function_input_vars (list): The values of the input variables to pass to the function
+        index_tuple (tuple[int]): The indices of these values in the N-dimensional result array
+        dims_name (list[str]): The names of the input dimensions
         constant_inputs (dict): Dictionary of any constant input values
         bench_cfg_sample_hash (str): Hash of the benchmark configuration without repeats
         tag (str): Tag for grouping related jobs
         function_input (dict): Complete input as a dictionary with dimension names as keys
-        canonical_input (Tuple[Any]): Canonical representation of inputs for caching
-        fn_inputs_sorted (List[Tuple[str, Any]]): Sorted representation of function inputs
+        canonical_input (tuple[Any]): Canonical representation of inputs for caching
+        fn_inputs_sorted (list[tuple[str, Any]]): Sorted representation of function inputs
         function_input_signature_pure (str): Hash of the function inputs and tag
         function_input_signature_benchmark_context (str): Comprehensive hash including benchmark context
         found_in_cache (bool): Whether this job result was found in cache
-        msgs (List[str]): Messages related to this job's execution
+        msgs (list[str]): Messages related to this job's execution
     """
 
-    function_input_vars: List[Any]
-    index_tuple: Tuple[int, ...]
-    dims_name: List[str]
+    function_input_vars: list[Any]
+    index_tuple: tuple[int, ...]
+    dims_name: list[str]
     constant_inputs: dict
     bench_cfg_sample_hash: str
     tag: str
 
     function_input: dict | None = None
-    canonical_input: Tuple[Any] | None = None
-    fn_inputs_sorted: List[Tuple[str, Any]] | None = None
+    canonical_input: tuple[Any] | None = None
+    fn_inputs_sorted: list[tuple[str, Any]] | None = None
     function_input_signature_pure: str | None = None
     function_input_signature_benchmark_context: str | None = None
     found_in_cache: bool = False
-    msgs: List[str] = field(default_factory=list)
+    msgs: list[str] = field(default_factory=list)
 
     def setup_hashes(self) -> None:
         """Set up the function inputs and calculate hash signatures for caching.

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -4,9 +4,11 @@ This module provides the WorkerManager class for handling worker function
 configuration and validation in benchmark runs.
 """
 
+from __future__ import annotations
+
 import logging
 from functools import partial
-from typing import Callable, List, Optional
+from typing import Callable
 
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
@@ -60,14 +62,14 @@ class WorkerManager:
 
     def __init__(self) -> None:
         """Initialize a new WorkerManager."""
-        self.worker: Optional[Callable] = None
-        self.worker_class_instance: Optional[ParametrizedSweep] = None
-        self.worker_input_cfg: Optional[ParametrizedSweep] = None
+        self.worker: Callable | None = None
+        self.worker_class_instance: ParametrizedSweep | None = None
+        self.worker_input_cfg: ParametrizedSweep | None = None
 
     def set_worker(
         self,
         worker: Callable | ParametrizedSweep,
-        worker_input_cfg: Optional[ParametrizedSweep] = None,
+        worker_input_cfg: ParametrizedSweep | None = None,
     ) -> None:
         """Set the benchmark worker function and its input configuration.
 
@@ -100,7 +102,7 @@ class WorkerManager:
             logger.info(f"setting worker {worker}")
         self.worker_input_cfg = worker_input_cfg
 
-    def get_result_vars(self, as_str: bool = True) -> List[str | ParametrizedSweep]:
+    def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
         """Retrieve the result variables from the worker class instance.
 
         Args:
@@ -109,7 +111,7 @@ class WorkerManager:
                            Default is True.
 
         Returns:
-            List[str | ParametrizedSweep]: A list of result variables, either as strings
+            list[str | ParametrizedSweep]: A list of result variables, either as strings
                 or in their original form.
 
         Raises:
@@ -121,11 +123,11 @@ class WorkerManager:
             return self.worker_class_instance.get_results_only()
         raise RuntimeError("Worker class instance not set")
 
-    def get_inputs_only(self) -> List[ParametrizedSweep]:
+    def get_inputs_only(self) -> list[ParametrizedSweep]:
         """Retrieve the input variables from the worker class instance.
 
         Returns:
-            List[ParametrizedSweep]: A list of input variables.
+            list[ParametrizedSweep]: A list of input variables.
 
         Raises:
             RuntimeError: If the worker class instance is not set.
@@ -134,11 +136,11 @@ class WorkerManager:
             return self.worker_class_instance.get_inputs_only()
         raise RuntimeError("Worker class instance not set")
 
-    def get_input_defaults(self) -> List:
+    def get_input_defaults(self) -> list:
         """Retrieve the default input values from the worker class instance.
 
         Returns:
-            List: A list of default input values as (parameter, value) tuples.
+            list: A list of default input values as (parameter, value) tuples.
 
         Raises:
             RuntimeError: If the worker class instance is not set.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.66.1
-  sha256: 69b08df2effb2c23a19f527591b4250ebf41dac3eb88d30086a6c2713ee88506
+  version: 1.66.3
+  sha256: bf30e6058f73f14bb6bf50717f477319b1068d4b7c82d825561090269353c186
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/test/test_combinations.py
+++ b/test/test_combinations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import unittest
 from hypothesis import given, settings, strategies as st
@@ -6,7 +8,6 @@ from datetime import datetime
 
 from strenum import StrEnum
 from enum import auto
-from typing import List
 from param import Parameter
 from itertools import combinations
 
@@ -99,8 +100,8 @@ class TestAllCombinations(unittest.TestCase):
 
     def run_bencher_over_time(
         self,
-        input_vars: List[Parameter],
-        result_vars: List[bch.ResultVar],
+        input_vars: list[Parameter],
+        result_vars: list[bch.ResultVar],
         repeats: int,
     ):
         """Base function used to run benchers with a set of inputs,results and repeats over time"""
@@ -129,15 +130,15 @@ class TestAllCombinations(unittest.TestCase):
     )
     def test_all_input_combinations_over_time_hyp(
         self,
-        input_vars: List[Parameter],
-        result_vars: List[bch.ResultVar],
+        input_vars: list[Parameter],
+        result_vars: list[bch.ResultVar],
         repeats: int,
     ):
         """Use hypothesis to enumerate combinations of inputs to bencher
 
         Args:
-            input_vars (List[Parameter]): all possible sets of inputs
-            result_vars (List[bch.ResultVar]): all possible sets of results
+            input_vars (list[Parameter]): all possible sets of inputs
+            result_vars (list[bch.ResultVar]): all possible sets of results
             repeats (int): 1 or 2 repeats (more than 2 repeats hits the same code as 2 repeats)
         """
         self.run_bencher_over_time(input_vars, result_vars, repeats)

--- a/test/test_latex_result.py
+++ b/test/test_latex_result.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import List
 import pytest
 from bencher.results.laxtex_result import (
     latex_text,
@@ -14,7 +15,7 @@ from bencher.results.laxtex_result import (
 @dataclass
 class MockVar:
     name: str
-    _values: List
+    _values: list
 
     def values(self):
         return self._values
@@ -22,8 +23,8 @@ class MockVar:
 
 @dataclass
 class MockBenchConfig:
-    all_vars: List[MockVar]
-    result_vars: List[MockVar]
+    all_vars: list[MockVar]
+    result_vars: list[MockVar]
 
 
 def test_latex_text():


### PR DESCRIPTION
## Summary
- Replace old-style `typing` generics with built-in equivalents (PEP 585): `List[X]` -> `list[X]`, `Dict[K,V]` -> `dict[K,V]`, `Tuple[...]` -> `tuple[...]`, `Type[X]` -> `type[X]`
- Replace `Optional[X]` -> `X | None` and `Union[X, Y]` -> `X | Y` (PEP 604)
- Remove unused typing imports (`List`, `Dict`, `Tuple`, `Optional`, `Union`, `Type`); keep `Callable`, `Any`, `TypeVar`, etc.
- Add `from __future__ import annotations` to 24 files that were missing it, ensuring runtime safety with `|` syntax on non-type objects

44 files updated across `bencher/` and `test/`.

## Test plan
- [x] `pixi run ci` passes (format, ruff lint, pylint 10.00/10, ty check, example generation, 555 tests pass)
- [x] Verified no old-style `List[`, `Dict[`, `Tuple[`, `Type[` remain in modified files
- [x] Verified `param.List` (param library class) preserved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Modernize type hints and docstrings across bencher core, results, variables, utilities, runner, and tests to use Python 3.10+ syntax.

Enhancements:
- Update annotations from typing.List/Dict/Tuple/Optional/Union/Type to built-in generics and PEP 604 union syntax throughout the codebase.
- Align docstrings with new type notation and improve type aliases and return type hints for plotting and result APIs.
- Add or rely on postponed evaluation of annotations where needed to safely use new union syntax at runtime.