### PR TITLE
Fix summarise_optuna_study for single/multi-objective studies

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -96,6 +96,7 @@ from .variables.singleton_parametrized_sweep import ParametrizedSweepSingleton
 from .sample_order import SampleOrder
 from .caching import CachedParams
 from .results.bench_result import BenchResult
+from .results.optimize_result import OptimizeResult
 from .results.video_result import VideoResult
 from .results.holoview_results.holoview_result import ReduceType, HoloviewResult
 from .bench_report import BenchReport, GithubPagesCfg

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -923,54 +923,13 @@ class Bench(BenchPlotServer):
         Returns:
             OptimizeResult wrapping the completed ``optuna.Study``.
         """
-        # --- resolve variables (mirrors plot_sweep logic) ---------------
-        input_vars_in = deepcopy(input_vars)
-        result_vars_in = deepcopy(result_vars)
-        const_vars_in = deepcopy(const_vars)
-
         if run_cfg is None:
             run_cfg = deepcopy(self.run_cfg) if self.run_cfg is not None else BenchRunCfg()
 
-        if self.worker_class_instance is not None:
-            if input_vars_in is None:
-                input_vars_in = (
-                    deepcopy(self.input_vars)
-                    if self.input_vars is not None
-                    else self.worker_class_instance.get_inputs_only()
-                )
-            if result_vars_in is None:
-                result_vars_in = (
-                    deepcopy(self.result_vars)
-                    if self.result_vars is not None
-                    else self.get_result_vars(as_str=False)
-                )
-            if const_vars_in is None:
-                const_vars_in = (
-                    deepcopy(self.const_vars)
-                    if self.const_vars is not None
-                    else self.worker_class_instance.get_input_defaults()
-                )
-        else:
-            input_vars_in = input_vars_in or []
-            result_vars_in = result_vars_in or []
-            const_vars_in = const_vars_in or []
-
-        # Convert to param.Parameter objects
-        for i in range(len(input_vars_in)):
-            input_vars_in[i] = self.convert_vars_to_params(input_vars_in[i], "input", run_cfg)
-        for i in range(len(result_vars_in)):
-            result_vars_in[i] = self.convert_vars_to_params(result_vars_in[i], "result", run_cfg)
-        if isinstance(const_vars_in, dict):
-            const_vars_in = list(const_vars_in.items())
-        for i in range(len(const_vars_in)):
-            cv_list = list(const_vars_in[i])
-            cv_list[0] = self.convert_vars_to_params(cv_list[0], "const", run_cfg)
-            const_vars_in[i] = cv_list
-
-        # Remove inputs that appear in const_vars
-        input_names = {iv.name for iv in input_vars_in}
-        const_vars_in = [c for c in const_vars_in if c[0].name not in input_names]
-
+        # --- resolve variables (mirrors plot_sweep logic) ---------------
+        input_vars_in, result_vars_in, const_vars_in = self._resolve_optimize_vars(
+            input_vars, result_vars, const_vars, run_cfg
+        )
         constant_inputs = self.define_const_inputs(const_vars_in) or {}
 
         if title is None:
@@ -991,8 +950,6 @@ class Bench(BenchPlotServer):
         )
 
         # --- (re)initialize sample cache for reading + writing -----------
-        # plot_sweep closes the sample_cache when it finishes, so we need
-        # to open a fresh one with overwrite=False to honour cached results.
         if self.sample_cache is not None:
             with suppress(Exception):
                 self.sample_cache.close()
@@ -1023,12 +980,12 @@ class Bench(BenchPlotServer):
         n_warm = 0
         if warm_start:
             n_warm = self._warm_start_from_cache(
-                study, bench_cfg, input_vars_in, constant_inputs, target_names, tag
+                study, bench_cfg, input_vars_in, constant_inputs, target_names
             )
 
         # --- run optimisation -------------------------------------------
         objective = self._make_optuna_objective(
-            bench_cfg, input_vars_in, constant_inputs, target_names, tag, run_cfg
+            input_vars_in, constant_inputs, target_names, bench_cfg.tag
         )
         study.optimize(objective, n_trials=n_trials)
 
@@ -1052,24 +1009,62 @@ class Bench(BenchPlotServer):
     # Private helpers for optimize()
     # ------------------------------------------------------------------
 
-    def _warm_start_from_cache(  # pylint: disable=unused-argument
-        self,
-        study: optuna.Study,
-        bench_cfg: BenchCfg,
-        input_vars: list,
-        constant_inputs: dict,
-        target_names: list[str],
-        tag: str,  # noqa: ARG002
-    ) -> int:
-        """Seed *study* with cached evaluations. Returns count of added trials.
+    def _resolve_optimize_vars(self, input_vars, result_vars, const_vars, run_cfg):
+        """Deep-copy and convert variable lists to param.Parameter objects."""
+        input_vars_in = deepcopy(input_vars)
+        result_vars_in = deepcopy(result_vars)
+        const_vars_in = deepcopy(const_vars)
 
