### PR TITLE
Add bencher self-introspection with over-time performance tracking

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -100,6 +100,7 @@ from .results.video_result import VideoResult
 from .results.holoview_results.holoview_result import ReduceType, HoloviewResult
 from .bench_report import BenchReport, GithubPagesCfg
 from .job import Executors
+from .sweep_timings import SweepTimings
 from .video_writer import VideoWriter, add_image
 from .class_enum import ClassEnum, ExampleEnum
 from .factories import create_bench, create_bench_runner

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -805,13 +805,16 @@ class Bench(BenchPlotServer):
                 result = self.sample_cache.submit(cache_job)
                 results_list.append(result)
                 callcount += 1
+
+                # For serial execution, store results immediately so that
+                # completed results are cached to disk before later jobs
+                # may crash.
+                if bench_run_cfg.executor == Executors.SERIAL:
+                    self.store_results(result, bench_res, job, bench_run_cfg)
         timings.job_submission_ms = elapsed()
 
         with phase_timer() as elapsed:
-            if bench_run_cfg.executor == Executors.SERIAL:
-                for job, res in zip(jobs, results_list):
-                    self.store_results(res, bench_res, job, bench_run_cfg)
-            else:
+            if bench_run_cfg.executor != Executors.SERIAL:
                 for job, res in zip(jobs, results_list):
                     self.store_results(res, bench_res, job, bench_run_cfg)
         timings.job_execution_ms = elapsed()

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -28,6 +28,7 @@ from bencher.job import Job, FutureCache, JobFuture, Executors
 from bencher.utils import params_to_str, resolve_aggregate, _handle_deprecated_agg_over_dims
 from bencher.sample_order import SampleOrder
 from bencher.regression import detect_regressions, RegressionError
+from bencher.sweep_timings import SweepTimings, phase_timer
 
 # Import helper classes
 from bencher.worker_manager import WorkerManager
@@ -520,6 +521,11 @@ class Bench(BenchPlotServer):
         Raises:
             FileNotFoundError: If only_plot=True and no cached results exist
         """
+        import time as _time
+
+        timings = SweepTimings()
+        sweep_t0 = _time.perf_counter()
+
         if run_cfg.cache_size is not None:
             cache_size_bytes = run_cfg.cache_size * 1_000_000
             self.cache_size = cache_size_bytes
@@ -557,29 +563,33 @@ class Bench(BenchPlotServer):
         # does not include repeats in hash as sample_hash already includes repeat as part of the per sample hash
         bench_cfg_sample_hash = bench_cfg.hash_persistent(False)
 
-        if self.sample_cache is None:
-            self.sample_cache = self.init_sample_cache(run_cfg)
-        if bench_cfg.clear_sample_cache:
-            self.clear_tag_from_sample_cache(bench_cfg.tag, run_cfg)
+        with phase_timer() as elapsed:
+            if self.sample_cache is None:
+                self.sample_cache = self.init_sample_cache(run_cfg)
+            if bench_cfg.clear_sample_cache:
+                self.clear_tag_from_sample_cache(bench_cfg.tag, run_cfg)
+        timings.sample_cache_init_ms = elapsed()
 
         calculate_results = True
-        with Cache("cachedir/benchmark_inputs", size_limit=self.cache_size) as c:
-            if run_cfg.clear_cache:
-                c.delete(bench_cfg_hash)
-                logging.info("cleared cache")
-            elif run_cfg.cache_results:
-                logging.info(
-                    f"checking for previously calculated results with key: {bench_cfg_hash}"
-                )
-                if bench_cfg_hash in c:
-                    logging.info(f"loading cached results from key: {bench_cfg_hash}")
-                    bench_res = c[bench_cfg_hash]
-                    # if not over_time:  # if over time we always want to calculate results
-                    calculate_results = False
-                else:
-                    logging.info("did not detect results in cache")
-                    if run_cfg.only_plot:
-                        raise FileNotFoundError("Was not able to load the results to plot!")
+        with phase_timer() as elapsed:
+            with Cache("cachedir/benchmark_inputs", size_limit=self.cache_size) as c:
+                if run_cfg.clear_cache:
+                    c.delete(bench_cfg_hash)
+                    logging.info("cleared cache")
+                elif run_cfg.cache_results:
+                    logging.info(
+                        f"checking for previously calculated results with key: {bench_cfg_hash}"
+                    )
+                    if bench_cfg_hash in c:
+                        logging.info(f"loading cached results from key: {bench_cfg_hash}")
+                        bench_res = c[bench_cfg_hash]
+                        # if not over_time:  # if over time we always want to calculate results
+                        calculate_results = False
+                    else:
+                        logging.info("did not detect results in cache")
+                        if run_cfg.only_plot:
+                            raise FileNotFoundError("Was not able to load the results to plot!")
+        timings.cache_check_ms = elapsed()
 
         if run_cfg.time_event is not None:
             time_src = run_cfg.time_event
@@ -588,18 +598,23 @@ class Bench(BenchPlotServer):
 
         if calculate_results:
             bench_res = self.calculate_benchmark_results(
-                bench_cfg, time_src, bench_cfg_sample_hash, run_cfg, sample_order
+                bench_cfg, time_src, bench_cfg_sample_hash, run_cfg, sample_order, timings
             )
 
             # use the hash of the inputs to look up historical values in the cache
             if run_cfg.over_time:
-                bench_res.ds = self.load_history_cache(
-                    bench_res.ds, bench_cfg_hash, run_cfg.clear_history, run_cfg.max_time_events
-                )
-                # sync the over_time meta variable with the actual accumulated values
-                if bench_cfg.iv_time and "over_time" in bench_res.ds.coords:
-                    bench_cfg.iv_time[0].objects = list(bench_res.ds.coords["over_time"].values)
-                    bench_cfg.iv_time[0].samples = len(bench_cfg.iv_time[0].objects)
+                with phase_timer() as elapsed:
+                    bench_res.ds = self.load_history_cache(
+                        bench_res.ds,
+                        bench_cfg_hash,
+                        run_cfg.clear_history,
+                        run_cfg.max_time_events,
+                    )
+                    # sync the over_time meta variable with the actual accumulated values
+                    if bench_cfg.iv_time and "over_time" in bench_res.ds.coords:
+                        bench_cfg.iv_time[0].objects = list(bench_res.ds.coords["over_time"].values)
+                        bench_cfg.iv_time[0].samples = len(bench_cfg.iv_time[0].objects)
+                timings.history_merge_ms = elapsed()
 
             # Regression detection runs after load_history_cache (which merges the current
             # run into the dataset) but before cache_results. The dataset already contains
@@ -618,7 +633,12 @@ class Bench(BenchPlotServer):
         logging.info(self.sample_cache.stats())
         self.sample_cache.close()
 
-        bench_res.post_setup()
+        with phase_timer() as elapsed:
+            bench_res.post_setup()
+        timings.post_setup_ms = elapsed()
+
+        timings.total_ms = (_time.perf_counter() - sweep_t0) * 1000.0
+        bench_res.timings = timings
 
         if bench_cfg.auto_plot:
             self.report.append_result(bench_res)
@@ -701,6 +721,7 @@ class Bench(BenchPlotServer):
         bench_cfg_sample_hash: str,
         bench_run_cfg: BenchRunCfg,
         sample_order: SampleOrder = SampleOrder.INORDER,
+        timings: SweepTimings | None = None,
     ) -> BenchResult:
         """Execute the benchmark runs and collect results into an n-dimensional array.
 
