### PR TITLE
Add optimize flag to sweep variables for Optuna aggregation

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -680,15 +680,22 @@ class BenchCfg(BenchRunCfg):
             col.append(pn.pane.Markdown("## Results:"))
         return col
 
+    @staticmethod
+    def partition_input_vars(vars_) -> tuple[list, list]:
+        """Split variables into (optimized, non-optimized) based on the optimize flag."""
+        opt = [v for v in vars_ if getattr(v, "optimize", True)]
+        non_opt = [v for v in vars_ if not getattr(v, "optimize", True)]
+        return opt, non_opt
+
     @property
     def optimized_input_vars(self) -> list:
         """Return input variables where optimize=True (suggested by Optuna)."""
-        return [iv for iv in (self.input_vars or []) if getattr(iv, "optimize", True)]
+        return self.partition_input_vars(self.input_vars or [])[0]
 
     @property
     def non_optimized_input_vars(self) -> list:
         """Return input variables where optimize=False (swept/aggregated, not suggested)."""
-        return [iv for iv in (self.input_vars or []) if not getattr(iv, "optimize", True)]
+        return self.partition_input_vars(self.input_vars or [])[1]
 
     def optuna_targets(self, as_var: bool = False) -> list[Any]:
         """Get the list of result variables that are optimization targets.

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -680,6 +680,16 @@ class BenchCfg(BenchRunCfg):
             col.append(pn.pane.Markdown("## Results:"))
         return col
 
+    @property
+    def optimized_input_vars(self) -> list:
+        """Return input variables where optimize=True (suggested by Optuna)."""
+        return [iv for iv in (self.input_vars or []) if getattr(iv, "optimize", True)]
+
+    @property
+    def non_optimized_input_vars(self) -> list:
+        """Return input variables where optimize=False (swept/aggregated, not suggested)."""
+        return [iv for iv in (self.input_vars or []) if not getattr(iv, "optimize", True)]
+
     def optuna_targets(self, as_var: bool = False) -> list[Any]:
         """Get the list of result variables that are optimization targets.
 

--- a/bencher/example/generated/optimization/optimise_1_objective_1d.py
+++ b/bencher/example/generated/optimization/optimise_1_objective_1d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization: 1 objective(s), 1D input."""
+"""Auto-generated example: Optimise 1 objective(s), 1D input."""
 
 from typing import Any
 
@@ -29,8 +29,8 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_1obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization: 1 objective(s), 1D input."""
+def example_optimise_1_objective_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise 1 objective(s), 1D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
@@ -47,4 +47,4 @@ def example_optim_1obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_1obj_1d, level=3, repeats=3)
+    bch.run(example_optimise_1_objective_1d, level=3, repeats=3)

--- a/bencher/example/generated/optimization/optimise_1_objective_2d.py
+++ b/bencher/example/generated/optimization/optimise_1_objective_2d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization: 2 objective(s), 2D input."""
+"""Auto-generated example: Optimise 1 objective(s), 2D input."""
 
 from typing import Any
 
@@ -29,17 +29,17 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_2obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization: 2 objective(s), 2D input."""
+def example_optimise_1_objective_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise 1 objective(s), 2D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
     res = bench.plot_sweep(
         input_vars=["cpu_cores", "memory_gb"],
-        result_vars=["performance", "cost"],
+        result_vars=["performance"],
         const_vars=dict(noise_scale=0.1),
-        description="Multi-objective optimization over 2D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
-        post_description="The Pareto front shows optimal trade-offs — no point can improve one objective without worsening the other.",
+        description="Single-objective optimization over 2D input space using Optuna. The optimizer searches for the parameter combination that maximizes performance.",
+        post_description="The Optuna importance plot shows which input parameters most affect the objective.",
     )
     bench.report.append(res.to_optuna_plots())
 
@@ -47,4 +47,4 @@ def example_optim_2obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_2obj_2d, level=2, repeats=3)
+    bch.run(example_optimise_1_objective_2d, level=2, repeats=3)

--- a/bencher/example/generated/optimization/optimise_2_objectives_1d.py
+++ b/bencher/example/generated/optimization/optimise_2_objectives_1d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization: 1 objective(s), 2D input."""
+"""Auto-generated example: Optimise 2 objective(s), 1D input."""
 
 from typing import Any
 
@@ -29,17 +29,17 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_1obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization: 1 objective(s), 2D input."""
+def example_optimise_2_objectives_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise 2 objective(s), 1D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
     res = bench.plot_sweep(
-        input_vars=["cpu_cores", "memory_gb"],
-        result_vars=["performance"],
+        input_vars=["cpu_cores"],
+        result_vars=["performance", "cost"],
         const_vars=dict(noise_scale=0.1),
-        description="Single-objective optimization over 2D input space using Optuna. The optimizer searches for the parameter combination that maximizes performance.",
-        post_description="The Optuna importance plot shows which input parameters most affect the objective.",
+        description="Multi-objective optimization over 1D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
+        post_description="The Pareto front shows optimal trade-offs — no point can improve one objective without worsening the other.",
     )
     bench.report.append(res.to_optuna_plots())
 
@@ -47,4 +47,4 @@ def example_optim_1obj_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_1obj_2d, level=2, repeats=3)
+    bch.run(example_optimise_2_objectives_1d, level=3, repeats=3)

--- a/bencher/example/generated/optimization/optimise_2_objectives_2d.py
+++ b/bencher/example/generated/optimization/optimise_2_objectives_2d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization: 2 objective(s), 1D input."""
+"""Auto-generated example: Optimise 2 objective(s), 2D input."""
 
 from typing import Any
 
@@ -29,16 +29,16 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_2obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization: 2 objective(s), 1D input."""
+def example_optimise_2_objectives_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise 2 objective(s), 2D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
     res = bench.plot_sweep(
-        input_vars=["cpu_cores"],
+        input_vars=["cpu_cores", "memory_gb"],
         result_vars=["performance", "cost"],
         const_vars=dict(noise_scale=0.1),
-        description="Multi-objective optimization over 1D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
+        description="Multi-objective optimization over 2D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
         post_description="The Pareto front shows optimal trade-offs — no point can improve one objective without worsening the other.",
     )
     bench.report.append(res.to_optuna_plots())
@@ -47,4 +47,4 @@ def example_optim_2obj_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_2obj_1d, level=3, repeats=3)
+    bch.run(example_optimise_2_objectives_2d, level=2, repeats=3)

--- a/bencher/example/generated/optimization_aggregated/optim_aggregated.py
+++ b/bencher/example/generated/optimization_aggregated/optim_aggregated.py
@@ -1,0 +1,49 @@
+"""Auto-generated example: Aggregated Optimization."""
+
+from typing import Any
+
+import math
+import random
+
+import bencher as bch
+
+
+class AlgorithmBench(bch.ParametrizedSweep):
+    """Finds best learning rate across algorithms (aggregated)."""
+
+    algorithm = bch.StringSweep(
+        ["gradient_descent", "adam", "rmsprop"],
+        doc="Optimization algorithm",
+        optimize=False,  # sweep but don't optimize — aggregate results
+    )
+    learning_rate = bch.FloatSweep(default=0.01, bounds=[0.001, 1.0], doc="Learning rate")
+
+    loss = bch.ResultVar("loss", bch.OptDir.minimize, doc="Training loss (minimize)")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        algo_sensitivity = {"gradient_descent": 1.0, "adam": 0.6, "rmsprop": 0.8}
+        optimal_lr = 0.01 * algo_sensitivity[self.algorithm]
+        self.loss = (math.log10(self.learning_rate) - math.log10(optimal_lr)) ** 2
+        self.loss += random.gauss(0, 0.02)
+        return super().__call__()
+
+
+def example_optim_aggregated(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Aggregated Optimization."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.use_optuna = True
+    bench = AlgorithmBench().to_bench(run_cfg)
+    res = bench.plot_sweep(
+        input_vars=["algorithm", "learning_rate"],
+        result_vars=["loss"],
+        description="Finds the best learning rate averaged across algorithms. algorithm has optimize=False so Optuna only suggests learning_rate and averages loss over all algorithm choices.",
+        post_description="The importance plot shows learning_rate and repeat — algorithm is aggregated away. Compare 'With Repeats' vs 'Without Repeats' to see if measurement noise affects the result.",
+    )
+    bench.report.append(res.to_optuna_plots())
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_optim_aggregated, level=3, repeats=3)

--- a/bencher/example/generated/optimization_aggregated/optim_aggregated_over_time.py
+++ b/bencher/example/generated/optimization_aggregated/optim_aggregated_over_time.py
@@ -1,0 +1,59 @@
+"""Auto-generated example: Aggregated Optimization (Over Time)."""
+
+from typing import Any
+
+import math
+import random
+from datetime import datetime, timedelta
+
+import bencher as bch
+
+
+class AlgorithmBench(bch.ParametrizedSweep):
+    """Finds best learning rate across algorithms (aggregated)."""
+
+    algorithm = bch.StringSweep(
+        ["gradient_descent", "adam", "rmsprop"],
+        doc="Optimization algorithm",
+        optimize=False,  # sweep but don't optimize — aggregate results
+    )
+    learning_rate = bch.FloatSweep(default=0.01, bounds=[0.001, 1.0], doc="Learning rate")
+
+    loss = bch.ResultVar("loss", bch.OptDir.minimize, doc="Training loss (minimize)")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        algo_sensitivity = {"gradient_descent": 1.0, "adam": 0.6, "rmsprop": 0.8}
+        optimal_lr = 0.01 * algo_sensitivity[self.algorithm]
+        self.loss = (math.log10(self.learning_rate) - math.log10(optimal_lr)) ** 2
+        self.loss += random.gauss(0, 0.02)
+        return super().__call__()
+
+
+def example_optim_aggregated_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Aggregated Optimization (Over Time)."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 3
+    benchable = AlgorithmBench()
+    bench = benchable.to_bench(run_cfg)
+    _base_time = datetime(2000, 1, 1)
+    for i in range(3):
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "over_time",
+            input_vars=["algorithm", "learning_rate"],
+            result_vars=["loss"],
+            description="Finds the best learning rate averaged across algorithms, tracked over time. algorithm has optimize=False so Optuna aggregates over it. The importance plot shows learning_rate, repeat, and over_time.",
+            post_description="The importance plot reveals which factors matter: the optimized parameter (learning_rate), measurement noise (repeat), or temporal drift (over_time).",
+            run_cfg=run_cfg,
+            time_src=_base_time + timedelta(seconds=i),
+        )
+    bench.report.append(res.to_optuna_plots())
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_optim_aggregated_over_time, level=3)

