### PR TITLE
Fix review feedback from self-introspection PR

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -521,10 +521,7 @@ class Bench(BenchPlotServer):
         Raises:
             FileNotFoundError: If only_plot=True and no cached results exist
         """
-        import time as _time
-
         timings = SweepTimings()
-        sweep_t0 = _time.perf_counter()
 
         if run_cfg.cache_size is not None:
             cache_size_bytes = run_cfg.cache_size * 1_000_000
@@ -637,7 +634,15 @@ class Bench(BenchPlotServer):
             bench_res.post_setup()
         timings.post_setup_ms = elapsed()
 
-        timings.total_ms = (_time.perf_counter() - sweep_t0) * 1000.0
+        timings.total_ms = (
+            timings.sample_cache_init_ms
+            + timings.cache_check_ms
+            + timings.dataset_setup_ms
+            + timings.job_submission_ms
+            + timings.job_execution_ms
+            + timings.history_merge_ms
+            + timings.post_setup_ms
+        )
         bench_res.timings = timings
 
         if bench_cfg.auto_plot:
@@ -779,6 +784,7 @@ class Bench(BenchPlotServer):
         callcount = 1
         results_list = []
         jobs = []
+        cache_jobs = []
 
         with phase_timer() as elapsed:
             for idx_tuple, function_input_vars in func_inputs:
@@ -795,25 +801,27 @@ class Bench(BenchPlotServer):
 
                 jid = f"{bench_res.bench_cfg.title}:call {callcount}/{len(func_inputs)}"
                 worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
-                cache_job = Job(
-                    job_id=jid,
-                    function=worker,
-                    job_args=job.function_input,
-                    job_key=job.function_input_signature_pure,
-                    tag=job.tag,
+                cache_jobs.append(
+                    Job(
+                        job_id=jid,
+                        function=worker,
+                        job_args=job.function_input,
+                        job_key=job.function_input_signature_pure,
+                        tag=job.tag,
+                    )
                 )
+                callcount += 1
+        timings.job_submission_ms = elapsed()
+
+        with phase_timer() as elapsed:
+            for job, cache_job in zip(jobs, cache_jobs):
                 result = self.sample_cache.submit(cache_job)
                 results_list.append(result)
-                callcount += 1
-
                 # For serial execution, store results immediately so that
                 # completed results are cached to disk before later jobs
                 # may crash.
                 if bench_run_cfg.executor == Executors.SERIAL:
                     self.store_results(result, bench_res, job, bench_run_cfg)
-        timings.job_submission_ms = elapsed()
-
-        with phase_timer() as elapsed:
             if bench_run_cfg.executor != Executors.SERIAL:
                 for job, res in zip(jobs, results_list):
                     self.store_results(res, bench_res, job, bench_run_cfg)

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -634,15 +634,7 @@ class Bench(BenchPlotServer):
             bench_res.post_setup()
         timings.post_setup_ms = elapsed()
 
-        timings.total_ms = (
-            timings.sample_cache_init_ms
-            + timings.cache_check_ms
-            + timings.dataset_setup_ms
-            + timings.job_submission_ms
-            + timings.job_execution_ms
-            + timings.history_merge_ms
-            + timings.post_setup_ms
-        )
+        timings.total_ms = timings.compute_total()
         bench_res.timings = timings
 
         if bench_cfg.auto_plot:

--- a/bencher/example/generated/performance/self_benchmark.py
+++ b/bencher/example/generated/performance/self_benchmark.py
@@ -28,7 +28,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     )
     use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
 
-    # Result variables - one per timing phase
+    # Result variables — one per timing phase
     total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
     dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
     job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")

--- a/bencher/example/generated/performance/self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/self_benchmark_over_time.py
@@ -28,7 +28,7 @@ class BencherSelfBenchmark(bch.ParametrizedSweep):
     )
     use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
 
-    # Result variables - one per timing phase
+    # Result variables — one per timing phase
     total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
     dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
     job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -4,9 +4,11 @@ Generates examples that benchmark bencher's own overhead, enabling
 performance tracking across commits via the documentation gallery.
 """
 
+import inspect
 from typing import Any
 
 import bencher as bch
+from bencher.example.example_self_benchmark import BencherSelfBenchmark, TrivialWorkload
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
 OUTPUT_DIR = "performance"
@@ -62,7 +64,7 @@ bench.plot_sweep(
             function_name="example_self_benchmark",
             imports=imports,
             body=body,
-            class_code=_SHARED_CLASS_CODE,
+            class_code=_get_shared_class_code(),
         )
 
     def _generate_self_benchmark_over_time(self):