@@ -713,75 +734,87 @@ class Bench(BenchPlotServer):
             time_src (datetime | str): Timestamp or event name for the benchmark run
             bench_cfg_sample_hash (str): Hash of the benchmark configuration without repeats
             bench_run_cfg (BenchRunCfg): Configuration for how the benchmark should be executed
+            timings (SweepTimings, optional): Timing collector to populate. Defaults to None.
 
         Returns:
             BenchResult: An object containing all the benchmark data and results
         """
-        bench_res, func_inputs, dims_name = self.setup_dataset(bench_cfg, time_src)
-        # Adjust only the sampling traversal; leave dims/plotting unchanged
-        if sample_order == SampleOrder.REVERSED:
-            total_dims = len(dims_name)
-            num_input_dims = len(bench_res.bench_cfg.input_vars)
+        if timings is None:
+            timings = SweepTimings()
 
-            # Extract coordinate values from the dataset to rebuild the Cartesian product
-            dim_values = [list(bench_res.ds.coords[n].values) for n in dims_name]
-            dim_indices = [list(range(len(v))) for v in dim_values]
+        with phase_timer() as elapsed:
+            bench_res, func_inputs, dims_name = self.setup_dataset(bench_cfg, time_src)
+            # Adjust only the sampling traversal; leave dims/plotting unchanged
+            if sample_order == SampleOrder.REVERSED:
+                total_dims = len(dims_name)
+                num_input_dims = len(bench_res.bench_cfg.input_vars)
 
-            # Build iteration order: reverse the input portion only
-            iter_order = list(range(num_input_dims))[::-1] + list(range(num_input_dims, total_dims))
+                # Extract coordinate values from the dataset to rebuild the Cartesian product
+                dim_values = [list(bench_res.ds.coords[n].values) for n in dims_name]
+                dim_indices = [list(range(len(v))) for v in dim_values]
 
-            # Generate product in iter_order and map back to original order
-            ordered = []
-            for idx_ord, val_ord in zip(
-                product(*[dim_indices[i] for i in iter_order]),
-                product(*[dim_values[i] for i in iter_order]),
-            ):
-                idx_orig = [None] * total_dims
-                val_orig = [None] * total_dims
-                for j, pos in enumerate(iter_order):
-                    idx_orig[pos] = idx_ord[j]
-                    val_orig[pos] = val_ord[j]
-                ordered.append((tuple(idx_orig), tuple(val_orig)))
+                # Build iteration order: reverse the input portion only
+                iter_order = list(range(num_input_dims))[::-1] + list(
+                    range(num_input_dims, total_dims)
+                )
 
-            func_inputs = ordered
-        bench_res.bench_cfg.hmap_kdims = sorted(dims_name)
-        constant_inputs = self.define_const_inputs(bench_res.bench_cfg.const_vars)
+                # Generate product in iter_order and map back to original order
+                ordered = []
+                for idx_ord, val_ord in zip(
+                    product(*[dim_indices[i] for i in iter_order]),
+                    product(*[dim_values[i] for i in iter_order]),
+                ):
+                    idx_orig = [None] * total_dims
+                    val_orig = [None] * total_dims
+                    for j, pos in enumerate(iter_order):
+                        idx_orig[pos] = idx_ord[j]
+                        val_orig[pos] = val_ord[j]
+                    ordered.append((tuple(idx_orig), tuple(val_orig)))
+
+                func_inputs = ordered
+            bench_res.bench_cfg.hmap_kdims = sorted(dims_name)
+            constant_inputs = self.define_const_inputs(bench_res.bench_cfg.const_vars)
+        timings.dataset_setup_ms = elapsed()
+
         callcount = 1
-
         results_list = []
         jobs = []
 
-        for idx_tuple, function_input_vars in func_inputs:
-            job = WorkerJob(
-                function_input_vars,
-                idx_tuple,
-                dims_name,
-                constant_inputs,
-                bench_cfg_sample_hash,
-                bench_res.bench_cfg.tag,
-            )
-            job.setup_hashes()
-            jobs.append(job)
+        with phase_timer() as elapsed:
+            for idx_tuple, function_input_vars in func_inputs:
+                job = WorkerJob(
+                    function_input_vars,
+                    idx_tuple,
+                    dims_name,
+                    constant_inputs,
+                    bench_cfg_sample_hash,
+                    bench_res.bench_cfg.tag,
+                )
+                job.setup_hashes()
+                jobs.append(job)
 
-            jid = f"{bench_res.bench_cfg.title}:call {callcount}/{len(func_inputs)}"
-            worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
-            cache_job = Job(
-                job_id=jid,
-                function=worker,
-                job_args=job.function_input,
-                job_key=job.function_input_signature_pure,
-                tag=job.tag,
-            )
-            result = self.sample_cache.submit(cache_job)
-            results_list.append(result)
-            callcount += 1
+                jid = f"{bench_res.bench_cfg.title}:call {callcount}/{len(func_inputs)}"
+                worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
+                cache_job = Job(
+                    job_id=jid,
+                    function=worker,
+                    job_args=job.function_input,
+                    job_key=job.function_input_signature_pure,
+                    tag=job.tag,
+                )
+                result = self.sample_cache.submit(cache_job)
+                results_list.append(result)
+                callcount += 1
+        timings.job_submission_ms = elapsed()
 
+        with phase_timer() as elapsed:
             if bench_run_cfg.executor == Executors.SERIAL:
-                self.store_results(result, bench_res, job, bench_run_cfg)
-
-        if bench_run_cfg.executor != Executors.SERIAL:
-            for job, res in zip(jobs, results_list):
-                self.store_results(res, bench_res, job, bench_run_cfg)
+                for job, res in zip(jobs, results_list):
+                    self.store_results(res, bench_res, job, bench_run_cfg)
+            else:
+                for job, res in zip(jobs, results_list):
+                    self.store_results(res, bench_res, job, bench_run_cfg)
+        timings.job_execution_ms = elapsed()
 
         for inp in bench_res.bench_cfg.all_vars:
             self.add_metadata_to_dataset(bench_res, inp)

--- a/bencher/example/example_self_benchmark.py
+++ b/bencher/example/example_self_benchmark.py
@@ -1,0 +1,97 @@
+"""Bencher self-introspection: benchmarks bencher's own overhead across problem sizes.
+
+This example uses bencher to benchmark itself, sweeping over the number of parameter
+samples and measuring the framework's timing for each phase of a sweep. The results
+reveal how overhead scales with problem size, helping identify optimization targets.
+
+Run locally:
+    python bencher/example/example_self_benchmark.py
+"""
+
+import bencher as bch
+
+
+class TrivialWorkload(bch.ParametrizedSweep):
+    """A near-zero-cost worker so we measure framework overhead, not compute."""
+
+    x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
+    result = bch.ResultVar(units="v", doc="trivial output")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.result = self.x * 2
+        return super().__call__(**kwargs)
+
+
+class BencherSelfBenchmark(bch.ParametrizedSweep):
+    """Sweep over problem sizes and measure bencher's own timing phases."""
+
+    num_samples = bch.IntSweep(
+        default=10,
+        bounds=[2, 100],
+        samples=6,
+        doc="Number of parameter samples in the inner sweep",
+    )
+    use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
+
+    # Result variables — one per timing phase
+    total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
+    dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
+    job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")
+    job_execution_ms = bch.ResultVar(units="ms", doc="Worker execution and result storage time")
+    cache_check_ms = bch.ResultVar(units="ms", doc="Benchmark cache lookup time")
+    sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
+    throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+
+        workload = TrivialWorkload()
+        x_sweep = bch.FloatSweep(default=0, bounds=[0, 1], samples=self.num_samples, doc="input")
+        x_sweep.name = "x"
+
+        inner_cfg = bch.BenchRunCfg()
+        inner_cfg.repeats = 1
+        inner_cfg.cache_samples = self.use_cache
+        inner_cfg.cache_results = False
+        inner_cfg.auto_plot = False
+
+        bench = bch.Bench("inner_bench", workload, run_cfg=inner_cfg)
+        bench.plot_sweep(input_vars=[x_sweep], result_vars=["result"])
+        res = bench.results[-1]
+
+        t = res.timings
+        self.total_ms = t.total_ms
+        self.dataset_setup_ms = t.dataset_setup_ms
+        self.job_submission_ms = t.job_submission_ms
+        self.job_execution_ms = t.job_execution_ms
+        self.cache_check_ms = t.cache_check_ms
+        self.sample_cache_init_ms = t.sample_cache_init_ms
+        self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
+
+        return super().__call__(**kwargs)
+
+
+def example_self_benchmark(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Benchmark bencher's own overhead across problem sizes."""
+    bench = BencherSelfBenchmark().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["num_samples"],
+        result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+        title="Bencher Self-Benchmark: Phase Timing vs Problem Size",
+    )
+    bench.plot_sweep(
+        input_vars=["num_samples"],
+        result_vars=["throughput"],
+        title="Bencher Self-Benchmark: Throughput vs Problem Size",
+    )
+    bench.plot_sweep(
+        input_vars=["num_samples", "use_cache"],
+        result_vars=["total_ms"],
+        title="Bencher Self-Benchmark: Cache Impact",
+    )
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_self_benchmark)

