### PR TITLE
Fix YamlSweep stale cache causing identical hashes

### DIFF
--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -390,7 +390,7 @@ class YamlSweep(SweepSelector):
         )
 
     @staticmethod
-    def _load_yaml(path: Path) -> Mapping[str, Any]:
+    def _load_yaml(path: Path) -> Any:
         with path.open("r", encoding="utf-8") as stream:
             data = yaml.safe_load(stream)
         return data if data is not None else {}

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -390,19 +389,11 @@ class YamlSweep(SweepSelector):
             **params,
         )
 
-    @classmethod
-    def _load_yaml(cls, path: Path) -> Mapping[str, Any]:
-        resolved = path.resolve()
-        stat = path.stat()
-        data = cls._read_yaml(str(resolved), stat.st_mtime_ns, stat.st_size)
-        return data if data is not None else {}
-
     @staticmethod
-    @lru_cache(maxsize=64)
-    def _read_yaml(path_str: str, modified_ns: int, size: int) -> Any:
-        _ = modified_ns, size  # values are part of the cache key
-        with Path(path_str).open("r", encoding="utf-8") as stream:
-            return yaml.safe_load(stream)
+    def _load_yaml(path: Path) -> Mapping[str, Any]:
+        with path.open("r", encoding="utf-8") as stream:
+            data = yaml.safe_load(stream)
+        return data if data is not None else {}
 
     def keys(self) -> list[str]:
         key_list = list(self._entries.keys())


### PR DESCRIPTION
## Summary
- Removed unreliable `lru_cache` from `YamlSweep._read_yaml` that used `(path, mtime_ns, size)` as cache key
- When YAML content changed but file size stayed the same (e.g., `param: 1` → `param: 2`) and writes happened faster than filesystem mtime resolution, stale cached data was returned
- This caused `hash_persistent()` to produce identical hashes for different YAML configs, making `test_yaml_sweep_hash_includes_value` fail when run with the full test suite

## Test plan
- [x] `test_yaml_sweep_hash_includes_value` now passes when run with the full suite (`pixi run pytest test/test_yaml_sweep.py`)
- [x] Full test suite passes (555 passed, 5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix YAML input loading to avoid stale cached content and ensure configuration changes are reflected in hashing.

Bug Fixes:
- Prevent YAML sweep hashes from remaining identical when YAML file contents change but filesystem metadata does not update accordingly.

Enhancements:
- Simplify YAML loading by removing an unreliable LRU cache layer and consolidating reading logic into a single helper.