@@ -96,72 +98,13 @@ bench.plot_sweep(
             function_name="example_self_benchmark_over_time",
             imports=imports,
             body=body,
-            class_code=_SHARED_CLASS_CODE,
+            class_code=_get_shared_class_code(),
         )
 
 
-_SHARED_CLASS_CODE = '''\
-class TrivialWorkload(bch.ParametrizedSweep):
-    """A near-zero-cost worker so we measure framework overhead, not compute."""
-
-    x = bch.FloatSweep(default=0, bounds=[0, 1], samples=2)
-    result = bch.ResultVar(units="v", doc="trivial output")
-
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.result = self.x * 2
-        return super().__call__(**kwargs)
-
-
-class BencherSelfBenchmark(bch.ParametrizedSweep):
-    """Sweep over problem sizes and measure bencher's own timing phases."""
-
-    num_samples = bch.IntSweep(
-        default=10,
-        bounds=[2, 100],
-        samples=6,
-        doc="Number of parameter samples in the inner sweep",
-    )
-    use_cache = bch.BoolSweep(default=False, doc="Whether sample caching is enabled")
-
-    # Result variables - one per timing phase
-    total_ms = bch.ResultVar(units="ms", doc="Total sweep wall-clock time")
-    dataset_setup_ms = bch.ResultVar(units="ms", doc="Dataset initialization time")
-    job_submission_ms = bch.ResultVar(units="ms", doc="Job creation and submission time")
-    job_execution_ms = bch.ResultVar(units="ms", doc="Worker execution and result storage time")
-    cache_check_ms = bch.ResultVar(units="ms", doc="Benchmark cache lookup time")
-    sample_cache_init_ms = bch.ResultVar(units="ms", doc="Sample cache initialization time")
-    throughput = bch.ResultVar(units="samples/s", doc="Samples processed per second")
-
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
-        workload = TrivialWorkload()
-        x_sweep = bch.FloatSweep(
-            default=0, bounds=[0, 1], samples=self.num_samples, doc="input"
-        )
-        x_sweep.name = "x"
-
-        inner_cfg = bch.BenchRunCfg()
-        inner_cfg.repeats = 1
-        inner_cfg.cache_samples = self.use_cache
-        inner_cfg.cache_results = False
-        inner_cfg.auto_plot = False
-
-        bench = bch.Bench("inner_bench", workload, run_cfg=inner_cfg)
-        bench.plot_sweep(input_vars=[x_sweep], result_vars=["result"])
-        res = bench.results[-1]
-
-        t = res.timings
-        self.total_ms = t.total_ms
-        self.dataset_setup_ms = t.dataset_setup_ms
-        self.job_submission_ms = t.job_submission_ms
-        self.job_execution_ms = t.job_execution_ms
-        self.cache_check_ms = t.cache_check_ms
-        self.sample_cache_init_ms = t.sample_cache_init_ms
-        self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
-
-        return super().__call__(**kwargs)'''
+def _get_shared_class_code():
+    """Extract class source from the canonical module to avoid duplication."""
+    return inspect.getsource(TrivialWorkload) + "\n\n" + inspect.getsource(BencherSelfBenchmark)
 
 
 def example_meta_performance():

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -103,8 +103,18 @@ bench.plot_sweep(
 
 
 def _get_shared_class_code():
-    """Extract class source from the canonical module to avoid duplication."""
-    return inspect.getsource(TrivialWorkload) + "\n\n" + inspect.getsource(BencherSelfBenchmark)
+    """Extract class source from the canonical module to avoid duplication.
+
+    Falls back to reading the source file directly if inspect.getsource is
+    unavailable (e.g. zipapp or compiled distributions).
+    """
+    try:
+        return inspect.getsource(TrivialWorkload) + "\n\n" + inspect.getsource(BencherSelfBenchmark)
+    except OSError:
+        import importlib.resources
+
+        src = importlib.resources.files("bencher.example").joinpath("example_self_benchmark.py")
+        return src.read_text(encoding="utf-8")
 
 
 def example_meta_performance():

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -133,7 +133,7 @@ def sweep_var_to_suggest(iv: ParametrizedSweep, trial: optuna.trial) -> object:
     if iv_type in (EnumSweep, StringSweep):
         return trial.suggest_categorical(iv.name, iv.objects)
     if iv_type in (TimeSnapshot, TimeEvent):
-        pass  # optuna does not like time
+        return None  # optuna does not like time
     if iv_type == BoolSweep:
         return trial.suggest_categorical(iv.name, [True, False])
     raise ValueError(f"This input type {iv_type} is not supported")

--- a/bencher/sweep_timings.py
+++ b/bencher/sweep_timings.py
@@ -25,6 +25,14 @@ class SweepTimings:
     post_setup_ms: float = 0.0
     total_ms: float = 0.0  #: Sum of all phase timings above
 
+    def compute_total(self) -> float:
+        """Compute total_ms as the sum of all phase timing fields."""
+        return sum(
+            getattr(self, f.name)
+            for f in fields(self)
+            if f.name != "total_ms" and f.name.endswith("_ms")
+        )
+
     def summary(self) -> dict[str, float]:
         """Return all phase timings as a dict."""
         return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/bencher/sweep_timings.py
+++ b/bencher/sweep_timings.py
@@ -19,11 +19,11 @@ class SweepTimings:
     cache_check_ms: float = 0.0
     sample_cache_init_ms: float = 0.0
     dataset_setup_ms: float = 0.0
-    job_submission_ms: float = 0.0
-    job_execution_ms: float = 0.0
+    job_submission_ms: float = 0.0  #: Job object creation (consistent across executors)
+    job_execution_ms: float = 0.0  #: Job submission, execution, and result storage
     history_merge_ms: float = 0.0
     post_setup_ms: float = 0.0
-    total_ms: float = 0.0
+    total_ms: float = 0.0  #: Sum of all phase timings above
 
     def summary(self) -> dict[str, float]:
         """Return all phase timings as a dict."""

--- a/test/test_sweep_timings.py
+++ b/test/test_sweep_timings.py
@@ -49,15 +49,8 @@ def test_bench_result_has_timings():
 
     # total_ms should equal the sum of all phase timings
     t = res.timings
-    expected_total = (
-        t.cache_check_ms
-        + t.sample_cache_init_ms
-        + t.dataset_setup_ms
-        + t.job_submission_ms
-        + t.job_execution_ms
-        + t.history_merge_ms
-        + t.post_setup_ms
-    )
+    summary = t.summary()
+    expected_total = sum(v for k, v in summary.items() if k != "total_ms")
     assert t.total_ms == expected_total
 
 

--- a/test/test_sweep_timings.py
+++ b/test/test_sweep_timings.py
@@ -47,6 +47,19 @@ def test_bench_result_has_timings():
     assert res.timings.job_submission_ms >= 0
     assert res.timings.job_execution_ms >= 0
 
+    # total_ms should equal the sum of all phase timings
+    t = res.timings
+    expected_total = (
+        t.cache_check_ms
+        + t.sample_cache_init_ms
+        + t.dataset_setup_ms
+        + t.job_submission_ms
+        + t.job_execution_ms
+        + t.history_merge_ms
+        + t.post_setup_ms
+    )
+    assert t.total_ms == expected_total
+
 
 def test_timings_accessible_via_public_api():
     """SweepTimings should be importable from the top-level bencher package."""


### PR DESCRIPTION
## Summary
- **Fix optuna bug**: `sweep_var_to_suggest` used `pass` for TimeSnapshot/TimeEvent, causing fall-through to `raise ValueError`. Now explicitly returns `None`.
- **Consistent timing semantics**: `job_submission_ms` now measures only job object creation (consistent across serial/parallel executors). `job_execution_ms` measures submission, execution, and result storage for both executor types.
- **Derive `total_ms` from phase sum**: Replaced separate `perf_counter` with sum of all phase timings, consistent with the `phase_timer` abstraction used everywhere else.
- **Deduplicate shared class code**: Meta generator now uses `inspect.getsource()` on the canonical `TrivialWorkload`/`BencherSelfBenchmark` classes instead of maintaining a duplicated string copy.

Addresses review feedback from #793 (Sourcery).

## Test plan
- [x] All 831 tests pass (1 pre-existing flask port-binding failure)
- [x] Lint/format clean (ruff, pylint, ty)
- [x] New assertion verifies `total_ms == sum(phases)`
- [x] Generated examples regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align sweep timing semantics, ensure total timing is derived from phase timings, and remove duplication in self-benchmark meta generation while fixing an Optuna sweep bug.

Bug Fixes:
- Return None for time-based sweep variables in Optuna conversions instead of falling through to an error.
- Ensure job submission and execution timing phases are correctly measured and assigned for serial and non-serial executors.
- Assert that total_ms equals the sum of individual timing phases to catch inconsistencies.

Enhancements:
- Derive total_ms from the sum of all timing phases instead of an independent wall-clock measurement.
- Clarify documentation on timing fields to define consistent semantics for job_submission_ms, job_execution_ms, and total_ms.
- Refactor self-benchmark meta generation to source canonical class definitions via inspect.getsource instead of maintaining duplicate class code.

Tests:
- Extend sweep timing tests to verify that total_ms equals the sum of all phase timings.