### PR TITLE
Compute _std when aggregating over dims with mean

### DIFF
--- a/bencher/example/example_agg_over_time.py
+++ b/bencher/example/example_agg_over_time.py
@@ -1,0 +1,48 @@
+"""Demo: aggregate over a swept dimension to produce a curve over time with error bounds.
+
+When ``over_time=True`` and a float input is swept, aggregating over that input
+(via ``agg_over_dims``) collapses it to mean +/- std at each time point.  The
+resulting ``CurveResult`` shows how the aggregate metric evolves over time with
+error bounds derived from the spread across the swept values.
+
+Run:
+    python bencher/example/example_agg_over_time.py
+"""
+
+from datetime import datetime, timedelta
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+
+
+def example_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    if run_cfg is None:
+        run_cfg = bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.level = 4
+
+    benchable = BenchableObject()
+    bench = benchable.to_bench(run_cfg)
+
+    time_offsets = [0.0, 0.5, 1.0, 1.5, 2.0]
+    base_time = datetime(2000, 1, 1)
+    for i, offset in enumerate(time_offsets):
+        benchable._time_offset = offset  # pylint: disable=protected-access
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        run_cfg.auto_plot = False
+        bench.plot_sweep(
+            "agg_over_time",
+            input_vars=["float1"],
+            result_vars=["distance"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+
+    res = bench.results[-1]
+    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["float1"]))
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_agg_over_time, save=True)

--- a/bencher/example/example_agg_over_time.py
+++ b/bencher/example/example_agg_over_time.py
@@ -1,9 +1,9 @@
-"""Demo: aggregate over a swept dimension to produce a curve over time with error bounds.
+"""Demo: aggregate a 2D sweep down to a scalar curve over time with error bounds.
 
-When ``over_time=True`` and a float input is swept, aggregating over that input
-(via ``agg_over_dims``) collapses it to mean +/- std at each time point.  The
-resulting ``CurveResult`` shows how the aggregate metric evolves over time with
-error bounds derived from the spread across the swept values.
+A 2D parameter sweep (float1 x float2) is run at each time snapshot.  The report
+first shows the raw 2D heatmap with an over_time slider, then shows both sweep
+dimensions collapsed via ``agg_over_dims`` into a single mean +/- std per time
+point — a curve showing how the plate-wide average evolves over time.
 
 Run:
     python bencher/example/example_agg_over_time.py
@@ -33,14 +33,20 @@ def example_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
         run_cfg.auto_plot = False
         bench.plot_sweep(
             "agg_over_time",
-            input_vars=["float1"],
+            input_vars=["float1", "float2"],
             result_vars=["distance"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
         )
 
     res = bench.results[-1]
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["float1"]))
+
+    # 1) Raw 2D heatmap with over_time slider
+    bench.report.append(res.to(bch.HeatmapResult))
+
+    # 2) Aggregated: collapse both sweep dims to scalar mean +/- std over time
+    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["float1", "float2"]))
+
     return bench
 
 

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -1,0 +1,63 @@
+"""Auto-generated example: Aggregate Over Time — curve with error bounds from swept dims."""
+
+from typing import Any
+
+import math
+import bencher as bch
+from datetime import datetime, timedelta
+
+
+class ThermalSweep(bch.ParametrizedSweep):
+    """Measures heat dissipation across sensor positions over time.
+
+    When over_time=True and a float input is swept, aggregating over that
+    input (via agg_over_dims) collapses it to mean +/- std at each time
+    point. The std shows the spread across sensor positions.
+    """
+
+    position = bch.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Sensor position along rod")
+
+    temperature = bch.ResultVar(units="C", doc="Measured temperature")
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        # Temperature varies along the rod and decays over time
+        self.temperature = (
+            80 * math.sin(math.pi * self.position) * math.exp(-0.3 * self._time_offset) + 20
+        )
+        return super().__call__()
+
+
+def example_advanced_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Aggregate Over Time — curve with error bounds from swept dims."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+
+    benchable = ThermalSweep()
+    bench = benchable.to_bench(run_cfg)
+
+    base_time = datetime(2024, 1, 1)
+    for i, offset in enumerate([0.0, 1.0, 2.0, 3.0, 4.0]):
+        benchable._time_offset = offset
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        run_cfg.auto_plot = False
+        bench.plot_sweep(
+            "thermal_sweep",
+            input_vars=["position"],
+            result_vars=["temperature"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+
+    # Aggregate over position: produces mean +/- std at each time point
+    res = bench.results[-1]
+    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["position"]))
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_advanced_agg_over_time, level=4)

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Aggregate Over Time — curve with error bounds from swept dims."""
+"""Auto-generated example: Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
 
 from typing import Any
 
