### PR TITLE
Improve test coverage across visualization and utility modules

### DIFF
--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -1,8 +1,11 @@
 import unittest
 import bencher as bch
 import numpy as np
+import holoviews as hv
+import panel as pn
 
 from bencher.example.meta.example_meta import BenchableObject
+from bencher.results.bench_result_base import ReduceType
 
 
 class TstBench(bch.ParametrizedSweep):
@@ -266,3 +269,214 @@ class TestBenchResultBase(unittest.TestCase):
 
         ds_filtered_names = res.select_level(ds_raw, 2, exclude_names="cat_var")
         asserts(ds_filtered_names, [0, 4], ["a", "b", "c", "d", "e"])
+
+    def _make_1d_result(self, repeats=1):
+        bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+        return bench.plot_sweep(
+            "test_base",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
+            run_cfg=bch.BenchRunCfg(repeats=repeats),
+            plot_callbacks=False,
+        )
+
+    def _make_2d_result(self, repeats=1):
+        bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+        return bench.plot_sweep(
+            "test_base_2d",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=repeats),
+            plot_callbacks=False,
+        )
+
+    def test_get_optimal_value_indices(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        da = res.get_optimal_value_indices(rv)
+        self.assertIsNotNone(da)
+
+    def test_get_optimal_vec(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        ivs = res.bench_cfg.input_vars
+        vec = res.get_optimal_vec(rv, ivs)
+        self.assertIsInstance(vec, list)
+        self.assertEqual(len(vec), len(ivs))
+
+    def test_get_optimal_inputs_tuple(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        output = res.get_optimal_inputs(rv)
+        self.assertIsInstance(output, list)
+        self.assertTrue(len(output) > 0)
+
+    def test_get_optimal_inputs_dict(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        output = res.get_optimal_inputs(rv, as_dict=True)
+        self.assertIsInstance(output, dict)
+
+    def test_get_optimal_inputs_no_consts(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        output = res.get_optimal_inputs(rv, keep_existing_consts=False)
+        self.assertIsInstance(output, list)
+
+    def test_get_hmap_none(self):
+        res = self._make_1d_result()
+        # No hmaps stored, should return None
+        result = res.get_hmap("nonexistent")
+        self.assertIsNone(result)
+
+    def test_to_plot_title(self):
+        res = self._make_1d_result()
+        title = res.to_plot_title()
+        self.assertIsInstance(title, str)
+        self.assertIn("distance", title)
+        self.assertIn("float1", title)
+
+    def test_to_plot_title_empty(self):
+        # Test with no input vars
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "test_base_empty",
+            input_vars=[],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        title = res.to_plot_title()
+        self.assertEqual(title, "")
+
+    def test_to_dataset_with_result_var_str(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(result_var="distance")
+        self.assertIn("distance", ds.data_vars)
+
+    def test_to_dataset_with_result_var_param(self):
+        res = self._make_1d_result()
+        rv = res.bench_cfg.result_vars[0]
+        ds = res.to_dataset(result_var=rv)
+        self.assertIn("distance", ds.data_vars)
+
+    def test_to_dataset_reduce_none(self):
+        res = self._make_1d_result(repeats=2)
+        ds = res.to_dataset(reduce=ReduceType.NONE)
+        self.assertIn("repeat", ds.dims)
+
+    def test_to_dataset_reduce_minmax(self):
+        res = self._make_1d_result(repeats=2)
+        ds = res.to_dataset(reduce=ReduceType.MINMAX)
+        # Should have mean and range vars
+        self.assertIn("distance", ds.data_vars)
+        self.assertIn("distance_range", ds.data_vars)
+
+    def test_to_dataset_agg_mean(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_to_dataset_agg_sum(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="sum")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_to_dataset_agg_max(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="max")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_to_dataset_agg_min(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="min")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_to_dataset_agg_median(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset(agg_over_dims=["float1"], agg_fn="median")
+        self.assertNotIn("float1", ds.dims)
+
+    def test_to_dataset_agg_missing_dim(self):
+        res = self._make_1d_result()
+        # Aggregate over non-existent dim - should warn and return unaggregated
+        ds = res.to_dataset(agg_over_dims=["nonexistent_dim"], agg_fn="mean")
+        self.assertIsNotNone(ds)
+
+    def test_describe_sweep(self):
+        res = self._make_1d_result()
+        desc = res.describe_sweep()
+        self.assertIsNotNone(desc)
+
+    def test_map_plot_panes(self):
+        res = self._make_1d_result()
+
+        def plot_cb(dataset, result_var, **kwargs):
+            return pn.pane.Markdown(f"# {result_var.name}")
+
+        result = res.map_plot_panes(plot_cb)
+        self.assertIsNotNone(result)
+
+    def test_to_hv_dataset_none_reduce(self):
+        res = self._make_1d_result(repeats=2)
+        hv_ds = res.to_hv_dataset(ReduceType.NONE)
+        self.assertIsInstance(hv_ds, hv.Dataset)
+
+    def test_to_pandas(self):
+        res = self._make_1d_result()
+        df = res.to_pandas()
+        self.assertIn("distance", df.columns)
+        self.assertIn("float1", df.columns)
+
+    def test_to_pandas_no_reset(self):
+        res = self._make_1d_result()
+        df = res.to_pandas(reset_index=False)
+        self.assertIn("distance", df.columns)
+
+    def test_to_xarray(self):
+        res = self._make_1d_result()
+        ds = res.to_xarray()
+        self.assertIn("distance", ds.data_vars)
+
+    def test_set_plot_size(self):
+        res = self._make_1d_result()
+        res.bench_cfg.plot_size = 500
+        kwargs = res.set_plot_size()
+        self.assertEqual(kwargs["width"], 500)
+        self.assertEqual(kwargs["height"], 500)
+
+    def test_set_plot_size_with_overrides(self):
+        res = self._make_1d_result()
+        res.bench_cfg.plot_size = 500
+        res.bench_cfg.plot_width = 700
+        res.bench_cfg.plot_height = 300
+        kwargs = res.set_plot_size()
+        self.assertEqual(kwargs["width"], 700)
+        self.assertEqual(kwargs["height"], 300)
+
+    def test_title_from_ds(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        title = res.title_from_ds(ds, rv)
+        self.assertIsInstance(title, str)
+
+    def test_title_from_ds_override(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        title = res.title_from_ds(ds, rv, title="Custom Title")
+        self.assertEqual(title, "Custom Title")
+
+    def test_title_from_ds_dataarray(self):
+        res = self._make_1d_result()
+        ds = res.to_dataset()
+        da = ds["distance"]
+        rv = res.bench_cfg.result_vars[0]
+        title = res.title_from_ds(da, rv)
+        self.assertIsInstance(title, str)
+
+    def test_result_samples(self):
+        res = self._make_1d_result()
+        samples = res.result_samples()
+        self.assertIsNotNone(samples)

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -280,21 +280,14 @@ class TestBenchResultBase(unittest.TestCase):
             plot_callbacks=False,
         )
 
-    def _make_2d_result(self, repeats=1):
-        bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-        return bench.plot_sweep(
-            "test_base_2d",
-            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
-            result_vars=[BenchableObject.param.distance],
-            run_cfg=bch.BenchRunCfg(repeats=repeats),
-            plot_callbacks=False,
-        )
-
     def test_get_optimal_value_indices(self):
         res = self._make_1d_result()
         rv = res.bench_cfg.result_vars[0]
         da = res.get_optimal_value_indices(rv)
         self.assertIsNotNone(da)
+        import xarray as xr
+
+        self.assertIsInstance(da, xr.DataArray)
 
     def test_get_optimal_vec(self):
         res = self._make_1d_result()
@@ -401,7 +394,7 @@ class TestBenchResultBase(unittest.TestCase):
         res = self._make_1d_result()
         # Aggregate over non-existent dim - should warn and return unaggregated
         ds = res.to_dataset(agg_over_dims=["nonexistent_dim"], agg_fn="mean")
-        self.assertIsNotNone(ds)
+        self.assertIn("float1", ds.dims)
 
     def test_describe_sweep(self):
         res = self._make_1d_result()

--- a/test/test_bench_runner.py
+++ b/test/test_bench_runner.py
@@ -288,6 +288,101 @@ class TestBenchRunner(unittest.TestCase):
         # Function should still have been added
         self.assertIn(bench_fn, bench_runner.bench_fns)
 
+    def test_benchrunner_grouped(self):
+        """Test running benchmarks in grouped mode."""
+        bench_runner = bch.BenchRunner("test_grouped")
+        bench_runner.add_bench(SimpleBenchClass())
+        results = bench_runner.run(level=2, repeats=1, grouped=True)
+        self.assertTrue(len(results) > 0)
+
+    def test_benchrunner_v2_signature(self):
+        """Test that BenchRunner handles V2 (single-arg) benchmark functions."""
+
+        def v2_benchmark(run_cfg: bch.BenchRunCfg) -> bch.BenchCfg:
+            bench = bch.Bench("v2_test", SimpleBenchClassFloat(), run_cfg=run_cfg)
+            return bench.plot_sweep("v2_sweep")
+
+        bench_runner = bch.BenchRunner("test_v2")
+        bench_runner.add(v2_benchmark)
+        results = bench_runner.run(level=2, repeats=1)
+        self.assertEqual(len(results), 1)
+
+    def test_benchrunner_progressive_levels(self):
+        """Test progressive level runs."""
+        executed = []
+
+        def tracking_benchmark(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) -> bch.BenchCfg:
+            executed.append(run_cfg.level)
+            bench = bch.Bench("track", SimpleBenchClassFloat(), run_cfg=run_cfg, report=report)
+            return bench.plot_sweep("track_sweep")
+
+        br = bch.BenchRunner("test_progressive")
+        br.add(tracking_benchmark)
+        br.run(level=2, max_level=3, repeats=1)
+        self.assertEqual(sorted(executed), [2, 3])
+
+    def test_benchrunner_merge_reports(self):
+        """Test the _merge_reports method."""
+        from bencher.bench_report import BenchReport
+
+        br = bch.BenchRunner("test_merge")
+        target = BenchReport("target")
+        source = BenchReport("source")
+        source.pane.append("test_pane")
+
+        initial_count = len(target.pane)
+        br._merge_reports(target, source)
+        # After merge, target should have more panes
+        self.assertGreater(len(target.pane), initial_count)
+
+    def test_benchrunner_merge_reports_none(self):
+        """Test _merge_reports with None source."""
+        from bencher.bench_report import BenchReport
+
+        br = bch.BenchRunner("test_merge_none")
+        target = BenchReport("target")
+        br._merge_reports(target, None)
+        # Should not crash
+
+    def test_benchrunner_merge_reports_same(self):
+        """Test _merge_reports when target is source."""
+        from bencher.bench_report import BenchReport
+
+        br = bch.BenchRunner("test_merge_same")
+        report = BenchReport("same")
+        br._merge_reports(report, report)
+        # Should not crash
+
+    def test_benchrunner_name_from_callable(self):
+        """Test that BenchRunner auto-names from a callable."""
+
+        def my_benchmark(run_cfg: bch.BenchRunCfg, report: bch.BenchReport) -> bch.BenchCfg:
+            bench = bch.Bench("test", SimpleBenchClassFloat(), run_cfg=run_cfg, report=report)
+            return bench.plot_sweep("test")
+
+        br = bch.BenchRunner(my_benchmark)
+        self.assertEqual(br.name, "my_benchmark")
+        self.assertEqual(len(br.bench_fns), 1)
+
+    def test_benchrunner_add_chaining(self):
+        """Test that add() supports method chaining."""
+        br = bch.BenchRunner("test_chain")
+        result = br.add(Mock())
+        self.assertIs(result, br)
+
+    def test_benchrunner_show_no_results(self):
+        """Test that show() raises with no results."""
+        br = bch.BenchRunner("test_show_empty")
+        with self.assertRaises(RuntimeError):
+            br.show()
+
+    def test_benchrunner_shutdown(self):
+        """Test shutdown method."""
+        br = bch.BenchRunner("test_shutdown")
+        br.servers = [Mock()]
+        br.shutdown()
+        self.assertEqual(len(br.servers), 0)
+
     # Tests that bch.BenchRunner can handle empty list of Benchable functions
     # def test_benchrunner_handle_empty_list(self):
 

--- a/test/test_bench_runner.py
+++ b/test/test_bench_runner.py
@@ -336,22 +336,24 @@ class TestBenchRunner(unittest.TestCase):
         self.assertGreater(len(target.pane), initial_count)
 
     def test_benchrunner_merge_reports_none(self):
-        """Test _merge_reports with None source."""
+        """Test _merge_reports with None source leaves target unchanged."""
         from bencher.bench_report import BenchReport
 
         br = bch.BenchRunner("test_merge_none")
         target = BenchReport("target")
+        initial_count = len(target.pane)
         br._merge_reports(target, None)  # pylint: disable=protected-access
-        # Should not crash
+        self.assertEqual(len(target.pane), initial_count)
 
     def test_benchrunner_merge_reports_same(self):
-        """Test _merge_reports when target is source."""
+        """Test _merge_reports when target is source leaves target unchanged."""
         from bencher.bench_report import BenchReport
 
         br = bch.BenchRunner("test_merge_same")
         report = BenchReport("same")
+        initial_count = len(report.pane)
         br._merge_reports(report, report)  # pylint: disable=protected-access
-        # Should not crash
+        self.assertEqual(len(report.pane), initial_count)
 
     def test_benchrunner_name_from_callable(self):
         """Test that BenchRunner auto-names from a callable."""

--- a/test/test_bench_runner.py
+++ b/test/test_bench_runner.py
@@ -331,7 +331,7 @@ class TestBenchRunner(unittest.TestCase):
         source.pane.append("test_pane")
 
         initial_count = len(target.pane)
-        br._merge_reports(target, source)
+        br._merge_reports(target, source)  # pylint: disable=protected-access
         # After merge, target should have more panes
         self.assertGreater(len(target.pane), initial_count)
 
@@ -341,7 +341,7 @@ class TestBenchRunner(unittest.TestCase):
 
         br = bch.BenchRunner("test_merge_none")
         target = BenchReport("target")
-        br._merge_reports(target, None)
+        br._merge_reports(target, None)  # pylint: disable=protected-access
         # Should not crash
 
     def test_benchrunner_merge_reports_same(self):
@@ -350,7 +350,7 @@ class TestBenchRunner(unittest.TestCase):
 
         br = bch.BenchRunner("test_merge_same")
         report = BenchReport("same")
-        br._merge_reports(report, report)
+        br._merge_reports(report, report)  # pylint: disable=protected-access
         # Should not crash
 
     def test_benchrunner_name_from_callable(self):

--- a/test/test_explorer_result.py
+++ b/test/test_explorer_result.py
@@ -1,0 +1,35 @@
+"""Tests for bencher/results/explorer_result.py"""
+
+import unittest
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+from bencher.results.explorer_result import ExplorerResult
+
+
+class TestExplorerResult(unittest.TestCase):
+    def test_to_plot_with_inputs(self):
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "explorer_test",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        # Call ExplorerResult.to_plot via the result object (it inherits from ExplorerResult)
+        result = ExplorerResult.to_plot(res)
+        self.assertIsNotNone(result)
+
+    def test_to_plot_without_inputs(self):
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "explorer_no_inputs",
+            input_vars=[],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        # Falls back to pandas hvplot explorer for 0D
+        result = ExplorerResult.to_plot(res)
+        self.assertIsNotNone(result)

--- a/test/test_flask_server.py
+++ b/test/test_flask_server.py
@@ -1,0 +1,42 @@
+"""Tests for bencher/flask_server.py"""
+
+import unittest
+import tempfile
+from pathlib import Path
+
+from bencher.flask_server import create_server, run_flask_in_thread
+
+
+class TestFlaskServer(unittest.TestCase):
+    def test_create_server(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write a test file
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("hello world")
+
+            app = create_server(tmpdir)
+            self.assertIsNotNone(app)
+
+            # Use Flask test client to verify GET
+            with app.test_client() as client:
+                resp = client.get("/test.txt")
+                self.assertEqual(resp.status_code, 200)
+                self.assertEqual(resp.data, b"hello world")
+
+    def test_create_server_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = create_server(tmpdir)
+            with app.test_client() as client:
+                resp = client.get("/nonexistent.txt")
+                self.assertEqual(resp.status_code, 404)
+
+    def test_run_flask_in_thread(self):
+        import time
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Use a high port to avoid conflicts
+            run_flask_in_thread(directory=tmpdir, port=18901)
+            # Give the thread a moment to start
+            time.sleep(0.5)
+            # The server should be running (we can't easily verify the thread
+            # but we can verify it didn't crash)

--- a/test/test_flask_server.py
+++ b/test/test_flask_server.py
@@ -32,11 +32,16 @@ class TestFlaskServer(unittest.TestCase):
 
     def test_run_flask_in_thread(self):
         import time
+        import urllib.request
+        import urllib.error
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Use a high port to avoid conflicts
+            test_file = Path(tmpdir) / "health.txt"
+            test_file.write_text("ok")
+
             run_flask_in_thread(directory=tmpdir, port=18901)
-            # Give the thread a moment to start
             time.sleep(0.5)
-            # The server should be running (we can't easily verify the thread
-            # but we can verify it didn't crash)
+
+            # Verify the server is actually serving requests
+            with urllib.request.urlopen("http://127.0.0.1:18901/health.txt") as resp:
+                self.assertEqual(resp.read(), b"ok")

--- a/test/test_heatmap_result.py
+++ b/test/test_heatmap_result.py
@@ -6,94 +6,74 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def _run_2d_sweep(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_hm",
-        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
-def _run_1d_sweep():
-    bench = BenchableObject().to_bench()
-    return bench.plot_sweep(
-        "test_hm_1d",
-        input_vars=[BenchableObject.param.float1],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=1),
-        plot_callbacks=False,
-    )
-
-
 class TestHeatmapResult(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        bench_2d = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_2d = bench_2d.plot_sweep(
+            "test_hm",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        bench_1d = BenchableObject().to_bench()
+        cls.res_1d = bench_1d.plot_sweep(
+            "test_hm_1d",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
     def test_to_heatmap_ds(self):
-        res = _run_2d_sweep()
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_heatmap_ds(ds, rv)
+        ds = self.res_2d.to_dataset()
+        rv = self.res_2d.bench_cfg.result_vars[0]
+        result = self.res_2d.to_heatmap_ds(ds, rv)
         self.assertIsNotNone(result)
 
     def test_to_heatmap_ds_returns_none(self):
-        res = _run_1d_sweep()
-        # Create a 1D dataset (< 2 dims) to test None return
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_heatmap_ds(ds, rv)
+        ds = self.res_1d.to_dataset()
+        rv = self.res_1d.bench_cfg.result_vars[0]
+        result = self.res_1d.to_heatmap_ds(ds, rv)
         self.assertIsNone(result)
 
     def test_to_heatmap(self):
-        res = _run_2d_sweep()
-        result = res.to_heatmap()
+        result = self.res_2d.to_heatmap()
         self.assertIsNotNone(result)
 
     def test_to_plot_delegates_to_heatmap(self):
         """to_plot delegates to to_heatmap."""
         from bencher.results.holoview_results.heatmap_result import HeatmapResult
 
-        res = _run_2d_sweep()
-        result = HeatmapResult.to_plot(res)
+        result = HeatmapResult.to_plot(self.res_2d)
         self.assertIsNotNone(result)
 
     def test_to_heatmap_no_tap(self):
-        res = _run_2d_sweep()
-        result = res.to_heatmap(use_tap=False)
-        self.assertIsNotNone(result)
-
-    def test_to_heatmap_tap_var_list(self):
-        res = _run_2d_sweep()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_heatmap(tap_var=[rv], use_tap=False)
+        result = self.res_2d.to_heatmap(use_tap=False)
         self.assertIsNotNone(result)
 
     def test_to_heatmap_tap_var_single(self):
-        res = _run_2d_sweep()
-        rv = res.bench_cfg.result_vars[0]
-        # Pass single var (not list) to test the list conversion path
-        result = res.to_heatmap(tap_var=rv, use_tap=False)
+        rv = self.res_2d.bench_cfg.result_vars[0]
+        # Pass single var (not list) to test the list conversion path (line 101-102)
+        result = self.res_2d.to_heatmap(tap_var=rv, use_tap=False)
         self.assertIsNotNone(result)
 
-    def test_to_heatmap_with_tap_var(self):
-        """Test the heatmap with tap functionality enabled via to_heatmap."""
-        res = _run_2d_sweep()
-        rv = res.bench_cfg.result_vars[0]
-        # Use to_heatmap with tap_var to exercise the tap code path
-        # use_tap=False avoids interactive issues, but tests the tap_var list handling
-        result = res.to_heatmap(tap_var=[rv], use_tap=False)
+    def test_to_heatmap_tap_var_list(self):
+        rv = self.res_2d.bench_cfg.result_vars[0]
+        # Pass list tap_var with use_tap=False to exercise list-handling (lines 99-112)
+        result = self.res_2d.to_heatmap(tap_var=[rv], use_tap=False)
         self.assertIsNotNone(result)
 
     def test_to_heatmap_single(self):
-        res = _run_2d_sweep()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_heatmap_single(rv)
+        rv = self.res_2d.bench_cfg.result_vars[0]
+        result = self.res_2d.to_heatmap_single(rv)
         self.assertIsNotNone(result)
 
     def test_to_heatmap_1d_single_filter_fail(self):
-        res = _run_1d_sweep()
-        rv = res.bench_cfg.result_vars[0]
+        rv = self.res_1d.bench_cfg.result_vars[0]
         # With 1 float var, the filter (float_range=VarRange(2, None)) should not match
-        result = res.to_heatmap_single(rv, override=False)
+        result = self.res_1d.to_heatmap_single(rv, override=False)
         # Should return the filter match panel (not a heatmap)
         self.assertIsNotNone(result)

--- a/test/test_heatmap_result.py
+++ b/test/test_heatmap_result.py
@@ -1,0 +1,99 @@
+"""Tests for bencher/results/holoview_results/heatmap_result.py"""
+
+import unittest
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+
+
+def _run_2d_sweep(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_hm",
+        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+def _run_1d_sweep():
+    bench = BenchableObject().to_bench()
+    return bench.plot_sweep(
+        "test_hm_1d",
+        input_vars=[BenchableObject.param.float1],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=1),
+        plot_callbacks=False,
+    )
+
+
+class TestHeatmapResult(unittest.TestCase):
+    def test_to_heatmap_ds(self):
+        res = _run_2d_sweep()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_heatmap_ds(ds, rv)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_ds_returns_none(self):
+        res = _run_1d_sweep()
+        # Create a 1D dataset (< 2 dims) to test None return
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_heatmap_ds(ds, rv)
+        self.assertIsNone(result)
+
+    def test_to_heatmap(self):
+        res = _run_2d_sweep()
+        result = res.to_heatmap()
+        self.assertIsNotNone(result)
+
+    def test_to_plot_delegates_to_heatmap(self):
+        """to_plot delegates to to_heatmap."""
+        from bencher.results.holoview_results.heatmap_result import HeatmapResult
+
+        res = _run_2d_sweep()
+        result = HeatmapResult.to_plot(res)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_no_tap(self):
+        res = _run_2d_sweep()
+        result = res.to_heatmap(use_tap=False)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_tap_var_list(self):
+        res = _run_2d_sweep()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_heatmap(tap_var=[rv], use_tap=False)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_tap_var_single(self):
+        res = _run_2d_sweep()
+        rv = res.bench_cfg.result_vars[0]
+        # Pass single var (not list) to test the list conversion path
+        result = res.to_heatmap(tap_var=rv, use_tap=False)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_with_tap_var(self):
+        """Test the heatmap with tap functionality enabled via to_heatmap."""
+        res = _run_2d_sweep()
+        rv = res.bench_cfg.result_vars[0]
+        # Use to_heatmap with tap_var to exercise the tap code path
+        # use_tap=False avoids interactive issues, but tests the tap_var list handling
+        result = res.to_heatmap(tap_var=[rv], use_tap=False)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_single(self):
+        res = _run_2d_sweep()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_heatmap_single(rv)
+        self.assertIsNotNone(result)
+
+    def test_to_heatmap_1d_single_filter_fail(self):
+        res = _run_1d_sweep()
+        rv = res.bench_cfg.result_vars[0]
+        # With 1 float var, the filter (float_range=VarRange(2, None)) should not match
+        result = res.to_heatmap_single(rv, override=False)
+        # Should return the filter match panel (not a heatmap)
+        self.assertIsNotNone(result)

--- a/test/test_holoview_result.py
+++ b/test/test_holoview_result.py
@@ -11,29 +11,45 @@ from bencher.results.bench_result_base import ReduceType
 from bencher.variables.results import ResultVar, ResultImage, ResultVideo
 
 
-def _run_1d_sweep(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_hv",
-        input_vars=[BenchableObject.param.float1],
-        result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
-def _run_2d_sweep(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_hv_2d",
-        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
 class TestHoloviewResult(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        bench1 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_1d = bench1.plot_sweep(
+            "test_hv",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        bench2 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=2))
+        cls.res_1d_r2 = bench2.plot_sweep(
+            "test_hv_r2",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+
+        bench3 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_2d = bench3.plot_sweep(
+            "test_hv_2d",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        bench4 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=2))
+        cls.res_2d_r2 = bench4.plot_sweep(
+            "test_hv_2d_r2",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+
     def test_set_default_opts(self):
         result = HoloviewResult.set_default_opts()
         self.assertIn("width", result)
@@ -48,131 +64,92 @@ class TestHoloviewResult(unittest.TestCase):
         self.assertEqual(result["height"], 400)
 
     def test_to_hv_type_curve(self):
-        res = _run_1d_sweep()
-        chart = res.to_hv_type(hv.Curve)
-        self.assertIsNotNone(chart)
+        chart = self.res_1d.to_hv_type(hv.Curve)
+        self.assertIsInstance(chart, hv.Element)
 
     def test_to_hv_type_bars(self):
-        res = _run_1d_sweep()
-        chart = res.to_hv_type(hv.Bars)
-        self.assertIsNotNone(chart)
+        chart = self.res_1d.to_hv_type(hv.Bars)
+        self.assertIsInstance(chart, hv.Element)
 
     def test_to_hv_type_2d_points(self):
-        res = _run_2d_sweep()
-        chart = res.to_hv_type(hv.Points)
-        self.assertIsNotNone(chart)
+        chart = self.res_2d.to_hv_type(hv.Points)
+        self.assertIsInstance(chart, hv.Element)
 
     def test_overlay_plots(self):
-        res = _run_1d_sweep()
-
         def plot_cb(rv):
-            ds = res.to_hv_dataset()
-            return ds.to(hv.Curve)
+            return self.res_1d.to_hv_dataset().to(hv.Curve)
 
-        result = res.overlay_plots(plot_cb)
-        self.assertIsNotNone(result)
+        result = self.res_1d.overlay_plots(plot_cb)
+        self.assertIsInstance(result, hv.Overlay)
 
     def test_overlay_plots_returns_none(self):
-        res = _run_1d_sweep()
-
-        def plot_cb(rv):
-            return None
-
-        result = res.overlay_plots(plot_cb)
+        result = self.res_1d.overlay_plots(lambda rv: None)
         self.assertIsNone(result)
 
     def test_overlay_plots_markdown(self):
-        res = _run_1d_sweep()
-
-        def plot_cb(rv):
-            return pn.pane.Markdown(f"# {rv.name}")
-
-        result = res.overlay_plots(plot_cb)
-        self.assertIsNotNone(result)
+        result = self.res_1d.overlay_plots(lambda rv: pn.pane.Markdown(f"# {rv.name}"))
         self.assertIsInstance(result, pn.Row)
 
     def test_layout_plots(self):
-        res = _run_1d_sweep()
-
         def plot_cb(rv):
-            ds = res.to_hv_dataset()
-            return ds.to(hv.Curve)
+            return self.res_1d.to_hv_dataset().to(hv.Curve)
 
-        result = res.layout_plots(plot_cb)
-        self.assertIsNotNone(result)
+        result = self.res_1d.layout_plots(plot_cb)
         self.assertIsInstance(result, hv.Layout)
 
     def test_layout_plots_none_results(self):
-        res = _run_1d_sweep()
-
-        def plot_cb(rv):
-            return None
-
-        result = res.layout_plots(plot_cb)
+        result = self.res_1d.layout_plots(lambda rv: None)
         self.assertIsNone(result)
 
     def test_time_widget(self):
-        res = _run_1d_sweep()
-        widget = res.time_widget("Test Title")
+        widget = self.res_1d.time_widget("Test Title")
         self.assertIsInstance(widget, dict)
         self.assertEqual(widget["title"], "Test Title")
 
     def test_hv_container_ds(self):
-        res = _run_1d_sweep()
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.hv_container_ds(ds, rv, container=hv.Bars)
-        self.assertIsNotNone(result)
+        ds = self.res_1d.to_dataset()
+        rv = self.res_1d.bench_cfg.result_vars[0]
+        result = self.res_1d.hv_container_ds(ds, rv, container=hv.Bars)
+        self.assertIsInstance(result, hv.Element)
 
     def test_to_hv_container(self):
-        res = _run_1d_sweep()
-        result = res.to_hv_container(hv.Bars)
-        self.assertIsNotNone(result)
+        result = self.res_1d.to_hv_container(hv.Bars)
+        self.assertIsInstance(result, pn.Row)
 
     def test_result_var_to_container_column(self):
-        res = _run_1d_sweep()
-        rv = ResultVar()
-        container = res.result_var_to_container(rv)
+        # Static-like method — no sweep data needed
+        container = HoloviewResult.result_var_to_container(self.res_1d, ResultVar())
         self.assertEqual(container, pn.Column)
 
     def test_result_var_to_container_image(self):
-        res = _run_1d_sweep()
-        rv = ResultImage()
-        container = res.result_var_to_container(rv)
+        container = HoloviewResult.result_var_to_container(self.res_1d, ResultImage())
         self.assertEqual(container, pn.pane.PNG)
 
     def test_result_var_to_container_video(self):
-        res = _run_1d_sweep()
-        rv = ResultVideo()
-        container = res.result_var_to_container(rv)
+        container = HoloviewResult.result_var_to_container(self.res_1d, ResultVideo())
         self.assertEqual(container, pn.pane.Video)
 
     def test_setup_results_and_containers_default(self):
-        res = _run_1d_sweep()
         rv = ResultVar()
-        vars_out, containers = res.setup_results_and_containers(rv)
+        vars_out, containers = self.res_1d.setup_results_and_containers(rv)
         self.assertEqual(len(vars_out), 1)
         self.assertEqual(len(containers), 1)
         self.assertIsInstance(containers[0], pn.Column)
 
     def test_setup_results_and_containers_explicit(self):
-        res = _run_1d_sweep()
         rv = ResultVar()
-        vars_out, containers = res.setup_results_and_containers(rv, container=pn.Column)
+        vars_out, containers = self.res_1d.setup_results_and_containers(rv, container=pn.Column)
         self.assertEqual(len(vars_out), 1)
         self.assertEqual(len(containers), 1)
 
     def test_to_error_bar(self):
-        res = _run_1d_sweep(repeats=2)
-        result = res.to_error_bar()
-        self.assertIsNotNone(result)
+        result = self.res_1d_r2.to_error_bar()
+        self.assertIsInstance(result, hv.Element)
 
     def test_to_points(self):
-        res = _run_2d_sweep()
-        result = res.to_points()
-        self.assertIsNotNone(result)
+        result = self.res_2d.to_points()
+        self.assertIsInstance(result, hv.Element)
 
     def test_to_points_reduce(self):
-        res = _run_2d_sweep(repeats=2)
-        result = res.to_points(reduce=ReduceType.REDUCE)
-        self.assertIsNotNone(result)
+        result = self.res_2d_r2.to_points(reduce=ReduceType.REDUCE)
+        self.assertIsInstance(result, hv.Element)

--- a/test/test_holoview_result.py
+++ b/test/test_holoview_result.py
@@ -1,0 +1,178 @@
+"""Tests for bencher/results/holoview_results/holoview_result.py"""
+
+import unittest
+import holoviews as hv
+import panel as pn
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.bench_result_base import ReduceType
+from bencher.variables.results import ResultVar, ResultImage, ResultVideo
+
+
+def _run_1d_sweep(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_hv",
+        input_vars=[BenchableObject.param.float1],
+        result_vars=[BenchableObject.param.distance, BenchableObject.param.sample_noise],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+def _run_2d_sweep(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_hv_2d",
+        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+class TestHoloviewResult(unittest.TestCase):
+    def test_set_default_opts(self):
+        result = HoloviewResult.set_default_opts()
+        self.assertIn("width", result)
+        self.assertIn("height", result)
+        self.assertIn("tools", result)
+        self.assertEqual(result["width"], 600)
+        self.assertEqual(result["height"], 600)
+
+    def test_set_default_opts_custom(self):
+        result = HoloviewResult.set_default_opts(width=800, height=400)
+        self.assertEqual(result["width"], 800)
+        self.assertEqual(result["height"], 400)
+
+    def test_to_hv_type_curve(self):
+        res = _run_1d_sweep()
+        chart = res.to_hv_type(hv.Curve)
+        self.assertIsNotNone(chart)
+
+    def test_to_hv_type_bars(self):
+        res = _run_1d_sweep()
+        chart = res.to_hv_type(hv.Bars)
+        self.assertIsNotNone(chart)
+
+    def test_to_hv_type_2d_points(self):
+        res = _run_2d_sweep()
+        chart = res.to_hv_type(hv.Points)
+        self.assertIsNotNone(chart)
+
+    def test_overlay_plots(self):
+        res = _run_1d_sweep()
+
+        def plot_cb(rv):
+            ds = res.to_hv_dataset()
+            return ds.to(hv.Curve)
+
+        result = res.overlay_plots(plot_cb)
+        self.assertIsNotNone(result)
+
+    def test_overlay_plots_returns_none(self):
+        res = _run_1d_sweep()
+
+        def plot_cb(rv):
+            return None
+
+        result = res.overlay_plots(plot_cb)
+        self.assertIsNone(result)
+
+    def test_overlay_plots_markdown(self):
+        res = _run_1d_sweep()
+
+        def plot_cb(rv):
+            return pn.pane.Markdown(f"# {rv.name}")
+
+        result = res.overlay_plots(plot_cb)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, pn.Row)
+
+    def test_layout_plots(self):
+        res = _run_1d_sweep()
+
+        def plot_cb(rv):
+            ds = res.to_hv_dataset()
+            return ds.to(hv.Curve)
+
+        result = res.layout_plots(plot_cb)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, hv.Layout)
+
+    def test_layout_plots_none_results(self):
+        res = _run_1d_sweep()
+
+        def plot_cb(rv):
+            return None
+
+        result = res.layout_plots(plot_cb)
+        self.assertIsNone(result)
+
+    def test_time_widget(self):
+        res = _run_1d_sweep()
+        widget = res.time_widget("Test Title")
+        self.assertIsInstance(widget, dict)
+        self.assertEqual(widget["title"], "Test Title")
+
+    def test_hv_container_ds(self):
+        res = _run_1d_sweep()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.hv_container_ds(ds, rv, container=hv.Bars)
+        self.assertIsNotNone(result)
+
+    def test_to_hv_container(self):
+        res = _run_1d_sweep()
+        result = res.to_hv_container(hv.Bars)
+        self.assertIsNotNone(result)
+
+    def test_result_var_to_container_column(self):
+        res = _run_1d_sweep()
+        rv = ResultVar()
+        container = res.result_var_to_container(rv)
+        self.assertEqual(container, pn.Column)
+
+    def test_result_var_to_container_image(self):
+        res = _run_1d_sweep()
+        rv = ResultImage()
+        container = res.result_var_to_container(rv)
+        self.assertEqual(container, pn.pane.PNG)
+
+    def test_result_var_to_container_video(self):
+        res = _run_1d_sweep()
+        rv = ResultVideo()
+        container = res.result_var_to_container(rv)
+        self.assertEqual(container, pn.pane.Video)
+
+    def test_setup_results_and_containers_default(self):
+        res = _run_1d_sweep()
+        rv = ResultVar()
+        vars_out, containers = res.setup_results_and_containers(rv)
+        self.assertEqual(len(vars_out), 1)
+        self.assertEqual(len(containers), 1)
+        self.assertIsInstance(containers[0], pn.Column)
+
+    def test_setup_results_and_containers_explicit(self):
+        res = _run_1d_sweep()
+        rv = ResultVar()
+        vars_out, containers = res.setup_results_and_containers(rv, container=pn.Column)
+        self.assertEqual(len(vars_out), 1)
+        self.assertEqual(len(containers), 1)
+
+    def test_to_error_bar(self):
+        res = _run_1d_sweep(repeats=2)
+        result = res.to_error_bar()
+        self.assertIsNotNone(result)
+
+    def test_to_points(self):
+        res = _run_2d_sweep()
+        result = res.to_points()
+        self.assertIsNotNone(result)
+
+    def test_to_points_reduce(self):
+        res = _run_2d_sweep(repeats=2)
+        result = res.to_points(reduce=ReduceType.REDUCE)
+        self.assertIsNotNone(result)

--- a/test/test_line_result.py
+++ b/test/test_line_result.py
@@ -6,62 +6,54 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def _run_1d_sweep(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_line",
-        input_vars=[BenchableObject.param.float1],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
-def _run_1d_sweep_with_cat(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_line_cat",
-        input_vars=[BenchableObject.param.float1, BenchableObject.param.wave],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
 class TestLineResult(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_1d = bench.plot_sweep(
+            "test_line",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        bench_cat = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_1d_cat = bench_cat.plot_sweep(
+            "test_line_cat",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.wave],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
     def test_to_line_ds(self):
-        res = _run_1d_sweep()
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_line_ds(ds, rv)
+        ds = self.res_1d.to_dataset()
+        rv = self.res_1d.bench_cfg.result_vars[0]
+        result = self.res_1d.to_line_ds(ds, rv)
         self.assertIsNotNone(result)
 
     def test_to_line(self):
-        res = _run_1d_sweep()
-        result = res.to_line()
+        result = self.res_1d.to_line()
         self.assertIsNotNone(result)
 
     def test_to_plot(self):
         """Test to_plot delegates to to_line."""
         from bencher.results.holoview_results.line_result import LineResult
 
-        res = _run_1d_sweep()
-        result = LineResult.to_plot(res)
+        result = LineResult.to_plot(self.res_1d)
         self.assertIsNotNone(result)
 
     def test_to_line_no_tap(self):
-        res = _run_1d_sweep()
-        result = res.to_line(use_tap=False)
+        result = self.res_1d.to_line(use_tap=False)
         self.assertIsNotNone(result)
 
     def test_to_line_with_cat(self):
-        res = _run_1d_sweep_with_cat()
-        result = res.to_line()
+        result = self.res_1d_cat.to_line()
         self.assertIsNotNone(result)
 
     def test_to_line_ds_with_cat(self):
-        res = _run_1d_sweep_with_cat()
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_line_ds(ds, rv)
+        ds = self.res_1d_cat.to_dataset()
+        rv = self.res_1d_cat.bench_cfg.result_vars[0]
+        result = self.res_1d_cat.to_line_ds(ds, rv)
         self.assertIsNotNone(result)

--- a/test/test_line_result.py
+++ b/test/test_line_result.py
@@ -1,0 +1,67 @@
+"""Tests for bencher/results/holoview_results/line_result.py"""
+
+import unittest
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+
+
+def _run_1d_sweep(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_line",
+        input_vars=[BenchableObject.param.float1],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+def _run_1d_sweep_with_cat(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_line_cat",
+        input_vars=[BenchableObject.param.float1, BenchableObject.param.wave],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+class TestLineResult(unittest.TestCase):
+    def test_to_line_ds(self):
+        res = _run_1d_sweep()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_line_ds(ds, rv)
+        self.assertIsNotNone(result)
+
+    def test_to_line(self):
+        res = _run_1d_sweep()
+        result = res.to_line()
+        self.assertIsNotNone(result)
+
+    def test_to_plot(self):
+        """Test to_plot delegates to to_line."""
+        from bencher.results.holoview_results.line_result import LineResult
+
+        res = _run_1d_sweep()
+        result = LineResult.to_plot(res)
+        self.assertIsNotNone(result)
+
+    def test_to_line_no_tap(self):
+        res = _run_1d_sweep()
+        result = res.to_line(use_tap=False)
+        self.assertIsNotNone(result)
+
+    def test_to_line_with_cat(self):
+        res = _run_1d_sweep_with_cat()
+        result = res.to_line()
+        self.assertIsNotNone(result)
+
+    def test_to_line_ds_with_cat(self):
+        res = _run_1d_sweep_with_cat()
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_line_ds(ds, rv)
+        self.assertIsNotNone(result)

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -6,6 +6,7 @@ from enum import auto
 from strenum import StrEnum
 
 import optuna
+import panel as pn
 import param
 
 import bencher as bch
@@ -173,6 +174,3 @@ class TestSummariseTrial(unittest.TestCase):
         self.assertIsInstance(output, list)
         self.assertTrue(len(output) > 0)
         self.assertIn("Trial id:", output[0])
-
-
-import panel as pn  # noqa: E402

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -1,0 +1,178 @@
+"""Tests for bencher/optuna_conversions.py"""
+
+import unittest
+from unittest.mock import MagicMock
+from enum import auto
+from strenum import StrEnum
+
+import optuna
+import param
+
+import bencher as bch
+from bencher.optuna_conversions import (
+    sweep_var_to_optuna_dist,
+    sweep_var_to_suggest,
+    summarise_optuna_study,
+    summarise_trial,
+)
+from bencher.variables.inputs import IntSweep, FloatSweep, StringSweep, EnumSweep, BoolSweep
+from bencher.variables.time import TimeSnapshot
+
+
+class SweepColor(StrEnum):
+    red = auto()
+    blue = auto()
+
+
+class SweepCfg(bch.ParametrizedSweep):
+    int_var = IntSweep(default=1, bounds=(0, 10))
+    float_var = FloatSweep(default=0.5, bounds=(0.0, 1.0))
+    enum_var = EnumSweep(SweepColor)
+    bool_var = BoolSweep(default=True)
+    string_var = StringSweep(["a", "b", "c"])
+    result = bch.ResultVar()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.result = self.float_var * 2
+        return super().__call__()
+
+
+class TestSweepVarToOptunaDist(unittest.TestCase):
+    def test_int_sweep(self):
+        var = SweepCfg.param.int_var
+        dist = sweep_var_to_optuna_dist(var)
+        self.assertIsInstance(dist, optuna.distributions.IntDistribution)
+        self.assertEqual(dist.low, 0)
+        self.assertEqual(dist.high, 10)
+
+    def test_float_sweep(self):
+        var = SweepCfg.param.float_var
+        dist = sweep_var_to_optuna_dist(var)
+        self.assertIsInstance(dist, optuna.distributions.FloatDistribution)
+        self.assertAlmostEqual(dist.low, 0.0)
+        self.assertAlmostEqual(dist.high, 1.0)
+
+    def test_enum_sweep(self):
+        var = SweepCfg.param.enum_var
+        dist = sweep_var_to_optuna_dist(var)
+        self.assertIsInstance(dist, optuna.distributions.CategoricalDistribution)
+
+    def test_bool_sweep(self):
+        var = SweepCfg.param.bool_var
+        dist = sweep_var_to_optuna_dist(var)
+        self.assertIsInstance(dist, optuna.distributions.CategoricalDistribution)
+        self.assertEqual(dist.choices, (False, True))
+
+    def test_string_sweep(self):
+        var = SweepCfg.param.string_var
+        dist = sweep_var_to_optuna_dist(var)
+        self.assertIsInstance(dist, optuna.distributions.CategoricalDistribution)
+
+    def test_time_snapshot(self):
+        from datetime import datetime
+
+        ts = TimeSnapshot(datetime_src=datetime.now())
+        dist = sweep_var_to_optuna_dist(ts)
+        self.assertIsInstance(dist, optuna.distributions.FloatDistribution)
+
+    def test_unsupported_type(self):
+        # A plain param.Parameter is not supported
+        var = param.Parameter()
+        with self.assertRaises(ValueError):
+            sweep_var_to_optuna_dist(var)
+
+
+class TestSweepVarToSuggest(unittest.TestCase):
+    def test_int_suggest(self):
+        trial = MagicMock()
+        trial.suggest_int.return_value = 5
+        var = SweepCfg.param.int_var
+        result = sweep_var_to_suggest(var, trial)
+        self.assertEqual(result, 5)
+        trial.suggest_int.assert_called_once()
+
+    def test_float_suggest(self):
+        trial = MagicMock()
+        trial.suggest_float.return_value = 0.5
+        var = SweepCfg.param.float_var
+        result = sweep_var_to_suggest(var, trial)
+        self.assertEqual(result, 0.5)
+
+    def test_enum_suggest(self):
+        trial = MagicMock()
+        trial.suggest_categorical.return_value = SweepColor.red
+        var = SweepCfg.param.enum_var
+        result = sweep_var_to_suggest(var, trial)
+        self.assertEqual(result, SweepColor.red)
+
+    def test_bool_suggest(self):
+        trial = MagicMock()
+        trial.suggest_categorical.return_value = True
+        var = SweepCfg.param.bool_var
+        result = sweep_var_to_suggest(var, trial)
+        self.assertTrue(result)
+
+    def test_string_suggest(self):
+        trial = MagicMock()
+        trial.suggest_categorical.return_value = "a"
+        var = SweepCfg.param.string_var
+        result = sweep_var_to_suggest(var, trial)
+        self.assertEqual(result, "a")
+
+    def test_unsupported_type(self):
+        trial = MagicMock()
+        var = param.Parameter()
+        with self.assertRaises(ValueError):
+            sweep_var_to_suggest(var, trial)
+
+
+class TestCfgFromOptunaTrial(unittest.TestCase):
+    def test_creates_config(self):
+        # cfg_from_optuna_trial uses param.set_param which may not exist
+        # in newer param versions, so we test via the full optuna pipeline
+        # (bench_result_to_study) rather than calling it directly.
+        bench = SweepCfg().to_bench()
+        res = bench.plot_sweep(
+            "test_optuna",
+            input_vars=["float_var"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        # Verify the study can be created from bench results
+        study = res.bench_result_to_study(include_meta=True)
+        self.assertIsInstance(study, optuna.Study)
+        self.assertTrue(len(study.trials) > 0)
+
+
+class TestSummariseOptunaStudy(unittest.TestCase):
+    def test_summarise_study(self):
+        study = optuna.create_study(direction="minimize")
+        study.optimize(lambda trial: trial.suggest_float("x", 0, 1) ** 2, n_trials=5)
+        result = summarise_optuna_study(study)
+        self.assertIsInstance(result, pn.Column)
+        self.assertTrue(len(result) > 0)
+
+
+class TestSummariseTrial(unittest.TestCase):
+    def test_summarise_trial(self):
+        bench = SweepCfg().to_bench()
+        res = bench.plot_sweep(
+            "test",
+            input_vars=["float_var"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        study = optuna.create_study(direction="minimize")
+        study.optimize(lambda trial: trial.suggest_float("float_var", 0, 1), n_trials=3)
+        trial = study.best_trial
+        output = summarise_trial(trial, res.bench_cfg)
+        self.assertIsInstance(output, list)
+        self.assertTrue(len(output) > 0)
+        self.assertIn("Trial id:", output[0])
+
+
+import panel as pn  # noqa: E402

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -1,77 +1,78 @@
 """Tests for bencher/results/optuna_result.py"""
 
 import unittest
+import panel as pn
 import optuna
 
 import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def _run_sweep(repeats=1, num_inputs=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    input_vars = [BenchableObject.param.float1]
-    if num_inputs >= 2:
-        input_vars.append(BenchableObject.param.float2)
-    return bench.plot_sweep(
-        "test_optuna_res",
-        input_vars=input_vars,
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
+class TestOptunaResult(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        bench_1 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_1d = bench_1.plot_sweep(
+            "test_optuna_1d",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
 
+        bench_2 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_2d = bench_2.plot_sweep(
+            "test_optuna_2d",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
 
-class TestBenchResultsToOptunaTrials(unittest.TestCase):
+        bench_r2 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=2))
+        cls.res_2d_r2 = bench_r2.plot_sweep(
+            "test_optuna_2d_r2",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+
+        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
+
     def test_bench_results_to_optuna_trials_with_meta(self):
-        res = _run_sweep()
-        trials = res.bench_results_to_optuna_trials(include_meta=True)
+        trials = self.res_1d.bench_results_to_optuna_trials(include_meta=True)
         self.assertIsInstance(trials, list)
-        self.assertTrue(len(trials) > 0)
+        self.assertGreater(len(trials), 0)
         self.assertIsInstance(trials[0], optuna.trial.FrozenTrial)
 
     def test_bench_results_to_optuna_trials_without_meta(self):
-        res = _run_sweep()
-        trials = res.bench_results_to_optuna_trials(include_meta=False)
+        trials = self.res_1d.bench_results_to_optuna_trials(include_meta=False)
         self.assertIsInstance(trials, list)
-        self.assertTrue(len(trials) > 0)
+        self.assertGreater(len(trials), 0)
 
-
-class TestBenchResultToStudy(unittest.TestCase):
     def test_bench_result_to_study(self):
-        res = _run_sweep()
-        study = res.bench_result_to_study(include_meta=True)
+        study = self.res_1d.bench_result_to_study(include_meta=True)
         self.assertIsInstance(study, optuna.Study)
-        self.assertTrue(len(study.trials) > 0)
+        self.assertGreater(len(study.trials), 0)
 
-
-class TestGetBestTrialParams(unittest.TestCase):
     def test_get_best_trial_params(self):
-        res = _run_sweep()
-        params = res.get_best_trial_params()
+        params = self.res_1d.get_best_trial_params()
         self.assertIsInstance(params, dict)
         self.assertIn("float1", params)
 
     def test_get_best_trial_params_canonical(self):
-        res = _run_sweep()
-        result = res.get_best_trial_params(canonical=True)
+        result = self.res_1d.get_best_trial_params(canonical=True)
         self.assertIsNotNone(result)
 
-
-class TestCollectOptunaPlots(unittest.TestCase):
     def test_collect_optuna_plots_single_result(self):
-        res = _run_sweep(num_inputs=2)
-        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
-        plots = res.collect_optuna_plots()
-        self.assertIsNotNone(plots)
+        plots = self.res_2d.collect_optuna_plots()
+        self.assertIsInstance(plots, pn.Row)
 
     def test_to_optuna_plots(self):
-        res = _run_sweep(num_inputs=2)
-        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
-        plots = res.to_optuna_plots()
-        self.assertIsNotNone(plots)
+        plots = self.res_2d.to_optuna_plots()
+        self.assertIsInstance(plots, pn.Row)
 
     def test_collect_optuna_plots_with_repeats(self):
-        res = _run_sweep(repeats=2, num_inputs=2)
-        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
-        plots = res.collect_optuna_plots()
-        self.assertIsNotNone(plots)
+        plots = self.res_2d_r2.collect_optuna_plots()
+        self.assertIsInstance(plots, pn.Row)

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -1,0 +1,77 @@
+"""Tests for bencher/results/optuna_result.py"""
+
+import unittest
+import optuna
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+
+
+def _run_sweep(repeats=1, num_inputs=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    input_vars = [BenchableObject.param.float1]
+    if num_inputs >= 2:
+        input_vars.append(BenchableObject.param.float2)
+    return bench.plot_sweep(
+        "test_optuna_res",
+        input_vars=input_vars,
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+class TestBenchResultsToOptunaTrials(unittest.TestCase):
+    def test_bench_results_to_optuna_trials_with_meta(self):
+        res = _run_sweep()
+        trials = res.bench_results_to_optuna_trials(include_meta=True)
+        self.assertIsInstance(trials, list)
+        self.assertTrue(len(trials) > 0)
+        self.assertIsInstance(trials[0], optuna.trial.FrozenTrial)
+
+    def test_bench_results_to_optuna_trials_without_meta(self):
+        res = _run_sweep()
+        trials = res.bench_results_to_optuna_trials(include_meta=False)
+        self.assertIsInstance(trials, list)
+        self.assertTrue(len(trials) > 0)
+
+
+class TestBenchResultToStudy(unittest.TestCase):
+    def test_bench_result_to_study(self):
+        res = _run_sweep()
+        study = res.bench_result_to_study(include_meta=True)
+        self.assertIsInstance(study, optuna.Study)
+        self.assertTrue(len(study.trials) > 0)
+
+
+class TestGetBestTrialParams(unittest.TestCase):
+    def test_get_best_trial_params(self):
+        res = _run_sweep()
+        params = res.get_best_trial_params()
+        self.assertIsInstance(params, dict)
+        self.assertIn("float1", params)
+
+    def test_get_best_trial_params_canonical(self):
+        res = _run_sweep()
+        result = res.get_best_trial_params(canonical=True)
+        self.assertIsNotNone(result)
+
+
+class TestCollectOptunaPlots(unittest.TestCase):
+    def test_collect_optuna_plots_single_result(self):
+        res = _run_sweep(num_inputs=2)
+        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
+        plots = res.collect_optuna_plots()
+        self.assertIsNotNone(plots)
+
+    def test_to_optuna_plots(self):
+        res = _run_sweep(num_inputs=2)
+        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
+        plots = res.to_optuna_plots()
+        self.assertIsNotNone(plots)
+
+    def test_collect_optuna_plots_with_repeats(self):
+        res = _run_sweep(repeats=2, num_inputs=2)
+        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
+        plots = res.collect_optuna_plots()
+        self.assertIsNotNone(plots)

--- a/test/test_surface_result.py
+++ b/test/test_surface_result.py
@@ -1,0 +1,69 @@
+"""Tests for bencher/results/holoview_results/surface_result.py"""
+
+import unittest
+import panel as pn
+
+import bencher as bch
+from bencher.example.meta.example_meta import BenchableObject
+
+
+def _run_2d_sweep(repeats=1):
+    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
+    return bench.plot_sweep(
+        "test_surface",
+        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=repeats),
+        plot_callbacks=False,
+    )
+
+
+def _run_1d_sweep():
+    bench = BenchableObject().to_bench()
+    return bench.plot_sweep(
+        "test_surface_1d",
+        input_vars=[BenchableObject.param.float1],
+        result_vars=[BenchableObject.param.distance],
+        run_cfg=bch.BenchRunCfg(repeats=1),
+        plot_callbacks=False,
+    )
+
+
+class TestSurfaceResult(unittest.TestCase):
+    def test_to_surface(self):
+        res = _run_2d_sweep()
+        result = res.to_surface()
+        self.assertIsNotNone(result)
+
+    def test_to_plot(self):
+        """Test to_plot delegates to to_surface."""
+        from bencher.results.holoview_results.surface_result import SurfaceResult
+
+        res = _run_2d_sweep()
+        result = SurfaceResult.to_plot(res)
+        self.assertIsNotNone(result)
+
+    def test_to_surface_ds(self):
+        res = _run_2d_sweep(repeats=2)
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        result = res.to_surface_ds(ds, rv)
+        self.assertIsNotNone(result)
+
+    def test_to_surface_ds_with_std(self):
+        res = _run_2d_sweep(repeats=2)
+        ds = res.to_dataset()
+        rv = res.bench_cfg.result_vars[0]
+        # With repeats > 1, should show std-dev bounds
+        result = res.to_surface_ds(ds, rv)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, pn.pane.Plotly)
+
+    def test_to_surface_1d_filter_fail(self):
+        res = _run_1d_sweep()
+        result = res.to_surface(override=False)
+        # 1D doesn't match the 2-float requirement, so filter rejects
+        # With override=False it should not produce a surface plot
+        # (returns None or filter panel)
+        # The result depends on filter match; just ensure no crash
+        self.assertTrue(True)

--- a/test/test_surface_result.py
+++ b/test/test_surface_result.py
@@ -7,63 +7,64 @@ import bencher as bch
 from bencher.example.meta.example_meta import BenchableObject
 
 
-def _run_2d_sweep(repeats=1):
-    bench = BenchableObject().to_bench(bch.BenchRunCfg(repeats=repeats))
-    return bench.plot_sweep(
-        "test_surface",
-        input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=repeats),
-        plot_callbacks=False,
-    )
-
-
-def _run_1d_sweep():
-    bench = BenchableObject().to_bench()
-    return bench.plot_sweep(
-        "test_surface_1d",
-        input_vars=[BenchableObject.param.float1],
-        result_vars=[BenchableObject.param.distance],
-        run_cfg=bch.BenchRunCfg(repeats=1),
-        plot_callbacks=False,
-    )
-
-
 class TestSurfaceResult(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        bench_2d = BenchableObject().to_bench(bch.BenchRunCfg(repeats=1))
+        cls.res_2d = bench_2d.plot_sweep(
+            "test_surface",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        bench_2d_r2 = BenchableObject().to_bench(bch.BenchRunCfg(repeats=2))
+        cls.res_2d_r2 = bench_2d_r2.plot_sweep(
+            "test_surface_r2",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+
+        bench_1d = BenchableObject().to_bench()
+        cls.res_1d = bench_1d.plot_sweep(
+            "test_surface_1d",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
     def test_to_surface(self):
-        res = _run_2d_sweep()
-        result = res.to_surface()
+        result = self.res_2d.to_surface()
         self.assertIsNotNone(result)
 
     def test_to_plot(self):
         """Test to_plot delegates to to_surface."""
         from bencher.results.holoview_results.surface_result import SurfaceResult
 
-        res = _run_2d_sweep()
-        result = SurfaceResult.to_plot(res)
+        result = SurfaceResult.to_plot(self.res_2d)
         self.assertIsNotNone(result)
 
     def test_to_surface_ds(self):
-        res = _run_2d_sweep(repeats=2)
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
-        result = res.to_surface_ds(ds, rv)
-        self.assertIsNotNone(result)
+        ds = self.res_2d_r2.to_dataset()
+        rv = self.res_2d_r2.bench_cfg.result_vars[0]
+        result = self.res_2d_r2.to_surface_ds(ds, rv)
+        self.assertIsInstance(result, pn.pane.Plotly)
 
     def test_to_surface_ds_with_std(self):
-        res = _run_2d_sweep(repeats=2)
-        ds = res.to_dataset()
-        rv = res.bench_cfg.result_vars[0]
+        ds = self.res_2d_r2.to_dataset()
+        rv = self.res_2d_r2.bench_cfg.result_vars[0]
         # With repeats > 1, should show std-dev bounds
-        result = res.to_surface_ds(ds, rv)
-        self.assertIsNotNone(result)
+        result = self.res_2d_r2.to_surface_ds(ds, rv)
         self.assertIsInstance(result, pn.pane.Plotly)
 
     def test_to_surface_1d_filter_fail(self):
         """1D data doesn't match the 2-float requirement for surface plots."""
         from bencher.results.holoview_results.surface_result import SurfaceResult
 
-        res = _run_1d_sweep()
-        result = SurfaceResult.to_surface(res, override=False)
+        result = SurfaceResult.to_surface(self.res_1d, override=False)
         # Filter rejects — returns None or a Markdown debug panel, not a Plotly surface
         self.assertNotIsInstance(result, pn.pane.Plotly)

--- a/test/test_surface_result.py
+++ b/test/test_surface_result.py
@@ -60,10 +60,10 @@ class TestSurfaceResult(unittest.TestCase):
         self.assertIsInstance(result, pn.pane.Plotly)
 
     def test_to_surface_1d_filter_fail(self):
+        """1D data doesn't match the 2-float requirement for surface plots."""
+        from bencher.results.holoview_results.surface_result import SurfaceResult
+
         res = _run_1d_sweep()
-        result = res.to_surface(override=False)
-        # 1D doesn't match the 2-float requirement, so filter rejects
-        # With override=False it should not produce a surface plot
-        # (returns None or filter panel)
-        # The result depends on filter match; just ensure no crash
-        self.assertTrue(True)
+        result = SurfaceResult.to_surface(res, override=False)
+        # Filter rejects — returns None or a Markdown debug panel, not a Plotly surface
+        self.assertNotIsInstance(result, pn.pane.Plotly)

--- a/test/test_video_controls.py
+++ b/test/test_video_controls.py
@@ -1,0 +1,31 @@
+"""Tests for bencher/results/video_controls.py"""
+
+import unittest
+
+import panel as pn
+
+from bencher.results.video_controls import VideoControls
+
+
+class TestVideoControls(unittest.TestCase):
+    def test_init(self):
+        vc = VideoControls()
+        self.assertEqual(vc.vid_p, [])
+
+    def test_video_container_nonexistent(self):
+        vc = VideoControls()
+        result = vc.video_container("/nonexistent/path/video.mp4")
+        self.assertIsInstance(result, pn.pane.Markdown)
+        self.assertIn("does not exist", result.object)
+
+    def test_video_container_none_path(self):
+        vc = VideoControls()
+        result = vc.video_container(None)
+        self.assertIsInstance(result, pn.pane.Markdown)
+
+    def test_video_controls(self):
+        vc = VideoControls()
+        result = vc.video_controls()
+        self.assertIsInstance(result, pn.Column)
+        # Should have a Row of buttons
+        self.assertTrue(len(result) > 0)

--- a/test/test_video_controls.py
+++ b/test/test_video_controls.py
@@ -1,5 +1,7 @@
 """Tests for bencher/results/video_controls.py"""
 
+import os
+import tempfile
 import unittest
 
 import panel as pn
@@ -18,6 +20,17 @@ class TestVideoControls(unittest.TestCase):
         self.assertIsInstance(result, pn.pane.Markdown)
         self.assertIn("does not exist", result.object)
 
+    def test_video_container_existing_file(self):
+        vc = VideoControls()
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            result = vc.video_container(tmp_path)
+            self.assertIsInstance(result, pn.pane.Video)
+            self.assertIn(result, vc.vid_p)
+        finally:
+            os.remove(tmp_path)
+
     def test_video_container_none_path(self):
         vc = VideoControls()
         result = vc.video_container(None)
@@ -28,4 +41,4 @@ class TestVideoControls(unittest.TestCase):
         result = vc.video_controls()
         self.assertIsInstance(result, pn.Column)
         # Should have a Row of buttons
-        self.assertTrue(len(result) > 0)
+        self.assertGreater(len(result), 0)

--- a/test/test_video_writer_extended.py
+++ b/test/test_video_writer_extended.py
@@ -1,0 +1,86 @@
+"""Tests for bencher/video_writer.py — extended coverage."""
+
+import unittest
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from bencher.video_writer import VideoWriter
+
+
+class TestVideoWriterCreateLabel(unittest.TestCase):
+    def test_create_label_default_width(self):
+        img = VideoWriter.create_label("hello")
+        self.assertIsInstance(img, Image.Image)
+        self.assertEqual(img.size[0], len("hello") * 10)
+        self.assertEqual(img.size[1], 16)
+
+    def test_create_label_custom_size(self):
+        img = VideoWriter.create_label("test", width=200, height=32)
+        self.assertIsInstance(img, Image.Image)
+        self.assertEqual(img.size, (200, 32))
+
+
+class TestVideoWriterLabelImage(unittest.TestCase):
+    def test_label_image(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a simple test image
+            img = Image.new("RGB", (100, 80), color=(0, 255, 0))
+            path = Path(tmpdir) / "test_img.png"
+            img.save(path)
+
+            result = VideoWriter.label_image(path, "Test Label")
+            self.assertIsInstance(result, Image.Image)
+            # Height should be original height + padding (default=20)
+            self.assertEqual(result.size[0], 100)
+            self.assertEqual(result.size[1], 80 + 20)
+
+
+class TestVideoWriterConvertAndExtract(unittest.TestCase):
+    def _create_test_video(self, tmpdir):
+        """Create a simple test video with solid frames."""
+        vw = VideoWriter("test_vid")
+        video_path = Path(tmpdir) / "test_video.mp4"
+        vw.filename = str(video_path)
+        # Create 10 frames of solid colors
+        for i in range(10):
+            frame = np.full((64, 64, 3), fill_value=i * 25, dtype=np.uint8)
+            vw.append(frame)
+        vw.write()
+        return str(video_path)
+
+    def test_write_and_extract_frame(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = self._create_test_video(tmpdir)
+            self.assertTrue(Path(video_path).exists())
+
+            # Extract a frame
+            output = VideoWriter.extract_frame(video_path, time=0.0)
+            self.assertTrue(Path(output).exists())
+            self.assertTrue(output.endswith(".png"))
+
+    def test_extract_frame_default_time(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = self._create_test_video(tmpdir)
+
+            # Extract frame with default time (last frame)
+            output = VideoWriter.extract_frame(video_path)
+            self.assertTrue(Path(output).exists())
+
+    def test_extract_frame_custom_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = self._create_test_video(tmpdir)
+            output_path = Path(tmpdir) / "custom_frame.png"
+
+            output = VideoWriter.extract_frame(video_path, time=0.0, output_path=str(output_path))
+            self.assertEqual(output, output_path.as_posix())
+            self.assertTrue(output_path.exists())
+
+    def test_convert_to_compatible_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            video_path = self._create_test_video(tmpdir)
+            new_path = VideoWriter.convert_to_compatible_format(video_path)
+            self.assertTrue(Path(new_path).exists())
+            self.assertIn("_fixed", new_path)

--- a/test/test_video_writer_extended.py
+++ b/test/test_video_writer_extended.py
@@ -78,6 +78,10 @@ class TestVideoWriterConvertAndExtract(unittest.TestCase):
             self.assertEqual(output, output_path.as_posix())
             self.assertTrue(output_path.exists())
 
+    def test_extract_frame_nonexistent_source(self):
+        with self.assertRaises(OSError):
+            VideoWriter.extract_frame("/nonexistent/path/video.mp4", time=0.0)
+
     def test_convert_to_compatible_format(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             video_path = self._create_test_video(tmpdir)


### PR DESCRIPTION
## Summary
- Add 10 new test files covering previously untested modules: `holoview_result`, `heatmap_result`, `line_result`, `surface_result`, `optuna_conversions`, `optuna_result`, `flask_server`, `video_writer`, `video_controls`, and `explorer_result`
- Extend existing `test_bench_result_base.py` with 30 new tests covering optimal value extraction, aggregation (sum/mean/max/min/median), dataset conversion, plot titles, and plot sizing
- Extend existing `test_bench_runner.py` with 10 new tests covering grouped runs, V2 signatures, progressive levels, report merging, callable naming, method chaining, and shutdown

## Test plan
- [ ] All 135 new tests pass locally with `pixi run test`
- [ ] No lint errors with `pixi run lint`
- [ ] CI pipeline passes
- [ ] Coverage improvement verified across targeted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand automated test coverage for bench result handling, visualization outputs, Optuna integration, and runtime utilities.

Tests:
- Add extensive tests for BenchResultBase optimal value extraction, dataset conversions, plot titling, and plot sizing.
- Extend BenchRunner tests to cover grouped execution, V2-style benchmarks, progressive levels, report merging, callable naming, method chaining, error cases, and shutdown behavior.
- Introduce new tests for Holoview-based result types (line, heatmap, surface, and general HoloviewResult) across 1D/2D sweeps, tap behavior, and container selection.
- Add tests for Optuna result conversions, best-trial extraction, and Optuna plot collection with varying inputs and repeats.
- Add tests for Flask file server creation and threaded execution, explorer-style result plotting, video controls UI, and video writer labeling, extraction, and format conversion.