--- a/bencher/example/generated/performance/self_benchmark.py
+++ b/bencher/example/generated/performance/self_benchmark.py
@@ -1,15 +1,6 @@
-"""Bencher self-introspection: benchmarks bencher's own overhead across problem sizes.
+"""Auto-generated example: Bencher self-introspection: overhead vs problem size."""
 
-This example uses bencher to benchmark itself, sweeping over the number of parameter
-samples and measuring the framework's timing for each phase of a sweep. The results
-reveal how overhead scales with problem size, helping identify optimization targets.
-
-When run with ``over_time=True`` (see ``example_self_benchmark_over_time``), results
-accumulate across commits so you can track framework performance regressions.
-
-Run locally:
-    python bencher/example/example_self_benchmark.py
-"""
+from typing import Any
 
 import bencher as bch
 
@@ -20,7 +11,7 @@ class TrivialWorkload(bch.ParametrizedSweep):
     x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bch.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.result = self.x * 2
         return super().__call__(**kwargs)
@@ -37,7 +28,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     )
     use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
 
-    # Result variables — one per timing phase
+    # Result variables - one per timing phase
     total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
     dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
     job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")
@@ -46,7 +37,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
 
         workload = TrivialWorkload()
@@ -76,59 +67,24 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
 
 
 def example_self_benchmark(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Benchmark bencher's own overhead across problem sizes."""
+    """Bencher self-introspection: overhead vs problem size."""
     bench = BencherSelfBenchmark().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["num_samples"],
-        result_vars=[
-            "total_ms",
-            "dataset_setup_ms",
-            "job_submission_ms",
-            "job_execution_ms",
-        ],
-        title="Bencher Self-Benchmark: Phase Timing vs Problem Size",
+        result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+        title="Phase Timing vs Problem Size",
     )
     bench.plot_sweep(
         input_vars=["num_samples"],
         result_vars=["throughput"],
-        title="Bencher Self-Benchmark: Throughput vs Problem Size",
+        title="Throughput vs Problem Size",
     )
     bench.plot_sweep(
         input_vars=["num_samples", "use_cache"],
         result_vars=["total_ms"],
-        title="Bencher Self-Benchmark: Cache Impact",
+        title="Cache Impact on Total Time",
     )