@@ -6,16 +6,21 @@ import math
 import bencher as bch
 from datetime import datetime, timedelta
 
+class ThermalPlate(bch.ParametrizedSweep):
+    """Measures temperature across a 2D plate that cools over time.
 
-class ThermalSweep(bch.ParametrizedSweep):
-    """Measures heat dissipation across sensor positions over time.
-
-    When over_time=True and a float input is swept, aggregating over that
-    input (via agg_over_dims) collapses it to mean +/- std at each time
-    point. The std shows the spread across sensor positions.
+    A 2D sweep (x, y) is run at each time snapshot. Both dimensions are
+    then collapsed via agg_over_dims, producing a single mean +/- std per
+    time point. The curve shows how the plate-wide average temperature
+    decays, with error bounds from the spatial variation across the grid.
     """
 
-    position = bch.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Sensor position along rod")
+    x = bch.FloatSweep(
+        default=0.5, bounds=[0.0, 1.0], doc="Horizontal position on plate"
+    )
+    y = bch.FloatSweep(
+        default=0.5, bounds=[0.0, 1.0], doc="Vertical position on plate"
+    )
 
     temperature = bch.ResultVar(units="C", doc="Measured temperature")
 
@@ -23,19 +28,21 @@ class ThermalSweep(bch.ParametrizedSweep):
 
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
-        # Temperature varies along the rod and decays over time
+        # Hot spot at centre, decaying over time
         self.temperature = (
-            80 * math.sin(math.pi * self.position) * math.exp(-0.3 * self._time_offset) + 20
+            100 * math.sin(math.pi * self.x) * math.sin(math.pi * self.y)
+            * math.exp(-0.3 * self._time_offset)
+            + 20
         )
         return super().__call__()
 
 
 def example_advanced_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Aggregate Over Time — curve with error bounds from swept dims."""
+    """Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
 
-    benchable = ThermalSweep()
+    benchable = ThermalPlate()
     bench = benchable.to_bench(run_cfg)
 
     base_time = datetime(2024, 1, 1)
@@ -45,16 +52,20 @@ def example_advanced_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bc
         run_cfg.clear_history = i == 0
         run_cfg.auto_plot = False
         bench.plot_sweep(
-            "thermal_sweep",
-            input_vars=["position"],
+            "thermal_plate",
+            input_vars=["x", "y"],
             result_vars=["temperature"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
         )
 
-    # Aggregate over position: produces mean +/- std at each time point
     res = bench.results[-1]
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["position"]))
+
+    # 1) Raw 2D heatmap with over_time slider
+    bench.report.append(res.to(bch.HeatmapResult))
+
+    # 2) Aggregate the full 2D grid down to a scalar: mean +/- std at each time point
+    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["x", "y"]))
 
     return bench
 

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -6,6 +6,7 @@ import math
 import bencher as bch
 from datetime import datetime, timedelta
 
+
 class ThermalPlate(bch.ParametrizedSweep):
     """Measures temperature across a 2D plate that cools over time.
 
