### PR TITLE
Add cache_size parameter to BenchRunCfg

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -146,6 +146,12 @@ class BenchRunCfg(BenchPlotSrvCfg):
         False, doc="Do not attempt to calculate benchmarks if no results are found in the cache"
     )
 
+    cache_size: int = param.Integer(
+        default=None,
+        allow_None=True,
+        doc="Maximum size of the disk cache in megabytes (MB). If None, uses the default (100 GB).",
+    )
+
     # ==================== DISPLAY PARAMETERS ====================
     # These parameters control console output and reporting
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -149,6 +149,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
     cache_size: int = param.Integer(
         default=None,
         allow_None=True,
+        bounds=(1, None),
         doc="Maximum size of the disk cache in megabytes (MB). If None, uses the default (100 GB).",
     )
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -504,6 +504,12 @@ class Bench(BenchPlotServer):
         Raises:
             FileNotFoundError: If only_plot=True and no cached results exist
         """
+        if run_cfg.cache_size is not None:
+            cache_size_bytes = run_cfg.cache_size * 1_000_000
+            self.cache_size = cache_size_bytes
+            self._executor.cache_size = cache_size_bytes
+            self._collector.cache_size = cache_size_bytes
+
         # Filter run_cfg parameters to only those that can override bench_cfg
         # (param 2.3 enforces constant parameters that cannot be overridden)
         run_cfg_values, missing_keys, constant_keys = self.filter_overridable_params(

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -509,6 +509,10 @@ class Bench(BenchPlotServer):
             self.cache_size = cache_size_bytes
             self._executor.cache_size = cache_size_bytes
             self._collector.cache_size = cache_size_bytes
+            # Invalidate existing sample cache so it gets recreated with the new size
+            if self.sample_cache is not None:
+                self.sample_cache.close()
+                self._executor.sample_cache = None
 
         # Filter run_cfg parameters to only those that can override bench_cfg
         # (param 2.3 enforces constant parameters that cannot be overridden)

--- a/test/test_bencher.py
+++ b/test/test_bencher.py
@@ -421,5 +421,9 @@ class TestBencher(unittest.TestCase):
         )
 
         self.assertEqual(bench.cache_size, expected_bytes)
-        self.assertEqual(bench._executor.cache_size, expected_bytes)
-        self.assertEqual(bench._collector.cache_size, expected_bytes)
+        self.assertEqual(bench._executor.cache_size, expected_bytes)  # pylint: disable=protected-access
+        self.assertEqual(bench._collector.cache_size, expected_bytes)  # pylint: disable=protected-access
+        self.assertEqual(
+            bench._executor.sample_cache.size_limit,  # pylint: disable=protected-access
+            expected_bytes,
+        )

--- a/test/test_bencher.py
+++ b/test/test_bencher.py
@@ -406,3 +406,20 @@ class TestBencher(unittest.TestCase):
                 result_vars=[ExampleBenchCfg.param.out_sin],
                 const_vars=[(ExampleBenchCfg.offset, 0.1)],  # forgot to use param here
             )
+
+    def test_cache_size_propagation(self) -> None:
+        """Check that cache_size from BenchRunCfg propagates to bench internals."""
+        bench = self.create_bench()
+        cache_size_mb = 500
+        expected_bytes = cache_size_mb * 1_000_000
+
+        bench.plot_sweep(
+            title="test_cache_size",
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(cache_size=cache_size_mb, auto_plot=False),
+        )
+
+        self.assertEqual(bench.cache_size, expected_bytes)
+        self.assertEqual(bench._executor.cache_size, expected_bytes)
+        self.assertEqual(bench._collector.cache_size, expected_bytes)


### PR DESCRIPTION
## Summary
- Add `cache_size` param (in MB) to `BenchRunCfg` so users can configure the disk cache size limit through the public API
- Propagate the value to `Bench`, `SweepExecutor`, and `ResultCollector` in `run_sweep()`
- Default `None` preserves the existing 100 GB default — no behavior change for existing users
- Add `bounds=(1, None)` validation to reject zero/negative cache sizes
- Invalidate and recreate the sample cache when `cache_size` changes between `run_sweep()` calls

## Test plan
- [x] New `test_cache_size_propagation` test verifies the value flows to all three internal attributes and the actual `FutureCache.size_limit`
- [x] Full CI passes (556 passed, format and lint clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)