### PR TITLE
Add xrotation=30 to scatter, line, and curve plots

### DIFF
--- a/bencher/results/holoview_results/bar_result.py
+++ b/bencher/results/holoview_results/bar_result.py
@@ -132,9 +132,7 @@ class BarResult(HoloviewResult):
                 plot = da.hvplot.line(
                     x="over_time", y=da.name, title=title, widget_location="bottom", **kwargs
                 )
-                if hasattr(plot, "opts"):
-                    plot = plot.opts(**opts_kwargs)
-                return plot
+                return self._apply_opts(plot, **opts_kwargs)
             # 0D + single time point: nothing meaningful to bar-chart.
             return None
 
@@ -144,14 +142,11 @@ class BarResult(HoloviewResult):
             for t in da.coords["over_time"].values:
                 da_t = da.sel(over_time=t)
                 plot_t = da_t.hvplot.bar(x=x_dim, y=da.name, by=by, title=title, **kwargs)
-                if hasattr(plot_t, "opts"):
-                    plot_t = plot_t.opts(**opts_kwargs)
+                plot_t = self._apply_opts(plot_t, **opts_kwargs)
                 holomap[t] = plot_t
             return self._holomap_with_slider_bottom(holomap)
 
         plot = da.hvplot.bar(
             x=x_dim, y=da.name, by=by, title=title, widget_location="bottom", **kwargs
         )
-        if hasattr(plot, "opts"):
-            plot = plot.opts(**opts_kwargs)
-        return plot
+        return self._apply_opts(plot, **opts_kwargs)

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -94,7 +94,7 @@ class CurveResult(HoloviewResult):
 
         hvds = hv.Dataset(dataset)
         pt = hv.Overlay()
-        pt *= hvds.to(hv.Curve, vdims=var, label=var).opts(title=title, **kwargs)
+        pt *= hvds.to(hv.Curve, vdims=var, label=var).opts(title=title, xrotation=30, **kwargs)
         if std_var in dataset.data_vars:
             pt *= hvds.to(hv.Spread, vdims=[var, std_var])
         pt = pt.opts(legend_position="right")

--- a/bencher/results/holoview_results/heatmap_result.py
+++ b/bencher/results/holoview_results/heatmap_result.py
@@ -157,17 +157,14 @@ class HeatmapResult(HoloviewResult):
                     plot_t = da_t.hvplot.heatmap(
                         x=x, y=y, C=C, cmap="plasma", title=title, **kwargs
                     )
-                    if hasattr(plot_t, "opts"):
-                        plot_t = plot_t.opts(xrotation=30)
+                    plot_t = self._apply_opts(plot_t, xrotation=30)
                     holomap[t] = plot_t
                 return self._holomap_with_slider_bottom(holomap)
 
             plot = dataset.hvplot.heatmap(
                 x=x, y=y, C=C, cmap="plasma", title=title, widget_location="bottom", **kwargs
             )
-            if hasattr(plot, "opts"):
-                plot = plot.opts(xrotation=30)
-            return plot
+            return self._apply_opts(plot, xrotation=30)
         return None
 
     def to_heatmap_container_tap_ds(

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -132,6 +132,19 @@ class HoloviewResult(VideoResult):
         )
 
     @staticmethod
+    def _apply_opts(plot, **opts_kwargs):
+        """Apply .opts() to a plot, handling panel.pane.HoloViews wrappers.
+
+        When hvplot is called with widget_location, it returns a panel pane
+        whose underlying .object is the actual holoviews element.
+        """
+        if hasattr(plot, "opts"):
+            return plot.opts(**opts_kwargs)
+        if hasattr(plot, "object") and hasattr(plot.object, "opts"):
+            plot.object = plot.object.opts(**opts_kwargs)
+        return plot
+
+    @staticmethod
     def _over_time_kdims() -> list:
         """Return the kdim list for over_time HoloMaps."""
         return ["over_time"]

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -145,13 +145,13 @@ class LineResult(HoloviewResult):
             holomap = hv.HoloMap(kdims=self._over_time_kdims())
             for t in da_plot.coords["over_time"].values:
                 da_t = da_plot.sel(over_time=t)
-                plot_t = da_t.hvplot.line(x=x, by=by, title=title, **kwargs)
+                plot_t = da_t.hvplot.line(x=x, by=by, title=title, xrotation=30, **kwargs)
                 holomap[t] = plot_t
             return self._holomap_with_slider_bottom(holomap)
 
         time_widget_args = self.time_widget(title)
         return da_plot.hvplot.line(
-            x=x, by=by, widget_location="bottom", **time_widget_args, **kwargs
+            x=x, by=by, widget_location="bottom", xrotation=30, **time_widget_args, **kwargs
         )
 
     def to_line_tap_ds(

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -145,14 +145,16 @@ class LineResult(HoloviewResult):
             holomap = hv.HoloMap(kdims=self._over_time_kdims())
             for t in da_plot.coords["over_time"].values:
                 da_t = da_plot.sel(over_time=t)
-                plot_t = da_t.hvplot.line(x=x, by=by, title=title, xrotation=30, **kwargs)
+                plot_t = da_t.hvplot.line(x=x, by=by, title=title, **kwargs)
+                plot_t = self._apply_opts(plot_t, xrotation=30)
                 holomap[t] = plot_t
             return self._holomap_with_slider_bottom(holomap)
 
         time_widget_args = self.time_widget(title)
-        return da_plot.hvplot.line(
-            x=x, by=by, widget_location="bottom", xrotation=30, **time_widget_args, **kwargs
+        plot = da_plot.hvplot.line(
+            x=x, by=by, widget_location="bottom", **time_widget_args, **kwargs
         )
+        return self._apply_opts(plot, xrotation=30)
 
     def to_line_tap_ds(
         self,

--- a/bencher/results/holoview_results/scatter_result.py
+++ b/bencher/results/holoview_results/scatter_result.py
@@ -66,14 +66,14 @@ class ScatterResult(HoloviewResult):
             if self.plt_cnt_cfg.cat_cnt > 1:
                 by = [v.name for v in self.bench_cfg.input_vars[1:]]
                 subplots = False
-            return hv_ds.data.hvplot.scatter(
+            plot = hv_ds.data.hvplot.scatter(
                 by=by,
                 subplots=subplots,
                 widget_location="bottom",
                 title=self.to_plot_title(),
-                xrotation=30,
                 **kwargs,
             )
+            return self._apply_opts(plot, xrotation=30)
         return match_res.to_panel(**kwargs)
 
     # def to_scatter_jitter(

--- a/bencher/results/holoview_results/scatter_result.py
+++ b/bencher/results/holoview_results/scatter_result.py
@@ -71,6 +71,7 @@ class ScatterResult(HoloviewResult):
                 subplots=subplots,
                 widget_location="bottom",
                 title=self.to_plot_title(),
+                xrotation=30,
                 **kwargs,
             )
         return match_res.to_panel(**kwargs)


### PR DESCRIPTION
## Summary
- Add `xrotation=30` to scatter, line, and curve plot types that were missing it
- Fix `xrotation=30` not being applied in bar and heatmap plots when `widget_location` is used — `hvplot` returns a `panel.pane.HoloViews` wrapper in that case, which lacks `.opts()`, so the existing `hasattr` guard silently skipped the rotation
- Add `_apply_opts()` helper to `HoloviewResult` that unwraps the panel pane to reach the underlying holoviews object, ensuring `.opts()` always works

## Test plan
- [x] `pixi run ci` passes (579 tests, 0 failures)
- [ ] Visual inspection of bar/scatter/line/curve example outputs confirms rotated labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)