@@ -15,12 +16,8 @@ class ThermalPlate(bch.ParametrizedSweep):
     decays, with error bounds from the spatial variation across the grid.
     """
 
-    x = bch.FloatSweep(
-        default=0.5, bounds=[0.0, 1.0], doc="Horizontal position on plate"
-    )
-    y = bch.FloatSweep(
-        default=0.5, bounds=[0.0, 1.0], doc="Vertical position on plate"
-    )
+    x = bch.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Horizontal position on plate")
+    y = bch.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Vertical position on plate")
 
     temperature = bch.ResultVar(units="C", doc="Measured temperature")
 
@@ -30,7 +27,9 @@ class ThermalPlate(bch.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         # Hot spot at centre, decaying over time
         self.temperature = (
-            100 * math.sin(math.pi * self.x) * math.sin(math.pi * self.y)
+            100
+            * math.sin(math.pi * self.x)
+            * math.sin(math.pi * self.y)
             * math.exp(-0.3 * self._time_offset)
             + 20
         )

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -16,6 +16,7 @@ ADVANCED_EXAMPLES = [
     "time_event",
     "max_time_events",
     "report_save",
+    "agg_over_time",
 ]
 
 
@@ -35,6 +36,8 @@ class MetaAdvanced(MetaGeneratorBase):
             self._generate_max_time_events()
         elif self.example == "report_save":
             self._generate_report_save()
+        elif self.example == "agg_over_time":
+            self._generate_agg_over_time()
 
         return super().__call__()
 
@@ -266,6 +269,71 @@ bench.report.append_markdown("## Custom Section\\n\\nYou can add **markdown** co
             body=body,
             class_code=class_code,
             run_kwargs={"level": 3},
+        )
+
+    def _generate_agg_over_time(self):
+        """Aggregate over a swept dimension to produce a curve over time with error bounds."""
+        imports = "import math\nimport bencher as bch\nfrom datetime import datetime, timedelta"
+        class_code = '''\
+class ThermalSweep(bch.ParametrizedSweep):
+    """Measures heat dissipation across sensor positions over time.
+
+    When over_time=True and a float input is swept, aggregating over that
+    input (via agg_over_dims) collapses it to mean +/- std at each time
+    point. The std shows the spread across sensor positions.
+    """
+
+    position = bch.FloatSweep(
+        default=0.5, bounds=[0.0, 1.0], doc="Sensor position along rod"
+    )
+
+    temperature = bch.ResultVar(units="C", doc="Measured temperature")
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        # Temperature varies along the rod and decays over time
+        self.temperature = (
+            80 * math.sin(math.pi * self.position)
+            * math.exp(-0.3 * self._time_offset)
+            + 20
+        )
+        return super().__call__()'''
+        body = """\
+run_cfg = run_cfg or bch.BenchRunCfg()
+run_cfg.over_time = True
+
+benchable = ThermalSweep()
+bench = benchable.to_bench(run_cfg)
+
+base_time = datetime(2024, 1, 1)
+for i, offset in enumerate([0.0, 1.0, 2.0, 3.0, 4.0]):
+    benchable._time_offset = offset
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    run_cfg.auto_plot = False
+    bench.plot_sweep(
+        "thermal_sweep",
+        input_vars=["position"],
+        result_vars=["temperature"],
+        run_cfg=run_cfg,
+        time_src=base_time + timedelta(seconds=i),
+    )
+
+# Aggregate over position: produces mean +/- std at each time point
+res = bench.results[-1]
+bench.report.append(res.to(bch.CurveResult, agg_over_dims=["position"]))
+"""
+        self.generate_example(
+            title="Aggregate Over Time — curve with error bounds from swept dims",
+            output_dir=OUTPUT_DIR,
+            filename="advanced_agg_over_time",
+            function_name="example_advanced_agg_over_time",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"level": 4},
         )
 
 

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -272,19 +272,23 @@ bench.report.append_markdown("## Custom Section\\n\\nYou can add **markdown** co
         )
 
     def _generate_agg_over_time(self):
-        """Aggregate over a swept dimension to produce a curve over time with error bounds."""
+        """Aggregate a 2D sweep down to a scalar curve over time with error bounds."""
         imports = "import math\nimport bencher as bch\nfrom datetime import datetime, timedelta"
         class_code = '''\
-class ThermalSweep(bch.ParametrizedSweep):
-    """Measures heat dissipation across sensor positions over time.
+class ThermalPlate(bch.ParametrizedSweep):
+    """Measures temperature across a 2D plate that cools over time.
 
-    When over_time=True and a float input is swept, aggregating over that
-    input (via agg_over_dims) collapses it to mean +/- std at each time
-    point. The std shows the spread across sensor positions.
+    A 2D sweep (x, y) is run at each time snapshot. Both dimensions are
+    then collapsed via agg_over_dims, producing a single mean +/- std per
+    time point. The curve shows how the plate-wide average temperature
+    decays, with error bounds from the spatial variation across the grid.
     """
 
