### PR TITLE
Fix over_time slider last position unreachable in embedded HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.1] - 2026-03-19
+
+### Fixed
+- Fix over_time slider starting at first position instead of last in embedded HTML — Panel's `DiscreteSlider` sets the Bokeh `Slider.title` to `''`, so the JS that matched by `title === "over_time"` never found the slider; now uses Panel State model's widgets map to reliably locate the slider
+
 ## [1.66.3] - 2026-03-14
 
 ### Fixed

--- a/bencher/example/example_over_time.py
+++ b/bencher/example/example_over_time.py
@@ -16,11 +16,6 @@ from bencher.example.meta.example_meta import BenchableObject
 def _run_over_time(bench, benchable, run_cfg, input_vars, title, result_vars=None):
     """Helper: run several time snapshots for a single sweep configuration.
 
-    All intermediate snapshots disable plotting. Only the final result (which
-    has the full accumulated history) is manually added to the report.
-    When input_vars are present, aggregated CurveResult and BandResult views
-    are automatically appended to show how the distribution evolves over time.
-
     Explicit time_src values are passed to simulate realistic usage where
     plot_sweep calls are naturally spaced apart in time.
     """
@@ -32,22 +27,15 @@ def _run_over_time(bench, benchable, run_cfg, input_vars, title, result_vars=Non
         benchable._time_offset = offset  # pylint: disable=protected-access
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
-        run_cfg.auto_plot = False
+        run_cfg.auto_plot = i == len(time_offsets) - 1
         bench.plot_sweep(
             title,
             input_vars=input_vars,
             result_vars=result_vars,
             run_cfg=run_cfg,
             time_src=base_time + timedelta(seconds=i),
+            aggregate=True if input_vars else None,
         )
-
-    res = bench.results[-1]
-    bench.report.append_result(res)
-
-    # Auto-aggregate: collapse sweep dims to show distribution evolution over time
-    if input_vars:
-        bench.report.append(res.to(bch.CurveResult, aggregate=True))
-        bench.report.append(res.to(bch.BandResult, aggregate=True))
 
 
 def example_over_time_0D(run_cfg: bch.BenchRunCfg | None = None, report=None) -> bch.Bench:

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -63,21 +63,25 @@ class BandResult(HoloviewResult):
         # band_agg_dims is passed through from to_band to avoid filter pre-aggregation
         agg_over_dims = kwargs.pop("band_agg_dims", None)
 
-        title = self.title_from_ds(dataset, result_var, **kwargs)
+        # Preserve explicit title if provided; otherwise defer to _band_* methods
+        # which build a title reflecting only the x-axis (not aggregated dims).
+        explicit_title = kwargs.pop("title", None)
 
         use_holomap = self._use_holomap_for_time(dataset)
 
         if use_holomap:
-            return self._band_over_time(dataset, var, title, agg_over_dims, **kwargs)
+            return self._band_over_time(
+                dataset, var, explicit_title, agg_over_dims, **kwargs
+            )
 
         # Without over_time: find a continuous x-axis from remaining dims
-        return self._band_static(dataset, var, title, agg_over_dims, **kwargs)
+        return self._band_static(dataset, var, explicit_title, agg_over_dims, **kwargs)
 
     def _band_over_time(
         self,
         dataset: xr.Dataset,
         var: str,
-        title: str,
+        title: str | None,
         agg_over_dims: list[str] | None,
         **kwargs,
     ) -> hv.Overlay | None:
@@ -92,6 +96,11 @@ class BandResult(HoloviewResult):
         sample_dims = [d for d in da.dims if d != "over_time"]
         if agg_over_dims:
             sample_dims = [d for d in sample_dims if d in agg_over_dims or d == "repeat"]
+
+        if title is None:
+            agg_names = [d for d in sample_dims if d != "repeat"]
+            agg_str = ", ".join(agg_names) if agg_names else "repeat"
+            title = f"{var} vs over_time (aggregated over {agg_str})"
         if not sample_dims:
             return None
 
@@ -127,7 +136,7 @@ class BandResult(HoloviewResult):
         self,
         dataset: xr.Dataset,
         var: str,
-        title: str,
+        title: str | None,
         agg_over_dims: list[str] | None,
         **kwargs,
     ) -> hv.Overlay | None:
@@ -145,6 +154,10 @@ class BandResult(HoloviewResult):
 
         x_dim = candidate_x[0]
         sample_dims = [d for d in all_dims if d != x_dim]
+        if title is None:
+            agg_names = [d for d in sample_dims if d != "repeat"]
+            agg_str = ", ".join(agg_names) if agg_names else "repeat"
+            title = f"{var} vs {x_dim} (aggregated over {agg_str})"
         if not sample_dims:
             return None
 

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -70,9 +70,7 @@ class BandResult(HoloviewResult):
         use_holomap = self._use_holomap_for_time(dataset)
 
         if use_holomap:
-            return self._band_over_time(
-                dataset, var, explicit_title, agg_over_dims, **kwargs
-            )
+            return self._band_over_time(dataset, var, explicit_title, agg_over_dims, **kwargs)
 
         # Without over_time: find a continuous x-axis from remaining dims
         return self._band_static(dataset, var, explicit_title, agg_over_dims, **kwargs)

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -270,5 +270,5 @@ class BandResult(HoloviewResult):
             ).opts(color="grey", alpha=0.3, size=3)
             overlay = overlay * scatter
 
-        overlay = overlay.opts(title=title, xrotation=30, legend_position="right")
+        overlay = overlay.opts(title=title, xrotation=30, ylabel=var, legend_position="right")
         return overlay

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -22,44 +22,6 @@ hv.extension("bokeh", "plotly")
 # Flag to enable or disable tap tool functionality in visualizations
 use_tap = True
 
-# JS snippet that runs after Bokeh renders to set the over_time slider to the
-# last position.  It finds the Panel State model among document roots, extracts
-# the Bokeh Slider model ID from State.widgets, and sets slider.value = slider.end.
-_OVER_TIME_INIT_JS = """\
-<script>
-(function() {
-  function _initOverTimeSlider() {
-    if (typeof Bokeh === "undefined" || !Bokeh.documents || !Bokeh.documents.length) {
-      setTimeout(_initOverTimeSlider, 50);
-      return;
-    }
-    var doc = Bokeh.documents[0];
-    var roots = doc.roots();
-    for (var i = 0; i < roots.length; i++) {
-      var root = roots[i];
-      if (root.state != null && root.widgets != null && root.values != null) {
-        var wids = root.widgets instanceof Map
-          ? Array.from(root.widgets.keys())
-          : Object.keys(root.widgets);
-        for (var j = 0; j < wids.length; j++) {
-          var slider = doc.get_model_by_id(wids[j]);
-          if (slider && slider.end != null && slider.step === 1) {
-            slider.value = slider.end;
-          }
-        }
-        break;
-      }
-    }
-  }
-  setTimeout(_initOverTimeSlider, 100);
-})();
-</script>"""
-
-
-def _over_time_init_last_script():
-    """Return a zero-size HTML pane containing the init-to-last JS snippet."""
-    return pn.pane.HTML(_OVER_TIME_INIT_JS, width=0, height=0, margin=0)
-
 
 class HoloviewResult(VideoResult):
     @staticmethod
@@ -201,16 +163,14 @@ class HoloviewResult(VideoResult):
         string-based ``TimeEvent`` coordinates get a slider instead of
         the default dropdown ``Select`` widget.
 
-        The slider defaults to the most recent (last) time point via a
-        client-side script that fires after Bokeh renders.  We must NOT
-        set ``w.value`` in Python because Panel's embed system stores an
-        empty patch for the initial widget value — making that position
-        unreachable when the user slides back to it.  Instead we keep the
-        Python default (first value) so every position gets a real patch,
-        then use JS to switch to the last position on page load.
-
         Safe to call on any HoloViews object; if no widgets are produced
         the original object is returned unchanged.