--- a/bencher/example/generated/optimization_aggregated/optimise_aggregated.py
+++ b/bencher/example/generated/optimization_aggregated/optimise_aggregated.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Aggregated Optimization."""
+"""Auto-generated example: Aggregated Optimisation."""
 
 from typing import Any
 
@@ -29,8 +29,8 @@ class AlgorithmBench(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_aggregated(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Aggregated Optimization."""
+def example_optimise_aggregated(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Aggregated Optimisation."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.use_optuna = True
     bench = AlgorithmBench().to_bench(run_cfg)
@@ -46,4 +46,4 @@ def example_optim_aggregated(run_cfg: bch.BenchRunCfg | None = None) -> bch.Benc
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_aggregated, level=3, repeats=3)
+    bch.run(example_optimise_aggregated, level=3, repeats=3)

--- a/bencher/example/generated/optimization_aggregated/optimise_aggregated_over_time.py
+++ b/bencher/example/generated/optimization_aggregated/optimise_aggregated_over_time.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Aggregated Optimization (Over Time)."""
+"""Auto-generated example: Aggregated Optimisation (Over Time)."""
 
 from typing import Any
 
@@ -30,8 +30,8 @@ class AlgorithmBench(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_aggregated_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Aggregated Optimization (Over Time)."""
+def example_optimise_aggregated_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Aggregated Optimisation (Over Time)."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     run_cfg.repeats = 3
@@ -56,4 +56,4 @@ def example_optim_aggregated_over_time(run_cfg: bch.BenchRunCfg | None = None) -
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_aggregated_over_time, level=3)
+    bch.run(example_optimise_aggregated_over_time, level=3)

--- a/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
@@ -1,0 +1,61 @@
+"""Auto-generated example: Optimization Over Time: 1D input."""
+
+from typing import Any
+
+import math
+import random
+from datetime import datetime, timedelta
+
+import bencher as bch
+
+
+class ServerOptimizer(bch.ParametrizedSweep):
+    """Optimizes server config — performance drifts over time."""
+
+    cpu_cores = bch.FloatSweep(default=4, bounds=[1, 32], doc="Number of CPU cores")
+    memory_gb = bch.FloatSweep(default=8, bounds=[1, 64], doc="Memory in GB")
+
+    performance = bch.ResultVar("score", bch.OptDir.maximize, doc="Performance score")
+
+    noise_scale = bch.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
+
+    _drift = 0.0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
+        self.performance *= 1.0 - self._drift * 0.15  # degrade over time
+        if self.noise_scale > 0:
+            self.performance += random.gauss(0, self.noise_scale * 5)
+        return super().__call__()
+
+
+def example_optim_over_time_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimization Over Time: 1D input."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 3
+    benchable = ServerOptimizer()
+    bench = benchable.to_bench(run_cfg)
+    _base_time = datetime(2000, 1, 1)
+    for i in range(4):
+        benchable._drift = float(i)
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "over_time",
+            input_vars=["cpu_cores"],
+            result_vars=["performance"],
+            const_vars=dict(noise_scale=0.15),
+            description="Optimization over 1D input space with temporal drift. Performance degrades over successive runs. The importance analysis shows repeat, over_time, and input parameters — revealing whether noise or temporal drift dominates.",
+            post_description="Check the 'Parameter Importance With Repeats' plot: if over_time has high importance, results are drifting. If repeat is high, measurements are noisy.",
+            run_cfg=run_cfg,
+            time_src=_base_time + timedelta(seconds=i),
+        )
+    bench.report.append(res.to_optuna_plots())
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_optim_over_time_1d, level=2)

--- a/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
@@ -1,0 +1,61 @@
+"""Auto-generated example: Optimization Over Time: 2D input."""
+
+from typing import Any
+
+import math
+import random
+from datetime import datetime, timedelta
+
+import bencher as bch
+
+
+class ServerOptimizer(bch.ParametrizedSweep):
+    """Optimizes server config — performance drifts over time."""
+
+    cpu_cores = bch.FloatSweep(default=4, bounds=[1, 32], doc="Number of CPU cores")
+    memory_gb = bch.FloatSweep(default=8, bounds=[1, 64], doc="Memory in GB")
+
+    performance = bch.ResultVar("score", bch.OptDir.maximize, doc="Performance score")
+
+    noise_scale = bch.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
+
+    _drift = 0.0
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
+        self.performance *= 1.0 - self._drift * 0.15  # degrade over time
+        if self.noise_scale > 0:
+            self.performance += random.gauss(0, self.noise_scale * 5)
+        return super().__call__()
+
+
+def example_optim_over_time_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimization Over Time: 2D input."""
+    run_cfg = run_cfg or bch.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 3
+    benchable = ServerOptimizer()
+    bench = benchable.to_bench(run_cfg)
+    _base_time = datetime(2000, 1, 1)
+    for i in range(4):
+        benchable._drift = float(i)
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "over_time",
+            input_vars=["cpu_cores", "memory_gb"],
+            result_vars=["performance"],
+            const_vars=dict(noise_scale=0.15),
+            description="Optimization over 2D input space with temporal drift. Performance degrades over successive runs. The importance analysis shows repeat, over_time, and input parameters — revealing whether noise or temporal drift dominates.",
+            post_description="Check the 'Parameter Importance With Repeats' plot: if over_time has high importance, results are drifting. If repeat is high, measurements are noisy.",
+            run_cfg=run_cfg,
+            time_src=_base_time + timedelta(seconds=i),
+        )
+    bench.report.append(res.to_optuna_plots())
+
+    return bench
+
+
+if __name__ == "__main__":
+    bch.run(example_optim_over_time_2d, level=2)

--- a/bencher/example/generated/optimization_over_time/optimise_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optimise_over_time_1d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization Over Time: 1D input."""
+"""Auto-generated example: Optimise Over Time: 1D input."""
 
 from typing import Any
 
@@ -30,8 +30,8 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_over_time_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization Over Time: 1D input."""
+def example_optimise_over_time_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise Over Time: 1D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     run_cfg.repeats = 3
@@ -58,4 +58,4 @@ def example_optim_over_time_1d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Be
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_over_time_1d, level=2)
+    bch.run(example_optimise_over_time_1d, level=2)

--- a/bencher/example/generated/optimization_over_time/optimise_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optimise_over_time_2d.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Optimization Over Time: 2D input."""
+"""Auto-generated example: Optimise Over Time: 2D input."""
 
 from typing import Any
 
@@ -30,8 +30,8 @@ class ServerOptimizer(bch.ParametrizedSweep):
         return super().__call__()
 
 
-def example_optim_over_time_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
-    """Optimization Over Time: 2D input."""
+def example_optimise_over_time_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    """Optimise Over Time: 2D input."""
     run_cfg = run_cfg or bch.BenchRunCfg()
     run_cfg.over_time = True
     run_cfg.repeats = 3
@@ -58,4 +58,4 @@ def example_optim_over_time_2d(run_cfg: bch.BenchRunCfg | None = None) -> bch.Be
 
 
 if __name__ == "__main__":