-    position = bch.FloatSweep(
-        default=0.5, bounds=[0.0, 1.0], doc="Sensor position along rod"
+    x = bch.FloatSweep(
+        default=0.5, bounds=[0.0, 1.0], doc="Horizontal position on plate"
+    )
+    y = bch.FloatSweep(
+        default=0.5, bounds=[0.0, 1.0], doc="Vertical position on plate"
     )
 
     temperature = bch.ResultVar(units="C", doc="Measured temperature")
@@ -293,9 +297,9 @@ class ThermalSweep(bch.ParametrizedSweep):
 
     def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
-        # Temperature varies along the rod and decays over time
+        # Hot spot at centre, decaying over time
         self.temperature = (
-            80 * math.sin(math.pi * self.position)
+            100 * math.sin(math.pi * self.x) * math.sin(math.pi * self.y)
             * math.exp(-0.3 * self._time_offset)
             + 20
         )
@@ -304,7 +308,7 @@ class ThermalSweep(bch.ParametrizedSweep):
 run_cfg = run_cfg or bch.BenchRunCfg()
 run_cfg.over_time = True
 
-benchable = ThermalSweep()
+benchable = ThermalPlate()
 bench = benchable.to_bench(run_cfg)
 
 base_time = datetime(2024, 1, 1)
@@ -314,19 +318,23 @@ for i, offset in enumerate([0.0, 1.0, 2.0, 3.0, 4.0]):
     run_cfg.clear_history = i == 0
     run_cfg.auto_plot = False
     bench.plot_sweep(
-        "thermal_sweep",
-        input_vars=["position"],
+        "thermal_plate",
+        input_vars=["x", "y"],
         result_vars=["temperature"],
         run_cfg=run_cfg,
         time_src=base_time + timedelta(seconds=i),
     )
 
-# Aggregate over position: produces mean +/- std at each time point
 res = bench.results[-1]
-bench.report.append(res.to(bch.CurveResult, agg_over_dims=["position"]))
+
+# 1) Raw 2D heatmap with over_time slider
+bench.report.append(res.to(bch.HeatmapResult))
+
+# 2) Aggregate the full 2D grid down to a scalar: mean +/- std at each time point
+bench.report.append(res.to(bch.CurveResult, agg_over_dims=["x", "y"]))
 """
         self.generate_example(
-            title="Aggregate Over Time — curve with error bounds from swept dims",
+            title="Aggregate Over Time — 2D sweep to scalar curve with error bounds",
             output_dir=OUTPUT_DIR,
             filename="advanced_agg_over_time",
             function_name="example_advanced_agg_over_time",

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -288,7 +288,19 @@ class BenchResultBase:
                 if fn == "sum":
                     ds_out = ds_out.sum(dim=dims_present, skipna=True)
                 elif fn == "mean":
-                    ds_out = ds_out.mean(dim=dims_present, skipna=True)
+                    ds_agg_mean = ds_out.mean(dim=dims_present, skipna=True)
+                    non_std_vars = [v for v in ds_out.data_vars if not v.endswith("_std")]
+                    if non_std_vars:
+                        ds_agg_std = ds_out[non_std_vars].std(dim=dims_present, skipna=True)
+                        ds_agg_std = rename_ds(ds_agg_std, "std")
+                        # Drop pre-existing _std vars (e.g. from repeat reduction) so the
+                        # aggregation std replaces them without a merge conflict.
+                        old_std = [v for v in ds_agg_mean.data_vars if v.endswith("_std")]
+                        if old_std:
+                            ds_agg_mean = ds_agg_mean.drop_vars(old_std)
+                        ds_out = xr.merge([ds_agg_mean, ds_agg_std])
+                    else:
+                        ds_out = ds_agg_mean
                 elif fn == "max":
                     ds_out = ds_out.max(dim=dims_present, skipna=True)
                 elif fn == "min":

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -293,9 +293,10 @@ class BenchResultBase:
                     if non_std_vars:
                         ds_agg_std = ds_out[non_std_vars].std(dim=dims_present, skipna=True)
                         ds_agg_std = rename_ds(ds_agg_std, "std")
-                        # Drop pre-existing _std vars (e.g. from repeat reduction) so the
-                        # aggregation std replaces them without a merge conflict.
-                        old_std = [v for v in ds_agg_mean.data_vars if v.endswith("_std")]
+                        # Drop pre-existing _std vars that will be replaced by the
+                        # aggregation std (e.g. from repeat reduction) to avoid merge conflicts.
+                        expected_std = {f"{v}_std" for v in non_std_vars}
+                        old_std = [v for v in ds_agg_mean.data_vars if v in expected_std]
                         if old_std:
                             ds_agg_mean = ds_agg_mean.drop_vars(old_std)
                         ds_out = xr.merge([ds_agg_mean, ds_agg_std])

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -16,51 +16,192 @@ class TstBench(bch.ParametrizedSweep):
 
 
 class TestAggOverDimsStd(unittest.TestCase):
-    """Test that agg_over_dims with mean produces _std variables."""
+    """Comprehensive tests for _std computation when aggregating over dims."""
 
-    def test_mean_agg_produces_std(self):
-        bench = BenchableObject().to_bench()
-        res = bench.plot_sweep(
-            "agg_std_test",
+    @classmethod
+    def setUpClass(cls):
+        """Create reusable sweep results to avoid repeated setup cost."""
+        cls.bench = BenchableObject().to_bench()
+
+        # Single-dim sweep, 1 repeat, 1 result var
+        cls.res_1d_1rep = cls.bench.plot_sweep(
+            "agg_1d_1rep",
             input_vars=[BenchableObject.param.float1],
             result_vars=[BenchableObject.param.distance],
             run_cfg=bch.BenchRunCfg(repeats=1),
             plot_callbacks=False,
         )
-        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
-        self.assertIn("distance_std", ds.data_vars)
-        self.assertIn("distance", ds.data_vars)
-        # std must be non-negative
-        self.assertTrue((ds["distance_std"].values >= 0).all())
 
-    def test_mean_agg_replaces_repeat_std(self):
-        """When repeats > 1, agg std should replace the repeat-based std."""
-        bench = BenchableObject().to_bench()
-        res = bench.plot_sweep(
-            "agg_std_repeat_test",
+        # Single-dim sweep, 2 repeats, 1 result var (has repeat-based _std)
+        cls.res_1d_2rep = cls.bench.plot_sweep(
+            "agg_1d_2rep",
             input_vars=[BenchableObject.param.float1],
             result_vars=[BenchableObject.param.distance],
             run_cfg=bch.BenchRunCfg(repeats=2),
             plot_callbacks=False,
         )
-        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
-        self.assertIn("distance_std", ds.data_vars)
-        # Should only have one distance_std, not a conflict
-        std_vars = [v for v in ds.data_vars if v.endswith("_std")]
-        self.assertEqual(std_vars, ["distance_std"])
 
-    def test_sum_agg_no_std(self):
-        """Non-mean aggregations should not produce _std variables."""
-        bench = BenchableObject().to_bench()
-        res = bench.plot_sweep(
-            "agg_sum_test",
+        # Single-dim sweep, 1 repeat, 2 result vars
+        cls.res_1d_multi = cls.bench.plot_sweep(
+            "agg_1d_multi",
             input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        # 2D sweep (float1 x float2), 1 repeat
+        cls.res_2d = cls.bench.plot_sweep(
+            "agg_2d",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
             result_vars=[BenchableObject.param.distance],
             run_cfg=bch.BenchRunCfg(repeats=1),
             plot_callbacks=False,
         )
-        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="sum")
+
+        # 2D sweep, 2 repeats
+        cls.res_2d_2rep = cls.bench.plot_sweep(
+            "agg_2d_2rep",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+
+    # --- mean agg produces _std ---
+
+    def test_mean_agg_produces_std(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertIn("distance", ds.data_vars)
+        self.assertIn("distance_std", ds.data_vars)
+
+    def test_mean_std_is_non_negative(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertTrue((ds["distance_std"].values >= 0).all())
+
+    def test_mean_agg_removes_aggregated_dim(self):
+        """The aggregated dimension should no longer appear as a coordinate."""
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_mean_agg_default_fn(self):
+        """agg_fn=None should default to mean and produce _std."""
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn=None)
+        self.assertIn("distance_std", ds.data_vars)
+
+    # --- multiple result vars ---
+
+    def test_mean_agg_multiple_result_vars(self):
+        """Each result var should get its own _std."""
+        ds = self.res_1d_multi.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertIn("distance", ds.data_vars)
+        self.assertIn("distance_std", ds.data_vars)
+        self.assertIn("sample_noise", ds.data_vars)
+        self.assertIn("sample_noise_std", ds.data_vars)
+
+    # --- repeat-based _std replacement ---
+
+    def test_mean_agg_replaces_repeat_std(self):
+        """Agg std should replace repeat-based std without merge conflict."""
+        ds = self.res_1d_2rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertIn("distance_std", ds.data_vars)
+        std_vars = [v for v in ds.data_vars if v.endswith("_std")]
+        self.assertEqual(std_vars, ["distance_std"])
+
+    def test_agg_std_differs_from_repeat_std(self):
+        """Agg std (across float1 values) should differ from repeat std."""
+        ds_repeat_only = self.res_1d_2rep.to_dataset()
+        ds_agg = self.res_1d_2rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        # Repeat std is per-float1-point; agg std is across float1 values.
+        # They measure different things, so the agg result should be a scalar
+        # while repeat result still has the float1 dim.
+        self.assertIn("float1", ds_repeat_only.dims)
+        self.assertNotIn("float1", ds_agg.dims)
+
+    # --- 2D sweep: partial and full aggregation ---
+
+    def test_2d_agg_one_dim(self):
+        """Aggregating one of two dims should keep the other."""
+        ds = self.res_2d.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertNotIn("float1", ds.dims)
+        self.assertIn("float2", ds.dims)
+        self.assertIn("distance_std", ds.data_vars)
+
+    def test_2d_agg_both_dims(self):
+        """Aggregating both dims should produce a scalar dataset."""
+        ds = self.res_2d.to_dataset(agg_over_dims=["float1", "float2"], agg_fn="mean")
+        self.assertNotIn("float1", ds.dims)
+        self.assertNotIn("float2", ds.dims)
+        self.assertIn("distance_std", ds.data_vars)
+
+    def test_2d_agg_with_repeats(self):
+        """2D sweep + repeats: agg should replace repeat std cleanly."""
+        ds = self.res_2d_2rep.to_dataset(agg_over_dims=["float1", "float2"], agg_fn="mean")
+        self.assertIn("distance_std", ds.data_vars)
+        std_vars = [v for v in ds.data_vars if v.endswith("_std")]
+        self.assertEqual(std_vars, ["distance_std"])
+
+    # --- std correctness: known values ---
+
+    def test_std_value_correctness(self):
+        """Verify std is computed from the spread of values, not zero."""
+        ds_raw = self.res_1d_1rep.to_dataset()
+        ds_agg = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        # Raw dataset has varying distance values across float1
+        raw_vals = ds_raw["distance"].values
+        if raw_vals.size > 1 and not np.all(raw_vals == raw_vals.flat[0]):
+            # If there is any variation, std should be > 0
+            self.assertGreater(float(ds_agg["distance_std"].values), 0.0)
+
+    def test_mean_value_correctness(self):
+        """Mean in the aggregated dataset should match manual computation."""
+        ds_raw = self.res_1d_1rep.to_dataset()
+        ds_agg = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        expected_mean = float(ds_raw["distance"].mean(skipna=True).values)
+        actual_mean = float(ds_agg["distance"].values)
+        np.testing.assert_allclose(actual_mean, expected_mean, rtol=1e-10)
+
+    # --- non-mean aggregations should NOT produce _std ---
+
+    def test_sum_agg_no_std(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="sum")
         self.assertNotIn("distance_std", ds.data_vars)
+
+    def test_max_agg_no_std(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="max")
+        self.assertNotIn("distance_std", ds.data_vars)
+
+    def test_min_agg_no_std(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="min")
+        self.assertNotIn("distance_std", ds.data_vars)
+
+    def test_median_agg_no_std(self):
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="median")
+        self.assertNotIn("distance_std", ds.data_vars)
+
+    # --- edge cases ---
+
+    def test_missing_dim_ignored(self):
+        """Requesting aggregation over a nonexistent dim should not error."""
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["nonexistent"], agg_fn="mean")
+        # Should return unaggregated dataset (with float1 still present)
+        self.assertIn("float1", ds.dims)
+
+    def test_partial_missing_dims(self):
+        """Only present dims should be aggregated; missing ones are ignored."""
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1", "nonexistent"], agg_fn="mean")
+        self.assertNotIn("float1", ds.dims)
+        self.assertIn("distance_std", ds.data_vars)
+
+    def test_no_agg_over_dims_no_std(self):
+        """Without agg_over_dims, no extra _std should appear (repeats=1)."""
+        ds = self.res_1d_1rep.to_dataset()
+        self.assertNotIn("distance_std", ds.data_vars)
+
+    def test_case_insensitive_agg_fn(self):
+        """agg_fn should be case-insensitive."""
+        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="MEAN")
+        self.assertIn("distance_std", ds.data_vars)
 
 
 class TestBenchResultBase(unittest.TestCase):

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -15,6 +15,54 @@ class TstBench(bch.ParametrizedSweep):
         return super().__call__()
 
 
+class TestAggOverDimsStd(unittest.TestCase):
+    """Test that agg_over_dims with mean produces _std variables."""
+
+    def test_mean_agg_produces_std(self):
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "agg_std_test",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertIn("distance_std", ds.data_vars)
+        self.assertIn("distance", ds.data_vars)
+        # std must be non-negative
+        self.assertTrue((ds["distance_std"].values >= 0).all())
+
+    def test_mean_agg_replaces_repeat_std(self):
+        """When repeats > 1, agg std should replace the repeat-based std."""
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "agg_std_repeat_test",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertIn("distance_std", ds.data_vars)
+        # Should only have one distance_std, not a conflict
+        std_vars = [v for v in ds.data_vars if v.endswith("_std")]
+        self.assertEqual(std_vars, ["distance_std"])
+
+    def test_sum_agg_no_std(self):
+        """Non-mean aggregations should not produce _std variables."""
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "agg_sum_test",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="sum")
+        self.assertNotIn("distance_std", ds.data_vars)
+
+
 class TestBenchResultBase(unittest.TestCase):
     def test_to_dataset(self):
         bench = BenchableObject().to_bench()


### PR DESCRIPTION
## Summary
- When `agg_over_dims` is used with `agg_fn="mean"` in `to_dataset()`, also compute `_std` variables from the spread across the aggregated dimensions. This gives `CurveResult` error bounds (`hv.Spread`) without needing `repeats > 1`.
- Pre-existing `_std` vars from repeat reduction are replaced by the aggregation std to avoid xarray merge conflicts.
- Adds standalone example (`example_agg_over_time.py`) and a meta-generated RTD gallery example under Advanced Patterns.

## Test plan
- [x] `python bencher/example/example_agg_over_time.py` — curve renders with error bounds
- [x] `pixi run ci` — 556 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Compute standard deviation alongside mean when aggregating over dimensions for curve results and document the behavior with a new aggregated-over-time example.

New Features:
- Add computation of aggregation-based standard deviation when applying mean aggregation over dimensions in dataset-to-curve conversion.
- Introduce example scripts demonstrating aggregation over swept dimensions to produce time-based curves with error bounds, including an RTD advanced gallery entry.

Enhancements:
- Replace pre-existing per-variable standard deviation values with aggregation-derived standard deviations to avoid dataset merge conflicts during mean aggregation.
- Extend meta-example generator to include an advanced aggregate-over-time example variant.