### PR TITLE
Fix TimeEvent curve plots using wrong x-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.70.4] - 2026-03-20
+
+### Fixed
+- Fix curve plots using string-typed over_time (TimeEvent) as x-axis instead of the float input variable — explicitly set kdims in `to_curve_ds` to match `to_line_ds` behavior
+- Classify TimeEvent as continuous in plot config so it is treated like TimeSnapshot for plotting
+- Add TimeEvent support in optuna conversions and trial building
+
+### Removed
+- Remove vestigial `iv_time_event` field from BenchCfg (was never populated)
+
 ## [1.70.2] - 2026-03-20
 
 ### Fixed

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -361,7 +361,6 @@ class BenchCfg(BenchRunCfg):
         meta_vars (list): Meta variables such as recording time and repeat id
         all_vars (list): Stores a list of both the input_vars and meta_vars
         iv_time (list[TimeSnapshot | TimeEvent]): Parameter for sampling the same inputs over time
-        iv_time_event (list[TimeEvent]): Parameter for sampling inputs over time as a discrete type
         over_time (bool): Controls whether the function is sampled over time
         name (str): The name of the benchmarkCfg
         title (str): The title of the benchmark
@@ -404,12 +403,6 @@ class BenchCfg(BenchRunCfg):
         default=[],
         item_type=TimeSnapshot | TimeEvent,
         doc="A parameter to represent the sampling the same inputs over time as a scalar type",
-    )
-
-    iv_time_event = param.List(
-        default=[],
-        item_type=TimeEvent,
-        doc="A parameter to represent the sampling the same inputs over time as a discrete type",
     )
 
     # Note: over_time is already inherited from BenchRunCfg

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -104,12 +104,9 @@ def sweep_var_to_optuna_dist(var: param.Parameter) -> optuna.distributions.BaseD
     if iv_type == BoolSweep:
         return optuna.distributions.CategoricalDistribution([False, True])
     if iv_type == TimeSnapshot:
-        # return optuna.distributions.IntDistribution(0, sys.maxsize)
         return optuna.distributions.FloatDistribution(0, 1e20)
-        # return optuna.distributions.CategoricalDistribution([])
-    # elif iv_type == TimeEvent:
-    #     pass
-    # return optuna.distributions.CategoricalDistribution(["now"])
+    if iv_type == TimeEvent:
+        return optuna.distributions.CategoricalDistribution(var.values())
 
     raise ValueError(f"This input type {iv_type} is not supported")
 

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -11,7 +11,7 @@ from bencher.variables.inputs import (
     StringSweep,
     YamlSweep,
 )
-from bencher.variables.time import TimeSnapshot
+from bencher.variables.time import TimeSnapshot, TimeEvent
 
 
 class PltCntCfg(param.Parameterized):
@@ -56,7 +56,7 @@ class PltCntCfg(param.Parameterized):
 
         for iv in bench_cfg.input_vars:
             type_allocated = False
-            if isinstance(iv, (IntSweep, FloatSweep, TimeSnapshot)):
+            if isinstance(iv, (IntSweep, FloatSweep, TimeSnapshot, TimeEvent)):
                 # if "IntSweep" in typestr or "FloatSweep" in typestr:
                 plt_cnt_cfg.float_vars.append(iv)
                 type_allocated = True

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -94,7 +94,10 @@ class CurveResult(HoloviewResult):
 
         hvds = hv.Dataset(dataset)
         pt = hv.Overlay()
-        pt *= hvds.to(hv.Curve, vdims=var, label=var).opts(title=title, xrotation=30, **kwargs)
+        x_kdim = self.plt_cnt_cfg.float_vars[0].name
+        pt *= hvds.to(hv.Curve, kdims=x_kdim, vdims=var, label=var).opts(
+            title=title, xrotation=30, **kwargs
+        )
         if std_var in dataset.data_vars:
             pt *= hvds.to(hv.Spread, vdims=[var, std_var])
         pt = pt.opts(legend_position="right")

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -91,10 +91,7 @@ class OptunaResult(BenchResultBase):
         if include_meta:
             # df = self.to_pandas()
             df = self.to_dataset(reduce=ReduceType.NONE).to_dataframe().reset_index()
-            all_vars = []
-            for v in self.bench_cfg.all_vars:
-                if type(v) is not TimeEvent:
-                    all_vars.append(v)
+            all_vars = list(self.bench_cfg.all_vars)
 
             print("All vars", all_vars)
         else:
@@ -125,6 +122,8 @@ class OptunaResult(BenchResultBase):
                 if type(i) is TimeSnapshot:
                     if type(row[1][i.name]) is np.datetime64:
                         params[i.name] = row[1][i.name].timestamp()