-    return bench
 
-
-def example_self_benchmark_over_time(
-    run_cfg: bch.BenchRunCfg | None = None,
-) -> bch.Bench:
-    """Track bencher's overhead over time, accumulating results across commits."""
-    run_cfg = run_cfg or bch.BenchRunCfg()
-    run_cfg.over_time = True
-    run_cfg.auto_plot = False
-
-    time_src = bch.git_time_event()
-
-    bench = BencherSelfBenchmark().to_bench(run_cfg)
-    bench.plot_sweep(
-        input_vars=["num_samples"],
-        result_vars=[
-            "total_ms",
-            "dataset_setup_ms",
-            "job_submission_ms",
-            "job_execution_ms",
-        ],
-        title="Bencher Overhead Over Time: Phase Timing",
-        time_src=time_src,
-    )
-    bench.plot_sweep(
-        input_vars=["num_samples"],
-        result_vars=["throughput"],
-        title="Bencher Overhead Over Time: Throughput",
-        time_src=time_src,
-    )
     return bench
 
 

--- a/bencher/example/generated/performance/self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/self_benchmark_over_time.py
@@ -1,15 +1,6 @@
-"""Bencher self-introspection: benchmarks bencher's own overhead across problem sizes.
+"""Auto-generated example: Bencher self-introspection: overhead tracked over time."""
 
-This example uses bencher to benchmark itself, sweeping over the number of parameter
-samples and measuring the framework's timing for each phase of a sweep. The results
-reveal how overhead scales with problem size, helping identify optimization targets.
-
-When run with ``over_time=True`` (see ``example_self_benchmark_over_time``), results
-accumulate across commits so you can track framework performance regressions.
-
-Run locally:
-    python bencher/example/example_self_benchmark.py
-"""
+from typing import Any
 
 import bencher as bch
 
