### PR TITLE
Add git_time_event() for date+commit slider labels

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -89,6 +89,7 @@ except ModuleNotFoundError as e:
 
 
 from .regression import RegressionResult, RegressionReport, RegressionError
+from .git_info import git_time_event
 from .plotting.plot_filter import VarRange, PlotFilter
 from .variables.parametrised_sweep import ParametrizedSweep
 from .variables.singleton_parametrized_sweep import ParametrizedSweepSingleton

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -573,6 +573,8 @@ class Bench(BenchPlotServer):
         if calculate_results:
             if run_cfg.time_event is not None:
                 time_src = run_cfg.time_event
+            elif isinstance(time_src, str):
+                bench_cfg.time_event = time_src
             bench_res = self.calculate_benchmark_results(
                 bench_cfg, time_src, bench_cfg_sample_hash, run_cfg, sample_order
             )

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -570,11 +570,12 @@ class Bench(BenchPlotServer):
                     if run_cfg.only_plot:
                         raise FileNotFoundError("Was not able to load the results to plot!")
 
+        if run_cfg.time_event is not None:
+            time_src = run_cfg.time_event
+        elif isinstance(time_src, str):
+            bench_cfg.time_event = time_src
+
         if calculate_results:
-            if run_cfg.time_event is not None:
-                time_src = run_cfg.time_event
-            elif isinstance(time_src, str):
-                bench_cfg.time_event = time_src
             bench_res = self.calculate_benchmark_results(
                 bench_cfg, time_src, bench_cfg_sample_hash, run_cfg, sample_order
             )

--- a/bencher/example/example_git_time_event.py
+++ b/bencher/example/example_git_time_event.py
@@ -1,6 +1,5 @@
 """Example showing how to use git_time_event() for over_time sliders with date+commit labels."""
 
-import math
 import bencher as bch
 
 
@@ -13,8 +12,7 @@ class ServerLatency(bch.ParametrizedSweep):
 
     def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
-        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
-        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
         return super().__call__()
 
 

