### PR TITLE
Add agg_over_dims option to BenchCfg

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -459,10 +459,10 @@ class BenchCfg(BenchRunCfg):
         doc="Dimensions to aggregate over. When set, an additional aggregated result "
         "(e.g. CurveResult with mean ± std) is automatically appended to the report.",
     )
-    agg_fn = param.String(
+    agg_fn = param.ObjectSelector(
         default="mean",
-        doc="Aggregation function to use when agg_over_dims is set. "
-        "One of: mean, sum, max, min, median.",
+        objects=["mean", "sum", "max", "min", "median"],
+        doc="Aggregation function to use when agg_over_dims is set.",
     )
 
     def __init__(self, **params: Any) -> None:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -454,6 +454,17 @@ class BenchCfg(BenchRunCfg):
         doc="A callable that takes a BenchResult and returns panel representation of the results",
     )
 
+    agg_over_dims = param.List(
+        default=None,
+        doc="Dimensions to aggregate over. When set, an additional aggregated result "
+        "(e.g. CurveResult with mean ± std) is automatically appended to the report.",
+    )
+    agg_fn = param.String(
+        default="mean",
+        doc="Aggregation function to use when agg_over_dims is set. "
+        "One of: mean, sum, max, min, median.",
+    )
+
     def __init__(self, **params: Any) -> None:
         """Initialize a BenchCfg with the given parameters.
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -609,16 +609,16 @@ class Bench(BenchPlotServer):
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
 
-        if bench_cfg.agg_over_dims:
-            from bencher.results.holoview_results.curve_result import CurveResult
+            if bench_cfg.agg_over_dims:
+                from bencher.results.holoview_results.curve_result import CurveResult
 
-            self.report.append(
-                bench_res.to(
-                    CurveResult,
-                    agg_over_dims=bench_cfg.agg_over_dims,
-                    agg_fn=bench_cfg.agg_fn,
+                self.report.append(
+                    bench_res.to(
+                        CurveResult,
+                        agg_over_dims=bench_cfg.agg_over_dims,
+                        agg_fn=bench_cfg.agg_fn,
+                    )
                 )
-            )
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -251,6 +251,8 @@ class Bench(BenchPlotServer):
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
+        agg_over_dims: list[str] | None = None,
+        agg_fn: str = "mean",
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
 
@@ -413,9 +415,7 @@ class Bench(BenchPlotServer):
                 result_vars_only.append(i)
 
         if post_description is None:
-            post_description = (
-                "## Results Description\nPlease set post_description to explain these results"
-            )
+            post_description = ""
 
         if plot_callbacks is None:
             if self.plot_callbacks is not None and len(self.plot_callbacks) == 0:
@@ -437,6 +437,8 @@ class Bench(BenchPlotServer):
             pass_repeat=pass_repeat,
             tag=run_cfg.run_tag + tag,
             plot_callbacks=plot_callbacks,
+            agg_over_dims=agg_over_dims,
+            agg_fn=agg_fn,
         )
         return self.run_sweep(bench_cfg, run_cfg, time_src, sample_order)
 
@@ -606,6 +608,17 @@ class Bench(BenchPlotServer):
 
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
+
+        if bench_cfg.agg_over_dims:
+            from bencher.results.holoview_results.curve_result import CurveResult
+
+            self.report.append(
+                bench_res.to(
+                    CurveResult,
+                    agg_over_dims=bench_cfg.agg_over_dims,
+                    agg_fn=bench_cfg.agg_fn,
+                )
+            )
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/example/example_agg_over_time.py
+++ b/bencher/example/example_agg_over_time.py
@@ -30,22 +30,15 @@ def example_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
         benchable._time_offset = offset  # pylint: disable=protected-access
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = False
+        run_cfg.auto_plot = i == len(time_offsets) - 1
         bench.plot_sweep(
             "agg_over_time",
             input_vars=["float1", "float2"],
             result_vars=["distance"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
+            agg_over_dims=["float1", "float2"],
         )
-
-    res = bench.results[-1]
-
-    # 1) Raw 2D heatmap with over_time slider
-    bench.report.append(res.to(bch.HeatmapResult))
-
-    # 2) Aggregated: collapse both sweep dims to scalar mean +/- std over time
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["float1", "float2"]))
 
     return bench
 

--- a/bencher/example/example_regression.py
+++ b/bencher/example/example_regression.py
@@ -66,26 +66,18 @@ def example_regression(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
         benchable._time_offset = offset  # pylint: disable=protected-access
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = False
+        run_cfg.auto_plot = i == len(releases) - 1
         bench.plot_sweep(
             "regression_detection",
             input_vars=["connections", "payload_kb"],
             result_vars=["response_time", "throughput"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
+            agg_over_dims=["connections", "payload_kb"],
         )
 
+    # Regression report
     res = bench.results[-1]
-
-    # 1) 2D heatmap with over_time slider — scrub through each release snapshot
-    bench.report.append(res.to(bch.HeatmapResult))
-
-    # 2) Aggregated curve: collapse sweep dims to scalar mean +/- std over time.
-    #    This trend line makes it visually clear when the metric goes outside
-    #    the bounds established by the early stable releases.
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["connections", "payload_kb"]))
-
-    # 3) Regression report
     report = res.regression_report
     if report is not None:
         print("\n" + report.summary())

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -45,11 +45,12 @@ def example_advanced_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bc
     bench = benchable.to_bench(run_cfg)
 
     base_time = datetime(2024, 1, 1)
-    for i, offset in enumerate([0.0, 1.0, 2.0, 3.0, 4.0]):
+    time_offsets = [0.0, 1.0, 2.0, 3.0, 4.0]
+    for i, offset in enumerate(time_offsets):
         benchable._time_offset = offset
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = i == len([0.0, 1.0, 2.0, 3.0, 4.0]) - 1
+        run_cfg.auto_plot = i == len(time_offsets) - 1
         bench.plot_sweep(
             "thermal_plate",
             input_vars=["x", "y"],

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -49,22 +49,15 @@ def example_advanced_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bc
         benchable._time_offset = offset
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = False
+        run_cfg.auto_plot = i == len([0.0, 1.0, 2.0, 3.0, 4.0]) - 1
         bench.plot_sweep(
             "thermal_plate",
             input_vars=["x", "y"],
             result_vars=["temperature"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
+            agg_over_dims=["x", "y"],
         )
-
-    res = bench.results[-1]
-
-    # 1) Raw 2D heatmap with over_time slider
-    bench.report.append(res.to(bch.HeatmapResult))
-
-    # 2) Aggregate the full 2D grid down to a scalar: mean +/- std at each time point
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["x", "y"]))
 
     return bench
 

--- a/bencher/example/generated/regression/regression_percentage.py
+++ b/bencher/example/generated/regression/regression_percentage.py
@@ -46,24 +46,18 @@ def example_regression_percentage(run_cfg: bch.BenchRunCfg | None = None) -> bch
         benchable._time_offset = offset
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = False
+        run_cfg.auto_plot = i == len(releases) - 1
         bench.plot_sweep(
             "regression_detection",
             input_vars=["connections", "payload_kb"],
             result_vars=["response_time", "throughput"],
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
+            agg_over_dims=["connections", "payload_kb"],
         )
 
-    res = bench.results[-1]
-
-    # 2D heatmap with over_time slider
-    bench.report.append(res.to(bch.HeatmapResult))
-
-    # Aggregated curve: collapse sweep dims to scalar mean +/- std over time
-    bench.report.append(res.to(bch.CurveResult, agg_over_dims=["connections", "payload_kb"]))
-
     # Regression report
+    res = bench.results[-1]
     report = res.regression_report
     if report is not None:
         print("\n" + report.summary())

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -312,26 +312,20 @@ benchable = ThermalPlate()
 bench = benchable.to_bench(run_cfg)
 
 base_time = datetime(2024, 1, 1)
-for i, offset in enumerate([0.0, 1.0, 2.0, 3.0, 4.0]):
+time_offsets = [0.0, 1.0, 2.0, 3.0, 4.0]
+for i, offset in enumerate(time_offsets):
     benchable._time_offset = offset
     run_cfg.clear_cache = True
     run_cfg.clear_history = i == 0
-    run_cfg.auto_plot = False
+    run_cfg.auto_plot = i == len(time_offsets) - 1
     bench.plot_sweep(
         "thermal_plate",
         input_vars=["x", "y"],
         result_vars=["temperature"],
         run_cfg=run_cfg,
         time_src=base_time + timedelta(seconds=i),
+        agg_over_dims=["x", "y"],
     )
-
-res = bench.results[-1]
-
-# 1) Raw 2D heatmap with over_time slider
-bench.report.append(res.to(bch.HeatmapResult))
-
-# 2) Aggregate the full 2D grid down to a scalar: mean +/- std at each time point
-bench.report.append(res.to(bch.CurveResult, agg_over_dims=["x", "y"]))
 """
         self.generate_example(
             title="Aggregate Over Time — 2D sweep to scalar curve with error bounds",

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -70,26 +70,18 @@ for i, offset in enumerate(releases):
     benchable._time_offset = offset
     run_cfg.clear_cache = True
     run_cfg.clear_history = i == 0
-    run_cfg.auto_plot = False
+    run_cfg.auto_plot = i == len(releases) - 1
     bench.plot_sweep(
         "regression_detection",
         input_vars=["connections", "payload_kb"],
         result_vars=["response_time", "throughput"],
         run_cfg=run_cfg,
         time_src=base_time + timedelta(seconds=i),
+        agg_over_dims=["connections", "payload_kb"],
     )
 
-res = bench.results[-1]
-
-# 2D heatmap with over_time slider
-bench.report.append(res.to(bch.HeatmapResult))
-
-# Aggregated curve: collapse sweep dims to scalar mean +/- std over time
-bench.report.append(
-    res.to(bch.CurveResult, agg_over_dims=["connections", "payload_kb"])
-)
-
 # Regression report
+res = bench.results[-1]
 report = res.regression_report
 if report is not None:
     print("\\n" + report.summary())


### PR DESCRIPTION
## Summary
- Add `agg_over_dims` and `agg_fn` parameters to `BenchCfg` and `plot_sweep()` so aggregation can be configured declaratively instead of requiring manual `res.to()` calls
- When `agg_over_dims` is set, an aggregated `CurveResult` (mean ± std) is automatically appended to the report after the sweep completes
- Remove the default "describe your results here" `post_description` — it now defaults to empty string
- Update `example_agg_over_time` and its generated variant to use the new config-driven aggregation

## Test plan
- [x] `pixi run lint` passes (10/10 pylint, ruff clean)
- [x] `pixi run test` passes (787 passed, 1 pre-existing flask failure)
- [x] `python bencher/example/example_agg_over_time.py` runs successfully with aggregated curve output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable aggregation options to benchmark sweeps and automatically append aggregated results to reports.

New Features:
- Allow configuring dimension aggregation in BenchCfg and plot_sweep via agg_over_dims and agg_fn parameters, including support for multiple aggregation functions.

Enhancements:
- Automatically append an aggregated CurveResult to the report when aggregation dimensions are configured in BenchCfg.
- Remove the default placeholder post_description so reports no longer include boilerplate text by default.
- Update the aggregation-over-time example and its generated variant to rely on the new configuration-driven aggregation behavior instead of manual result transformations.