+
+        The slider defaults to the most recent (last) time point.  We keep
+        the Python-side value at its default (first) so that Panel's embed
+        system generates non-empty JSON patches for every position.  A
+        small JS snippet then moves the slider to the last position once
+        the page has rendered, which triggers the embedded patch callback.
         """
         # Force a slider (not a dropdown) for the over_time dimension
         row = pn.panel(hvobj, widgets={"over_time": pn.widgets.DiscreteSlider})
@@ -219,13 +179,55 @@ class HoloviewResult(VideoResult):
         widget_box = row[1]
         widget_box.align = ("start", "start")
 
-        # Build a JS snippet that sets the slider to the last position once
-        # Bokeh has finished rendering.  This triggers the existing
-        # change:value callback which calls State.set_state(), applying the
-        # correct patch for the last time point.
-        init_script = _over_time_init_last_script()
+        # Count slider positions so the JS snippet knows the target value.
+        n_positions = 0
+        for w in widget_box:
+            if hasattr(w, "name") and w.name == "over_time" and hasattr(w, "options") and w.options:
+                opts = w.options.values() if isinstance(w.options, dict) else w.options
+                n_positions = len(list(opts))
+                break
 
-        return pn.Column(row[0], widget_box, init_script)
+        # JS that finds the Bokeh Slider model and sets value = end.
+        # In Panel's embed mode this triggers the CustomJS callback that
+        # calls State.set_state(), applying the pre-computed patch.
+        if n_positions > 1:
+            init_js = pn.pane.HTML(
+                """\
+<script>
+(function() {
+  var attempts = 0;
+  function _setSliderToEnd() {
+    attempts++;
+    if (attempts > 50) return;
+    if (typeof Bokeh === "undefined" || !Bokeh.documents || !Bokeh.documents.length) {
+      setTimeout(_setSliderToEnd, 100);
+      return;
+    }
+    var doc = Bokeh.documents[0];
+    var found = false;
+    doc._all_models.forEach(function(model) {
+      if (!found && model.end != null && model.start != null
+          && model.value != null && model.step === 1) {
+        model.value = model.end;
+        found = true;
+      }
+    });
+    if (!found) setTimeout(_setSliderToEnd, 100);
+  }
+  if (document.readyState === "complete") {
+    setTimeout(_setSliderToEnd, 50);
+  } else {
+    window.addEventListener("load", function() { setTimeout(_setSliderToEnd, 50); });
+  }
+})();
+</script>""",
+                width=0,
+                height=0,
+                margin=0,
+            )
+            return pn.Column(row[0], widget_box, init_js)
+
+        return pn.Column(row[0], widget_box)
 
     def hv_container_ds(
         self,

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -179,40 +179,60 @@ class HoloviewResult(VideoResult):
         widget_box = row[1]
         widget_box.align = ("start", "start")
 
-        # Count slider positions so the JS snippet knows the target value.
-        n_positions = 0
+        # Find the over_time slider and its last option value.
+        over_time_slider = None
+        last_option = None
         for w in widget_box:
             if hasattr(w, "name") and w.name == "over_time" and hasattr(w, "options") and w.options:
                 opts = w.options.values() if isinstance(w.options, dict) else w.options
-                n_positions = len(list(opts))
+                opts = list(opts)
+                if len(opts) > 1:
+                    over_time_slider = w
+                    last_option = opts[-1]
                 break
 
-        # JS that finds the Bokeh Slider model and sets value = end.
-        # In Panel's embed mode this triggers the CustomJS callback that
-        # calls State.set_state(), applying the pre-computed patch.
-        if n_positions > 1:
+        # For static HTML embeds, inject JS to move the slider to the last
+        # position after Bokeh renders.  In Panel's embed mode this triggers
+        # the CustomJS callback that calls State.set_state(), applying the
+        # pre-computed patch.  We match the Bokeh slider by its title
+        # ("over_time") so unrelated sliders on the page are not affected.
+        if over_time_slider is not None and last_option is not None:
             init_js = pn.pane.HTML(
                 """\
 <script>
 (function() {
+  // Poll until Bokeh finishes rendering.  50 attempts * 100 ms = 5 s
+  // which is generous for even large embedded documents.
+  var MAX_ATTEMPTS = 50;
+  var POLL_MS = 100;
   var attempts = 0;
   function _setSliderToEnd() {
     attempts++;
-    if (attempts > 50) return;
-    if (typeof Bokeh === "undefined" || !Bokeh.documents || !Bokeh.documents.length) {
-      setTimeout(_setSliderToEnd, 100);
+    if (attempts > MAX_ATTEMPTS) return;
+    if (typeof Bokeh === "undefined"
+        || !Bokeh.index || !Object.keys(Bokeh.index).length) {
+      setTimeout(_setSliderToEnd, POLL_MS);
       return;
     }
-    var doc = Bokeh.documents[0];
     var found = false;
-    doc._all_models.forEach(function(model) {
-      if (!found && model.end != null && model.start != null
-          && model.value != null && model.step === 1) {
-        model.value = model.end;
-        found = true;
+    var keys = Object.keys(Bokeh.index);
+    for (var i = 0; i < keys.length; i++) {
+      if (found) break;
+      var view = Bokeh.index[keys[i]];
+      if (!view || !view.model || !view.model.document) continue;
+      var iter = view.model.document._all_models.values();
+      var entry = iter.next();
+      while (!entry.done) {
+        var m = entry.value;
+        if (m.title === "over_time" && m.end != null && m.value != null) {
+          m.value = m.end;
+          found = true;
+          break;
+        }
+        entry = iter.next();
       }
-    });
-    if (!found) setTimeout(_setSliderToEnd, 100);
+    }
+    if (!found) setTimeout(_setSliderToEnd, POLL_MS);
   }
   if (document.readyState === "complete") {
     setTimeout(_setSliderToEnd, 50);

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -194,8 +194,12 @@ class HoloviewResult(VideoResult):
         # For static HTML embeds, inject JS to move the slider to the last
         # position after Bokeh renders.  In Panel's embed mode this triggers
         # the CustomJS callback that calls State.set_state(), applying the
-        # pre-computed patch.  We match the Bokeh slider by its title
-        # ("over_time") so unrelated sliders on the page are not affected.
+        # pre-computed patch.
+        #
+        # Panel's DiscreteSlider renders the label ("over_time: <b>…</b>")
+        # in a separate Div and sets the Bokeh Slider's title to ''.  So we
+        # find the slider through the Panel State model's widgets map, which
+        # explicitly tracks registered widget model IDs.
         if over_time_slider is not None and last_option is not None:
             init_js = pn.pane.HTML(
                 """\
@@ -220,16 +224,23 @@ class HoloviewResult(VideoResult):
       if (found) break;
       var view = Bokeh.index[keys[i]];
       if (!view || !view.model || !view.model.document) continue;
-      var iter = view.model.document._all_models.values();
-      var entry = iter.next();
-      while (!entry.done) {
-        var m = entry.value;
-        if (m.title === "over_time" && m.end != null && m.value != null) {
-          m.value = m.end;
-          found = true;
-          break;
+      var doc = view.model.document;
+      // Find the Panel State root which holds registered widget IDs
+      var roots = doc.roots();
+      for (var r = 0; r < roots.length; r++) {
+        var root = roots[r];
+        if (root.state == null || root.widgets == null) continue;
+        var wids = root.widgets instanceof Map
+          ? Array.from(root.widgets.keys())
+          : Object.keys(root.widgets);
+        for (var j = 0; j < wids.length; j++) {
+          var slider = doc.get_model_by_id(wids[j]);
+          if (slider && slider.end != null && slider.value != null) {
+            slider.value = slider.end;
+            found = true;
+          }
         }
-        entry = iter.next();
+        break;
       }
     }
     if (!found) setTimeout(_setSliderToEnd, POLL_MS);

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -22,6 +22,44 @@ hv.extension("bokeh", "plotly")
 # Flag to enable or disable tap tool functionality in visualizations
 use_tap = True
 
+# JS snippet that runs after Bokeh renders to set the over_time slider to the
+# last position.  It finds the Panel State model among document roots, extracts
+# the Bokeh Slider model ID from State.widgets, and sets slider.value = slider.end.
+_OVER_TIME_INIT_JS = """\
+<script>
+(function() {
+  function _initOverTimeSlider() {
+    if (typeof Bokeh === "undefined" || !Bokeh.documents || !Bokeh.documents.length) {
+      setTimeout(_initOverTimeSlider, 50);
+      return;
+    }
+    var doc = Bokeh.documents[0];
+    var roots = doc.roots();
+    for (var i = 0; i < roots.length; i++) {
+      var root = roots[i];
+      if (root.state != null && root.widgets != null && root.values != null) {
+        var wids = root.widgets instanceof Map
+          ? Array.from(root.widgets.keys())
+          : Object.keys(root.widgets);
+        for (var j = 0; j < wids.length; j++) {
+          var slider = doc.get_model_by_id(wids[j]);
+          if (slider && slider.end != null && slider.step === 1) {
+            slider.value = slider.end;
+          }
+        }
+        break;
+      }
+    }
+  }
+  setTimeout(_initOverTimeSlider, 100);
+})();
+</script>"""
+
+
+def _over_time_init_last_script():
+    """Return a zero-size HTML pane containing the init-to-last JS snippet."""
+    return pn.pane.HTML(_OVER_TIME_INIT_JS, width=0, height=0, margin=0)
+
 
 class HoloviewResult(VideoResult):
     @staticmethod
@@ -163,6 +201,14 @@ class HoloviewResult(VideoResult):
         string-based ``TimeEvent`` coordinates get a slider instead of
         the default dropdown ``Select`` widget.
 
+        The slider defaults to the most recent (last) time point via a
+        client-side script that fires after Bokeh renders.  We must NOT
+        set ``w.value`` in Python because Panel's embed system stores an
+        empty patch for the initial widget value — making that position
+        unreachable when the user slides back to it.  Instead we keep the
+        Python default (first value) so every position gets a real patch,
+        then use JS to switch to the last position on page load.
+
         Safe to call on any HoloViews object; if no widgets are produced
         the original object is returned unchanged.
         """
@@ -172,12 +218,14 @@ class HoloviewResult(VideoResult):
             return hvobj
         widget_box = row[1]
         widget_box.align = ("start", "start")
-        # Default slider to the most recent (last) time point
-        for w in widget_box:
-            if hasattr(w, "name") and w.name == "over_time" and hasattr(w, "options") and w.options:
-                opts = w.options.values() if isinstance(w.options, dict) else w.options
-                w.value = list(opts)[-1]
-        return pn.Column(row[0], widget_box)
+
+        # Build a JS snippet that sets the slider to the last position once
+        # Bokeh has finished rendering.  This triggers the existing
+        # change:value callback which calls State.set_state(), applying the
+        # correct patch for the last time point.
+        init_script = _over_time_init_last_script()
+
+        return pn.Column(row[0], widget_box, init_script)
 
     def hv_container_ds(
         self,

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.70.0
-  sha256: 627b744f13bb68c6e7133575617d3398e462c3c531ec567f6ec6b2ee7c952bf0
+  version: 1.70.1
+  sha256: 1412203e7dbb8243dc7811f467c2d97ed388c689ae71b5d5cbad80ebbcb1fa48
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -1553,6 +1553,7 @@ packages:
   - libgcc >=14
   - libstdcxx >=14
   license: MIT
+  license_family: MIT
   purls: []
   size: 12723451
   timestamp: 1773822285671

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.70.0"
+version = "1.70.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Panel's embed system stores an empty JSON patch for the initial widget value, making that slider position unreachable in saved HTML
- Keep the Python-side slider default at the first value so all positions get real patches
- Add a client-side JS snippet that moves the slider to the last (most recent) time point after Bokeh renders, triggering the embedded patch callback

## Test plan
- [ ] Run `python bencher/example/example_over_time.py` — verify slider defaults to last time point in live view
- [ ] Save as HTML and verify all slider positions (including last) are reachable
- [ ] Check examples with multiple over_time points (e.g. `example_time_event.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add a client-side JavaScript snippet to move the Bokeh slider to its final position after page load while keeping the Python-side default at the first value.