### PR TITLE
Fix band plots sharing axes across different metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.2] - 2026-03-20
+
+### Fixed
+- Fix band plots sharing axes across different metrics
+- Fix plot server not working with container port forwarding
+
 ## [1.70.1] - 2026-03-19
 
 ### Fixed

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -99,14 +99,14 @@ class BenchPlotServer:
         for logger in ["tornado", "bokeh"]:
             logging.getLogger(logger).setLevel(logging.WARNING)
 
+        serve_kwargs = dict(
+            title=bench_name,
+            threaded=True,
+            show=show,
+            address="0.0.0.0",
+            websocket_origin=["*"],
+        )
         if port is not None:
-            return pn.serve(
-                plots_instance,
-                title=bench_name,
-                websocket_origin=["*"],
-                port=port,
-                threaded=True,
-                show=show,
-            )
+            serve_kwargs["port"] = port
 
-        return pn.serve(plots_instance, title=bench_name, threaded=True, show=show)
+        return pn.serve(plots_instance, **serve_kwargs)

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -67,13 +67,17 @@ class BandResult(HoloviewResult):
         # which build a title reflecting only the x-axis (not aggregated dims).
         explicit_title = kwargs.pop("title", None)
 
+        units = getattr(result_var, "units", "") or ""
+
         use_holomap = self._use_holomap_for_time(dataset)
 
         if use_holomap:
-            return self._band_over_time(dataset, var, explicit_title, agg_over_dims, **kwargs)
+            return self._band_over_time(
+                dataset, var, explicit_title, agg_over_dims, units=units, **kwargs
+            )
 
         # Without over_time: find a continuous x-axis from remaining dims
-        return self._band_static(dataset, var, explicit_title, agg_over_dims, **kwargs)
+        return self._band_static(dataset, var, explicit_title, agg_over_dims, units=units, **kwargs)
 
     def _band_over_time(
         self,
@@ -81,6 +85,7 @@ class BandResult(HoloviewResult):
         var: str,
         title: str | None,
         agg_over_dims: list[str] | None,
+        units: str = "",
         **kwargs,
     ) -> hv.Overlay | None:
         """Build percentile bands with time on x-axis."""
@@ -127,6 +132,7 @@ class BandResult(HoloviewResult):
             var,
             title,
             x_dim="over_time",
+            units=units,
             **kwargs,
         )
 
@@ -136,6 +142,7 @@ class BandResult(HoloviewResult):
         var: str,
         title: str | None,
         agg_over_dims: list[str] | None,
+        units: str = "",
         **kwargs,
     ) -> hv.Overlay | None:
         """Build percentile bands over a non-time continuous axis."""
@@ -183,6 +190,7 @@ class BandResult(HoloviewResult):
             var,
             title,
             x_dim=x_dim,
+            units=units,
             **kwargs,
         )
 
@@ -236,6 +244,7 @@ class BandResult(HoloviewResult):
         var: str,
         title: str,
         x_dim: str = "x",
+        units: str = "",
         **_kwargs,
     ) -> hv.Overlay:
         """Construct the overlay of Area bands + median Curve + scatter points.
@@ -248,7 +257,7 @@ class BandResult(HoloviewResult):
         band_outer = hv.Area(
             (x_coords, p10, p90),
             kdims=[x_dim],
-            vdims=["p10", "p90"],
+            vdims=[f"{var}_p10", f"{var}_p90"],
             label="10th\u201390th pctl",
         ).opts(alpha=0.2, color="steelblue", line_alpha=0)
 
@@ -256,7 +265,7 @@ class BandResult(HoloviewResult):
         band_inner = hv.Area(
             (x_coords, p25, p75),
             kdims=[x_dim],
-            vdims=["p25", "p75"],
+            vdims=[f"{var}_p25", f"{var}_p75"],
             label="25th\u201375th pctl",
         ).opts(alpha=0.4, color="steelblue", line_alpha=0)
 
@@ -281,5 +290,6 @@ class BandResult(HoloviewResult):
             ).opts(color="grey", alpha=0.3, size=3)
             overlay = overlay * scatter
 
-        overlay = overlay.opts(title=title, xrotation=30, ylabel=var, legend_position="right")
+        ylabel = f"{var} [{units}]" if units else var
+        overlay = overlay.opts(title=title, xrotation=30, ylabel=ylabel, legend_position="right")
         return overlay

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.70.1"
+version = "1.70.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Make `hv.Area` vdim names metric-specific (`{var}_p10` instead of generic `p10`) so HoloViews treats each metric's bands as distinct dimensions and doesn't link their y-axes
- Pass `units` from `result_var` through the call chain to `_build_band_overlay`
- Include units in ylabel (`response_time [ms]`) for consistency with BarResult and DistributionResult

## Test plan
- [ ] Run `python bencher/example/example_regression.py` and verify `response_time` (ms) and `throughput` (req/s) band plots have independent y-axes with units in ylabel
- [ ] Run `python bencher/example/example_agg_over_time.py` as single-metric sanity check
- [ ] `pixi run ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix percentile band plots so different metrics render independently with proper labelling and ensure the plot server works correctly when running behind container port forwarding.

Bug Fixes:
- Prevent percentile band plots for different metrics from sharing a y-axis by treating each metric’s bands as distinct dimensions.
- Propagate result variable units into band plots and include them in y-axis labels for consistency across visualisations.
- Fix Panel plot server configuration so it serves correctly with or without an explicit port, including container port forwarding scenarios.

Build:
- Bump project version to 1.70.2 and update the changelog entry for the new release.