@@ -20,7 +11,7 @@ class TrivialWorkload(bch.ParametrizedSweep):
     x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bch.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         self.result = self.x * 2
         return super().__call__(**kwargs)
@@ -37,7 +28,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     )
     use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
 
-    # Result variables — one per timing phase
+    # Result variables - one per timing phase
     total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
     dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
     job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")
@@ -46,7 +37,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs):
+    def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
 
         workload = TrivialWorkload()
@@ -75,62 +66,28 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
         return super().__call__(**kwargs)
 
 
-def example_self_benchmark(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Benchmark bencher's own overhead across problem sizes."""
-    bench = BencherSelfBenchmark().to_bench(run_cfg)
-    bench.plot_sweep(
-        input_vars=["num_samples"],
-        result_vars=[
-            "total_ms",
-            "dataset_setup_ms",
-            "job_submission_ms",
-            "job_execution_ms",
-        ],
-        title="Bencher Self-Benchmark: Phase Timing vs Problem Size",
-    )
-    bench.plot_sweep(
-        input_vars=["num_samples"],
-        result_vars=["throughput"],
-        title="Bencher Self-Benchmark: Throughput vs Problem Size",
-    )
-    bench.plot_sweep(
-        input_vars=["num_samples", "use_cache"],
-        result_vars=["total_ms"],
-        title="Bencher Self-Benchmark: Cache Impact",
-    )
-    return bench
-
-
-def example_self_benchmark_over_time(
-    run_cfg: bch.BenchRunCfg | None = None,
-) -> bch.Bench:
-    """Track bencher's overhead over time, accumulating results across commits."""
+def example_self_benchmark_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Bencher self-introspection: overhead tracked over time."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     run_cfg.auto_plot = False
-
     time_src = bch.git_time_event()
-
     bench = BencherSelfBenchmark().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["num_samples"],
-        result_vars=[
-            "total_ms",
-            "dataset_setup_ms",
-            "job_submission_ms",
-            "job_execution_ms",
-        ],
-        title="Bencher Overhead Over Time: Phase Timing",
+        result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+        title="Overhead Over Time: Phase Timing",
         time_src=time_src,
     )
     bench.plot_sweep(
         input_vars=["num_samples"],
         result_vars=["throughput"],
-        title="Bencher Overhead Over Time: Throughput",
+        title="Overhead Over Time: Throughput",
         time_src=time_src,
     )
+
     return bench
 
 
 if __name__ == "__main__":
-    bch.run(example_self_benchmark)
+    bch.run(example_self_benchmark_over_time)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -111,6 +111,7 @@ def generate_python_files():
 
     from bencher.example.meta.generate_meta_regression import example_meta_regression
     from bencher.example.meta.generate_meta_yaml import example_meta_yaml
+    from bencher.example.meta.generate_meta_performance import example_meta_performance
 
     example_meta()
     example_meta_result_types()
@@ -126,6 +127,7 @@ def generate_python_files():
     example_meta_bool_plot_types()
     example_meta_regression()
     example_meta_yaml()
+    example_meta_performance()
 
     # Write __init__.py files so generated examples are importable
     for d in GENERATED_DIR.rglob("*"):