--- a/bencher/example/example_git_time_event.py
+++ b/bencher/example/example_git_time_event.py
@@ -22,13 +22,12 @@ def example_git_time_event(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
     """Track benchmark results over time using the current git commit as the time label.
 
     ``git_time_event()`` returns a string like ``"2024-06-15 abc1234d"`` combining the commit
-    date and short hash.  Pass it as ``time_event`` with ``over_time=True`` so the slider
-    shows which commit produced each data point.
+    date and short hash.  Pass it as ``time_src`` to ``plot_sweep`` so the slider shows which
+    commit produced each data point.
     """
 
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
-    run_cfg.time_event = bch.git_time_event()
 
     bench = ServerLatency().to_bench(run_cfg)
 
@@ -38,6 +37,7 @@ def example_git_time_event(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
         result_vars=["latency"],
         description=example_git_time_event.__doc__,
         run_cfg=run_cfg,
+        time_src=bch.git_time_event(),
     )
     return bench
 

--- a/bencher/example/example_git_time_event.py
+++ b/bencher/example/example_git_time_event.py
@@ -1,0 +1,46 @@
+"""Example showing how to use git_time_event() for over_time sliders with date+commit labels."""
+
+import math
+import bencher as bch
+
+
+class ServerLatency(bch.ParametrizedSweep):
+    """Simulates server latency measurements across endpoints."""
+
+    endpoint = bch.StringSweep(["/api/users", "/api/orders", "/api/health"], doc="API endpoint")
+
+    latency = bch.ResultVar(units="ms", doc="Response latency")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
+        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        return super().__call__()
+
+
+def example_git_time_event(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Track benchmark results over time using the current git commit as the time label.
+
+    ``git_time_event()`` returns a string like ``"2024-06-15 abc1234d"`` combining the commit
+    date and short hash.  Pass it as ``time_event`` with ``over_time=True`` so the slider
+    shows which commit produced each data point.
+    """
+
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.time_event = bch.git_time_event()
+
+    bench = ServerLatency().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Latency by Endpoint",
+        input_vars=["endpoint"],
+        result_vars=["latency"],
+        description=example_git_time_event.__doc__,
+        run_cfg=run_cfg,
+    )
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_git_time_event)

--- a/bencher/example/generated/advanced/advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/advanced_git_time_event.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import math
 import bencher as bch
 
 
@@ -21,8 +20,7 @@ class ServerLatency(bch.ParametrizedSweep):
 
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
-        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
-        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
         return super().__call__()
 
 

--- a/bencher/example/generated/advanced/advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/advanced_git_time_event.py
@@ -1,0 +1,52 @@
+"""Auto-generated example: Git Time Event — date + commit hash slider labels."""
+
+from typing import Any
+
+import math
+import bencher as bch
+
+
+class ServerLatency(bch.ParametrizedSweep):
+    """Simulates server latency measurements across endpoints.
+
+    Use ``bch.git_time_event()`` as the ``time_src`` argument to
+    ``plot_sweep`` to label each over_time slider tick with the commit
+    date and short hash, e.g. ``"2024-06-15 abc1234d"``.  This lets you
+    trace benchmark results back to the exact code that produced them.
+    """
+
+    endpoint = bch.StringSweep(["/api/users", "/api/orders", "/api/health"], doc="API endpoint")
+
+    latency = bch.ResultVar(units="ms", doc="Response latency")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
+        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        return super().__call__()
+
+
+def example_advanced_git_time_event(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Git Time Event — date + commit hash slider labels."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+
+    bench = ServerLatency().to_bench(run_cfg)
+
+    # git_time_event() returns a string like "2024-06-15 abc1234d".
+    # Pass it as time_src so each commit gets its own slider tick.
+    bench.plot_sweep(
+        title="Latency by Endpoint",
+        input_vars=["endpoint"],
+        result_vars=["latency"],
+        description="Demonstrates git_time_event() for labelling over_time "
+        "slider ticks with the commit date and short hash.",
+        run_cfg=run_cfg,
+        time_src=bch.git_time_event(),
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_advanced_git_time_event, level=3)

--- a/bencher/example/generated/regression/regression_percentage.py
+++ b/bencher/example/generated/regression/regression_percentage.py
@@ -1,9 +1,9 @@
 """Auto-generated example: Regression detection — percentage threshold over time."""
 
 from typing import Any
+from datetime import datetime, timedelta
 
 import bencher as bch
-from datetime import datetime, timedelta
 
 
 class ServerBenchmark(bch.ParametrizedSweep):

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -168,7 +168,7 @@ for i, event_name in enumerate(events):
 
     def _generate_git_time_event(self):
         """Git commit time event example."""
-        imports = "import math\nimport bencher as bch"
+        imports = "import bencher as bch"
         class_code = '''\
 class ServerLatency(bch.ParametrizedSweep):
     """Simulates server latency measurements across endpoints.
@@ -187,8 +187,7 @@ class ServerLatency(bch.ParametrizedSweep):
 
     def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
-        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
-        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
         return super().__call__()'''
         body = """\
 run_cfg = run_cfg or bch.BenchRunCfg()

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -173,10 +173,10 @@ for i, event_name in enumerate(events):
 class ServerLatency(bch.ParametrizedSweep):
     """Simulates server latency measurements across endpoints.
 
-    Use ``bch.git_time_event()`` as the ``time_event`` to label each
-    over_time slider tick with the commit date and short hash, e.g.
-    ``"2024-06-15 abc1234d"``.  This lets you trace benchmark results
-    back to the exact code that produced them.
+    Use ``bch.git_time_event()`` as the ``time_src`` argument to
+    ``plot_sweep`` to label each over_time slider tick with the commit
+    date and short hash, e.g. ``"2024-06-15 abc1234d"``.  This lets you
+    trace benchmark results back to the exact code that produced them.
     """
 
     endpoint = bch.StringSweep(
@@ -194,13 +194,10 @@ class ServerLatency(bch.ParametrizedSweep):
 run_cfg = run_cfg or bch.BenchRunCfg()
 run_cfg.over_time = True
 
-# git_time_event() returns a string like "2024-06-15 abc1234d".
-# Each time this script runs on a different commit, a new slider
-# tick is added so you can see how results change across commits.
-run_cfg.time_event = bch.git_time_event()
-
 bench = ServerLatency().to_bench(run_cfg)
 
+# git_time_event() returns a string like "2024-06-15 abc1234d".
+# Pass it as time_src so each commit gets its own slider tick.
 bench.plot_sweep(
     title="Latency by Endpoint",
     input_vars=["endpoint"],
@@ -208,6 +205,7 @@ bench.plot_sweep(
     description="Demonstrates git_time_event() for labelling over_time "
     "slider ticks with the commit date and short hash.",
     run_cfg=run_cfg,
+    time_src=bch.git_time_event(),
 )
 """
         self.generate_example(

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -14,6 +14,7 @@ OUTPUT_DIR = "advanced"
 ADVANCED_EXAMPLES = [
     "cache_patterns",
     "time_event",
+    "git_time_event",
     "max_time_events",
     "report_save",
     "agg_over_time",
@@ -32,6 +33,8 @@ class MetaAdvanced(MetaGeneratorBase):
             self._generate_cache_patterns()
         elif self.example == "time_event":
             self._generate_time_event()
+        elif self.example == "git_time_event":
+            self._generate_git_time_event()
         elif self.example == "max_time_events":
             self._generate_max_time_events()
         elif self.example == "report_save":
@@ -157,6 +160,61 @@ for i, event_name in enumerate(events):
             output_dir=OUTPUT_DIR,
             filename="advanced_time_event",
             function_name="example_advanced_time_event",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"level": 3},
+        )
+
+    def _generate_git_time_event(self):
+        """Git commit time event example."""
+        imports = "import math\nimport bencher as bch"
+        class_code = '''\
+class ServerLatency(bch.ParametrizedSweep):
+    """Simulates server latency measurements across endpoints.
+
+    Use ``bch.git_time_event()`` as the ``time_event`` to label each
+    over_time slider tick with the commit date and short hash, e.g.
+    ``"2024-06-15 abc1234d"``.  This lets you trace benchmark results
+    back to the exact code that produced them.
+    """
+
+    endpoint = bch.StringSweep(
+        ["/api/users", "/api/orders", "/api/health"], doc="API endpoint"
+    )
+
+    latency = bch.ResultVar(units="ms", doc="Response latency")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        base = {"/api/users": 45, "/api/orders": 120, "/api/health": 5}[self.endpoint]
+        self.latency = base + 10 * math.sin(hash(self.endpoint))
+        return super().__call__()'''
+        body = """\
+run_cfg = run_cfg or bch.BenchRunCfg()
+run_cfg.over_time = True
+
+# git_time_event() returns a string like "2024-06-15 abc1234d".
+# Each time this script runs on a different commit, a new slider
+# tick is added so you can see how results change across commits.
+run_cfg.time_event = bch.git_time_event()
+
+bench = ServerLatency().to_bench(run_cfg)
+
+bench.plot_sweep(
+    title="Latency by Endpoint",
+    input_vars=["endpoint"],
+    result_vars=["latency"],
+    description="Demonstrates git_time_event() for labelling over_time "
+    "slider ticks with the commit date and short hash.",
+    run_cfg=run_cfg,
+)
+"""
+        self.generate_example(
+            title="Git Time Event — date + commit hash slider labels",
+            output_dir=OUTPUT_DIR,
+            filename="advanced_git_time_event",
+            function_name="example_advanced_git_time_event",
             imports=imports,
             body=body,
             class_code=class_code,

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -31,7 +31,7 @@ class MetaRegression(MetaGeneratorBase):
 
     def _generate_percentage(self):
         """Percentage-based regression detection over time."""
-        imports = "import bencher as bch\nfrom datetime import datetime, timedelta"
+        imports = "from typing import Any\nfrom datetime import datetime, timedelta\n\nimport bencher as bch"
         class_code = '''\
 class ServerBenchmark(bch.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""

--- a/bencher/git_info.py
+++ b/bencher/git_info.py
@@ -1,0 +1,41 @@
+"""Git metadata helpers for benchmark time tracking."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def _run_git(args: list[str], repo_path: str | None = None) -> str:
+    """Run a git subcommand and return its stripped stdout, or empty string on failure."""
+    try:
+        return (
+            subprocess.check_output(  # noqa: S603
+                ["git", *args], cwd=repo_path, stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return ""
+
+
+def git_time_event(repo_path: str | None = None) -> str:
+    """Return a time-event label combining the commit date and short hash.
+
+    Example return value: ``"2024-06-15 abc1234d"``
+
+    Intended to be used with ``BenchRunCfg(over_time=True, time_event=...)``
+    so the over-time slider shows *when* and *which commit* produced the data.
+
+    Falls back to just the short hash if the commit date is unavailable,
+    or an empty string if not inside a git repository.
+    """
+    commit = _run_git(["rev-parse", "HEAD"], repo_path)
+    if not commit:
+        return ""
+    short = commit[:8]
+    date = _run_git(["log", "-1", "--format=%cI"], repo_path)
+    date_part = date.split("T")[0] if date else ""
+    if date_part:
+        return f"{date_part} {short}"
+    return short

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.67.0
-  sha256: 090d42b47505a315675fb9a2f9878b63b5bc9ef733a6d16168992be40abe41f6
+  version: 1.68.0
+  sha256: cadbff39eebafb70afc39faf1b30e93570bcfbe3b57fed954802d351888899cf
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.67.0"
+version = "1.68.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_git_info.py
+++ b/test/test_git_info.py
@@ -8,10 +8,17 @@ from bencher.git_info import git_time_event
 
 
 class TestGitTimeEvent(unittest.TestCase):
-    def test_returns_date_and_hash_in_repo(self):
-        result = git_time_event()
-        # We're in a git repo, so should get "YYYY-MM-DD abcdefgh"
-        self.assertRegex(result, r"\d{4}-\d{2}-\d{2} [0-9a-f]{8}")
+    def test_returns_date_and_hash(self):
+        def fake(cmd, **_kwargs):
+            if "rev-parse" in cmd:
+                return b"abc1234def5678901234567890abcdef12345678\n"
+            if "log" in cmd:
+                return b"2024-06-15T12:00:00+00:00\n"
+            return b""
+
+        with mock.patch("subprocess.check_output", side_effect=fake):
+            result = git_time_event()
+        self.assertEqual(result, "2024-06-15 abc1234d")
 
     def test_returns_empty_outside_repo(self):
         with mock.patch(

--- a/test/test_git_info.py
+++ b/test/test_git_info.py
@@ -1,0 +1,54 @@
+"""Tests for bencher.git_info module."""
+
+import subprocess
+import unittest
+from unittest import mock
+
+from bencher.git_info import git_time_event
+
+
+class TestGitTimeEvent(unittest.TestCase):
+    def test_returns_date_and_hash_in_repo(self):
+        result = git_time_event()
+        # We're in a git repo, so should get "YYYY-MM-DD abcdefgh"
+        self.assertRegex(result, r"\d{4}-\d{2}-\d{2} [0-9a-f]{8}")
+
+    def test_returns_empty_outside_repo(self):
+        with mock.patch(
+            "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "")
+        ):
+            self.assertEqual(git_time_event(), "")
+
+    def test_returns_empty_when_git_not_installed(self):
+        with mock.patch("subprocess.check_output", side_effect=FileNotFoundError):
+            self.assertEqual(git_time_event(), "")
+
+    def test_falls_back_to_hash_without_date(self):
+        def fake(cmd, **_kwargs):
+            if "rev-parse" in cmd:
+                return b"a" * 40 + b"\n"
+            if "log" in cmd:
+                return b""
+            return b""
+
+        with mock.patch("subprocess.check_output", side_effect=fake):
+            self.assertEqual(git_time_event(), "a" * 8)
+
+    def test_used_as_time_event(self):
+        """git_time_event() works as a time_event in a real sweep."""
+        import bencher as bch
+        from bencher.example.benchmark_data import ExampleBenchCfg
+
+        bench = bch.Bench("test_git", ExampleBenchCfg())
+        run_cfg = bch.BenchRunCfg(over_time=True, time_event=bch.git_time_event())
+        res = bench.plot_sweep(
+            input_vars=[ExampleBenchCfg.param.theta],
+            run_cfg=run_cfg,
+            plot_callbacks=False,
+        )
+        over_time_val = str(res.ds.coords["over_time"].values[0])
+        self.assertRegex(over_time_val, r"\d{4}-\d{2}-\d{2} [0-9a-f]{8}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_git_info.py
+++ b/test/test_git_info.py
@@ -34,16 +34,17 @@ class TestGitTimeEvent(unittest.TestCase):
         with mock.patch("subprocess.check_output", side_effect=fake):
             self.assertEqual(git_time_event(), "a" * 8)
 
-    def test_used_as_time_event(self):
-        """git_time_event() works as a time_event in a real sweep."""
+    def test_used_as_time_src(self):
+        """git_time_event() works as time_src in plot_sweep."""
         import bencher as bch
         from bencher.example.benchmark_data import ExampleBenchCfg
 
         bench = bch.Bench("test_git", ExampleBenchCfg())
-        run_cfg = bch.BenchRunCfg(over_time=True, time_event=bch.git_time_event())
+        run_cfg = bch.BenchRunCfg(over_time=True)
         res = bench.plot_sweep(
             input_vars=[ExampleBenchCfg.param.theta],
             run_cfg=run_cfg,
+            time_src=bch.git_time_event(),
             plot_callbacks=False,
         )
         over_time_val = str(res.ds.coords["over_time"].values[0])


### PR DESCRIPTION
## Summary
- Add `bencher.git_info` module with `git_time_event()` that returns `"YYYY-MM-DD abcdefgh"` for labelling over_time slider ticks with commit date and short hash
- Use `time_src=bch.git_time_event()` pattern in `plot_sweep` instead of setting `run_cfg.time_event` directly
- Fix: propagate string `time_src` to `bench_cfg.time_event` so `wrap_long_time_labels` takes the correct branch
- Includes example, meta-generator entry, and comprehensive tests

## Test plan
- [x] Unit tests for git_time_event() in-repo, outside-repo, missing git, and date fallback
- [x] Integration test using time_src in plot_sweep
- [ ] CI passes (format, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce git-based time event labels for over-time benchmarking and wire them into plotting and examples.

New Features:
- Add git_time_event() helper to generate date plus commit-hash labels for benchmark time events.
- Provide new git_time_event benchmark examples and integrate the advanced example into the meta-example generator.

Bug Fixes:
- Ensure string-based time_src values are propagated into bench_cfg.time_event so over-time label handling works correctly.

Enhancements:
- Refine regression percentage example imports for clearer typing and module structure.

Build:
- Bump project version from 1.67.0 to 1.68.0.

Documentation:
- Document usage of git_time_event() in new example modules for over-time slider labelling.

Tests:
- Add unit and integration tests covering git_time_event() behavior inside and outside git repositories, missing git, date fallbacks, and use as time_src.