-    bch.run(example_optim_over_time_2d, level=2)
+    bch.run(example_optimise_over_time_2d, level=2)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -352,51 +352,79 @@ def generate_section_index(
     index_path.write_text("\n".join(lines), encoding="utf-8")
 
 
-SECTIONS = {
-    "0 Float Inputs": "0_float/no_repeats",
-    "0 Float Inputs (Repeated)": "0_float/with_repeats",
-    "0 Float Inputs (Over Time)": "0_float/over_time",
-    "0 Float Inputs (Over Time + Repeated)": "0_float/over_time_repeats",
-    "1 Float Input": "1_float/no_repeats",
-    "1 Float Input (Repeated)": "1_float/with_repeats",
-    "1 Float Input (Over Time)": "1_float/over_time",
-    "1 Float Input (Over Time + Repeated)": "1_float/over_time_repeats",
-    "2 Float Inputs": "2_float/no_repeats",
-    "2 Float Inputs (Repeated)": "2_float/with_repeats",
-    "2 Float Inputs (Over Time)": "2_float/over_time",
-    "3 Float Inputs": "3_float/no_repeats",
-    "3 Float Inputs (Repeated)": "3_float/with_repeats",
-    "3 Float Inputs (Over Time)": "3_float/over_time",
-    "Result Types": "result_types",
-    "Plot Types": "plot_types",
-    "Bool Plot Types": "bool_plot_types",
-    "Optimization": "optimization",
-    "Optimization (Over Time)": "optimization_over_time",
-    "Optimization (Aggregated)": "optimization_aggregated",
-    "Sampling Strategies": "sampling",
-    "Composable Containers": "composable_containers",
-    "Constant Variables": "const_vars",
-    "Statistics": "statistics",
-    "Workflows": "workflows",
-    "YAML Sweeps": "yaml",
-    "Advanced Patterns": "advanced",
-    "Regression Detection": "regression",
-    "Performance": "performance",
-}
+# Gallery hierarchy: list of (group_title | None, [(section_title, rel_path), ...])
+# Groups with title=None have their sections rendered at the top level.
+SECTION_GROUPS = [
+    (
+        None,
+        [
+            ("0 Float Inputs", "0_float/no_repeats"),
+            ("0 Float Inputs (Repeated)", "0_float/with_repeats"),
+            ("0 Float Inputs (Over Time)", "0_float/over_time"),
+            ("0 Float Inputs (Over Time + Repeated)", "0_float/over_time_repeats"),
+            ("1 Float Input", "1_float/no_repeats"),
+            ("1 Float Input (Repeated)", "1_float/with_repeats"),
+            ("1 Float Input (Over Time)", "1_float/over_time"),
+            ("1 Float Input (Over Time + Repeated)", "1_float/over_time_repeats"),
+            ("2 Float Inputs", "2_float/no_repeats"),
+            ("2 Float Inputs (Repeated)", "2_float/with_repeats"),
+            ("2 Float Inputs (Over Time)", "2_float/over_time"),
+            ("3 Float Inputs", "3_float/no_repeats"),
+            ("3 Float Inputs (Repeated)", "3_float/with_repeats"),
+            ("3 Float Inputs (Over Time)", "3_float/over_time"),
+        ],
+    ),
+    (
+        "Optimisation",
+        [
+            ("Basic", "optimization"),
+            ("Over Time", "optimization_over_time"),
+            ("Aggregated", "optimization_aggregated"),
+        ],
+    ),
+    (
+        None,
+        [
+            ("Result Types", "result_types"),
+            ("Plot Types", "plot_types"),
+            ("Bool Plot Types", "bool_plot_types"),
+            ("Sampling Strategies", "sampling"),
+            ("Composable Containers", "composable_containers"),
+            ("Constant Variables", "const_vars"),
+            ("Statistics", "statistics"),
+            ("Workflows", "workflows"),
+            ("YAML Sweeps", "yaml"),
+            ("Advanced Patterns", "advanced"),
+            ("Regression Detection", "regression"),
+            ("Performance", "performance"),
+        ],
+    ),
+]
+
+
+def _flat_sections():
+    """Yield (section_title, rel_path) pairs from SECTION_GROUPS."""
+    for _group_title, sections in SECTION_GROUPS:
+        yield from sections
+
+
+# Flat view used by section index generation and toctree
+SECTIONS = dict(_flat_sections())
 
 
 def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
     """Generate a single gallery.rst page with PNG thumbnail cards grouped by section."""
     from collections import OrderedDict
 
-    grouped = OrderedDict()
-    for title, rel_path in SECTIONS.items():
-        grouped[title] = {"rel_path": rel_path, "examples": []}
+    # Build lookup: section_title -> {rel_path, examples}
+    section_lookup = OrderedDict()
+    for title, rel_path in _flat_sections():
+        section_lookup[title] = {"rel_path": rel_path, "examples": []}
 
     for meta in examples_metadata:
-        for title, rel_path in SECTIONS.items():
+        for title, rel_path in _flat_sections():
             if _match_section(meta["section_rel"], rel_path):
-                grouped[title]["examples"].append(meta)
+                section_lookup[title]["examples"].append(meta)
                 break
 
     lines = [
@@ -411,18 +439,35 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
         '   <div class="gallery-container">',
     ]
 
-    for section_title, info in grouped.items():
-        if not info["examples"]:
+    for group_title, sections in SECTION_GROUPS:
+        # Check if this group has any examples at all
+        group_has_examples = any(section_lookup[sec_title]["examples"] for sec_title, _ in sections)
+        if not group_has_examples:
             continue
-        lines.append(f'   <h3 class="gallery-section-title">{html.escape(section_title)}</h3>')
-        lines += _render_subgrouped_gallery(
-            info["examples"],
-            info["rel_path"],
-            href_fn=lambda ex: f"{ex['rst_rel']}.html",
-            thumb_src_fn=lambda ex: f"_thumbs/{ex['section_rel']}/{ex['stem']}.png",
-            heading_tag="h4",
-            heading_class="gallery-subsection-title",
-        )
+
+        # Emit group heading if present
+        if group_title:
+            lines.append(f'   <h2 class="gallery-group-title">{html.escape(group_title)}</h2>')
+
+        section_tag = "h4" if group_title else "h3"
+        subsection_tag = "h5" if group_title else "h4"
+
+        for section_title, _rel_path in sections:
+            info = section_lookup[section_title]
+            if not info["examples"]:
+                continue
+            lines.append(
+                f'   <{section_tag} class="gallery-section-title">'
+                f"{html.escape(section_title)}</{section_tag}>"
+            )
+            lines += _render_subgrouped_gallery(
+                info["examples"],
+                info["rel_path"],
+                href_fn=lambda ex: f"{ex['rst_rel']}.html",
+                thumb_src_fn=lambda ex: f"_thumbs/{ex['section_rel']}/{ex['stem']}.png",
+                heading_tag=subsection_tag,
+                heading_class="gallery-subsection-title",
+            )
 
     lines.append("   </div>")
     lines.append("")

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -102,7 +102,11 @@ def generate_python_files():
     from bencher.example.meta.generate_meta_composable import example_meta_composable
     from bencher.example.meta.generate_meta_const_vars import example_meta_const_vars
     from bencher.example.meta.generate_meta_image_video import example_meta_image_video
-    from bencher.example.meta.generate_meta_optimization import example_meta_optimization
+    from bencher.example.meta.generate_meta_optimization import (
+        example_meta_optimization,
+        example_meta_optimization_over_time,
+        example_meta_optimization_aggregated,
+    )
     from bencher.example.meta.generate_meta_plot_types import example_meta_plot_types
     from bencher.example.meta.generate_meta_result_types import example_meta_result_types
     from bencher.example.meta.generate_meta_sampling import example_meta_sampling
@@ -122,6 +126,8 @@ def generate_python_files():
     example_meta_statistics()
     example_meta_const_vars()
     example_meta_optimization()
+    example_meta_optimization_over_time()
+    example_meta_optimization_aggregated()
     example_meta_workflows()
     example_meta_advanced()
     example_meta_bool_plot_types()
@@ -365,6 +371,8 @@ SECTIONS = {
     "Plot Types": "plot_types",
     "Bool Plot Types": "bool_plot_types",
     "Optimization": "optimization",
+    "Optimization (Over Time)": "optimization_over_time",
+    "Optimization (Aggregated)": "optimization_aggregated",
     "Sampling Strategies": "sampling",
     "Composable Containers": "composable_containers",
     "Constant Variables": "const_vars",

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -536,15 +536,59 @@ def generate_all() -> list[Path]:
         if section_dir.exists():
             generate_section_index(section_dir, title, meta_by_section.get(rel_path, []), rel_path)
 
+    # Generate group index pages for hierarchical groups
+    for group_title, sections in SECTION_GROUPS:
+        if group_title is None:
+            continue
+        child_entries = []
+        for _sec_title, rel_path in sections:
+            section_dir = META_DOCS_DIR / rel_path
+            if (section_dir / "index.rst").exists():
+                child_entries.append(f"   {Path(rel_path).name}/index")
+        if not child_entries:
+            continue
+        # Find the common parent directory for the group's sections
+        group_dir = META_DOCS_DIR / Path(sections[0][1]).parent
+        if group_dir == META_DOCS_DIR:
+            # Sections are at the top level — write a group index alongside them
+            group_slug = group_title.lower().replace(" ", "_")
+            group_index_dir = META_DOCS_DIR / group_slug
+            group_index_dir.mkdir(parents=True, exist_ok=True)
+            # Recompute relative paths from the group index directory
+            child_entries = []
+            for _sec_title, rel_path in sections:
+                section_dir = META_DOCS_DIR / rel_path
+                if (section_dir / "index.rst").exists():
+                    child_entries.append(f"   ../{rel_path}/index")
+            if not child_entries:
+                continue
+            underline = "=" * len(group_title)
+            group_index = (
+                f"{group_title}\n{underline}\n\n"
+                ".. toctree::\n   :maxdepth: 1\n\n" + "\n".join(child_entries) + "\n"
+            )
+            (group_index_dir / "index.rst").write_text(group_index, encoding="utf-8")
+
     # Phase 4: Generate gallery overview page
     generate_gallery_page(examples_metadata, META_DOCS_DIR)
 
-    # Generate top-level meta index
+    # Generate top-level meta index with hierarchy
     meta_index_entries = []
-    for rel_path in SECTIONS.values():
-        section_dir = META_DOCS_DIR / rel_path
-        if (section_dir / "index.rst").exists():
-            meta_index_entries.append(f"   {rel_path}/index")
+    used_paths = set()
+    for group_title, sections in SECTION_GROUPS:
+        if group_title:
+            group_slug = group_title.lower().replace(" ", "_")
+            group_index = META_DOCS_DIR / group_slug / "index.rst"
+            if group_index.exists():
+                meta_index_entries.append(f"   {group_slug}/index")
+                for _, rel_path in sections:
+                    used_paths.add(rel_path)
+        else:
+            for _, rel_path in sections:
+                section_dir = META_DOCS_DIR / rel_path
+                if (section_dir / "index.rst").exists() and rel_path not in used_paths:
+                    meta_index_entries.append(f"   {rel_path}/index")
+                    used_paths.add(rel_path)
 
     entries_str = "\n".join(meta_index_entries)
     meta_index = f"""Reference Gallery

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -95,9 +95,10 @@ class MetaOptimization(MetaGeneratorBase):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
 
-        filename = f"optim_{self.n_objectives}obj_{self.input_dims}d"
-        function_name = f"example_optim_{self.n_objectives}obj_{self.input_dims}d"
-        title = f"Optimization: {self.n_objectives} objective(s), {self.input_dims}D input"
+        obj_word = "1_objective" if self.n_objectives == 1 else "2_objectives"
+        filename = f"optimise_{obj_word}_{self.input_dims}d"
+        function_name = f"example_optimise_{obj_word}_{self.input_dims}d"
+        title = f"Optimise {self.n_objectives} objective(s), {self.input_dims}D input"
 
         if self.n_objectives == 1:
             result_vars_code = '["performance"]'
@@ -162,9 +163,9 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
 
-        filename = f"optim_over_time_{self.input_dims}d"
-        function_name = f"example_optim_over_time_{self.input_dims}d"
-        title = f"Optimization Over Time: {self.input_dims}D input"
+        filename = f"optimise_over_time_{self.input_dims}d"
+        function_name = f"example_optimise_over_time_{self.input_dims}d"
+        title = f"Optimise Over Time: {self.input_dims}D input"
 
         if self.input_dims == 1:
             input_vars_code = '["cpu_cores"]'
@@ -236,9 +237,9 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
         self.update_params_from_kwargs(**kwargs)
 
         if self.with_over_time:
-            filename = "optim_aggregated_over_time"
-            function_name = "example_optim_aggregated_over_time"
-            title = "Aggregated Optimization (Over Time)"
+            filename = "optimise_aggregated_over_time"
+            function_name = "example_optimise_aggregated_over_time"
+            title = "Aggregated Optimisation (Over Time)"
             description = (
                 "Finds the best learning rate averaged across algorithms, tracked over time. "
                 "algorithm has optimize=False so Optuna aggregates over it. "
@@ -285,9 +286,9 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 run_kwargs={"level": 3},
             )
         else:
-            filename = "optim_aggregated"
-            function_name = "example_optim_aggregated"
-            title = "Aggregated Optimization"
+            filename = "optimise_aggregated"
+            function_name = "example_optimise_aggregated"
+            title = "Aggregated Optimisation"
             description = (
                 "Finds the best learning rate averaged across algorithms. "
                 "algorithm has optimize=False so Optuna only suggests learning_rate "

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -1,6 +1,7 @@
 """Meta-generator: Optimization & Pareto.
 
-Shows optimization direction, Optuna integration, and multi-objective Pareto.
+Shows optimization direction, Optuna integration, multi-objective Pareto,
+over-time importance analysis, and optimize=False aggregation.
 """
 
 from typing import Any
@@ -30,6 +31,56 @@ CLASS_CODE = "\n".join(
         "        if self.noise_scale > 0:",
         "            self.performance += random.gauss(0, self.noise_scale * 5)",
         "            self.cost += random.gauss(0, self.noise_scale * 0.1)",
+        "        return super().__call__()",
+    ]
+)
+
+# Class with a _drift field for over_time examples (performance degrades over time)
+CLASS_CODE_OVERTIME = "\n".join(
+    [
+        "class ServerOptimizer(bch.ParametrizedSweep):",
+        '    """Optimizes server config — performance drifts over time."""',
+        "",
+        '    cpu_cores = bch.FloatSweep(default=4, bounds=[1, 32], doc="Number of CPU cores")',
+        '    memory_gb = bch.FloatSweep(default=8, bounds=[1, 64], doc="Memory in GB")',
+        "",
+        '    performance = bch.ResultVar("score", bch.OptDir.maximize, doc="Performance score")',
+        "",
+        '    noise_scale = bch.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")',
+        "",
+        "    _drift = 0.0",
+        "",
+        "    def __call__(self, **kwargs):",
+        "        self.update_params_from_kwargs(**kwargs)",
+        "        self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10",
+        "        self.performance *= (1.0 - self._drift * 0.15)  # degrade over time",
+        "        if self.noise_scale > 0:",
+        "            self.performance += random.gauss(0, self.noise_scale * 5)",
+        "        return super().__call__()",
+    ]
+)
+
+# Class with optimize=False on a categorical var for aggregation examples
+CLASS_CODE_AGG = "\n".join(
+    [
+        "class AlgorithmBench(bch.ParametrizedSweep):",
+        '    """Finds best learning rate across algorithms (aggregated)."""',
+        "",
+        "    algorithm = bch.StringSweep(",
+        '        ["gradient_descent", "adam", "rmsprop"],',
+        '        doc="Optimization algorithm",',
+        "        optimize=False,  # sweep but don't optimize — aggregate results",
+        "    )",
+        '    learning_rate = bch.FloatSweep(default=0.01, bounds=[0.001, 1.0], doc="Learning rate")',
+        "",
+        '    loss = bch.ResultVar("loss", bch.OptDir.minimize, doc="Training loss (minimize)")',
+        "",
+        "    def __call__(self, **kwargs):",
+        "        self.update_params_from_kwargs(**kwargs)",
+        '        algo_sensitivity = {"gradient_descent": 1.0, "adam": 0.6, "rmsprop": 0.8}',
+        "        optimal_lr = 0.01 * algo_sensitivity[self.algorithm]",
+        "        self.loss = (math.log10(self.learning_rate) - math.log10(optimal_lr)) ** 2",
+        "        self.loss += random.gauss(0, 0.02)",
         "        return super().__call__()",
     ]
 )
@@ -99,6 +150,176 @@ class MetaOptimization(MetaGeneratorBase):
         return super().__call__()
 
 
+class MetaOptimizationOverTime(MetaGeneratorBase):
+    """Generate optimization examples that run over time with importance analysis.
+
+    The importance plots show repeat AND over_time alongside input parameters,
+    revealing whether measurement noise or temporal drift affects results.
+    """
+
+    input_dims = bch.IntSweep(default=1, bounds=(1, 2), doc="Number of input dimensions")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+
+        filename = f"optim_over_time_{self.input_dims}d"
+        function_name = f"example_optim_over_time_{self.input_dims}d"
+        title = f"Optimization Over Time: {self.input_dims}D input"
+
+        if self.input_dims == 1:
+            input_vars_code = '["cpu_cores"]'
+        else:
+            input_vars_code = '["cpu_cores", "memory_gb"]'
+
+        description = (
+            f"Optimization over {self.input_dims}D input space with temporal drift. "
+            "Performance degrades over successive runs. The importance analysis shows "
+            "repeat, over_time, and input parameters — revealing whether noise or "
+            "temporal drift dominates."
+        )
+        post_description = (
+            "Check the 'Parameter Importance With Repeats' plot: if over_time has high "
+            "importance, results are drifting. If repeat is high, measurements are noisy."
+        )
+
+        body_lines = [
+            "run_cfg = run_cfg or bch.BenchRunCfg()",
+            "run_cfg.over_time = True",
+            "run_cfg.repeats = 3",
+            "benchable = ServerOptimizer()",
+            "bench = benchable.to_bench(run_cfg)",
+            "_base_time = datetime(2000, 1, 1)",
+            "for i in range(4):",
+            "    benchable._drift = float(i)",
+            "    run_cfg.clear_cache = True",
+            "    run_cfg.clear_history = i == 0",
+            "    res = bench.plot_sweep(",
+            '        "over_time",',
+            f"        input_vars={input_vars_code},",
+            '        result_vars=["performance"],',
+            "        const_vars=dict(noise_scale=0.15),",
+            f"        description={description!r},",
+            f"        post_description={post_description!r},",
+            "        run_cfg=run_cfg,",
+            "        time_src=_base_time + timedelta(seconds=i),",
+            "    )",
+            "bench.report.append(res.to_optuna_plots())",
+        ]
+
+        self.generate_example(
+            title=title,
+            output_dir="optimization_over_time",
+            filename=filename,
+            function_name=function_name,
+            imports=(
+                "import math\nimport random\nfrom datetime import datetime, timedelta"
+                "\n\nimport bencher as bch"
+            ),
+            body="\n".join(body_lines) + "\n",
+            class_code=CLASS_CODE_OVERTIME,
+            run_kwargs={"level": 2},
+        )
+
+        return super().__call__()
+
+
+class MetaOptimizationAggregated(MetaGeneratorBase):
+    """Generate examples showing optimize=False aggregation with Optuna.
+
+    A categorical variable (algorithm) is swept but not optimized — Optuna
+    finds the best learning_rate by averaging loss across all algorithms.
+    """
+
+    with_over_time = bch.BoolSweep(default=False, doc="Include over_time dimension")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+
+        if self.with_over_time:
+            filename = "optim_aggregated_over_time"
+            function_name = "example_optim_aggregated_over_time"
+            title = "Aggregated Optimization (Over Time)"
+            description = (
+                "Finds the best learning rate averaged across algorithms, tracked over time. "
+                "algorithm has optimize=False so Optuna aggregates over it. "
+                "The importance plot shows learning_rate, repeat, and over_time."
+            )
+            post_description = (
+                "The importance plot reveals which factors matter: the optimized parameter "
+                "(learning_rate), measurement noise (repeat), or temporal drift (over_time)."
+            )
+
+            body_lines = [
+                "run_cfg = run_cfg or bch.BenchRunCfg()",
+                "run_cfg.over_time = True",
+                "run_cfg.repeats = 3",
+                "benchable = AlgorithmBench()",
+                "bench = benchable.to_bench(run_cfg)",
+                "_base_time = datetime(2000, 1, 1)",
+                "for i in range(3):",
+                "    run_cfg.clear_cache = True",
+                "    run_cfg.clear_history = i == 0",
+                "    res = bench.plot_sweep(",
+                '        "over_time",',
+                '        input_vars=["algorithm", "learning_rate"],',
+                '        result_vars=["loss"],',
+                f"        description={description!r},",
+                f"        post_description={post_description!r},",
+                "        run_cfg=run_cfg,",
+                "        time_src=_base_time + timedelta(seconds=i),",
+                "    )",
+                "bench.report.append(res.to_optuna_plots())",
+            ]
+
+            self.generate_example(
+                title=title,
+                output_dir="optimization_aggregated",
+                filename=filename,
+                function_name=function_name,
+                imports=(
+                    "import math\nimport random\nfrom datetime import datetime, timedelta"
+                    "\n\nimport bencher as bch"
+                ),
+                body="\n".join(body_lines) + "\n",
+                class_code=CLASS_CODE_AGG,
+                run_kwargs={"level": 3},
+            )
+        else:
+            filename = "optim_aggregated"
+            function_name = "example_optim_aggregated"
+            title = "Aggregated Optimization"
+            description = (
+                "Finds the best learning rate averaged across algorithms. "
+                "algorithm has optimize=False so Optuna only suggests learning_rate "
+                "and averages loss over all algorithm choices."
+            )
+            post_description = (
+                "The importance plot shows learning_rate and repeat — algorithm is "
+                "aggregated away. Compare 'With Repeats' vs 'Without Repeats' to see "
+                "if measurement noise affects the result."
+            )
+
+            self.generate_sweep_example(
+                title=title,
+                output_dir="optimization_aggregated",
+                filename=filename,
+                function_name=function_name,
+                benchable_class="AlgorithmBench",
+                benchable_module=None,
+                class_code=CLASS_CODE_AGG,
+                extra_imports=["import math", "import random"],
+                input_vars='["algorithm", "learning_rate"]',
+                result_vars='["loss"]',
+                description=description,
+                post_description=post_description,
+                post_sweep_line="res.to_optuna_plots()",
+                run_cfg_lines=["run_cfg.use_optuna = True"],
+                run_kwargs={"level": 3, "repeats": 3},
+            )
+
+        return super().__call__()
+
+
 def example_meta_optimization(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
     bench = MetaOptimization().to_bench(run_cfg)
 
@@ -108,6 +329,28 @@ def example_meta_optimization(run_cfg: bch.BenchRunCfg | None = None) -> bch.Ben
             bch.p("n_objectives", [1, 2]),
             bch.p("input_dims", [1, 2]),
         ],
+    )
+
+    return bench
+
+
+def example_meta_optimization_over_time(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    bench = MetaOptimizationOverTime().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Optimization Over Time",
+        input_vars=[bch.p("input_dims", [1, 2])],
+    )
+
+    return bench
+
+
+def example_meta_optimization_aggregated(run_cfg: bch.BenchRunCfg | None = None) -> bch.Bench:
+    bench = MetaOptimizationAggregated().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Optimization Aggregated",
+        input_vars=[bch.p("with_over_time", [False, True])],
     )
 
     return bench

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -21,19 +21,25 @@ from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 
 # BENCH_CFG
-def optuna_grid_search(bench_cfg: BenchCfg) -> optuna.Study:
+def optuna_grid_search(bench_cfg: BenchCfg, trial_vars: list | None = None) -> optuna.Study:
     """use optuna to perform a grid search
 
     Args:
         bench_cfg (BenchCfg): setting for grid search
+        trial_vars (list | None): If provided, use these variables for the search space.
+            Otherwise, filter bench_cfg.all_vars by optimize=True.
 
     Returns:
         optuna.Study: results of grid search
     """
     search_space = {}
-    for iv in bench_cfg.all_vars:
-        if getattr(iv, "optimize", True):
+    if trial_vars is not None:
+        for iv in trial_vars:
             search_space[iv.name] = iv.values()
+    else:
+        for iv in bench_cfg.all_vars:
+            if getattr(iv, "optimize", True):
+                search_space[iv.name] = iv.values()
     directions = []
     for rv in bench_cfg.optuna_targets(True):
         directions.append(rv.direction)

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -32,7 +32,8 @@ def optuna_grid_search(bench_cfg: BenchCfg) -> optuna.Study:
     """
     search_space = {}
     for iv in bench_cfg.all_vars:
-        search_space[iv.name] = iv.values()
+        if getattr(iv, "optimize", True):
+            search_space[iv.name] = iv.values()
     directions = []
     for rv in bench_cfg.optuna_targets(True):
         directions.append(rv.direction)
@@ -143,9 +144,11 @@ def cfg_from_optuna_trial(
 ) -> ParametrizedSweep:
     cfg = cfg_type()
     for iv in bench_cfg.input_vars:
-        cfg.param.set_param(iv.name, sweep_var_to_suggest(iv, trial))
+        if getattr(iv, "optimize", True):
+            cfg.param.set_param(iv.name, sweep_var_to_suggest(iv, trial))
     for mv in bench_cfg.meta_vars:
-        sweep_var_to_suggest(mv, trial)
+        if getattr(mv, "optimize", True):
+            sweep_var_to_suggest(mv, trial)
     return cfg
 
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -169,6 +169,7 @@ class ResultCollector:
             samples=repeats,
             units="repeats",
             doc="The number of times a sample was measured",
+            optimize=False,
         )
         bench_cfg.iv_repeat.name = "repeat"
         extra_vars = [bench_cfg.iv_repeat]

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -101,7 +101,7 @@ class OptunaResult(BenchResultBase):
         results_list = extra_results if extra_results is not None else [self]
         for res in results_list:
             if len(res.ds.sizes) > 0:
-                study.add_trials(res.bench_results_to_optuna_trials(True))
+                study.add_trials(res.bench_results_to_optuna_trials(False))
 
         opt_vars, non_opt_vars = self.bench_cfg.partition_input_vars(self.bench_cfg.input_vars)
 
@@ -128,39 +128,44 @@ class OptunaResult(BenchResultBase):
         """Convert an xarray dataset to optuna trials so optuna can further optimise or plot.
 
         Args:
-            include_meta (bool): Whether to include meta variables (time, repeat).
+            include_meta (bool): When True, include all variables (inputs + meta like repeat
+                and over_time) as trial parameters for importance analysis. When False, use
+                only input variables with partition/aggregation via the optimize flag.
 
         Returns:
             list[optuna.trial.FrozenTrial]: Optuna trials derived from benchmark results.
         """
+        target_names = self.bench_cfg.optuna_targets()
+
         if include_meta:
+            # Importance analysis: every raw data point becomes a trial with all vars
             df = self.to_dataset(reduce=ReduceType.NONE).to_dataframe().reset_index()
-            all_vars = list(self.bench_cfg.all_vars)
+            trial_vars = list(self.bench_cfg.all_vars)
         else:
-            all_vars = self.bench_cfg.input_vars
+            # Optimization mode: partition by optimize flag, aggregate non-optimized
+            input_vars = self.bench_cfg.input_vars
             df = self.to_dataset(reduce=ReduceType.AUTO).to_dataframe().reset_index()
+            opt_vars, non_opt_vars = self.bench_cfg.partition_input_vars(input_vars)
+
+            if not opt_vars:
+                raise ValueError(
+                    "At least one input variable must have optimize=True for Optuna optimization."
+                )
+
+            df = _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names)
+            trial_vars = opt_vars
 
         df.dropna(inplace=True)
 
