### PR TITLE
Show aggregate plots first + bump to 1.70.0

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -623,11 +623,13 @@ class Bench(BenchPlotServer):
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
 
-        # Auto-append aggregated BandResult into the same tab, right after the main plots
+        # Insert aggregated BandResult at the top of the tab, before main plots
         if bench_cfg.auto_plot and bench_cfg.agg_over_dims:
             from bencher.results.holoview_results.band_result import BandResult
 
-            self.report.append(bench_res.to(BandResult, aggregate=bench_cfg.agg_over_dims))
+            agg_plot = bench_res.to(BandResult, aggregate=bench_cfg.agg_over_dims)
+            if agg_plot is not None:
+                self.report.pane[-1].insert(0, agg_plot)
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -623,14 +623,6 @@ class Bench(BenchPlotServer):
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
 
-        # Insert aggregated BandResult at the top of the tab, before main plots
-        if bench_cfg.auto_plot and bench_cfg.agg_over_dims:
-            from bencher.results.holoview_results.band_result import BandResult
-
-            agg_plot = bench_res.to(BandResult, aggregate=bench_cfg.agg_over_dims)
-            if agg_plot is not None:
-                self.report.pane[-1].insert(0, agg_plot)
-
         self.results.append(bench_res)
         return bench_res
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -620,14 +620,14 @@ class Bench(BenchPlotServer):
 
         bench_res.post_setup()
 
-        if bench_cfg.auto_plot:
-            self.report.append_result(bench_res)
-
-        # Auto-append aggregated BandResult (percentile bands + scatter) when agg_over_dims is set
+        # Auto-append aggregated BandResult (percentile bands + scatter) before main plots
         if bench_cfg.auto_plot and bench_cfg.agg_over_dims:
             from bencher.results.holoview_results.band_result import BandResult
 
             self.report.append(bench_res.to(BandResult, aggregate=bench_cfg.agg_over_dims))
+
+        if bench_cfg.auto_plot:
+            self.report.append_result(bench_res)
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -620,14 +620,14 @@ class Bench(BenchPlotServer):
 
         bench_res.post_setup()
 
-        # Auto-append aggregated BandResult (percentile bands + scatter) before main plots
+        if bench_cfg.auto_plot:
+            self.report.append_result(bench_res)
+
+        # Auto-append aggregated BandResult into the same tab, right after the main plots
         if bench_cfg.auto_plot and bench_cfg.agg_over_dims:
             from bencher.results.holoview_results.band_result import BandResult
 
             self.report.append(bench_res.to(BandResult, aggregate=bench_cfg.agg_over_dims))
-
-        if bench_cfg.auto_plot:
-            self.report.append_result(bench_res)
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -212,6 +212,8 @@ class BenchResult(
         """
         plot_cols = pn.Column()
         plot_cols.append(self.to_sweep_summary(name="Plots View"))
+        if self.bench_cfg.agg_over_dims:
+            plot_cols.append(self.to(BandResult, aggregate=self.bench_cfg.agg_over_dims))
         plot_cols.append(self.to_auto(**kwargs))
         plot_cols.append(self.bench_cfg.to_post_description())
         return plot_cols

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -213,6 +213,13 @@ class BenchResult(
         plot_cols = pn.Column()
         plot_cols.append(self.to_sweep_summary(name="Plots View"))
         if self.bench_cfg.agg_over_dims:
+            dims = ", ".join(self.bench_cfg.agg_over_dims)
+            plot_cols.append(
+                pn.pane.Markdown(
+                    f"### Aggregated View\n"
+                    f"Mean and percentile bands aggregated over: **{dims}**"
+                )
+            )
             plot_cols.append(self.to(BandResult, aggregate=self.bench_cfg.agg_over_dims))
         plot_cols.append(self.to_auto(**kwargs))
         plot_cols.append(self.bench_cfg.to_post_description())

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -216,8 +216,7 @@ class BenchResult(
             dims = ", ".join(self.bench_cfg.agg_over_dims)
             plot_cols.append(
                 pn.pane.Markdown(
-                    f"### Aggregated View\n"
-                    f"Mean and percentile bands aggregated over: **{dims}**"
+                    f"### Aggregated View\nMean and percentile bands aggregated over: **{dims}**"
                 )
             )
             plot_cols.append(self.to(BandResult, aggregate=self.bench_cfg.agg_over_dims))

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.69.0
-  sha256: 22d0a460a7e709e8fad11655efcfe2a89a73d99255e45795e4c2e9c255174714
+  version: 1.70.0
+  sha256: 627b744f13bb68c6e7133575617d3398e462c3c531ec567f6ec6b2ee7c952bf0
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.69.0"
+version = "1.70.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Reorder report so aggregated BandResult plots appear **before** main benchmark plots when `agg_over_dims` is set, since the summary view is typically more useful
- Bump version from 1.69.0 → 1.70.0

## Test plan
- [ ] `pixi run ci` passes (format, lint, tests)
- [ ] Verify aggregate plots appear first in report output when `aggregate=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reorder benchmark reporting so aggregated BandResult plots are shown before the main benchmark plots when aggregation over dimensions is enabled, and bump the package version to 1.70.0.

Enhancements:
- Adjust report generation order so aggregated BandResult visualizations are appended ahead of standard benchmark plots when automatic plotting with dimension aggregation is enabled.

Build:
- Update project version from 1.69.0 to 1.70.0 in packaging metadata.