### PR TITLE
Fix BandResult y-axis label showing 'p10'

### DIFF
--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -63,21 +63,25 @@ class BandResult(HoloviewResult):
         # band_agg_dims is passed through from to_band to avoid filter pre-aggregation
         agg_over_dims = kwargs.pop("band_agg_dims", None)
 
-        title = self.title_from_ds(dataset, result_var, **kwargs)
+        # Preserve explicit title if provided; otherwise defer to _band_* methods
+        # which build a title reflecting only the x-axis (not aggregated dims).
+        explicit_title = kwargs.pop("title", None)
 
         use_holomap = self._use_holomap_for_time(dataset)
 
         if use_holomap:
-            return self._band_over_time(dataset, var, title, agg_over_dims, **kwargs)
+            return self._band_over_time(
+                dataset, var, explicit_title, agg_over_dims, **kwargs
+            )
 
         # Without over_time: find a continuous x-axis from remaining dims
-        return self._band_static(dataset, var, title, agg_over_dims, **kwargs)
+        return self._band_static(dataset, var, explicit_title, agg_over_dims, **kwargs)
 
     def _band_over_time(
         self,
         dataset: xr.Dataset,
         var: str,
-        title: str,
+        title: str | None,
         agg_over_dims: list[str] | None,
         **kwargs,
     ) -> hv.Overlay | None:
@@ -92,6 +96,11 @@ class BandResult(HoloviewResult):
         sample_dims = [d for d in da.dims if d != "over_time"]
         if agg_over_dims:
             sample_dims = [d for d in sample_dims if d in agg_over_dims or d == "repeat"]
+
+        if title is None:
+            agg_names = [d for d in sample_dims if d != "repeat"]
+            agg_str = ", ".join(agg_names) if agg_names else "repeat"
+            title = f"{var} vs over_time (aggregated over {agg_str})"
         if not sample_dims:
             return None
 
@@ -127,7 +136,7 @@ class BandResult(HoloviewResult):
         self,
         dataset: xr.Dataset,
         var: str,
-        title: str,
+        title: str | None,
         agg_over_dims: list[str] | None,
         **kwargs,
     ) -> hv.Overlay | None:
@@ -145,6 +154,10 @@ class BandResult(HoloviewResult):
 
         x_dim = candidate_x[0]
         sample_dims = [d for d in all_dims if d != x_dim]
+        if title is None:
+            agg_names = [d for d in sample_dims if d != "repeat"]
+            agg_str = ", ".join(agg_names) if agg_names else "repeat"
+            title = f"{var} vs {x_dim} (aggregated over {agg_str})"
         if not sample_dims:
             return None
 

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -70,9 +70,7 @@ class BandResult(HoloviewResult):
         use_holomap = self._use_holomap_for_time(dataset)
 
         if use_holomap:
-            return self._band_over_time(
-                dataset, var, explicit_title, agg_over_dims, **kwargs
-            )
+            return self._band_over_time(dataset, var, explicit_title, agg_over_dims, **kwargs)
 
         # Without over_time: find a continuous x-axis from remaining dims
         return self._band_static(dataset, var, explicit_title, agg_over_dims, **kwargs)

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -270,5 +270,5 @@ class BandResult(HoloviewResult):
             ).opts(color="grey", alpha=0.3, size=3)
             overlay = overlay * scatter
 
-        overlay = overlay.opts(title=title, xrotation=30, legend_position="right")
+        overlay = overlay.opts(title=title, xrotation=30, ylabel=var, legend_position="right")
         return overlay

--- a/pixi.lock
+++ b/pixi.lock
@@ -1553,6 +1553,7 @@ packages:
   - libgcc >=14
   - libstdcxx >=14
   license: MIT
+  license_family: MIT
   purls: []
   size: 12723451
   timestamp: 1773822285671


### PR DESCRIPTION
## Summary
- The `BandResult` percentile band plot was showing `p10` as the y-axis label instead of the actual result variable name (e.g. `distance`)
- Root cause: `hv.Area` uses the first `vdim` as the y-axis label, which was the internal percentile column name `"p10"`
- Fix: add explicit `ylabel=var` to the overlay opts

## Test plan
- [x] Ran `example_over_time_1D` smoke test — band plots now show the correct y-axis label
- [ ] Visual check: run `python bencher/example/example_over_time.py` and verify y-axis labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Set an explicit y-axis label on BandResult percentile band overlays so they display the result variable name rather than the percentile column (e.g., p10).