-        opt_vars, non_opt_vars = self.bench_cfg.partition_input_vars(all_vars)
-        target_names = self.bench_cfg.optuna_targets()
-
-        if not opt_vars:
-            raise ValueError(
-                "At least one input variable must have optimize=True for Optuna optimization."
-            )
-
-        df = _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names)
-
         distributions = {}
-        for i in opt_vars:
+        for i in trial_vars:
             distributions[i.name] = sweep_var_to_optuna_dist(i)
 
         trials = []
         for row in df.iterrows():
             params = {}
             values = []
-            for i in opt_vars:
+            for i in trial_vars:
                 if isinstance(i, TimeSnapshot):
                     val = row[1][i.name]
                     if hasattr(val, "timestamp") and not (hasattr(val, "isnull") and val.isnull()):
@@ -194,7 +199,8 @@ class OptunaResult(BenchResultBase):
 
     def bench_result_to_study(self, include_meta: bool) -> optuna.Study:
         trials = self.bench_results_to_optuna_trials(include_meta)
-        study = optuna_grid_search(self.bench_cfg)
+        trial_vars = list(self.bench_cfg.all_vars) if include_meta else None
+        study = optuna_grid_search(self.bench_cfg, trial_vars=trial_vars)
         optuna.logging.set_verbosity(optuna.logging.CRITICAL)
         import warnings
 
