### PR TITLE
Add BandResult with percentile bands and scatter overlay

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -57,6 +57,7 @@ from bencher.results.holoview_results.bar_result import BarResult
 from bencher.results.holoview_results.line_result import LineResult
 from bencher.results.holoview_results.curve_result import CurveResult
 from bencher.results.holoview_results.heatmap_result import HeatmapResult
+from bencher.results.holoview_results.band_result import BandResult
 from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
 from bencher.results.holoview_results.table_result import TableResult

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -454,6 +454,13 @@ class BenchCfg(BenchRunCfg):
         doc="A callable that takes a BenchResult and returns panel representation of the results",
     )
 
+    agg_over_dims = param.List(
+        default=None,
+        doc="Dimension names to aggregate over when auto-appending aggregated views. "
+        "When set, run_sweep will automatically append CurveResult (mean +/- std) "
+        "and BandResult (percentile bands) with these dims collapsed.",
+    )
+
     def __init__(self, **params: Any) -> None:
         """Initialize a BenchCfg with the given parameters.
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -251,6 +251,7 @@ class Bench(BenchPlotServer):
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
+        agg_over_dims: list[str] | None = None,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
 
@@ -437,6 +438,7 @@ class Bench(BenchPlotServer):
             pass_repeat=pass_repeat,
             tag=run_cfg.run_tag + tag,
             plot_callbacks=plot_callbacks,
+            agg_over_dims=agg_over_dims,
         )
         return self.run_sweep(bench_cfg, run_cfg, time_src, sample_order)
 
@@ -606,6 +608,14 @@ class Bench(BenchPlotServer):
 
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
+
+        # Auto-append aggregated views (CurveResult + BandResult) when agg_over_dims is set
+        if bench_cfg.auto_plot and bench_cfg.agg_over_dims:
+            from bencher.results.holoview_results.curve_result import CurveResult
+            from bencher.results.holoview_results.band_result import BandResult
+
+            self.report.append(bench_res.to(CurveResult, agg_over_dims=bench_cfg.agg_over_dims))
+            self.report.append(bench_res.to(BandResult, agg_over_dims=bench_cfg.agg_over_dims))
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/example/example_agg_over_time.py
+++ b/bencher/example/example_agg_over_time.py
@@ -1,9 +1,14 @@
-"""Demo: aggregate a 2D sweep down to a scalar curve over time with error bounds.
+"""Demo: aggregate a 2D sweep to visualise distribution evolution over time.
 
-A 2D parameter sweep (float1 x float2) is run at each time snapshot.  The report
-first shows the raw 2D heatmap with an over_time slider, then shows both sweep
-dimensions collapsed via ``agg_over_dims`` into a single mean +/- std per time
-point — a curve showing how the plate-wide average evolves over time.
+A 2D parameter sweep (float1 x float2) is run at each time snapshot.  Early on
+the spatial variation is uniform (tight distribution).  Over time a hot spot
+develops at one corner, making the distribution increasingly skewed — the mean
+barely moves but the spread and tail grow dramatically.
+
+Three views are shown:
+1. Raw 2D heatmap with an over_time slider — explore each snapshot.
+2. CurveResult (mean +/- std) — the classic scalar summary over time.
+3. BandResult (percentile bands) — reveals the growing skew that mean +/- std hides.
 
 Run:
     python bencher/example/example_agg_over_time.py
@@ -46,6 +51,10 @@ def example_agg_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
     # 2) Aggregated: collapse both sweep dims to scalar mean +/- std over time
     bench.report.append(res.to(bch.CurveResult, agg_over_dims=["float1", "float2"]))
+
+    # 3) Percentile bands: shows full distribution shape over time — reveals
+    #    skew and tail behaviour that mean +/- std cannot capture
+    bench.report.append(res.to(bch.BandResult, agg_over_dims=["float1", "float2"]))
 
     return bench
 

--- a/bencher/example/example_over_time.py
+++ b/bencher/example/example_over_time.py
@@ -18,6 +18,8 @@ def _run_over_time(bench, benchable, run_cfg, input_vars, title, result_vars=Non
 
     All intermediate snapshots disable plotting. Only the final result (which
     has the full accumulated history) is manually added to the report.
+    When input_vars are present, aggregated CurveResult and BandResult views
+    are automatically appended to show how the distribution evolves over time.
 
     Explicit time_src values are passed to simulate realistic usage where
     plot_sweep calls are naturally spaced apart in time.
@@ -38,7 +40,15 @@ def _run_over_time(bench, benchable, run_cfg, input_vars, title, result_vars=Non
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
         )
-    bench.report.append_result(bench.results[-1])
+
+    res = bench.results[-1]
+    bench.report.append_result(res)
+
+    # Auto-aggregate: collapse sweep dims to show distribution evolution over time
+    if input_vars:
+        dim_names = input_vars if isinstance(input_vars[0], str) else [v.name for v in input_vars]
+        bench.report.append(res.to(bch.CurveResult, agg_over_dims=dim_names))
+        bench.report.append(res.to(bch.BandResult, agg_over_dims=dim_names))
 
 
 def example_over_time_0D(run_cfg: bch.BenchRunCfg | None = None, report=None) -> bch.Bench:

--- a/bencher/example/example_regression.py
+++ b/bencher/example/example_regression.py
@@ -85,7 +85,10 @@ def example_regression(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
     #    the bounds established by the early stable releases.
     bench.report.append(res.to(bch.CurveResult, agg_over_dims=["connections", "payload_kb"]))
 
-    # 3) Regression report
+    # 3) Percentile bands: the outlier tail reveals regression before the mean does
+    bench.report.append(res.to(bch.BandResult, agg_over_dims=["connections", "payload_kb"]))
+
+    # 4) Regression report
     report = res.regression_report
     if report is not None:
         print("\n" + report.summary())

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -20,6 +20,7 @@ from bencher.results.holoview_results.distribution_result.scatter_jitter_result 
 from bencher.results.holoview_results.bar_result import BarResult
 from bencher.results.holoview_results.line_result import LineResult
 from bencher.results.holoview_results.curve_result import CurveResult
+from bencher.results.holoview_results.band_result import BandResult
 from bencher.results.holoview_results.heatmap_result import HeatmapResult
 from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.histogram_result import HistogramResult
@@ -38,6 +39,7 @@ class BenchResult(
     BarResult,
     HeatmapResult,
     CurveResult,
+    BandResult,
     SurfaceResult,
     HoloviewResult,
     HistogramResult,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -181,17 +181,16 @@ class BenchResultBase:
         """
 
         if reduce == ReduceType.NONE:
