### PR TITLE
Remove deprecated agg_over_dims public API parameter

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -30,7 +30,7 @@ from bencher.variables.results import ResultHmap
 from bencher.results.bench_result import BenchResult
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.job import Job, FutureCache, JobFuture, Executors
-from bencher.utils import params_to_str, resolve_aggregate, _handle_deprecated_agg_over_dims
+from bencher.utils import params_to_str, resolve_aggregate
 from bencher.sample_order import SampleOrder
 from bencher.regression import detect_regressions, RegressionError
 from bencher.sweep_timings import SweepTimings, phase_timer
@@ -196,7 +196,6 @@ class Bench(BenchPlotServer):
         plot_callbacks: list[Callable] | bool | None = None,
         aggregate: bool | int | list[str] | None = None,
         agg_fn: str = "mean",
-        agg_over_dims: list[str] | None = None,
     ) -> list[BenchResult]:
         """Run a sequence of benchmarks by sweeping through groups of input variables.
 
@@ -224,7 +223,6 @@ class Bench(BenchPlotServer):
         """
         if relationship_cb is None:
             relationship_cb = combinations
-        aggregate = _handle_deprecated_agg_over_dims(aggregate, agg_over_dims)
         if input_vars is None:
             input_vars = self.worker_class_instance.get_inputs_only()
         results = []
@@ -265,7 +263,6 @@ class Bench(BenchPlotServer):
         sample_order: SampleOrder = SampleOrder.INORDER,
         aggregate: bool | int | list[str] | None = None,
         agg_fn: str = "mean",
-        agg_over_dims: list[str] | None = None,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
 
@@ -438,7 +435,6 @@ class Bench(BenchPlotServer):
         elif isinstance(plot_callbacks, bool):
             plot_callbacks = [BenchResult.to_auto_plots] if plot_callbacks else []
 
-        aggregate = _handle_deprecated_agg_over_dims(aggregate, agg_over_dims)
         input_var_names = [i.name for i in input_vars_in]
         agg_over_dims = resolve_aggregate(aggregate, input_var_names)
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -26,7 +26,7 @@ from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.histogram_result import HistogramResult
 from bencher.results.optuna_result import OptunaResult
 from bencher.results.dataset_result import DataSetResult
-from bencher.utils import listify, resolve_aggregate, _handle_deprecated_agg_over_dims
+from bencher.utils import listify, resolve_aggregate
 
 
 class BenchResult(
@@ -77,7 +77,6 @@ class BenchResult(
         # Aggregation controls (applied in filter())
         aggregate: bool | int | list[str] | None = None,
         agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
-        agg_over_dims: list[str] | None = None,
         **kwargs: Any,
     ) -> BenchResult:
         """Return the current instance of BenchResult.
@@ -85,7 +84,6 @@ class BenchResult(
         Returns:
             BenchResult: The current instance of the benchmark result
         """
-        aggregate = _handle_deprecated_agg_over_dims(aggregate, agg_over_dims)
         input_var_names = [iv.name for iv in self.bench_cfg.input_vars]
         agg_over_dims = resolve_aggregate(aggregate, input_var_names)
 

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from uuid import uuid4
 from functools import partial
 from typing import Callable, Any
-import warnings
 import logging
 import os
 import tempfile
@@ -344,27 +343,6 @@ def resolve_aggregate(
     raise TypeError(
         f"aggregate must be bool, int, list[str], or None, got {type(aggregate).__name__}"
     )
-
-
-def _handle_deprecated_agg_over_dims(
-    aggregate: bool | int | list[str] | None,
-    agg_over_dims: list[str] | None,
-) -> bool | int | list[str] | None:
-    """Merge the deprecated ``agg_over_dims`` kwarg into ``aggregate``.
-
-    If both are supplied, ``aggregate`` wins and a warning is emitted.
-    If only ``agg_over_dims`` is supplied, it is forwarded as ``aggregate``
-    with a deprecation warning.
-    """
-    if agg_over_dims is not None:
-        warnings.warn(
-            "agg_over_dims is deprecated, use aggregate instead",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-        if aggregate is None:
-            return agg_over_dims
-    return aggregate
 
 
 def callable_name(any_callable: Callable[..., Any]) -> str:

--- a/test/test_resolve_aggregate.py
+++ b/test/test_resolve_aggregate.py
@@ -116,34 +116,6 @@ class TestResolveAggregate(unittest.TestCase):
             resolve_aggregate(2.5, self.vars3)
 
 
-class TestHandleDeprecatedAggOverDims(unittest.TestCase):
-    """Tests for the deprecated agg_over_dims alias."""
-
-    def test_agg_over_dims_forwards_to_aggregate(self):
-        from bencher.utils import _handle_deprecated_agg_over_dims
-
-        with self.assertWarns(DeprecationWarning):
-            result = _handle_deprecated_agg_over_dims(None, ["x", "y"])
-        self.assertEqual(result, ["x", "y"])
-
-    def test_aggregate_takes_precedence(self):
-        from bencher.utils import _handle_deprecated_agg_over_dims
-
-        with self.assertWarns(DeprecationWarning):
-            result = _handle_deprecated_agg_over_dims(True, ["x", "y"])
-        self.assertIs(result, True)
-
-    def test_no_warning_when_agg_over_dims_is_none(self):
-        import warnings
-
-        from bencher.utils import _handle_deprecated_agg_over_dims
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            result = _handle_deprecated_agg_over_dims(True, None)
-        self.assertIs(result, True)
-
-
 class TestResolveAggregateIntegration(unittest.TestCase):
     """Integration: verify aggregate=True matches explicit dim list via plot_sweep."""
 


### PR DESCRIPTION
## Summary
- Removed the deprecated `_handle_deprecated_agg_over_dims()` helper from `bencher/utils.py`
- Removed the `agg_over_dims` parameter from `sweep_sequential()`, `plot_sweep()`, and `BenchResult.to()` public method signatures
- Removed the `TestHandleDeprecatedAggOverDims` test class
- The `aggregate` parameter is the supported way to specify aggregation; internal `agg_over_dims` on `BenchCfg` and result processing remains unchanged

## Test plan
- [x] Full CI suite passes (868 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the deprecated agg_over_dims public API support in favor of the aggregate parameter.

Enhancements:
- Eliminate the deprecated _handle_deprecated_agg_over_dims helper and its usage in sweep_sequential(), plot_sweep(), and BenchResult.to().

Tests:
- Remove tests covering the deprecated agg_over_dims alias behavior now that the deprecated path is gone.