@@ -371,6 +373,7 @@ SECTIONS = {
     "YAML Sweeps": "yaml",
     "Advanced Patterns": "advanced",
     "Regression Detection": "regression",
+    "Performance": "performance",
 }
 
 

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -1,0 +1,132 @@
+"""Meta-generator: Performance self-introspection examples.
+
+Generates examples that benchmark bencher's own overhead, enabling
+performance tracking across commits via the documentation gallery.
+"""
+
+from typing import Any
+
+import bencher as bch
+from bencher.example.meta.meta_generator_base import MetaGeneratorBase
+
+OUTPUT_DIR = "performance"
+
+PERFORMANCE_EXAMPLES = [
+    "self_benchmark",
+]
+
+
+class MetaPerformance(MetaGeneratorBase):
+    """Generate Python examples for bencher self-introspection."""
+
+    example = bch.StringSweep(PERFORMANCE_EXAMPLES, doc="Which performance example to generate")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+
+        if self.example == "self_benchmark":
+            self._generate_self_benchmark()
+
+        return super().__call__()
+
+    def _generate_self_benchmark(self):
+        """Generate the self-benchmark example."""
+        imports = "import bencher as bch"
+        class_code = '''\
+class TrivialWorkload(bch.ParametrizedSweep):
+    """A near-zero-cost worker so we measure framework overhead, not compute."""
+
+    x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
+    result = bch.ResultVar(units="v", doc="trivial output")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self.result = self.x * 2
+        return super().__call__(**kwargs)
+
+
+class BencherSelfBenchmark(bch.ParametrizedSweep):
+    """Sweep over problem sizes and measure bencher's own timing phases."""
+
+    num_samples = bch.IntSweep(
+        default=10,
+        bounds=[2, 100],
+        samples=6,
+        doc="Number of parameter samples in the inner sweep",
+    )
+    use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
+
+    # Result variables - one per timing phase
+    total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
+    dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
+    job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")
+    job_execution_ms = bch.ResultVar(units="ms", doc="Worker execution and result storage time")
+    cache_check_ms = bch.ResultVar(units="ms", doc="Benchmark cache lookup time")
+    sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
+    throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+
+        workload = TrivialWorkload()
+        x_sweep = bch.FloatSweep(
+            default=0, bounds=[0, 1], samples=self.num_samples, doc="input"
+        )
+        x_sweep.name = "x"
+
+        inner_cfg = bch.BenchRunCfg()
+        inner_cfg.repeats = 1
+        inner_cfg.cache_samples = self.use_cache
+        inner_cfg.cache_results = False
+        inner_cfg.auto_plot = False
+
+        bench = bch.Bench("inner_bench", workload, run_cfg=inner_cfg)
+        bench.plot_sweep(input_vars=[x_sweep], result_vars=["result"])
+        res = bench.results[-1]
+
+        t = res.timings
+        self.total_ms = t.total_ms
+        self.dataset_setup_ms = t.dataset_setup_ms
+        self.job_submission_ms = t.job_submission_ms
+        self.job_execution_ms = t.job_execution_ms
+        self.cache_check_ms = t.cache_check_ms
+        self.sample_cache_init_ms = t.sample_cache_init_ms
+        self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
+
+        return super().__call__(**kwargs)'''
+
+        body = """\
+bench = BencherSelfBenchmark().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+    title="Phase Timing vs Problem Size",
+)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["throughput"],
+    title="Throughput vs Problem Size",
+)
+bench.plot_sweep(
+    input_vars=["num_samples", "use_cache"],
+    result_vars=["total_ms"],
+    title="Cache Impact on Total Time",
+)
+"""
+
+        self.generate_example(
+            title="Bencher self-introspection: overhead vs problem size",
+            output_dir=OUTPUT_DIR,
+            filename="self_benchmark",
+            function_name="example_self_benchmark",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+        )
+
+
+def example_meta_performance():
+    """Generate all performance self-introspection examples."""
+    gen = MetaPerformance()
+    for example in PERFORMANCE_EXAMPLES:
+        gen(example=example)

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -13,6 +13,7 @@ OUTPUT_DIR = "performance"
 
 PERFORMANCE_EXAMPLES = [
     "self_benchmark",
+    "self_benchmark_over_time",
 ]
 
 
@@ -26,20 +27,87 @@ class MetaPerformance(MetaGeneratorBase):
 
         if self.example == "self_benchmark":
             self._generate_self_benchmark()
+        elif self.example == "self_benchmark_over_time":
+            self._generate_self_benchmark_over_time()
 
         return super().__call__()
 
     def _generate_self_benchmark(self):
         """Generate the self-benchmark example."""
         imports = "import bencher as bch"
-        class_code = '''\
+
+        body = """\
+bench = BencherSelfBenchmark().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+    title="Phase Timing vs Problem Size",
+)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["throughput"],
+    title="Throughput vs Problem Size",
+)
+bench.plot_sweep(
+    input_vars=["num_samples", "use_cache"],
+    result_vars=["total_ms"],
+    title="Cache Impact on Total Time",
+)
+"""
+
+        self.generate_example(
+            title="Bencher self-introspection: overhead vs problem size",
+            output_dir=OUTPUT_DIR,
+            filename="self_benchmark",
+            function_name="example_self_benchmark",
+            imports=imports,
+            body=body,
+            class_code=_SHARED_CLASS_CODE,
+        )
+
+    def _generate_self_benchmark_over_time(self):
+        """Generate the over-time self-benchmark example."""
+        imports = "import bencher as bch"
+
+        body = """\
+run_cfg = run_cfg or bch.BenchRunCfg()
+run_cfg.over_time = True
+run_cfg.auto_plot = False
+time_src = bch.git_time_event()
+bench = BencherSelfBenchmark().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
+    title="Overhead Over Time: Phase Timing",
+    time_src=time_src,
+)
+bench.plot_sweep(
+    input_vars=["num_samples"],
+    result_vars=["throughput"],
+    title="Overhead Over Time: Throughput",
+    time_src=time_src,
+)
+"""
+
+        self.generate_example(
+            title="Bencher self-introspection: overhead tracked over time",
+            output_dir=OUTPUT_DIR,
+            filename="self_benchmark_over_time",
+            function_name="example_self_benchmark_over_time",
+            imports=imports,
+            body=body,
+            class_code=_SHARED_CLASS_CODE,
+        )
+
+
+_SHARED_CLASS_CODE = '''\
 class TrivialWorkload(bch.ParametrizedSweep):
     """A near-zero-cost worker so we measure framework overhead, not compute."""
 
     x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bch.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
         self.result = self.x * 2
         return super().__call__(**kwargs)