-        Uses two sources:
-        1. In-memory ``self.results`` from prior ``plot_sweep()`` calls (always available).
-        2. The on-disk sample cache (only when ``cache_samples=True``).
-        """
+        if self.worker_class_instance is not None:
+            if input_vars_in is None:
+                input_vars_in = (
+                    deepcopy(self.input_vars)
+                    if self.input_vars is not None
+                    else self.worker_class_instance.get_inputs_only()
+                )
+            if result_vars_in is None:
+                result_vars_in = (
+                    deepcopy(self.result_vars)
+                    if self.result_vars is not None
+                    else self.get_result_vars(as_str=False)
+                )
+            if const_vars_in is None:
+                const_vars_in = (
+                    deepcopy(self.const_vars)
+                    if self.const_vars is not None
+                    else self.worker_class_instance.get_input_defaults()
+                )
+        else:
+            input_vars_in = input_vars_in or []
+            result_vars_in = result_vars_in or []
+            const_vars_in = const_vars_in or []
+
+        def _convert_seq(seq, kind):
+            return [self.convert_vars_to_params(v, kind, run_cfg) for v in seq]
+
+        input_vars_in = _convert_seq(input_vars_in, "input")
+        result_vars_in = _convert_seq(result_vars_in, "result")
+
+        if isinstance(const_vars_in, dict):
+            const_vars_in = list(const_vars_in.items())
+        const_vars_in = [
+            (self.convert_vars_to_params(k, "const", run_cfg), v) for k, v in const_vars_in
+        ]
+
+        # Remove inputs that appear in const_vars
+        input_names = {iv.name for iv in input_vars_in}
+        const_vars_in = [c for c in const_vars_in if c[0].name not in input_names]
+
+        return input_vars_in, result_vars_in, const_vars_in
+
+    @staticmethod
+    def _build_cache_key(inputs: dict, tag: str) -> str:
+        """Build a deterministic cache key from an input dict and tag."""
+        return hash_sha1((sorted(inputs.items()), tag))
+
+    def _warm_from_results(self, study: optuna.Study) -> int:
+        """Seed *study* from in-memory BenchResult objects. Returns count added."""
         added = 0
-
-        # --- 1. Warm-start from in-memory BenchResult objects -----------
         for res in self.results:
             try:
                 if len(res.ds.sizes) > 0:
@@ -1078,15 +1073,22 @@ class Bench(BenchPlotServer):
                     added += len(trials)
             except Exception:  # pylint: disable=broad-except
                 pass
+        return added
 
-        # --- 2. Warm-start from sample cache (if available) -------------
+    def _warm_from_sample_cache(
+        self,
+        study: optuna.Study,
+        bench_cfg: BenchCfg,
+        input_vars: list,
+        constant_inputs: dict,
+        target_names: list[str],
+    ) -> int:
+        """Seed *study* from the on-disk sample cache. Returns count added."""
         cache = self.sample_cache.cache
         if cache is None or len(cache) == 0:
-            return added
+            return 0
 
-        distributions = {}
-        for iv in input_vars:
-            distributions[iv.name] = sweep_var_to_optuna_dist(iv)
+        distributions = {iv.name: sweep_var_to_optuna_dist(iv) for iv in input_vars}
 
         iv_grid_values = []
         iv_names = []
@@ -1099,8 +1101,9 @@ class Bench(BenchPlotServer):
             iv_names.append(iv.name)
 
         if not iv_grid_values:
-            return added
+            return 0
 
+        added = 0
         resolved_tag = bench_cfg.tag
 
         for combo in product(*iv_grid_values):
@@ -1108,8 +1111,7 @@ class Bench(BenchPlotServer):
             input_dict.update(constant_inputs)
             input_dict["repeat"] = 1
 
-            fn_inputs_sorted = sorted(input_dict.items())
-            key = hash_sha1((fn_inputs_sorted, resolved_tag))
+            key = self._build_cache_key(input_dict, resolved_tag)
 
             if key in cache:
                 result_dict = cache[key]
@@ -1139,45 +1141,46 @@ class Bench(BenchPlotServer):
 
         return added
 
-    def _make_optuna_objective(  # pylint: disable=unused-argument
+    def _warm_start_from_cache(
         self,
+        study: optuna.Study,
         bench_cfg: BenchCfg,
         input_vars: list,
         constant_inputs: dict,
         target_names: list[str],
-        tag: str,  # noqa: ARG002
-        run_cfg: BenchRunCfg,  # noqa: ARG002
-    ):
+    ) -> int:
+        """Seed *study* with cached evaluations. Returns count of added trials."""
+        added = self._warm_from_results(study)
+        added += self._warm_from_sample_cache(
+            study, bench_cfg, input_vars, constant_inputs, target_names
+        )
+        return added
+
+    def _make_optuna_objective(self, input_vars, constant_inputs, target_names, tag):
         """Return an objective function compatible with ``study.optimize()``."""
-        resolved_tag = bench_cfg.tag
 
         def objective(trial: optuna.trial.Trial):
             kwargs = {}
             for iv in input_vars:
                 kwargs[iv.name] = sweep_var_to_suggest(iv, trial)
 
-            # Build full input dict (with constants + repeat) for cache key
             full_input = dict(kwargs)
             full_input.update(constant_inputs)
             full_input["repeat"] = 1
 
-            fn_inputs_sorted = sorted(full_input.items())
-            cache_key = hash_sha1((fn_inputs_sorted, resolved_tag))
+            cache_key = self._build_cache_key(full_input, tag)
 
-            # Submit through FutureCache (handles cache lookup + storage)
             job = Job(
                 job_id=f"optimize:trial_{trial.number}",
                 function=self.worker,
                 job_args=kwargs,
                 job_key=cache_key,
-                tag=resolved_tag,
+                tag=tag,
             )
             job_future = self.sample_cache.submit(job)
             result_dict = job_future.result()
 
-            output = []
-            for tn in target_names:
-                output.append(result_dict[tn])
+            output = [result_dict[tn] for tn in target_names]
             return tuple(output) if len(output) > 1 else output[0]
 
         return objective

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -14,7 +14,12 @@ from contextlib import suppress
 from functools import partial
 import panel as pn
 
+import optuna
+
 from bencher.worker_job import WorkerJob
+from bencher.results.optimize_result import OptimizeResult
+from bencher.optuna_conversions import sweep_var_to_suggest, sweep_var_to_optuna_dist
+from bencher.variables.sweep_base import hash_sha1
 
 from bencher.bench_cfg import BenchCfg, BenchRunCfg
 from bencher.bench_plot_server import BenchPlotServer
@@ -882,6 +887,300 @@ class Bench(BenchPlotServer):
                 return [i.name for i in self.worker_class_instance.get_results_only()]
             return self.worker_class_instance.get_results_only()
         raise RuntimeError("Worker class instance not set")
+
+    # ------------------------------------------------------------------
+    # First-class optimization API
+    # ------------------------------------------------------------------
+
+    def optimize(
+        self,
+        title: str | None = None,
+        input_vars=None,
+        result_vars=None,
+        const_vars=None,
+        n_trials: int = 100,
+        sampler: optuna.samplers.BaseSampler | None = None,
+        warm_start: bool = True,
+        tag: str = "",
+        run_cfg: BenchRunCfg | None = None,
+        plot: bool = True,
+    ) -> OptimizeResult:
+        """Run optuna optimization directly — no full grid sweep required.
+
+        Args:
+            title: Study name. Auto-generated when *None*.
+            input_vars: Input variables to optimize over.  Detected from
+                ``worker_class_instance`` when *None*.
+            result_vars: Result variables (objectives).  Detected when *None*.
+            const_vars: Constant variables.  Detected when *None*.
+            n_trials: Number of new optuna trials to run.
+            sampler: Optuna sampler.  Defaults to ``TPESampler``.
+            warm_start: Seed the study with previously cached evaluations.
+            tag: Cache tag (same semantics as ``plot_sweep``).
+            run_cfg: Run configuration.  Defaults to ``BenchRunCfg()``.
+            plot: If *True*, append visualisation to ``self.report``.
+
+        Returns:
+            OptimizeResult wrapping the completed ``optuna.Study``.
+        """
+        # --- resolve variables (mirrors plot_sweep logic) ---------------
+        input_vars_in = deepcopy(input_vars)
+        result_vars_in = deepcopy(result_vars)
+        const_vars_in = deepcopy(const_vars)
+
+        if run_cfg is None:
+            run_cfg = deepcopy(self.run_cfg) if self.run_cfg is not None else BenchRunCfg()
+
+        if self.worker_class_instance is not None:
+            if input_vars_in is None:
+                input_vars_in = (
+                    deepcopy(self.input_vars)
+                    if self.input_vars is not None
+                    else self.worker_class_instance.get_inputs_only()
+                )
+            if result_vars_in is None:
+                result_vars_in = (
+                    deepcopy(self.result_vars)
+                    if self.result_vars is not None
+                    else self.get_result_vars(as_str=False)
+                )
+            if const_vars_in is None:
+                const_vars_in = (
+                    deepcopy(self.const_vars)
+                    if self.const_vars is not None
+                    else self.worker_class_instance.get_input_defaults()
+                )
+        else:
+            input_vars_in = input_vars_in or []
+            result_vars_in = result_vars_in or []
+            const_vars_in = const_vars_in or []
+
+        # Convert to param.Parameter objects
+        for i in range(len(input_vars_in)):
+            input_vars_in[i] = self.convert_vars_to_params(input_vars_in[i], "input", run_cfg)
+        for i in range(len(result_vars_in)):
+            result_vars_in[i] = self.convert_vars_to_params(result_vars_in[i], "result", run_cfg)
+        if isinstance(const_vars_in, dict):
+            const_vars_in = list(const_vars_in.items())
+        for i in range(len(const_vars_in)):
+            cv_list = list(const_vars_in[i])
+            cv_list[0] = self.convert_vars_to_params(cv_list[0], "const", run_cfg)
+            const_vars_in[i] = cv_list
+
+        # Remove inputs that appear in const_vars
+        input_names = {iv.name for iv in input_vars_in}
+        const_vars_in = [c for c in const_vars_in if c[0].name not in input_names]
+
+        constant_inputs = self.define_const_inputs(const_vars_in) or {}
+
+        if title is None:
+            title = "Optimize " + " vs ".join(iv.name for iv in input_vars_in)
+
+        # --- build lightweight BenchCfg for metadata --------------------
+        result_hmaps = [r for r in result_vars_in if isinstance(r, ResultHmap)]
+        result_vars_only = [r for r in result_vars_in if not isinstance(r, ResultHmap)]
+
+        bench_cfg = BenchCfg(
+            input_vars=input_vars_in,
+            result_vars=result_vars_only,
+            result_hmaps=result_hmaps,
+            const_vars=const_vars_in,
+            bench_name=self.bench_name,
+            title=title,
+            tag=run_cfg.run_tag + tag,
+        )
+
+        # --- (re)initialize sample cache for reading + writing -----------
+        # plot_sweep closes the sample_cache when it finishes, so we need
+        # to open a fresh one with overwrite=False to honour cached results.
+        if self.sample_cache is not None:
+            with suppress(Exception):
+                self.sample_cache.close()
+        run_cfg_for_cache = deepcopy(run_cfg)
+        run_cfg_for_cache.overwrite_sample_cache = False
+        self.sample_cache = self.init_sample_cache(run_cfg_for_cache)
+
+        # --- determine optimisation directions --------------------------
+        targets = bench_cfg.optuna_targets(as_var=True)
+        if not targets:
+            raise ValueError(
+                "No result variables with an optimization direction found. "
+                "Set direction=OptDir.minimize or OptDir.maximize on your ResultVar."
+            )
+        directions = [t.direction for t in targets]
+        target_names = [t.name for t in targets]
+
+        # --- create study -----------------------------------------------
+        if sampler is None:
+            sampler = optuna.samplers.TPESampler()
+        study = optuna.create_study(
+            sampler=sampler,
+            directions=directions,
+            study_name=title,
+        )
+
+        # --- warm-start from cache / prior results ----------------------
+        n_warm = 0
+        if warm_start:
+            n_warm = self._warm_start_from_cache(
+                study, bench_cfg, input_vars_in, constant_inputs, target_names, tag
+            )
+
+        # --- run optimisation -------------------------------------------
+        objective = self._make_optuna_objective(
+            bench_cfg, input_vars_in, constant_inputs, target_names, tag, run_cfg
+        )
+        study.optimize(objective, n_trials=n_trials)
+
+        # --- clean up cache -------------------------------------------------
+        logging.info(self.sample_cache.stats())
+        self.sample_cache.close()
+
+        result = OptimizeResult(
+            study=study,
+            n_warm_start_trials=n_warm,
+            n_new_trials=n_trials,
+            target_names=target_names,
+        )
+
+        if plot:
+            self.report.append(result.to_panel())
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers for optimize()
+    # ------------------------------------------------------------------
+
+    def _warm_start_from_cache(  # pylint: disable=unused-argument
+        self,
+        study: optuna.Study,
+        bench_cfg: BenchCfg,
+        input_vars: list,
+        constant_inputs: dict,
+        target_names: list[str],
+        tag: str,  # noqa: ARG002
+    ) -> int:
+        """Seed *study* with cached evaluations. Returns count of added trials.
+
+        Uses two sources:
+        1. In-memory ``self.results`` from prior ``plot_sweep()`` calls (always available).
+        2. The on-disk sample cache (only when ``cache_samples=True``).
+        """
+        added = 0
+
+        # --- 1. Warm-start from in-memory BenchResult objects -----------
+        for res in self.results:
+            try:
+                if len(res.ds.sizes) > 0:
+                    trials = res.bench_results_to_optuna_trials(True)
+                    study.add_trials(trials)
+                    added += len(trials)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        # --- 2. Warm-start from sample cache (if available) -------------
+        cache = self.sample_cache.cache
+        if cache is None or len(cache) == 0:
+            return added
+
+        distributions = {}
+        for iv in input_vars:
+            distributions[iv.name] = sweep_var_to_optuna_dist(iv)
+
+        iv_grid_values = []
+        iv_names = []
+        for iv in input_vars:
+            try:
+                vals = list(iv.values())
+            except Exception:  # pylint: disable=broad-except
+                continue
+            iv_grid_values.append(vals)
+            iv_names.append(iv.name)
+
+        if not iv_grid_values:
+            return added
+
+        resolved_tag = bench_cfg.tag
+
+        for combo in product(*iv_grid_values):
+            input_dict = dict(zip(iv_names, combo))
+            input_dict.update(constant_inputs)
+            input_dict["repeat"] = 1
+
+            fn_inputs_sorted = sorted(input_dict.items())
+            key = hash_sha1((fn_inputs_sorted, resolved_tag))
+
+            if key in cache:
+                result_dict = cache[key]
+                if not isinstance(result_dict, dict):
+                    continue
+                values = []
+                skip = False
+                for tn in target_names:
+                    if tn not in result_dict:
+                        skip = True
+                        break
+                    values.append(result_dict[tn])
+                if skip:
+                    continue
+
+                params = dict(zip(iv_names, combo))
+                try:
+                    trial = optuna.trial.create_trial(
+                        params=params,
+                        distributions=distributions,
+                        values=values,
+                    )
+                    study.add_trial(trial)
+                    added += 1
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+        return added
+
+    def _make_optuna_objective(  # pylint: disable=unused-argument
+        self,
+        bench_cfg: BenchCfg,
+        input_vars: list,
+        constant_inputs: dict,
+        target_names: list[str],
+        tag: str,  # noqa: ARG002
+        run_cfg: BenchRunCfg,  # noqa: ARG002
+    ):
+        """Return an objective function compatible with ``study.optimize()``."""
+        resolved_tag = bench_cfg.tag
+
+        def objective(trial: optuna.trial.Trial):
+            kwargs = {}
+            for iv in input_vars:
+                kwargs[iv.name] = sweep_var_to_suggest(iv, trial)
+
+            # Build full input dict (with constants + repeat) for cache key
+            full_input = dict(kwargs)
+            full_input.update(constant_inputs)
+            full_input["repeat"] = 1
+
+            fn_inputs_sorted = sorted(full_input.items())
+            cache_key = hash_sha1((fn_inputs_sorted, resolved_tag))
+
+            # Submit through FutureCache (handles cache lookup + storage)
+            job = Job(
+                job_id=f"optimize:trial_{trial.number}",
+                function=self.worker,
+                job_args=kwargs,
+                job_key=cache_key,
+                tag=resolved_tag,
+            )
+            job_future = self.sample_cache.submit(job)
+            result_dict = job_future.result()
+
+            output = []
+            for tn in target_names:
+                output.append(result_dict[tn])
+            return tuple(output) if len(output) > 1 else output[0]
+
+        return objective
 
     def to(
         self,

--- a/bencher/example/optuna/example_optimize.py
+++ b/bencher/example/optuna/example_optimize.py
@@ -1,0 +1,74 @@
+"""First-class optimization API example.
+
+Demonstrates:
+  1. Basic single-objective optimization via ``bench.optimize()``
+  2. ``to_optimize()`` one-liner on ParametrizedSweep
+  3. Sweep-then-optimize (warm-start automatic via shared cache)
+"""
+
+import numpy as np
+
+import bencher as bch
+
+
+class Rastrigin(bch.ParametrizedSweep):
+    """A 2-D Rastrigin function — classic optimization benchmark."""
+
+    x = bch.FloatSweep(default=0, bounds=[-5.12, 5.12], samples=10)
+    y = bch.FloatSweep(default=0, bounds=[-5.12, 5.12], samples=10)
+
+    loss = bch.ResultVar("ul", bch.OptDir.minimize)
+
+    def __call__(self, **kwargs) -> dict:
+        self.update_params_from_kwargs(**kwargs)
+        A = 10
+        self.loss = float(
+            A * 2
+            + (self.x**2 - A * np.cos(2 * np.pi * self.x))
+            + (self.y**2 - A * np.cos(2 * np.pi * self.y))
+        )
+        return super().__call__(**kwargs)
+
+
+def example_optimize(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Demonstrate the first-class optimization API."""
+    cfg = Rastrigin()
+    bench = bch.Bench("OptimizeExample", cfg, run_cfg=run_cfg)
+
+    # --- 1. Direct optimization -----------------------------------------
+    result = bench.optimize(n_trials=30, plot=True)
+    bench.report.append_markdown(
+        f"### Direct optimization\n"
+        f"Best value: {result.best_value:.4f}  \n"
+        f"Best params: {result.best_params}"
+    )
+
+    # --- 2. Sweep then optimize (warm-start from cache) -----------------
+    bench.plot_sweep(
+        title="Grid sweep",
+        input_vars=[cfg.param.x, cfg.param.y],
+        result_vars=[cfg.param.loss],
+        run_cfg=run_cfg,
+    )
+    opt2 = bench.optimize(n_trials=20, title="Warm-started optimization")
+    bench.report.append_markdown(
+        f"### Warm-started optimization\n"
+        f"Warm-start trials: {opt2.n_warm_start_trials}  \n"
+        f"Best value: {opt2.best_value:.4f}"
+    )
+
+    return bench
+
+
+def example_optimize_one_liner(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """One-liner convenience via ``to_optimize()``."""
+    result = Rastrigin().to_optimize(n_trials=50, run_cfg=run_cfg)
+    print(result.summary())
+    # Return a bench for consistency with the docs generator
+    bench = bch.Bench("OptimizeOneLiner", Rastrigin(), run_cfg=run_cfg)
+    bench.report.append(result.to_panel())
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_optimize)

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -153,6 +153,14 @@ def cfg_from_optuna_trial(
     return cfg
 
 
+def _append_safe(row, plot_fn, *args, **kwargs):
+    """Append a plot to *row*, logging any exception instead of propagating."""
+    try:
+        row.append(plot_fn(*args, **kwargs))
+    except Exception as e:  # pylint: disable=broad-except
+        logging.exception(e)
+
+
 def summarise_optuna_study(study: optuna.study.Study) -> pn.pane.panel:
     """Summarise an optuna study in a panel format"""
     row = pn.Column(name="Optimisation Results")
@@ -160,44 +168,23 @@ def summarise_optuna_study(study: optuna.study.Study) -> pn.pane.panel:
     is_multi = n_objectives >= 2
 
     if is_multi:
-        # Multi-objective: plot_optimization_history and plot_param_importances
-        # require an explicit target callback.
         for idx in range(n_objectives):
             target_name = f"Objective {idx}"
-            try:
-                row.append(
-                    plot_optimization_history(
-                        study,
-                        target=lambda t, i=idx: t.values[i],
-                        target_name=target_name,
-                    )
-                )
-            except Exception as e:  # pylint: disable=broad-except
-                logging.exception(e)
-            try:
-                row.append(
-                    plot_param_importances(
-                        study,
-                        target=lambda t, i=idx: t.values[i],
-                        target_name=target_name,
-                    )
-                )
-            except Exception as e:  # pylint: disable=broad-except
-                logging.exception(e)
-        try:
-            row.append(plot_pareto_front(study))
-        except Exception as e:  # pylint: disable=broad-except
-            logging.exception(e)
-        row.append(
-            pn.pane.Markdown(f"```\nPareto-front size: {len(study.best_trials)}```")
-        )
-    else:
-        row.append(plot_optimization_history(study))
-        row.append(plot_param_importances(study))
-        row.append(
-            pn.pane.Markdown(
-                f"```\nBest value: {study.best_value}\nParams: {study.best_params}```"
-            )
-        )
 
+            def target(t, i=idx):
+                return t.values[i]
+
+            _append_safe(
+                row, plot_optimization_history, study, target=target, target_name=target_name
+            )
+            _append_safe(row, plot_param_importances, study, target=target, target_name=target_name)
+
+        _append_safe(row, plot_pareto_front, study)
+        summary = f"Pareto-front size: {len(study.best_trials)}"
+    else:
+        _append_safe(row, plot_optimization_history, study)
+        _append_safe(row, plot_param_importances, study)
+        summary = f"Best value: {study.best_value}\nParams: {study.best_params}"
+
+    row.append(pn.pane.Markdown(f"```\n{summary}```"))
     return row

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -156,15 +156,48 @@ def cfg_from_optuna_trial(
 def summarise_optuna_study(study: optuna.study.Study) -> pn.pane.panel:
     """Summarise an optuna study in a panel format"""
     row = pn.Column(name="Optimisation Results")
-    row.append(plot_optimization_history(study))
-    row.append(plot_param_importances(study))
-    try:
-        row.append(plot_pareto_front(study))
-    except Exception as e:  # pylint: disable=broad-except
-        logging.exception(e)
+    n_objectives = len(study.directions)
+    is_multi = n_objectives >= 2
 
-    row.append(
-        pn.pane.Markdown(f"```\nBest value: {study.best_value}\nParams: {study.best_params}```")
-    )
+    if is_multi:
+        # Multi-objective: plot_optimization_history and plot_param_importances
+        # require an explicit target callback.
+        for idx in range(n_objectives):
+            target_name = f"Objective {idx}"
+            try:
+                row.append(
+                    plot_optimization_history(
+                        study,
+                        target=lambda t, i=idx: t.values[i],
+                        target_name=target_name,
+                    )
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logging.exception(e)
+            try:
+                row.append(
+                    plot_param_importances(
+                        study,
+                        target=lambda t, i=idx: t.values[i],
+                        target_name=target_name,
+                    )
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logging.exception(e)
+        try:
+            row.append(plot_pareto_front(study))
+        except Exception as e:  # pylint: disable=broad-except
+            logging.exception(e)
+        row.append(
+            pn.pane.Markdown(f"```\nPareto-front size: {len(study.best_trials)}```")
+        )
+    else:
+        row.append(plot_optimization_history(study))
+        row.append(plot_param_importances(study))
+        row.append(
+            pn.pane.Markdown(
+                f"```\nBest value: {study.best_value}\nParams: {study.best_params}```"
+            )
+        )
 
     return row

--- a/bencher/results/optimize_result.py
+++ b/bencher/results/optimize_result.py
@@ -1,0 +1,79 @@
+"""OptimizeResult — first-class container for optimization results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import optuna
+import panel as pn
+
+from bencher.optuna_conversions import summarise_optuna_study
+
+
+@dataclass
+class OptimizeResult:
+    """Wraps an ``optuna.Study`` with bencher-friendly accessors.
+
+    Attributes:
+        study: The underlying optuna study.
+        n_warm_start_trials: Number of trials seeded from cache / prior results.
+        n_new_trials: Number of new trials evaluated during optimization.
+        target_names: Names of the optimization target variables.
+    """
+
+    study: optuna.Study
+    n_warm_start_trials: int = 0
+    n_new_trials: int = 0
+    target_names: list[str] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Single-objective helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def best_params(self) -> dict[str, Any]:
+        """Best parameters found (single-objective only)."""
+        return self.study.best_params
+
+    @property
+    def best_value(self) -> float:
+        """Best objective value (single-objective only)."""
+        return self.study.best_value
+
+    # ------------------------------------------------------------------
+    # Multi-objective helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def best_trials(self) -> list[optuna.trial.FrozenTrial]:
+        """Pareto-optimal trials (multi-objective)."""
+        return self.study.best_trials
+
+    # ------------------------------------------------------------------
+    # Visualization
+    # ------------------------------------------------------------------
+
+    def to_panel(self) -> pn.pane.panel:
+        """Panel visualization reusing the existing ``summarise_optuna_study`` helper."""
+        return summarise_optuna_study(self.study)
+
+    # ------------------------------------------------------------------
+    # Text summary
+    # ------------------------------------------------------------------
+
+    def summary(self) -> str:
+        """Return a human-readable summary of the optimization."""
+        lines = [
+            f"Study: {self.study.study_name}",
+            f"  warm-start trials: {self.n_warm_start_trials}",
+            f"  new trials:        {self.n_new_trials}",
+            f"  total trials:      {len(self.study.trials)}",
+        ]
+        directions = self.study.directions
+        if len(directions) == 1:
+            lines.append(f"  best value:  {self.study.best_value}")
+            lines.append(f"  best params: {self.study.best_params}")
+        else:
+            lines.append(f"  Pareto-front size: {len(self.study.best_trials)}")
+        return "\n".join(lines)

--- a/bencher/results/optimize_result.py
+++ b/bencher/results/optimize_result.py
@@ -31,14 +31,24 @@ class OptimizeResult:
     # Single-objective helpers
     # ------------------------------------------------------------------
 
+    def _ensure_single_objective(self) -> None:
+        """Raise if study is multi-objective."""
+        if len(self.study.directions) != 1:
+            raise RuntimeError(
+                "best_params/best_value are only defined for single-objective studies. "
+                "For multi-objective studies use best_trials instead."
+            )
+
     @property
     def best_params(self) -> dict[str, Any]:
         """Best parameters found (single-objective only)."""
+        self._ensure_single_objective()
         return self.study.best_params
 
     @property
     def best_value(self) -> float:
         """Best objective value (single-objective only)."""
+        self._ensure_single_objective()
         return self.study.best_value
 
     # ------------------------------------------------------------------

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -28,6 +28,7 @@ def run(
     publish: bool = False,
     grouped: bool = False,
     cache_results: bool = True,
+    optimise: int = 0,
 ) -> list[BenchCfg]:
     """Run a benchmark target with sensible defaults.
 
@@ -50,6 +51,9 @@ def run(
         publish: Publish results. Defaults to False.
         grouped: Produce a single HTML page with all benchmarks. Defaults to False.
         cache_results: Use sample cache for previous results. Defaults to True.
+        optimise: Number of extra optuna optimisation trials to run after the sweep.
+            When > 0, ``bench.optimize(n_trials=optimise)`` is called and the
+            optimisation plots are appended to the report. Defaults to 0 (no optimisation).
 
     Returns:
         list[BenchCfg]: A list of benchmark configuration objects with results.
@@ -71,6 +75,18 @@ def run(
 
         _sweep_fn.__name__ = f"bench_{instance.name}"
         target = _sweep_fn
+
+    # Wrap target to add optimisation if requested
+    if optimise > 0:
+        _original_target = target
+
+        def _with_optimise(run_cfg: BenchRunCfg | None = None) -> "Bench":
+            bench = _original_target(run_cfg)
+            bench.optimize(n_trials=optimise)
+            return bench
+
+        _with_optimise.__name__ = getattr(_original_target, "__name__", "optimised")
+        target = _with_optimise
 
     # Case 1: Callable — wrap in BenchRunner
     br = BenchRunner(target)

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -213,6 +213,20 @@ class ParametrizedSweep(Parameterized):
         """Create a Bench instance from this ParametrizedSweep."""
         return create_bench(self, run_cfg=run_cfg, report=report, name=name)
 
+    def to_optimize(self, n_trials=100, run_cfg=None, **kwargs):
+        """Create a Bench and run optimization in one call.
+
+        Args:
+            n_trials: Number of optuna trials.
+            run_cfg: Optional BenchRunCfg.
+            **kwargs: Forwarded to ``Bench.optimize()``.
+
+        Returns:
+            OptimizeResult wrapping the completed study.
+        """
+        bench = self.to_bench(run_cfg=run_cfg)
+        return bench.optimize(n_trials=n_trials, run_cfg=run_cfg, **kwargs)
+
     def to_bench_runner(self, run_cfg=None, name=None):
         """Create a BenchRunner instance from this ParametrizedSweep.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.70.3
-  sha256: 9effb6c52473127a4ef2b40c05ad0a188ae0148388f00f6cec1653331e432797
+  version: 1.70.5
+  sha256: 8ac63fc8a2e933422e08385219dfd2ecb1725c7c4858cc4823f57bea53021d23
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pixi.lock
+++ b/pixi.lock
@@ -27,7 +27,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.0-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -190,7 +190,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.0-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -356,7 +356,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.0-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -519,7 +519,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.0-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -680,7 +680,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.0-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.70.2
-  sha256: a1677da9992cd1d466e9868903b4383f0ea8e5a0c30465e2885a4c9ec3dc2681
+  version: 1.70.3
+  sha256: 9effb6c52473127a4ef2b40c05ad0a188ae0148388f00f6cec1653331e432797
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -2186,19 +2186,18 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
   purls: []
-  size: 60963
-  timestamp: 1727963148474
+  size: 63629
+  timestamp: 1774072609062
 - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
   name: linkify-it-py
   version: 2.1.0

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -1,0 +1,233 @@
+"""Tests for the first-class optimization API (Bench.optimize / to_optimize)."""
+
+from __future__ import annotations
+
+from enum import auto
+
+import pytest
+
+import bencher as bch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class Sphere(bch.ParametrizedSweep):
+    """Simple sphere function: minimum at origin."""
+
+    x = bch.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+    y = bch.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+
+    loss = bch.ResultVar("ul", bch.OptDir.minimize)
+
+    def __call__(self, **kwargs) -> dict:
+        self.update_params_from_kwargs(**kwargs)
+        self.loss = float(self.x**2 + self.y**2)
+        return super().__call__(**kwargs)
+
+
+class MultiObjective(bch.ParametrizedSweep):
+    """Two conflicting objectives."""
+
+    x = bch.FloatSweep(default=0, bounds=[0, 5], samples=5)
+
+    obj1 = bch.ResultVar("ul", bch.OptDir.minimize)
+    obj2 = bch.ResultVar("ul", bch.OptDir.maximize)
+
+    def __call__(self, **kwargs) -> dict:
+        self.update_params_from_kwargs(**kwargs)
+        self.obj1 = float(self.x**2)
+        self.obj2 = float(-((self.x - 3) ** 2))
+        return super().__call__(**kwargs)
+
+
+class Color(bch.ClassEnum):
+    red = auto()
+    green = auto()
+    blue = auto()
+
+    @classmethod
+    def to_class(cls, enum_val):
+        return enum_val
+
+
+class CategoricalProblem(bch.ParametrizedSweep):
+    """Problem with categorical + boolean inputs."""
+
+    flag = bch.BoolSweep(default=False)
+    color = bch.EnumSweep(Color, default=Color.red)
+
+    score = bch.ResultVar("ul", bch.OptDir.minimize)
+
+    def __call__(self, **kwargs) -> dict:
+        self.update_params_from_kwargs(**kwargs)
+        lookup = {Color.red: 1.0, Color.green: 0.5, Color.blue: 2.0}
+        self.score = lookup[self.color] + (0.0 if self.flag else 0.3)
+        return super().__call__(**kwargs)
+
+
+def _run_cfg():
+    """Minimal run config with caching enabled."""
+    cfg = bch.BenchRunCfg()
+    cfg.repeats = 1
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSingleObjective:
+    def test_basic_optimize(self):
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_single", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=20, plot=False)
+
+        assert result.best_params is not None
+        assert "x" in result.best_params
+        assert "y" in result.best_params
+        assert result.best_value >= 0
+        assert result.n_new_trials == 20
+        assert result.best_value < 10  # should find something reasonable
+
+    def test_summary(self):
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_summary", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        text = result.summary()
+        assert "best value" in text
+        assert "warm-start trials" in text
+
+
+class TestMultiObjective:
+    def test_pareto_front(self):
+        cfg = MultiObjective()
+        bench = bch.Bench("test_opt_multi", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=20, plot=False)
+
+        assert len(result.best_trials) > 0
+        assert result.n_new_trials == 20
+        # Multi-objective: best_value should raise
+        with pytest.raises(RuntimeError):
+            _ = result.best_value
+
+
+class TestWarmStart:
+    def test_warm_start_from_sweep(self):
+        cfg = Sphere()
+        run_cfg = _run_cfg()
+        bench = bch.Bench("test_opt_warm", cfg, run_cfg=run_cfg)
+
+        # Run a grid sweep first to populate cache
+        bench.plot_sweep(
+            input_vars=[cfg.param.x, cfg.param.y],
+            result_vars=[cfg.param.loss],
+            run_cfg=run_cfg,
+        )
+
+        result = bench.optimize(n_trials=10, warm_start=True, plot=False)
+        assert result.n_warm_start_trials > 0
+
+    def test_no_warm_start(self):
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_no_warm", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, warm_start=False, plot=False)
+        assert result.n_warm_start_trials == 0
+
+
+class TestAutoDetection:
+    def test_auto_detect_vars(self):
+        """optimize() should auto-detect input/result vars from the worker class."""
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_auto", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        assert "x" in result.best_params
+        assert "y" in result.best_params
+
+
+class TestConvenience:
+    def test_to_optimize(self):
+        result = Sphere().to_optimize(n_trials=15, plot=False)
+        assert result.best_params is not None
+        assert result.best_value >= 0
+        assert result.n_new_trials == 15
+
+
+class TestCategoricalInputs:
+    def test_enum_and_bool(self):
+        cfg = CategoricalProblem()
+        bench = bch.Bench("test_opt_cat", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=15, plot=False)
+        assert "flag" in result.best_params
+        assert "color" in result.best_params
+        assert result.best_value <= 1.0  # best is green + flag=True → 0.5
+
+
+class TestOptimizeResult:
+    def test_to_panel(self):
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_panel", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        panel = result.to_panel()
+        assert panel is not None
+
+    def test_target_names(self):
+        cfg = Sphere()
+        bench = bch.Bench("test_opt_targets", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=5, plot=False)
+        assert result.target_names == ["loss"]
+
+
+class TestSummariseOptunaStudy:
+    """Tests for summarise_optuna_study handling single vs multi-objective correctly."""
+
+    def test_single_objective_no_pareto_error(self, caplog):
+        """Single-objective study should not attempt plot_pareto_front."""
+        cfg = Sphere()
+        bench = bch.Bench("test_summary_single", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=5, plot=False)
+        panel = result.to_panel()
+        assert panel is not None
+        # Should not log any plot_pareto_front error
+        assert "plot_pareto_front" not in caplog.text
+
+    def test_single_objective_panel_shows_best_value(self):
+        """Single-objective panel should contain best value text."""
+        import panel as pn
+
+        cfg = Sphere()
+        bench = bch.Bench("test_summary_best", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=5, plot=False)
+        panel = result.to_panel()
+        # Find Markdown panes and check their content
+        md_texts = [
+            obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)
+        ]
+        combined = " ".join(md_texts)
+        assert "Best value" in combined
+
+    def test_multi_objective_panel_no_best_value_error(self):
+        """Multi-objective panel should not call study.best_value (which raises)."""
+        cfg = MultiObjective()
+        bench = bch.Bench("test_summary_multi", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        # Should not raise — previously would crash on study.best_value
+        panel = result.to_panel()
+        assert panel is not None
+
+    def test_multi_objective_panel_shows_pareto_size(self):
+        """Multi-objective panel should show Pareto-front size."""
+        import panel as pn
+
+        cfg = MultiObjective()
+        bench = bch.Bench("test_summary_pareto_size", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        panel = result.to_panel()
+        md_texts = [
+            obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)
+        ]
+        combined = " ".join(md_texts)
+        assert "Pareto-front size" in combined

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -203,9 +203,7 @@ class TestSummariseOptunaStudy:
         result = bench.optimize(n_trials=5, plot=False)
         panel = result.to_panel()
         # Find Markdown panes and check their content
-        md_texts = [
-            obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)
-        ]
+        md_texts = [obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)]
         combined = " ".join(md_texts)
         assert "Best value" in combined
 
@@ -226,8 +224,6 @@ class TestSummariseOptunaStudy:
         bench = bch.Bench("test_summary_pareto_size", cfg, run_cfg=_run_cfg())
         result = bench.optimize(n_trials=10, plot=False)
         panel = result.to_panel()
-        md_texts = [
-            obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)
-        ]
+        md_texts = [obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)]
         combined = " ".join(md_texts)
         assert "Pareto-front size" in combined


### PR DESCRIPTION
## Summary
- **Single-objective studies**: `summarise_optuna_study` no longer calls `plot_pareto_front` (which requires ≥2 objectives and was logging noisy `ValueError` tracebacks). Shows best value and params instead.
- **Multi-objective studies**: Passes explicit `target` callbacks to `plot_optimization_history` and `plot_param_importances` (both raise `ValueError` without one for multi-objective). Shows Pareto-front size instead of `study.best_value` (which raises `RuntimeError` for multi-objective).
- Adds 4 new tests in `TestSummariseOptunaStudy` covering both code paths.

## Test plan
- [x] All 14 optimization tests pass (`test/test_optimize.py`)
- [x] Full test suite passes (837 passed, 5 skipped)
- [x] `example_optimize.py` runs with no errors logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a first-class Optuna optimization API and fix study summarisation for single- vs multi-objective studies.

New Features:
- Add Bench.optimize() API and OptimizeResult wrapper to run Optuna-based optimization without a full grid sweep.
- Allow ParametrizedSweep.to_optimize() as a convenience one-liner for running optimization.
- Extend the top-level run() helper with an optimise parameter to run additional optimization trials after a sweep.
- Add an example script demonstrating the new optimization workflow and warm-starting from sweeps.

Bug Fixes:
- Update summarise_optuna_study to correctly handle single- and multi-objective Optuna studies without raising errors or logging noisy tracebacks.

Enhancements:
- Warm-start optimization studies from prior sweeps and cached samples when available, and surface warm-start metadata in OptimizeResult summaries.

Documentation:
- Document the optimization workflow via a new example_optimize example showcasing direct optimization, warm-started optimization, and the to_optimize() one-liner.

Tests:
- Add a dedicated test suite for the optimization API covering single- and multi-objective studies, warm-start behavior, categorical inputs, and OptimizeResult helpers.
- Add tests verifying that summarise_optuna_study panels render correctly for both single- and multi-objective studies and display appropriate summary text.