+                elif type(i) is TimeEvent:
+                    params[i.name] = str(row[1][i.name])
                 elif type(i) is BoolSweep:
                     # Handle boolean values that may have been converted to strings
                     val = row[1][i.name]

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.70.2
-  sha256: a1677da9992cd1d466e9868903b4383f0ea8e5a0c30465e2885a4c9ec3dc2681
+  version: 1.70.4
+  sha256: d38096b909c065caf2cc835e058c06786534fe4cbad24faa9691247bd669c2cf
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.70.3"
+version = "1.70.4"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_time_event_curve.py
+++ b/test/test_time_event_curve.py
@@ -1,0 +1,90 @@
+"""Tests that curve plots use the float var as x-axis when over_time uses string-based TimeEvent."""
+
+from typing import Any
+
+import panel as pn
+
+import bencher as bch
+
+
+class FloatWithTimeBench(bch.ParametrizedSweep):
+    """Benchmark with one float input for testing TimeEvent + curve interaction."""
+
+    size = bch.FloatSweep(default=50, bounds=[10, 100], samples=3, doc="Size")
+    throughput = bch.ResultVar(units="MB/s", doc="Throughput")
+
+    offset = 0.0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self.throughput = self.size * 0.5 + self.offset
+        return super().__call__()
+
+
+class FloatCatWithTimeBench(bch.ParametrizedSweep):
+    """Benchmark with one float + one cat input for testing TimeEvent + curve interaction."""
+
+    size = bch.FloatSweep(default=50, bounds=[10, 100], samples=3, doc="Size")
+    backend = bch.StringSweep(["redis", "local"], doc="Backend")
+    throughput = bch.ResultVar(units="MB/s", doc="Throughput")
+
+    offset = 0.0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        base = {"redis": 1.0, "local": 2.0}[self.backend]
+        self.throughput = self.size * base + self.offset
+        return super().__call__()
+
+
+def _run_string_over_time(benchable, input_vars, result_vars, repeats=1, snapshots=3):
+    """Run a benchmark over multiple time points using string time_src (TimeEvent)."""
+    run_cfg = bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = repeats
+    bench = benchable.to_bench(run_cfg)
+
+    for i in range(snapshots):
+        benchable.offset = i * 0.5
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "time_event_curve_test",
+            input_vars=input_vars,
+            result_vars=result_vars,
+            run_cfg=run_cfg,
+            time_src=f"2026-03-{18 + i:02d} abc{i:04d}",
+        )
+    return res
+
+
+class TestTimeEventCurvePlot:
+    """Verify curve plots use float var as x-axis when over_time creates a TimeEvent."""
+
+    def test_curve_with_string_time_src(self):
+        """1 float + repeats + string over_time -> curve with float on x-axis."""
+        benchable = FloatWithTimeBench()
+        res = _run_string_over_time(benchable, ["size"], ["throughput"], repeats=3, snapshots=3)
+        plots = res.to_auto_plots()
+        assert plots is not None
+        assert len(plots) > 0
+        assert any(isinstance(p, pn.Column) for p in plots)
+
+    def test_curve_with_string_time_src_and_cat(self):
+        """1 float + 1 cat + repeats + string over_time -> curve with float on x-axis."""
+        benchable = FloatCatWithTimeBench()
+        res = _run_string_over_time(
+            benchable, ["size", "backend"], ["throughput"], repeats=3, snapshots=3
+        )
+        plots = res.to_auto_plots()
+        assert plots is not None
+        assert len(plots) > 0
+        assert any(isinstance(p, pn.Column) for p in plots)
+
+    def test_line_with_string_time_src(self):
+        """1 float + 1 repeat + string over_time -> line plot works."""
+        benchable = FloatWithTimeBench()
+        res = _run_string_over_time(benchable, ["size"], ["throughput"], repeats=1, snapshots=3)
+        plots = res.to_auto_plots()
+        assert plots is not None
+        assert len(plots) > 0


### PR DESCRIPTION
## Summary
- Fix curve plots putting the string-typed `over_time` (TimeEvent) dimension on the x-axis instead of the FloatSweep variable, by explicitly setting `kdims` in `to_curve_ds`
- Classify `TimeEvent` as continuous in `PltCntCfg` alongside `TimeSnapshot` so both time types are treated as float vars for plotting
- Add `TimeEvent` support in optuna conversions (categorical distribution for string values) and trial building
- Remove vestigial `iv_time_event` field from `BenchCfg` that was never populated

## Test plan
- [x] New `test/test_time_event_curve.py` with 3 tests: curve with string time_src, curve with string time_src + cat var, line with string time_src
- [x] All existing tests pass (`pixi run ci` green)
- [x] Pylint 10/10, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)