### PR TITLE
Update git_time_event() for wall-clock time and fork safety

### DIFF
--- a/bencher/example/example_git_time_event.py
+++ b/bencher/example/example_git_time_event.py
@@ -19,9 +19,9 @@ class ServerLatency(bch.ParametrizedSweep):
 def example_git_time_event(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
     """Track benchmark results over time using the current git commit as the time label.
 
-    ``git_time_event()`` returns a string like ``"2024-06-15 abc1234d"`` combining the commit
-    date and short hash.  Pass it as ``time_src`` to ``plot_sweep`` so the slider shows which
-    commit produced each data point.
+    ``git_time_event()`` returns a string like ``"2024-06-15 14:59 abc1234d"`` combining
+    wall-clock time and short hash.  Pass it as ``time_src`` to ``plot_sweep`` so the slider
+    shows which run and commit produced each data point.
     """
 
     run_cfg = run_cfg or bch.BenchRunCfg()

--- a/bencher/git_info.py
+++ b/bencher/git_info.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from datetime import datetime
 
 
 def _run_git(args: list[str], repo_path: str | None = None) -> str:
@@ -20,22 +21,27 @@ def _run_git(args: list[str], repo_path: str | None = None) -> str:
 
 
 def git_time_event(repo_path: str | None = None) -> str:
-    """Return a time-event label combining the commit date and short hash.
+    """Return a time-event label combining wall-clock time and short commit hash.
 
-    Example return value: ``"2024-06-15 abc1234d"``
+    Example return value: ``"2024-06-15 14:59 abc1234d"``
 
     Intended to be used with ``BenchRunCfg(over_time=True, time_event=...)``
     so the over-time slider shows *when* and *which commit* produced the data.
 
-    Falls back to just the short hash if the commit date is unavailable,
-    or an empty string if not inside a git repository.
+    Wall-clock time is used instead of commit time so that multiple benchmark
+    runs on the same commit produce distinct labels.
+
+    For fork-safety in multithreaded environments (ROS 2, DDS, etc.),
+    call this at module level before starting background threads::
+
+        _TIME_EVENT = bch.git_time_event()  # safe: no threads yet
+
+    Falls back to just the timestamp if not inside a git repository.
     """
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+
     commit = _run_git(["rev-parse", "HEAD"], repo_path)
     if not commit:
-        return ""
+        return timestamp
     short = commit[:8]
-    date = _run_git(["log", "-1", "--format=%cI"], repo_path)
-    date_part = date.split("T")[0] if date else ""
-    if date_part:
-        return f"{date_part} {short}"
-    return short
+    return f"{timestamp} {short}"

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -135,7 +135,7 @@ class BenchResultBase:
         if bench_cfg.over_time and "over_time" in self.ds.coords:
             if bench_cfg.time_event is not None:
                 self.ds.coords["over_time"] = [
-                    "\n".join(wrap(str(t), 20)) for t in self.ds.coords["over_time"].values
+                    "\n".join(wrap(str(t), 30)) for t in self.ds.coords["over_time"].values
                 ]
             else:
                 time_values = self.ds.coords["over_time"].values

--- a/pixi.lock
+++ b/pixi.lock
@@ -45,7 +45,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
@@ -207,7 +207,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
@@ -373,7 +373,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
@@ -536,7 +536,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
@@ -698,7 +698,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5b/03/c17464bbf682ea87e7e3de2ddc63395e359a78ae9c01f55fc78759ecbd79/anywidget-0.9.21-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f6/a8/877f306720bc114c612579c5af36bcb359026b83d051226945499b306b1a/bokeh-3.8.2-py3-none-any.whl
@@ -869,10 +869,10 @@ packages:
   - pytest-cov ; extra == 'test'
   - pytest-xdist ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
   name: attrs
-  version: 25.4.0
-  sha256: adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373
+  version: 26.1.0
+  sha256: c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
   name: bleach
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.70.1
-  sha256: 1412203e7dbb8243dc7811f467c2d97ed388c689ae71b5d5cbad80ebbcb1fa48
+  version: 1.70.2
+  sha256: a1677da9992cd1d466e9868903b4383f0ea8e5a0c30465e2885a4c9ec3dc2681
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.70.2"
+version = "1.70.3"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_git_info.py
+++ b/test/test_git_info.py
@@ -8,38 +8,35 @@ from bencher.git_info import git_time_event
 
 
 class TestGitTimeEvent(unittest.TestCase):
-    def test_returns_date_and_hash(self):
+    def test_returns_timestamp_and_hash(self):
         def fake(cmd, **_kwargs):
             if "rev-parse" in cmd:
                 return b"abc1234def5678901234567890abcdef12345678\n"
-            if "log" in cmd:
-                return b"2024-06-15T12:00:00+00:00\n"
             return b""
 
-        with mock.patch("subprocess.check_output", side_effect=fake):
-            result = git_time_event()
-        self.assertEqual(result, "2024-06-15 abc1234d")
-
-    def test_returns_empty_outside_repo(self):
-        with mock.patch(
-            "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "")
+        with (
+            mock.patch("subprocess.check_output", side_effect=fake),
+            mock.patch("bencher.git_info.datetime") as mock_dt,
         ):
-            self.assertEqual(git_time_event(), "")
+            mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
+            result = git_time_event()
+        self.assertEqual(result, "2024-06-15 14:59 abc1234d")
 
-    def test_returns_empty_when_git_not_installed(self):
-        with mock.patch("subprocess.check_output", side_effect=FileNotFoundError):
-            self.assertEqual(git_time_event(), "")
+    def test_returns_timestamp_outside_repo(self):
+        with (
+            mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "")),
+            mock.patch("bencher.git_info.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
+            self.assertEqual(git_time_event(), "2024-06-15 14:59")
 
-    def test_falls_back_to_hash_without_date(self):
-        def fake(cmd, **_kwargs):
-            if "rev-parse" in cmd:
-                return b"a" * 40 + b"\n"
-            if "log" in cmd:
-                return b""
-            return b""
-
-        with mock.patch("subprocess.check_output", side_effect=fake):
-            self.assertEqual(git_time_event(), "a" * 8)
+    def test_returns_timestamp_when_git_not_installed(self):
+        with (
+            mock.patch("subprocess.check_output", side_effect=FileNotFoundError),
+            mock.patch("bencher.git_info.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
+            self.assertEqual(git_time_event(), "2024-06-15 14:59")
 
     def test_used_as_time_src(self):
         """git_time_event() works as time_src in plot_sweep."""
@@ -55,7 +52,7 @@ class TestGitTimeEvent(unittest.TestCase):
             plot_callbacks=False,
         )
         over_time_val = str(res.ds.coords["over_time"].values[0])
-        self.assertRegex(over_time_val, r"\d{4}-\d{2}-\d{2} [0-9a-f]{8}")
+        self.assertRegex(over_time_val, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} [0-9a-f]{8}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Wall-clock time**: `git_time_event()` now uses `datetime.now()` instead of commit date, producing labels like `"2024-06-15 14:59 abc1234d"`. Multiple runs on the same commit get distinct labels, preventing over_time data collisions.
- **Fewer subprocesses**: Removed the `git log` call (only `git rev-parse HEAD` remains), making the function inherently lighter for fork-sensitive environments.
- **Fork-safety docs**: Docstring documents the recommended import-time caching pattern for threaded/multiprocess environments (ROS 2, DDS, etc.).
- **Wrap width fix**: Increased `wrap_long_time_labels` width from 20→30 so the longer label format isn't broken by newlines.

## Test plan
- [x] Unit tests updated and passing (mocked datetime + subprocess)
- [x] Integration test verifies new format in xarray over_time coordinate
- [x] Full CI pipeline passes (`pixi run ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch git_time_event() to wall-clock timestamps so over-time labels remain unique per run and document fork-safe caching guidance.

Enhancements:
- Remove the git log subprocess and always include the current timestamp with the short commit hash in git_time_event() for more informative labels.
- Loosen over_time label wrapping to 30 characters to accommodate the longer timestamped format.

Documentation:
- Update the example git_time_event docs to describe the new timestamp-inclusive label format.

Tests:
- Refresh git_time_event unit tests to mock datetime, cover non-repo and missing git scenarios, and ensure the over_time integration regex matches the timestamped label.