-            kdims = [i.name for i in self.bench_cfg.all_vars]
-            return hv.Dataset(
-                self.to_dataset(
-                    reduce,
-                    result_var=result_var,
-                    level=level,
-                    agg_over_dims=agg_over_dims,
-                    agg_fn=agg_fn,
-                ),
-                kdims=kdims,
+            ds_out = self.to_dataset(
+                reduce,
+                result_var=result_var,
+                level=level,
+                agg_over_dims=agg_over_dims,
+                agg_fn=agg_fn,
             )
+            # Filter kdims to only those that survived aggregation
+            kdims = [i.name for i in self.bench_cfg.all_vars if i.name in ds_out.dims]
+            return hv.Dataset(ds_out, kdims=kdims)
         return hv.Dataset(
             self.to_dataset(
                 reduce,

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -84,7 +84,11 @@ class BandResult(HoloviewResult):
         """Build percentile bands with time on x-axis."""
         da = dataset[var]
 
-        # Determine which dims to flatten (everything except over_time)
+        # Determine which dims to collapse into the sample pool.
+        # By default every dim except the x-axis (over_time) becomes a sample.
+        # When agg_over_dims is given, only those dims (plus the implicit repeat
+        # dim, which always represents independent trials) are collapsed, leaving
+        # the remaining dims as separate facets/groups upstream.
         sample_dims = [d for d in da.dims if d != "over_time"]
         if agg_over_dims:
             sample_dims = [d for d in sample_dims if d in agg_over_dims or d == "repeat"]
@@ -102,13 +106,21 @@ class BandResult(HoloviewResult):
         p75 = np.nanpercentile(values, 75, axis=1)
         p90 = np.nanpercentile(values, 90, axis=1)
 
-        # Build scatter data: repeat each time coord for every sample
-        n_time, n_samples = values.shape
-        scatter_x = np.repeat(time_coords, n_samples)
-        scatter_y = values.ravel()
+        scatter_x, scatter_y = self._build_scatter_data(time_coords, values, **kwargs)
 
         return self._build_band_overlay(
-            time_coords, p10, p25, p50, p75, p90, scatter_x, scatter_y, var, title, **kwargs
+            time_coords,
+            p10,
+            p25,
+            p50,
+            p75,
+            p90,
+            scatter_x,
+            scatter_y,
+            var,
+            title,
+            x_dim="over_time",
+            **kwargs,
         )
 
     def _band_static(
@@ -123,12 +135,12 @@ class BandResult(HoloviewResult):
         da = dataset[var]
         all_dims = list(da.dims)
 
-        # Figure out which dim is the x-axis (not aggregated, not repeat)
+        # The x-axis is the first dimension that is neither being aggregated
+        # nor the repeat dim (which always represents independent trials).
         agg_set = set(agg_over_dims) if agg_over_dims else set()
         candidate_x = [d for d in all_dims if d not in agg_set and d != "repeat"]
 
         if not candidate_x:
-            # All dims aggregated and no time — can't make a meaningful band plot
             return None
 
         x_dim = candidate_x[0]
@@ -146,14 +158,59 @@ class BandResult(HoloviewResult):
         p75 = np.nanpercentile(values, 75, axis=1)
         p90 = np.nanpercentile(values, 90, axis=1)
 
-        # Build scatter data: repeat each x coord for every sample
-        n_x, n_samples = values.shape
-        scatter_x = np.repeat(x_coords, n_samples)
-        scatter_y = values.ravel()
+        scatter_x, scatter_y = self._build_scatter_data(x_coords, values, **kwargs)
 
         return self._build_band_overlay(
-            x_coords, p10, p25, p50, p75, p90, scatter_x, scatter_y, var, title, **kwargs
+            x_coords,
+            p10,
+            p25,
+            p50,
+            p75,
+            p90,
+            scatter_x,
+            scatter_y,
+            var,
+            title,
+            x_dim=x_dim,
+            **kwargs,
         )
+
+    @staticmethod
+    def _build_scatter_data(
+        x_coords,
+        values,
+        **kwargs,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Build scatter arrays from the 2-D values grid, with optional downsampling.
+
+        Args:
+            x_coords: 1-D array of x-axis coordinates.
+            values: 2-D array of shape (n_x, n_samples).
+            **kwargs: Optional ``max_scatter_points`` (int, default 50_000) to cap
+                the number of scatter points, and ``enable_scatter`` (bool, default
+                True) to disable the scatter layer entirely.
+
+        Returns:
+            (scatter_x, scatter_y) arrays, or (None, None) when scatter is disabled.
+        """
+        max_scatter_points: int = kwargs.pop("max_scatter_points", 50_000)
+        enable_scatter: bool = kwargs.pop("enable_scatter", True)
+
+        n_x, n_samples = values.shape
+        total_points = n_x * n_samples
+
+        if not enable_scatter or total_points == 0:
+            return None, None
+
+        full_x = np.repeat(x_coords, n_samples)
+        full_y = values.ravel()
+
+        if total_points <= max_scatter_points:
+            return full_x, full_y
+
+        # Uniform downsampling to keep plots responsive on large sweeps
+        idx = np.linspace(0, total_points - 1, max_scatter_points, dtype=int)
+        return full_x[idx], full_y[idx]
 
     @staticmethod
     def _build_band_overlay(
@@ -167,13 +224,19 @@ class BandResult(HoloviewResult):
         scatter_y,
         var: str,
         title: str,
-        **kwargs,
+        x_dim: str = "x",
+        **_kwargs,
     ) -> hv.Overlay:
-        """Construct the overlay of Area bands + median Curve + scatter points."""
+        """Construct the overlay of Area bands + median Curve + scatter points.
+
+        Args:
+            x_dim: Name of the x-axis dimension, used as the kdim label so that
+                axis labels reflect the original coordinate (e.g. ``over_time``).
+        """
         # Outer band: 10th-90th percentile
         band_outer = hv.Area(
             (x_coords, p10, p90),
-            kdims=["x"],
+            kdims=[x_dim],
             vdims=["p10", "p90"],
             label="10th\u201390th pctl",
         ).opts(alpha=0.2, color="steelblue", line_alpha=0)
@@ -181,7 +244,7 @@ class BandResult(HoloviewResult):
         # Inner band: 25th-75th percentile
         band_inner = hv.Area(
             (x_coords, p25, p75),
-            kdims=["x"],
+            kdims=[x_dim],
             vdims=["p25", "p75"],
             label="25th\u201375th pctl",
         ).opts(alpha=0.4, color="steelblue", line_alpha=0)
@@ -189,20 +252,23 @@ class BandResult(HoloviewResult):
         # Median line
         median_line = hv.Curve(
             (x_coords, p50),
-            kdims=["x"],
+            kdims=[x_dim],
             vdims=[var],
             label="median",
         ).opts(color="steelblue", line_width=2)
 
-        # Scatter overlay: individual data points (drop NaNs)
-        mask = ~np.isnan(scatter_y)
-        scatter = hv.Scatter(
-            (scatter_x[mask], scatter_y[mask]),
-            kdims=["x"],
-            vdims=[var],
-            label="samples",
-        ).opts(color="grey", alpha=0.3, size=3)
+        overlay = band_outer * band_inner * median_line
 
-        overlay = band_outer * band_inner * median_line * scatter
+        # Scatter overlay: individual data points (skip when disabled)
+        if scatter_x is not None and scatter_y is not None:
+            mask = ~np.isnan(scatter_y)
+            scatter = hv.Scatter(
+                (scatter_x[mask], scatter_y[mask]),
+                kdims=[x_dim],
+                vdims=[var],
+                label="samples",
+            ).opts(color="grey", alpha=0.3, size=3)
+            overlay = overlay * scatter
+
         overlay = overlay.opts(title=title, xrotation=30, legend_position="right")
         return overlay

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import holoviews as hv
+import numpy as np
+from param import Parameter
+import xarray as xr
+
+from bencher.results.bench_result_base import ReduceType
+from bencher.plotting.plot_filter import VarRange
+from bencher.variables.results import ResultVar, ResultBool
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+
+
+class BandResult(HoloviewResult):
+    """Percentile band plot showing distribution spread over a continuous axis.
+
+    Displays nested shaded bands (e.g. 10th-90th and 25th-75th percentiles)
+    with a median line and individual scatter points, giving a richer view of
+    the distribution than mean +/- std.  Particularly useful with
+    ``agg_over_dims`` to show how a high-dimensional sweep's distribution
+    evolves over time.
+    """
+
+    def to_plot(
+        self, result_var: Parameter | None = None, override: bool = True, **kwargs
+    ) -> hv.Overlay | None:
+        return self.to_band(result_var=result_var, override=override, **kwargs)
+
+    def to_band(
+        self,
+        result_var: Parameter | None = None,
+        override: bool = True,
+        **kwargs,
+    ):
+        # Extract agg_over_dims so filter() doesn't pre-aggregate the dataset.
+        # BandResult computes its own percentiles from the raw data.
+        band_agg_dims = kwargs.pop("agg_over_dims", None)
+        kwargs.pop("agg_fn", None)
+        return self.filter(
+            self.to_band_ds,
+            float_range=VarRange(0, None),
+            cat_range=VarRange(0, None),
+            repeats_range=VarRange(1, None),
+            input_range=VarRange(0, None),
+            reduce=ReduceType.NONE,
+            target_dimension=None,
+            result_var=result_var,
+            result_types=(ResultVar, ResultBool),
+            override=override,
+            agg_over_dims=None,
+            band_agg_dims=band_agg_dims,
+            **kwargs,
+        )
+
+    def to_band_ds(self, dataset: xr.Dataset, result_var: Parameter, **kwargs) -> hv.Overlay | None:
+        """Create a percentile band plot from the provided dataset.
+
+        Flattens all dimensions except the continuous axis (typically over_time)
+        into a sample pool and computes percentiles across those samples.
+        """
+        var = result_var.name
+
+        # band_agg_dims is passed through from to_band to avoid filter pre-aggregation
+        agg_over_dims = kwargs.pop("band_agg_dims", None)
+
+        title = self.title_from_ds(dataset, result_var, **kwargs)
+
+        use_holomap = self._use_holomap_for_time(dataset)
+
+        if use_holomap:
+            return self._band_over_time(dataset, var, title, agg_over_dims, **kwargs)
+
+        # Without over_time: find a continuous x-axis from remaining dims
+        return self._band_static(dataset, var, title, agg_over_dims, **kwargs)
+
+    def _band_over_time(
+        self,
+        dataset: xr.Dataset,
+        var: str,
+        title: str,
+        agg_over_dims: list[str] | None,
+        **kwargs,
+    ) -> hv.Overlay | None:
+        """Build percentile bands with time on x-axis."""
+        da = dataset[var]
+
+        # Determine which dims to flatten (everything except over_time)
+        sample_dims = [d for d in da.dims if d != "over_time"]
+        if agg_over_dims:
+            sample_dims = [d for d in sample_dims if d in agg_over_dims or d == "repeat"]
+        if not sample_dims:
+            return None
+
+        # Stack sample dims, compute percentiles at each time point
+        stacked = da.stack(sample=sample_dims).transpose("over_time", "sample")
+        values = stacked.values  # shape: (n_time, n_samples)
+
+        time_coords = da.coords["over_time"].values
+        p10 = np.nanpercentile(values, 10, axis=1)
+        p25 = np.nanpercentile(values, 25, axis=1)
+        p50 = np.nanpercentile(values, 50, axis=1)
+        p75 = np.nanpercentile(values, 75, axis=1)
+        p90 = np.nanpercentile(values, 90, axis=1)
+
+        # Build scatter data: repeat each time coord for every sample
+        n_time, n_samples = values.shape
+        scatter_x = np.repeat(time_coords, n_samples)
+        scatter_y = values.ravel()
+
+        return self._build_band_overlay(
+            time_coords, p10, p25, p50, p75, p90, scatter_x, scatter_y, var, title, **kwargs
+        )
+
+    def _band_static(
+        self,
+        dataset: xr.Dataset,
+        var: str,
+        title: str,
+        agg_over_dims: list[str] | None,
+        **kwargs,
+    ) -> hv.Overlay | None:
+        """Build percentile bands over a non-time continuous axis."""
+        da = dataset[var]
+        all_dims = list(da.dims)
+
+        # Figure out which dim is the x-axis (not aggregated, not repeat)
+        agg_set = set(agg_over_dims) if agg_over_dims else set()
+        candidate_x = [d for d in all_dims if d not in agg_set and d != "repeat"]
+
+        if not candidate_x:
+            # All dims aggregated and no time — can't make a meaningful band plot
+            return None
+
+        x_dim = candidate_x[0]
+        sample_dims = [d for d in all_dims if d != x_dim]
+        if not sample_dims:
+            return None
+
+        stacked = da.stack(sample=sample_dims).transpose(x_dim, "sample")
+        values = stacked.values  # shape: (n_x, n_samples)
+
+        x_coords = da.coords[x_dim].values
+        p10 = np.nanpercentile(values, 10, axis=1)
+        p25 = np.nanpercentile(values, 25, axis=1)
+        p50 = np.nanpercentile(values, 50, axis=1)
+        p75 = np.nanpercentile(values, 75, axis=1)
+        p90 = np.nanpercentile(values, 90, axis=1)
+
+        # Build scatter data: repeat each x coord for every sample
+        n_x, n_samples = values.shape
+        scatter_x = np.repeat(x_coords, n_samples)
+        scatter_y = values.ravel()
+
+        return self._build_band_overlay(
+            x_coords, p10, p25, p50, p75, p90, scatter_x, scatter_y, var, title, **kwargs
+        )
+
+    @staticmethod
+    def _build_band_overlay(
+        x_coords,
+        p10,
+        p25,
+        p50,
+        p75,
+        p90,
+        scatter_x,
+        scatter_y,
+        var: str,
+        title: str,
+        **kwargs,
+    ) -> hv.Overlay:
+        """Construct the overlay of Area bands + median Curve + scatter points."""
+        # Outer band: 10th-90th percentile
+        band_outer = hv.Area(
+            (x_coords, p10, p90),
+            kdims=["x"],
+            vdims=["p10", "p90"],
+            label="10th\u201390th pctl",
+        ).opts(alpha=0.2, color="steelblue", line_alpha=0)
+
+        # Inner band: 25th-75th percentile
+        band_inner = hv.Area(
+            (x_coords, p25, p75),
+            kdims=["x"],
+            vdims=["p25", "p75"],
+            label="25th\u201375th pctl",
+        ).opts(alpha=0.4, color="steelblue", line_alpha=0)
+
+        # Median line
+        median_line = hv.Curve(
+            (x_coords, p50),
+            kdims=["x"],
+            vdims=[var],
+            label="median",
+        ).opts(color="steelblue", line_width=2)
+
+        # Scatter overlay: individual data points (drop NaNs)
+        mask = ~np.isnan(scatter_y)
+        scatter = hv.Scatter(
+            (scatter_x[mask], scatter_y[mask]),
+            kdims=["x"],
+            vdims=[var],
+            label="samples",
+        ).opts(color="grey", alpha=0.3, size=3)
+
+        overlay = band_outer * band_inner * median_line * scatter
+        overlay = overlay.opts(title=title, xrotation=30, legend_position="right")
+        return overlay

--- a/pixi.lock
+++ b/pixi.lock
@@ -50,7 +50,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
@@ -116,7 +116,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -212,7 +212,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/2f/8a1d989bfadd120c90114ab33e0d2a0cbde05278c1fc15e83e62d570f50a/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/ce/865e4e09b041bad659d682bbd98b47fb490b8e124f9398c9448065f64fee/charset_normalizer-3.4.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
@@ -278,7 +278,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -378,7 +378,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/60/ac/3233d262a310c1b12633536a07cde5ddd16985e6e7e238e9f3f9423d8eb9/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
@@ -444,7 +444,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -541,7 +541,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
@@ -607,7 +607,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -703,7 +703,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/c6/9963d588cc3d75d766c819e0377a168ef83cf3316a92769971527a1ad1de/colorcet-3.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
@@ -769,7 +769,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -928,25 +928,25 @@ packages:
   version: 2026.2.25
   sha256: 027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.5
-  sha256: 5bcb3227c3d9aaf73eaaab1db7ccd80a8995c509ee9941e2aae060ca6e4e5d81
+  version: 3.4.6
+  sha256: 530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/4b/2f/8a1d989bfadd120c90114ab33e0d2a0cbde05278c1fc15e83e62d570f50a/charset_normalizer-3.4.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.5
-  sha256: 340810d34ef83af92148e96e3e44cb2d3f910d2bf95e5618a5c467d9f102231d
+  version: 3.4.6
+  sha256: 0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/60/ac/3233d262a310c1b12633536a07cde5ddd16985e6e7e238e9f3f9423d8eb9/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.5
-  sha256: 7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d
+  version: 3.4.6
+  sha256: 9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fd/ce/865e4e09b041bad659d682bbd98b47fb490b8e124f9398c9448065f64fee/charset_normalizer-3.4.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.5
-  sha256: 0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819
+  version: 3.4.6
+  sha256: 51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89
   requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
   name: click
@@ -3248,10 +3248,10 @@ packages:
   - pytest-benchmark ; extra == 'testing'
   - coverage ; extra == 'testing'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/ba/18/321dcff9ece8065d42c8c1c7a53a23b45d2b4330aa70993be75dc5f2822f/prek-0.3.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/0a/d3/bae4a351b9b095e317ad294817d3dff980d73a907a0449b49a9549894a80/prek-0.3.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek
-  version: 0.3.5
-  sha256: 45ee84199bb48e013bdfde0c84352c17a44cc42d5792681b86d94e9474aab6f8
+  version: 0.3.6
+  sha256: 8a38d8061caae4ffd757316b9ef65409d808ae92482386385413365bad033c26
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
   name: proglog


### PR DESCRIPTION
## Summary
- **New `BandResult` class** — percentile band plots (10-90th, 25-75th bands + median line + scatter overlay of individual data points) for richer distribution visualization than mean ± std
- **`agg_over_dims` on `BenchCfg`** — when set, `run_sweep` auto-appends aggregated CurveResult and BandResult views alongside the main plot
- **Scatter overlay** on band plots shows individual sample points so outliers and distribution shape are visible at a glance
- **Updated examples** — `example_over_time` now auto-aggregates for 1D/2D sweeps; `example_regression` adds BandResult; `example_agg_over_time` showcases all three views

## Changed files
- `bencher/results/holoview_results/band_result.py` — new BandResult class
- `bencher/bench_cfg.py` — `agg_over_dims` parameter
- `bencher/bencher.py` — `plot_sweep` accepts `agg_over_dims`; `run_sweep` auto-appends
- `bencher/results/bench_result.py` — BandResult in MRO
- `bencher/results/bench_result_base.py` — fix `to_hv_dataset` kdims after aggregation
- `bencher/__init__.py` — export BandResult
- `bencher/example/example_over_time.py` — auto-aggregate for sweeps with input vars
- `bencher/example/example_agg_over_time.py` — add BandResult view
- `bencher/example/example_regression.py` — add BandResult view

## Test plan
- [x] `python bencher/example/example_agg_over_time.py` — runs successfully
- [x] `python bencher/example/example_regression.py` — runs successfully
- [x] `python bencher/example/example_over_time.py` — runs successfully
- [x] `pixi run format` — no changes
- [x] `pixi run lint` — pylint 10/10
- [x] `pixi run test` — 788 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce percentile band visualizations and automatic aggregation for benchmark sweeps to better show distribution evolution over time.

New Features:
- Add BandResult visualization that plots percentile bands with median line and scatter overlay from benchmark results.
- Allow BenchCfg and plot_sweep/run_sweep to specify agg_over_dims so aggregated CurveResult and BandResult views are auto-appended to reports.

Bug Fixes:
- Ensure HoloViews datasets only include key dimensions that remain after aggregation when no reduction is applied.

Enhancements:
- Extend BenchResult mixin hierarchy and package exports to include the new BandResult view.
- Update time-series and regression examples to generate aggregated CurveResult and BandResult views that highlight distribution skew and outliers over time.