@@ -207,7 +213,7 @@ class OptunaResult(BenchResultBase):
         return study
 
     def get_best_trial_params(self, canonical=False):
-        studies = self.bench_result_to_study(True)
+        studies = self.bench_result_to_study(False)
         out = studies.best_trials[0].params
         if canonical:
             return hmap_canonical_input(out)

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -66,59 +66,81 @@ class OptunaResult(BenchResultBase):
             if len(res.ds.sizes) > 0:
                 study.add_trials(res.bench_results_to_optuna_trials(True))
 
+        opt_vars = self.bench_cfg.optimized_input_vars
+        non_opt_vars = self.bench_cfg.non_optimized_input_vars
+
+        if not opt_vars:
+            raise ValueError(
+                "At least one input variable must have optimize=True for Optuna optimization."
+            )
+
         def wrapped(trial) -> tuple:
             kwargs = {}
-            for iv in self.bench_cfg.input_vars:
+            for iv in opt_vars:
                 kwargs[iv.name] = sweep_var_to_suggest(iv, trial)
-            result = worker(**kwargs)
-            output = []
-            for rv in self.bench_cfg.result_vars:
-                output.append(result[rv.name])
-            return tuple(output)
+
+            if not non_opt_vars:
+                result = worker(**kwargs)
+                return tuple(result[rv.name] for rv in self.bench_cfg.result_vars)
+
+            # Evaluate across all combinations of non-optimized vars, average results
+            from itertools import product as iter_product
+
+            non_opt_value_lists = [iv.values() for iv in non_opt_vars]
+            all_outputs = []
+            for combo in iter_product(*non_opt_value_lists):
+                call_kwargs = dict(kwargs)
+                for iv, val in zip(non_opt_vars, combo):
+                    call_kwargs[iv.name] = val
+                result = worker(**call_kwargs)
+                all_outputs.append([result[rv.name] for rv in self.bench_cfg.result_vars])
+            aggregated = np.mean(all_outputs, axis=0)
+            return tuple(aggregated)
 
         study.optimize(wrapped, n_trials=n_trials)
         return study
 
-    def bench_results_to_optuna_trials(self, include_meta: bool = True) -> optuna.Study:
-        """Convert an xarray dataset to an optuna study so optuna can further optimise or plot the statespace
+    def bench_results_to_optuna_trials(self, include_meta: bool = True) -> list:
+        """Convert an xarray dataset to optuna trials so optuna can further optimise or plot.
 
         Args:
-            bench_cfg (BenchCfg): benchmark config to convert
+            include_meta (bool): Whether to include meta variables (time, repeat).
 
         Returns:
-            optuna.Study: optuna description of the study
+            list[optuna.trial.FrozenTrial]: Optuna trials derived from benchmark results.
         """
         if include_meta:
-            # df = self.to_pandas()
             df = self.to_dataset(reduce=ReduceType.NONE).to_dataframe().reset_index()
             all_vars = list(self.bench_cfg.all_vars)
-
-            print("All vars", all_vars)
         else:
             all_vars = self.bench_cfg.input_vars
-            # df = self.ds.
-            # if "repeat" in self.
-            # if self.bench_cfg.repeats>1:
-            # df = self.bench_cfg.ds.mean("repeat").to_dataframe().reset_index()
-            # else:
-            # df = self.to_pandas().reset_index()
             df = self.to_dataset(reduce=ReduceType.AUTO).to_dataframe().reset_index()
-        # df = self.bench_cfg.ds.mean("repeat").to_dataframe.reset_index()
-        # self.bench_cfg.all_vars
-        # del self.bench_cfg.meta_vars[1]
 
-        # optuna does not like the nan values so remove them.
         df.dropna(inplace=True)
 
-        trials = []
+        # Partition into optimized and non-optimized vars
+        opt_vars = [v for v in all_vars if getattr(v, "optimize", True)]
+        non_opt_vars = [v for v in all_vars if not getattr(v, "optimize", True)]
+
+        target_names = self.bench_cfg.optuna_targets()
+
+        # If there are non-optimized vars, group by optimized vars and average results
+        if non_opt_vars and opt_vars and target_names:
+            group_cols = [v.name for v in opt_vars if v.name in df.columns]
+            if group_cols:
+                agg_cols = [t for t in target_names if t in df.columns]
+                if agg_cols:
+                    df = df.groupby(group_cols, as_index=False)[agg_cols].mean()
+
         distributions = {}
-        for i in all_vars:
+        for i in opt_vars:
             distributions[i.name] = sweep_var_to_optuna_dist(i)
 
+        trials = []
         for row in df.iterrows():
             params = {}
             values = []
-            for i in all_vars:
+            for i in opt_vars:
                 if isinstance(i, TimeSnapshot):
                     val = row[1][i.name]
                     if hasattr(val, "timestamp") and not (hasattr(val, "isnull") and val.isnull()):
@@ -130,7 +152,6 @@ class OptunaResult(BenchResultBase):
                 elif isinstance(i, TimeEvent):
                     params[i.name] = str(row[1][i.name])
                 elif isinstance(i, BoolSweep):
-                    # Handle boolean values that may have been converted to strings
                     val = row[1][i.name]
                     if isinstance(val, str):
                         params[i.name] = val.lower() == "true"
@@ -139,10 +160,7 @@ class OptunaResult(BenchResultBase):
                 else:
                     params[i.name] = row[1][i.name]
 
-            for r in self.bench_cfg.optuna_targets():
-                # print(row[1][r])
-                # print(np.isnan(row[1][r]))
-                # if not np.isnan(row[1][r]):
+            for r in target_names:
                 values.append(row[1][r])
 
             trials.append(

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from copy import deepcopy
+from itertools import product as iter_product
 
 import numpy as np
 import optuna
@@ -24,6 +25,42 @@ from bencher.optuna_conversions import (
     summarise_optuna_study,
     sweep_var_to_suggest,
 )
+
+
+def _evaluate_over_non_optimized(worker, opt_kwargs, non_opt_vars, result_vars):
+    """Evaluate worker across all combinations of non-optimized vars and return mean results."""
+    non_opt_value_lists = [iv.values() for iv in non_opt_vars]
+    all_results = []
+    for combo in iter_product(*non_opt_value_lists):
+        call_kwargs = dict(opt_kwargs)
+        for iv, val in zip(non_opt_vars, combo):
+            call_kwargs[iv.name] = val
+        all_results.append(worker(**call_kwargs))
+
+    aggregated = []
+    for rv in result_vars:
+        values = [res[rv.name] for res in all_results]
+        arr = np.asarray(values)
+        if not np.issubdtype(arr.dtype, np.number):
+            raise TypeError(
+                f"Result variable '{rv.name}' must be numeric to aggregate over "
+                f"non-optimized variable combinations, but got dtype {arr.dtype}"
+            )
+        aggregated.append(float(np.mean(arr)))
+    return tuple(aggregated)
+
+
+def _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names):
+    """Group DataFrame by optimized vars and average target columns over non-optimized vars."""
+    if not (non_opt_vars and opt_vars and target_names):
+        return df
+    group_cols = [v.name for v in opt_vars if v.name in df.columns]
+    if not group_cols:
+        return df
+    agg_cols = [t for t in target_names if t in df.columns]
+    if not agg_cols:
+        return df
+    return df.groupby(group_cols, as_index=False)[agg_cols].mean()
 
 
 class OptunaResult(BenchResultBase):
@@ -66,8 +103,7 @@ class OptunaResult(BenchResultBase):
             if len(res.ds.sizes) > 0:
                 study.add_trials(res.bench_results_to_optuna_trials(True))
 
-        opt_vars = self.bench_cfg.optimized_input_vars
-        non_opt_vars = self.bench_cfg.non_optimized_input_vars
+        opt_vars, non_opt_vars = self.bench_cfg.partition_input_vars(self.bench_cfg.input_vars)
 
         if not opt_vars:
             raise ValueError(
@@ -75,27 +111,15 @@ class OptunaResult(BenchResultBase):
             )
 
         def wrapped(trial) -> tuple:
-            kwargs = {}
-            for iv in opt_vars:
-                kwargs[iv.name] = sweep_var_to_suggest(iv, trial)
+            kwargs = {iv.name: sweep_var_to_suggest(iv, trial) for iv in opt_vars}
 
             if not non_opt_vars:
                 result = worker(**kwargs)
                 return tuple(result[rv.name] for rv in self.bench_cfg.result_vars)
 
-            # Evaluate across all combinations of non-optimized vars, average results
-            from itertools import product as iter_product
-
-            non_opt_value_lists = [iv.values() for iv in non_opt_vars]
-            all_outputs = []
-            for combo in iter_product(*non_opt_value_lists):
-                call_kwargs = dict(kwargs)
-                for iv, val in zip(non_opt_vars, combo):
-                    call_kwargs[iv.name] = val
-                result = worker(**call_kwargs)
-                all_outputs.append([result[rv.name] for rv in self.bench_cfg.result_vars])
-            aggregated = np.mean(all_outputs, axis=0)
-            return tuple(aggregated)
+            return _evaluate_over_non_optimized(
+                worker, kwargs, non_opt_vars, self.bench_cfg.result_vars
+            )
 
         study.optimize(wrapped, n_trials=n_trials)
         return study
@@ -118,19 +142,15 @@ class OptunaResult(BenchResultBase):
 
         df.dropna(inplace=True)
 
-        # Partition into optimized and non-optimized vars
-        opt_vars = [v for v in all_vars if getattr(v, "optimize", True)]
-        non_opt_vars = [v for v in all_vars if not getattr(v, "optimize", True)]
-
+        opt_vars, non_opt_vars = self.bench_cfg.partition_input_vars(all_vars)
         target_names = self.bench_cfg.optuna_targets()
 
-        # If there are non-optimized vars, group by optimized vars and average results
-        if non_opt_vars and opt_vars and target_names:
-            group_cols = [v.name for v in opt_vars if v.name in df.columns]
-            if group_cols:
-                agg_cols = [t for t in target_names if t in df.columns]
-                if agg_cols:
-                    df = df.groupby(group_cols, as_index=False)[agg_cols].mean()
+        if not opt_vars:
+            raise ValueError(
+                "At least one input variable must have optimize=True for Optuna optimization."
+            )
+
+        df = _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names)
 
         distributions = {}
         for i in opt_vars:

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -38,7 +38,9 @@ class SweepSelector(Selector, SweepBase):
 
     __slots__ = shared_slots
 
-    def __init__(self, units: str = "ul", samples: int | None = None, **params):
+    def __init__(
+        self, units: str = "ul", samples: int | None = None, optimize: bool = True, **params
+    ):
         SweepBase.__init__(self)
         Selector.__init__(self, **params)
 
@@ -47,6 +49,7 @@ class SweepSelector(Selector, SweepBase):
             self.samples = len(self.objects)
         else:
             self.samples = samples
+        self.optimize = optimize
 
     def values(self) -> list[Any]:
         """Return all the values for the parameter sweep.