@@ -65,7 +133,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
 
         workload = TrivialWorkload()
@@ -94,35 +162,6 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
         self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
 
         return super().__call__(**kwargs)'''
-
-        body = """\
-bench = BencherSelfBenchmark().to_bench(run_cfg)
-bench.plot_sweep(
-    input_vars=["num_samples"],
-    result_vars=["total_ms", "dataset_setup_ms", "job_submission_ms", "job_execution_ms"],
-    title="Phase Timing vs Problem Size",
-)
-bench.plot_sweep(
-    input_vars=["num_samples"],
-    result_vars=["throughput"],
-    title="Throughput vs Problem Size",
-)
-bench.plot_sweep(
-    input_vars=["num_samples", "use_cache"],
-    result_vars=["total_ms"],
-    title="Cache Impact on Total Time",
-)
-"""
-
-        self.generate_example(
-            title="Bencher self-introspection: overhead vs problem size",
-            output_dir=OUTPUT_DIR,
-            filename="self_benchmark",
-            function_name="example_self_benchmark",
-            imports=imports,
-            body=body,
-            class_code=class_code,
-        )
 
 
 def example_meta_performance():

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -58,6 +58,7 @@ class BenchResult(
         VolumeResult.__init__(self, bench_cfg)
         HoloviewResult.__init__(self, bench_cfg)
         # DataSetResult.__init__(self.bench_cfg)
+        self.timings = None  # Populated by Bench.run_sweep() with SweepTimings
 
     @classmethod
     def from_existing(cls, original: BenchResult) -> BenchResult:

--- a/bencher/sweep_timings.py
+++ b/bencher/sweep_timings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 
 
 @dataclass
@@ -27,7 +27,7 @@ class SweepTimings:
 
     def summary(self) -> dict[str, float]:
         """Return all phase timings as a dict."""
-        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+        return {f.name: getattr(self, f.name) for f in fields(self)}
 
 
 @contextmanager

--- a/bencher/sweep_timings.py
+++ b/bencher/sweep_timings.py
@@ -1,0 +1,50 @@
+"""Lightweight timing instrumentation for bencher sweep phases."""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass
+class SweepTimings:
+    """Timing data for a single run_sweep() call.
+
+    Each field records the wall-clock duration in milliseconds of a
+    major phase inside ``Bench.run_sweep()`` or
+    ``Bench.calculate_benchmark_results()``.
+    """
+
+    cache_check_ms: float = 0.0
+    sample_cache_init_ms: float = 0.0
+    dataset_setup_ms: float = 0.0
+    job_submission_ms: float = 0.0
+    job_execution_ms: float = 0.0
+    history_merge_ms: float = 0.0
+    post_setup_ms: float = 0.0
+    total_ms: float = 0.0
+
+    def summary(self) -> dict[str, float]:
+        """Return all phase timings as a dict."""
+        return {k: getattr(self, k) for k in self.__dataclass_fields__}
+
+
+@contextmanager
+def phase_timer():
+    """Context manager that yields a callable returning elapsed milliseconds.
+
+    Usage::
+
+        with phase_timer() as elapsed:
+            do_work()
+        timings.some_phase_ms = elapsed()
+    """
+    t0 = time.perf_counter()
+    result = [0.0]
+
+    def _elapsed():
+        return result[0]
+
+    yield _elapsed
+    result[0] = (time.perf_counter() - t0) * 1000.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ py313 = ["py313", "test", "rerun"]
 agent-iterate = { depends-on = [
     "generate-docs",
     "ci",
+    "perf-track",
     "git-commit-all",
     "fix-commit-push",
 ] }
@@ -122,6 +123,7 @@ dev-restart-vs = { cmd = "devpod up . --recreate --ide vscode", depends-on = [
 prek = "prek run -a"
 prek-update = "prek autoupdate"
 perf = "python bencher/example/example_self_benchmark.py"
+perf-track = "python -c \"from bencher.example.example_self_benchmark import example_self_benchmark_over_time; example_self_benchmark_over_time()\""
 format = "ruff format ."
 check-clean-workspace = "git diff --exit-code"
 ruff-lint = "ruff check . --fix"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ dev-restart-vs = { cmd = "devpod up . --recreate --ide vscode", depends-on = [
 ] }
 prek = "prek run -a"
 prek-update = "prek autoupdate"
+perf = "python bencher/example/example_self_benchmark.py"
 format = "ruff format ."
 check-clean-workspace = "git diff --exit-code"
 ruff-lint = "ruff check . --fix"

--- a/test/test_sweep_timings.py
+++ b/test/test_sweep_timings.py
@@ -1,0 +1,54 @@
+"""Tests for sweep timing instrumentation."""
+
+import math
+
+import bencher as bch
+from bencher.sweep_timings import SweepTimings, phase_timer
+
+
+def test_phase_timer():
+    """phase_timer context manager returns positive elapsed time."""
+    with phase_timer() as elapsed:
+        _ = sum(range(1000))
+    assert elapsed() > 0
+
+
+def test_sweep_timings_summary():
+    """SweepTimings.summary() returns all fields as a dict."""
+    t = SweepTimings(total_ms=42.0, cache_check_ms=1.5)
+    s = t.summary()
+    assert s["total_ms"] == 42.0
+    assert s["cache_check_ms"] == 1.5
+    assert "dataset_setup_ms" in s
+
+
+class TrivialSweep(bch.ParametrizedSweep):
+    theta = bch.FloatSweep(default=0, bounds=[0, math.pi], samples=5)
+    out = bch.ResultVar(units="v", doc="output")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.out = math.sin(self.theta)
+        return super().__call__(**kwargs)
+
+
+def test_bench_result_has_timings():
+    """After plot_sweep(), the BenchResult should have populated timings."""
+    run_cfg = bch.BenchRunCfg()
+    run_cfg.auto_plot = False
+    bench = TrivialSweep().to_bench(run_cfg)
+    bench.plot_sweep()
+
+    res = bench.results[-1]
+    assert res.timings is not None
+    assert isinstance(res.timings, SweepTimings)
+    assert res.timings.total_ms > 0
+    assert res.timings.dataset_setup_ms >= 0
+    assert res.timings.job_submission_ms >= 0
+    assert res.timings.job_execution_ms >= 0
+
+
+def test_timings_accessible_via_public_api():
+    """SweepTimings should be importable from the top-level bencher package."""
+    assert hasattr(bch, "SweepTimings")
+    assert bch.SweepTimings is SweepTimings


### PR DESCRIPTION
## Summary
- Instruments `Bench.run_sweep()` and `calculate_benchmark_results()` with `SweepTimings` to measure phase-level overhead (dataset setup, job submission, execution, cache checks, etc.)
- Adds `example_self_benchmark` to sweep across problem sizes and `example_self_benchmark_over_time` to accumulate metrics across commits via `git_time_event()`
- Adds `perf-track` pixi task wired into `agent-iterate` so performance is tracked on every commit cycle
- Adds "Performance" section to the docs gallery with both generated examples

## Bug fix
- Restores `store_results` inside the serial submission loop so that completed results are cached to disk before later jobs may crash (fixes `test_sample_cache` regression introduced by the original branch)

## Code quality
- Fixes pylint E1101 by using `dataclasses.fields()` instead of `__dataclass_fields__`
- Moves `import time` to module-level in `bencher.py`

## Test plan
- [x] `test_sample_cache` passes (was broken by the original branch)
- [x] `test_sweep_timings` — 4 new tests for `SweepTimings` and `phase_timer`
- [x] Full test suite: 828 passed, 5 skipped
- [x] Lint/format clean (ruff, pylint, ty)
- [x] `pixi run generate-examples` produces performance gallery files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Instrument benchmark sweeps with phase-level timing metrics and add self-benchmarking examples and CI wiring to track bencher performance over time.

New Features:
- Add SweepTimings dataclass and phase_timer context manager to capture per-phase timings for benchmark sweeps.
- Attach SweepTimings to BenchResult so benchmarks can introspect timing data via the public API.
- Introduce example_self_benchmark and example_self_benchmark_over_time to benchmark bencher’s own overhead across problem sizes and commits.
- Generate performance-focused example files via a new MetaPerformance generator and add a Performance section to the docs gallery.
- Add perf and perf-track pixi tasks, integrating perf-track into the agent-iterate workflow to run self-benchmarks on each commit cycle.

Bug Fixes:
- Ensure results are stored immediately during serial execution so completed samples are cached to disk even if later jobs fail, restoring sample cache behavior.

Enhancements:
- Instrument Bench.run_sweep and calculate_benchmark_results to record timings for cache checks, sample cache init, dataset setup, job submission/execution, history merge, post-setup, and total sweep time.
- Store timing metrics for over-time runs when merging history and running post-setup processing.
- Expose SweepTimings from the top-level bencher package and initialize BenchResult with an optional timings field for consistent access.

Build:
- Extend pixi configuration with perf and perf-track commands and wire perf-track into the agent-iterate task sequence.

Documentation:
- Add a Performance section to the generated examples gallery populated with self-benchmarking examples that visualize phase timings, throughput, and cache impact.

Tests:
- Add tests for phase_timer, SweepTimings.summary, propagation of timings into BenchResult, and public API access via the bencher package.