@@ -163,12 +166,18 @@ class BoolSweep(SweepSelector):
     """
 
     def __init__(
-        self, units: str = "ul", samples: int | None = None, default: bool = True, **params
+        self,
+        units: str = "ul",
+        samples: int | None = None,
+        default: bool = True,
+        optimize: bool = True,
+        **params,
     ):
         SweepSelector.__init__(
             self,
             units=units,
             samples=samples,
+            optimize=optimize,
             default=default,
             objects=[True, False] if default else [False, True],
             **params,
@@ -191,6 +200,7 @@ class StringSweep(SweepSelector):
         string_list: list[str],
         units: str = "ul",
         samples: int | None = None,
+        optimize: bool = True,
         **params,
     ):
         SweepSelector.__init__(
@@ -199,6 +209,7 @@ class StringSweep(SweepSelector):
             instantiate=True,
             units=units,
             samples=samples,
+            optimize=optimize,
             **params,
         )
 
@@ -253,7 +264,12 @@ class EnumSweep(SweepSelector):
     __slots__ = shared_slots
 
     def __init__(
-        self, enum_type: Enum | list[Enum], units: str = "ul", samples: int | None = None, **params
+        self,
+        enum_type: Enum | list[Enum],
+        units: str = "ul",
+        samples: int | None = None,
+        optimize: bool = True,
+        **params,
     ):
         # The enum can either be an Enum type or a list of enums
         list_of_enums = isinstance(enum_type, list)
@@ -264,6 +280,7 @@ class EnumSweep(SweepSelector):
             instantiate=True,
             units=units,
             samples=samples,
+            optimize=optimize,
             **params,
         )
         if not list_of_enums:  # Grab the docs from the enum type def
@@ -347,6 +364,7 @@ class YamlSweep(SweepSelector):
         units: str = "ul",
         samples: int | None = None,
         default_key: str | None = None,
+        optimize: bool = True,
         **params,
     ):
         path = Path(yaml_path)
@@ -385,6 +403,7 @@ class YamlSweep(SweepSelector):
             instantiate=False,
             units=units,
             samples=samples,
+            optimize=optimize,
             default=default_value,
             **params,
         )
@@ -441,12 +460,14 @@ class IntSweep(Integer, SweepBase):
         units: str = "ul",
         samples: int | None = None,
         sample_values: list[int] | None = None,
+        optimize: bool = True,
         **params,
     ):
         SweepBase.__init__(self)
         Integer.__init__(self, **params)
 
         self.units = units
+        self.optimize = optimize
 
         if sample_values is None:
             if samples is None:
@@ -520,12 +541,14 @@ class FloatSweep(Number, SweepBase):
         samples: int = 10,
         sample_values: list[float] | None = None,
         step: float | None = None,
+        optimize: bool = True,
         **params,
     ):
         SweepBase.__init__(self)
         Number.__init__(self, step=step, **params)
 
         self.units = units
+        self.optimize = optimize
 
         self.sample_values = sample_values
 

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -11,7 +11,7 @@ from bencher.utils import hash_sha1
 
 # slots that are shared across all Sweep classes
 # param and slots don't work easily with multiple inheritance so define here
-shared_slots = ["units", "samples"]
+shared_slots = ["units", "samples", "optimize"]
 
 
 def describe_variable(

--- a/bencher/variables/time.py
+++ b/bencher/variables/time.py
@@ -62,6 +62,7 @@ class TimeSnapshot(TimeBase):
                 **params,
             )
         self.units = units
+        self.optimize = False
         if samples is None:
             self.samples = len(self.objects)
         else:
@@ -87,6 +88,7 @@ class TimeEvent(TimeBase):
             **params,
         )
         self.units = units
+        self.optimize = False
         if samples is None:
             self.samples = len(self.objects)
         else:

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -84,6 +84,37 @@ class TestOptimizeFlag(unittest.TestCase):
         f2 = f.with_samples(5)
         self.assertFalse(f2.optimize)
 
+    def test_yaml_sweep_optimize_default_and_override(self):
+        from pathlib import Path
+        from bencher.variables.inputs import YamlSweep
+
+        yaml_path = (
+            Path(__file__).resolve().parent.parent / "bencher/example/example_yaml_sweep_list.yaml"
+        )
+        default_yaml = YamlSweep(yaml_path)
+        self.assertTrue(default_yaml.optimize)
+
+        disabled_yaml = YamlSweep(yaml_path, optimize=False)
+        self.assertFalse(disabled_yaml.optimize)
+
+    def test_selector_sweep_deepcopy_and_with_samples(self):
+        from copy import deepcopy
+
+        s = StringSweep(["a", "b", "c"], optimize=False)
+        s_copy = deepcopy(s)
+        self.assertFalse(s_copy.optimize)
+
+        s_sampled = s.with_samples(2)
+        self.assertFalse(s_sampled.optimize)
+
+        e = EnumSweep(SweepColor, optimize=False)
+        e_copy = deepcopy(e)
+        self.assertFalse(e_copy.optimize)
+
+        b = BoolSweep(optimize=False)
+        b_copy = deepcopy(b)
+        self.assertFalse(b_copy.optimize)
+
 
 class TestSweepVarToOptunaDist(unittest.TestCase):
     def test_int_sweep(self):

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -15,6 +15,7 @@ from bencher.optuna_conversions import (
     sweep_var_to_suggest,
     summarise_optuna_study,
     summarise_trial,
+    optuna_grid_search,
 )
 from bencher.variables.inputs import IntSweep, FloatSweep, StringSweep, EnumSweep, BoolSweep
 from bencher.variables.time import TimeSnapshot
@@ -251,3 +252,35 @@ class TestSummariseTrial(unittest.TestCase):
         self.assertIsInstance(output, list)
         self.assertTrue(len(output) > 0)
         self.assertIn("Trial id:", output[0])
+
+
+class TestOptunaGridSearch(unittest.TestCase):
+    def test_default_excludes_optimize_false(self):
+        bench = SweepCfg().to_bench()
+        res = bench.plot_sweep(
+            "test_grid",
+            input_vars=["float_var"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        study = optuna_grid_search(res.bench_cfg)
+        # repeat has optimize=False, should not be in search space
+        search_space = study.sampler._search_space  # pylint: disable=protected-access
+        self.assertNotIn("repeat", search_space)
+
+    def test_trial_vars_includes_all(self):
+        bench = SweepCfg().to_bench()
+        res = bench.plot_sweep(
+            "test_grid_vars",
+            input_vars=["float_var"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=2),
+            plot_callbacks=False,
+        )
+        trial_vars = list(res.bench_cfg.all_vars)
+        study = optuna_grid_search(res.bench_cfg, trial_vars=trial_vars)
+        # When trial_vars provided, all vars should be in search space
+        search_space = study.sampler._search_space  # pylint: disable=protected-access
+        self.assertIn("repeat", search_space)
+        self.assertIn("float_var", search_space)

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -39,6 +39,52 @@ class SweepCfg(bch.ParametrizedSweep):
         return super().__call__()
 
 
+class TestOptimizeFlag(unittest.TestCase):
+    """Tests for the optimize flag on sweep variables."""
+
+    def test_default_optimize_true_for_input_types(self):
+        self.assertTrue(SweepCfg.param.int_var.optimize)
+        self.assertTrue(SweepCfg.param.float_var.optimize)
+        self.assertTrue(SweepCfg.param.enum_var.optimize)
+        self.assertTrue(SweepCfg.param.bool_var.optimize)
+        self.assertTrue(SweepCfg.param.string_var.optimize)
+
+    def test_default_optimize_false_for_time_types(self):
+        from datetime import datetime
+
+        ts = TimeSnapshot(datetime_src=datetime.now())
+        self.assertFalse(ts.optimize)
+
+        from bencher.variables.time import TimeEvent
+
+        te = TimeEvent(time_event="ev1")
+        self.assertFalse(te.optimize)
+
+    def test_explicit_optimize_false(self):
+        f = FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)
+        self.assertFalse(f.optimize)
+        i = IntSweep(default=1, bounds=(0, 10), optimize=False)
+        self.assertFalse(i.optimize)
+        s = StringSweep(["a", "b"], optimize=False)
+        self.assertFalse(s.optimize)
+        e = EnumSweep(SweepColor, optimize=False)
+        self.assertFalse(e.optimize)
+        b = BoolSweep(optimize=False)
+        self.assertFalse(b.optimize)
+
+    def test_deepcopy_preserves_flag(self):
+        from copy import deepcopy
+
+        f = FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)
+        f_copy = deepcopy(f)
+        self.assertFalse(f_copy.optimize)
+
+    def test_with_samples_preserves_flag(self):
+        f = FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)
+        f2 = f.with_samples(5)
+        self.assertFalse(f2.optimize)
+
+
 class TestSweepVarToOptunaDist(unittest.TestCase):
     def test_int_sweep(self):
         var = SweepCfg.param.int_var

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -58,8 +58,8 @@ class TestOptimizeFlag(unittest.TestCase):
 
         from bencher.variables.time import TimeEvent
 
-        te = TimeEvent(time_event="ev1")
-        self.assertFalse(te.optimize)
+        time_ev = TimeEvent(time_event="ev1")
+        self.assertFalse(time_ev.optimize)
 
     def test_explicit_optimize_false(self):
         f = FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -1,6 +1,7 @@
 """Tests for bencher/results/optuna_result.py"""
 
 import unittest
+import numpy as np
 import panel as pn
 import optuna
 
@@ -89,6 +90,22 @@ class _AggCfg(bch.ParametrizedSweep):
         return super().__call__()
 
 
+class _MultiAggCfg(bch.ParametrizedSweep):
+    """Helper config to exercise multi-output aggregation (two ResultVars)."""
+
+    algorithm = bch.StringSweep(["algo_a", "algo_b"], optimize=False)
+    param1 = bch.FloatSweep(default=0.5, bounds=(0.0, 1.0))
+    score = bch.ResultVar(units="score", direction=bch.OptDir.minimize)
+    aux_score = bch.ResultVar(units="aux", direction=bch.OptDir.minimize)
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        baseline = (self.param1 - 0.3) ** 2
+        self.score = baseline
+        self.aux_score = baseline + 0.1
+        return super().__call__()
+
+
 class _TrialCfg(bch.ParametrizedSweep):
     category = bch.StringSweep(["cat_a", "cat_b"], optimize=False)
     value = bch.FloatSweep(default=0.5, bounds=(0.0, 1.0), samples=3)
@@ -134,8 +151,15 @@ class TestOptunaOptimizeFlag(unittest.TestCase):
         self.assertIn("param1", study.best_params)
         self.assertNotIn("algorithm", study.best_params)
 
+        # Verify the objective value matches mean aggregation over algorithms
+        # _AggCfg.score = (param1 - 0.3)^2, same for both algorithms, so mean == value
+        best_p1 = study.best_params["param1"]
+        expected = (best_p1 - 0.3) ** 2
+        self.assertAlmostEqual(study.best_value, expected, places=5)
+
     def test_optimize_false_trials_exclude_non_optimized(self):
-        """bench_results_to_optuna_trials should only include optimized vars in trial params."""
+        """bench_results_to_optuna_trials should only include optimized vars in trial params
+        and aggregate results over non-optimized vars."""
         cfg = _TrialCfg()
         bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
         res = bench.plot_sweep(
@@ -152,6 +176,63 @@ class TestOptunaOptimizeFlag(unittest.TestCase):
             self.assertNotIn("category", trial.params)
             self.assertIn("value", trial.params)
 
+        # Number of trials should equal unique optimized-param combinations (samples=3)
+        unique_values = {t.params["value"] for t in trials}
+        self.assertEqual(len(trials), len(unique_values))
+
+        # Each trial's value should be the mean over categories.
+        # _TrialCfg.result = value * 2 (same for both categories), so mean == value * 2
+        for trial in trials:
+            val = trial.params["value"]
+            expected_mean = val * 2
+            self.assertAlmostEqual(trial.values[0], expected_mean, places=5)
+
+    def test_multi_output_aggregation(self):
+        """Multi-output aggregation should average each result var independently."""
+        cfg = _MultiAggCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_multi_agg",
+            input_vars=["algorithm", "param1"],
+            result_vars=["score", "aux_score"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        study = res.to_optuna_from_results(cfg, n_trials=10)
+        # Multi-objective study: use best_trials instead of best_params
+        self.assertGreater(len(study.best_trials), 0)
+        for trial in study.best_trials:
+            self.assertIn("param1", trial.params)
+            self.assertNotIn("algorithm", trial.params)
+
+        # Verify both objectives are present in trial values
+        for trial in study.trials:
+            self.assertEqual(len(trial.values), 2)
+            # aux_score should be score + 0.1
+            np.testing.assert_almost_equal(trial.values[1], trial.values[0] + 0.1, decimal=5)
+
+    def test_multi_output_trials_aggregation(self):
+        """bench_results_to_optuna_trials should aggregate both result vars over non-opt vars."""
+        cfg = _MultiAggCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_multi_trials",
+            input_vars=["algorithm", "param1"],
+            result_vars=["score", "aux_score"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        trials = res.bench_results_to_optuna_trials(include_meta=False)
+        self.assertGreater(len(trials), 0)
+        for trial in trials:
+            self.assertNotIn("algorithm", trial.params)
+            self.assertIn("param1", trial.params)
+            self.assertEqual(len(trial.values), 2)
+            # aux_score == score + 0.1
+            np.testing.assert_almost_equal(trial.values[1], trial.values[0] + 0.1, decimal=5)
+
     def test_all_optimize_false_raises(self):
         """Should raise ValueError when all input vars have optimize=False."""
         cfg = _AllFalseCfg()
@@ -166,3 +247,18 @@ class TestOptunaOptimizeFlag(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             res.to_optuna_from_results(cfg, n_trials=5)
+
+    def test_all_optimize_false_raises_in_trials(self):
+        """bench_results_to_optuna_trials should also raise when all vars have optimize=False."""
+        cfg = _AllFalseCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_all_false_trials",
+            input_vars=["x"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        with self.assertRaises(ValueError):
+            res.bench_results_to_optuna_trials(include_meta=False)

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -46,11 +46,25 @@ class TestOptunaResult(unittest.TestCase):
         self.assertIsInstance(trials, list)
         self.assertGreater(len(trials), 0)
         self.assertIsInstance(trials[0], optuna.trial.FrozenTrial)
+        # include_meta=True should include repeat as a trial parameter
+        self.assertIn("repeat", trials[0].params)
 
     def test_bench_results_to_optuna_trials_without_meta(self):
         trials = self.res_1d.bench_results_to_optuna_trials(include_meta=False)
         self.assertIsInstance(trials, list)
         self.assertGreater(len(trials), 0)
+        # include_meta=False should NOT include repeat
+        self.assertNotIn("repeat", trials[0].params)
+
+    def test_include_meta_true_no_aggregation(self):
+        """include_meta=True should produce one trial per raw data point (no aggregation)."""
+        trials_meta = self.res_2d_r2.bench_results_to_optuna_trials(include_meta=True)
+        trials_no_meta = self.res_2d_r2.bench_results_to_optuna_trials(include_meta=False)
+        # With repeats=2, meta trials should have ~2x as many entries
+        self.assertGreater(len(trials_meta), len(trials_no_meta))
+        # All meta trials should have repeat as a parameter
+        for t in trials_meta:
+            self.assertIn("repeat", t.params)
 
     def test_bench_result_to_study(self):
         study = self.res_1d.bench_result_to_study(include_meta=True)
@@ -249,7 +263,7 @@ class TestOptunaOptimizeFlag(unittest.TestCase):
             res.to_optuna_from_results(cfg, n_trials=5)
 
     def test_all_optimize_false_raises_in_trials(self):
-        """bench_results_to_optuna_trials should also raise when all vars have optimize=False."""
+        """include_meta=False should raise when all input vars have optimize=False."""
         cfg = _AllFalseCfg()
         bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
         res = bench.plot_sweep(
@@ -262,3 +276,22 @@ class TestOptunaOptimizeFlag(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             res.bench_results_to_optuna_trials(include_meta=False)
+
+    def test_all_optimize_false_include_meta_true_succeeds(self):
+        """include_meta=True should succeed even when all input vars have optimize=False,
+        because importance analysis uses all vars regardless of optimize flag."""
+        cfg = _AllFalseCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_all_false_meta",
+            input_vars=["x"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        trials = res.bench_results_to_optuna_trials(include_meta=True)
+        self.assertGreater(len(trials), 0)
+        # x and repeat should both appear as trial params
+        self.assertIn("x", trials[0].params)
+        self.assertIn("repeat", trials[0].params)

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -76,3 +76,93 @@ class TestOptunaResult(unittest.TestCase):
     def test_collect_optuna_plots_with_repeats(self):
         plots = self.res_2d_r2.collect_optuna_plots()
         self.assertIsInstance(plots, pn.Row)
+
+
+class _AggCfg(bch.ParametrizedSweep):
+    algorithm = bch.StringSweep(["algo_a", "algo_b"], optimize=False)
+    param1 = bch.FloatSweep(default=0.5, bounds=(0.0, 1.0))
+    score = bch.ResultVar(units="score", direction=bch.OptDir.minimize)
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.score = (self.param1 - 0.3) ** 2
+        return super().__call__()
+
+
+class _TrialCfg(bch.ParametrizedSweep):
+    category = bch.StringSweep(["cat_a", "cat_b"], optimize=False)
+    value = bch.FloatSweep(default=0.5, bounds=(0.0, 1.0), samples=3)
+    result = bch.ResultVar(units="v", direction=bch.OptDir.minimize)
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.result = self.value * 2
+        return super().__call__()
+
+
+class _AllFalseCfg(bch.ParametrizedSweep):
+    x = bch.FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)
+    result = bch.ResultVar(units="v", direction=bch.OptDir.minimize)
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.result = self.x
+        return super().__call__()
+
+
+class TestOptunaOptimizeFlag(unittest.TestCase):
+    """Tests for the optimize=False aggregation behavior in Optuna optimization."""
+
+    @classmethod
+    def setUpClass(cls):
+        optuna.logging.set_verbosity(optuna.logging.CRITICAL)
+
+    def test_optimize_false_aggregation(self):
+        """Optuna should only suggest optimized vars and aggregate over non-optimized ones."""
+        cfg = _AggCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_agg",
+            input_vars=["algorithm", "param1"],
+            result_vars=["score"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        study = res.to_optuna_from_results(cfg, n_trials=10)
+        self.assertIsInstance(study, optuna.Study)
+        self.assertIn("param1", study.best_params)
+        self.assertNotIn("algorithm", study.best_params)
+
+    def test_optimize_false_trials_exclude_non_optimized(self):
+        """bench_results_to_optuna_trials should only include optimized vars in trial params."""
+        cfg = _TrialCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_trials",
+            input_vars=["category", "value"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        trials = res.bench_results_to_optuna_trials(include_meta=False)
+        self.assertGreater(len(trials), 0)
+        for trial in trials:
+            self.assertNotIn("category", trial.params)
+            self.assertIn("value", trial.params)
+
+    def test_all_optimize_false_raises(self):
+        """Should raise ValueError when all input vars have optimize=False."""
+        cfg = _AllFalseCfg()
+        bench = cfg.to_bench(bch.BenchRunCfg(repeats=1))
+        res = bench.plot_sweep(
+            "test_all_false",
+            input_vars=["x"],
+            result_vars=["result"],
+            run_cfg=bch.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+        with self.assertRaises(ValueError):
+            res.to_optuna_from_results(cfg, n_trials=5)


### PR DESCRIPTION
## Summary
- Add `optimize: bool = True` parameter to all sweep variable types (`FloatSweep`, `IntSweep`, `StringSweep`, `EnumSweep`, `BoolSweep`, `YamlSweep`)
- When `optimize=False`, the variable is excluded from Optuna suggestions and instead iterated over with results averaged (mean aggregation), enabling finding settings that work best **across** categories rather than finding the best (category, setting) pair
- Time variables (`TimeSnapshot`, `TimeEvent`) default to `optimize=False` since they are never optimized by Optuna
- `iv_repeat` now also defaults to `optimize=False` (semantically correct — never optimized)
- Decouple `include_meta` from `optimize` flag: `include_meta=True` uses **all** vars (inputs + repeat + over_time) as trial parameters for importance analysis, regardless of `optimize` flag. This means both `repeat` and `over_time` now appear in parameter importance plots, letting you diagnose measurement noise vs temporal drift.

## Usage
```python
class MyBench(bch.ParametrizedSweep):
    algorithm = bch.StringSweep(["algo_a", "algo_b", "algo_c"], optimize=False)
    learning_rate = bch.FloatSweep(default=0.01, bounds=(0.001, 1.0))
    score = bch.ResultVar(units="score", direction=bch.OptDir.maximize)
```

Optuna will only suggest `learning_rate`. Each trial evaluates all 3 algorithms and returns the mean score.

## Code changes

### Core
- **`bencher/bench_cfg.py`**: Add `partition_input_vars()` static method centralizing opt/non-opt split; `optimized_input_vars` and `non_optimized_input_vars` properties reuse it
- **`bencher/results/optuna_result.py`**: Extract `_evaluate_over_non_optimized()` (with numeric dtype validation) and `_aggregate_non_optimized()` helpers. `bench_results_to_optuna_trials(include_meta=True)` now uses all vars without partition/aggregation; `include_meta=False` partitions + aggregates. `get_best_trial_params` and `to_optuna_from_results` seeding switched to `include_meta=False`
- **`bencher/optuna_conversions.py`**: Add `trial_vars` parameter to `optuna_grid_search()` so study search space matches trial params in importance mode
- **`bencher/result_collector.py`**: Set `optimize=False` on `iv_repeat`

### Examples & docs
- **New "Optimization (Over Time)" section**: `optim_over_time_1d.py`, `optim_over_time_2d.py` — shows repeat + over_time in importance analysis with temporal drift
- **New "Optimization (Aggregated)" section**: `optim_aggregated.py`, `optim_aggregated_over_time.py` — shows `optimize=False` on categorical var with Optuna aggregation
- Gallery sections registered in `generate_examples.py`

## Test plan
- [x] Verify `optimize` defaults to `True` for input types, `False` for time types
- [x] Verify `deepcopy` / `with_samples` preserves the flag (including YamlSweep, selector sweeps)
- [x] Test Optuna objective aggregates correctly with mixed optimize flags (single + multi-output)
- [x] Test `bench_results_to_optuna_trials` excludes non-optimized var params (include_meta=False)
- [x] Test `bench_results_to_optuna_trials` includes repeat in params (include_meta=True)
- [x] Test `bench_results_to_optuna_trials` produces more trials with include_meta=True (no aggregation)
- [x] Test `ValueError` raised when all vars have `optimize=False` (include_meta=False only)
- [x] Test include_meta=True succeeds even when all input vars have optimize=False
- [x] Test `optuna_grid_search` with explicit `trial_vars`
- [x] Numeric dtype validation on aggregation (TypeError for non-numeric results)
- [x] Full CI passes (870 passed, 1 pre-existing flask test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)