### PR TITLE
Simplify optimization examples to use bn.run(optimise=X)

### DIFF
--- a/bencher/example/generated/optimization/optimise_1_objective_1d.py
+++ b/bencher/example/generated/optimization/optimise_1_objective_1d.py
@@ -31,20 +31,17 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optimise_1_objective_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise 1 objective(s), 1D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
-    run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         input_vars=["cpu_cores"],
         result_vars=["performance"],
         const_vars=dict(noise_scale=0.1),
         description="Single-objective optimization over 1D input space using Optuna. The optimizer searches for the parameter combination that maximizes performance.",
         post_description="The Optuna importance plot shows which input parameters most affect the objective.",
     )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_1_objective_1d, level=3, repeats=3)
+    bn.run(example_optimise_1_objective_1d, level=3, repeats=3, optimise=30)

--- a/bencher/example/generated/optimization/optimise_1_objective_2d.py
+++ b/bencher/example/generated/optimization/optimise_1_objective_2d.py
@@ -31,20 +31,17 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optimise_1_objective_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise 1 objective(s), 2D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
-    run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         input_vars=["cpu_cores", "memory_gb"],
         result_vars=["performance"],
         const_vars=dict(noise_scale=0.1),
         description="Single-objective optimization over 2D input space using Optuna. The optimizer searches for the parameter combination that maximizes performance.",
         post_description="The Optuna importance plot shows which input parameters most affect the objective.",
     )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_1_objective_2d, level=2, repeats=3)
+    bn.run(example_optimise_1_objective_2d, level=2, repeats=3, optimise=30)

--- a/bencher/example/generated/optimization/optimise_2_objectives_1d.py
+++ b/bencher/example/generated/optimization/optimise_2_objectives_1d.py
@@ -31,20 +31,17 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optimise_2_objectives_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise 2 objective(s), 1D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
-    run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         input_vars=["cpu_cores"],
         result_vars=["performance", "cost"],
         const_vars=dict(noise_scale=0.1),
         description="Multi-objective optimization over 1D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
         post_description="The Pareto front shows optimal trade-offs — no point can improve one objective without worsening the other.",
     )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_2_objectives_1d, level=3, repeats=3)
+    bn.run(example_optimise_2_objectives_1d, level=3, repeats=3, optimise=30)

--- a/bencher/example/generated/optimization/optimise_2_objectives_2d.py
+++ b/bencher/example/generated/optimization/optimise_2_objectives_2d.py
@@ -31,20 +31,17 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optimise_2_objectives_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise 2 objective(s), 2D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
-    run_cfg.use_optuna = True
     bench = ServerOptimizer().to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         input_vars=["cpu_cores", "memory_gb"],
         result_vars=["performance", "cost"],
         const_vars=dict(noise_scale=0.1),
         description="Multi-objective optimization over 2D input space using Optuna. The optimizer finds the Pareto front trading off performance vs cost.",
         post_description="The Pareto front shows optimal trade-offs — no point can improve one objective without worsening the other.",
     )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_2_objectives_2d, level=2, repeats=3)
+    bn.run(example_optimise_2_objectives_2d, level=2, repeats=3, optimise=30)

--- a/bencher/example/generated/optimization_aggregated/optimise_aggregated.py
+++ b/bencher/example/generated/optimization_aggregated/optimise_aggregated.py
@@ -31,19 +31,16 @@ class AlgorithmBench(bn.ParametrizedSweep):
 
 def example_optimise_aggregated(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregated Optimisation."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
-    run_cfg.use_optuna = True
     bench = AlgorithmBench().to_bench(run_cfg)
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         input_vars=["algorithm", "learning_rate"],
         result_vars=["loss"],
         description="Finds the best learning rate averaged across algorithms. algorithm has optimize=False so Optuna only suggests learning_rate and averages loss over all algorithm choices.",
         post_description="The importance plot shows learning_rate and repeat — algorithm is aggregated away. Compare 'With Repeats' vs 'Without Repeats' to see if measurement noise affects the result.",
     )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_aggregated, level=3, repeats=3)
+    bn.run(example_optimise_aggregated, level=3, repeats=3, optimise=30)

--- a/bencher/example/generated/optimization_aggregated/optimise_aggregated_over_time.py
+++ b/bencher/example/generated/optimization_aggregated/optimise_aggregated_over_time.py
@@ -50,10 +50,9 @@ def example_optimise_aggregated_over_time(run_cfg: bn.BenchRunCfg | None = None)
             run_cfg=run_cfg,
             time_src=_base_time + timedelta(seconds=i),
         )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_aggregated_over_time, level=3)
+    bn.run(example_optimise_aggregated_over_time, level=3, optimise=30)

--- a/bencher/example/generated/optimization_over_time/optimise_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optimise_over_time_1d.py
@@ -52,10 +52,9 @@ def example_optimise_over_time_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.B
             run_cfg=run_cfg,
             time_src=_base_time + timedelta(seconds=i),
         )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_over_time_1d, level=2)
+    bn.run(example_optimise_over_time_1d, level=2, optimise=30)

--- a/bencher/example/generated/optimization_over_time/optimise_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optimise_over_time_2d.py
@@ -52,10 +52,9 @@ def example_optimise_over_time_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.B
             run_cfg=run_cfg,
             time_src=_base_time + timedelta(seconds=i),
         )
-    bench.report.append(res.to_optuna_plots())
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_optimise_over_time_2d, level=2)
+    bn.run(example_optimise_over_time_2d, level=2, optimise=30)

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -143,9 +143,7 @@ class MetaOptimization(MetaGeneratorBase):
             const_vars="dict(noise_scale=0.1)",
             description=description,
             post_description=post_description,
-            post_sweep_line="res.to_optuna_plots()",
-            run_cfg_lines=["run_cfg.use_optuna = True"],
-            run_kwargs={"level": level, "repeats": 3},
+            run_kwargs={"level": level, "repeats": 3, "optimise": 30},
         )
 
         return super().__call__()
@@ -204,7 +202,6 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
             "        run_cfg=run_cfg,",
             "        time_src=_base_time + timedelta(seconds=i),",
             "    )",
-            "bench.report.append(res.to_optuna_plots())",
         ]
 
         self.generate_example(
@@ -218,7 +215,7 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
             ),
             body="\n".join(body_lines) + "\n",
             class_code=CLASS_CODE_OVERTIME,
-            run_kwargs={"level": 2},
+            run_kwargs={"level": 2, "optimise": 30},
         )
 
         return super().__call__()
@@ -269,7 +266,6 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 "        run_cfg=run_cfg,",
                 "        time_src=_base_time + timedelta(seconds=i),",
                 "    )",
-                "bench.report.append(res.to_optuna_plots())",
             ]
 
             self.generate_example(
@@ -283,7 +279,7 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 ),
                 body="\n".join(body_lines) + "\n",
                 class_code=CLASS_CODE_AGG,
-                run_kwargs={"level": 3},
+                run_kwargs={"level": 3, "optimise": 30},
             )
         else:
             filename = "optimise_aggregated"
@@ -313,9 +309,7 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 result_vars='["loss"]',
                 description=description,
                 post_description=post_description,
-                post_sweep_line="res.to_optuna_plots()",
-                run_cfg_lines=["run_cfg.use_optuna = True"],
-                run_kwargs={"level": 3, "repeats": 3},
+                run_kwargs={"level": 3, "repeats": 3, "optimise": 30},
             )
 
         return super().__call__()

--- a/bencher/example/optuna/example_optuna.py
+++ b/bencher/example/optuna/example_optuna.py
@@ -1,16 +1,6 @@
-import bencher as bn
 import numpy as np
-import optuna
-from optuna.samplers import TPESampler
 
-
-def objective(trial):
-    x = trial.suggest_float("x", -10, 10)
-    return x**2
-
-
-study = optuna.create_study(sampler=TPESampler())
-study.optimize(objective, n_trials=10)
+import bencher as bn
 
 rast_range = 1.5
 
@@ -50,22 +40,13 @@ def optuna_rastrigin(run_cfg: bn.BenchRunCfg | None = None):
 
     bench = bn.Bench("Rastrigin", explorer.rastrigin, run_cfg=run_cfg)
 
-    # res = bench.to_optuna(
-    #     input_vars=[explorer.param.input1, explorer.param.input2],
-    #     result_vars=[explorer.param.output],
-    #     n_trials=30
-    # )
-
-    # run_cfg.use_optuna = True
-    res = bench.plot_sweep(
+    bench.plot_sweep(
         "Rastrigin",
         input_vars=[explorer.param.input1, explorer.param.input2],
         result_vars=[explorer.param.output],
         run_cfg=run_cfg,
     )
 
-    bench.report.append(res.to_optuna_plots())
-    bench.report.append(res.to_optuna_from_sweep(bench))
     bench.report.append_markdown(
         f"The optimal value should be input1:{-optimal_value},input2:{-optimal_value} with a value of 0"
     )
@@ -73,4 +54,4 @@ def optuna_rastrigin(run_cfg: bn.BenchRunCfg | None = None):
 
 
 if __name__ == "__main__":
-    bn.run(optuna_rastrigin)
+    bn.run(optuna_rastrigin, optimise=30)


### PR DESCRIPTION
## Summary
- Replace the lower-level `run_cfg.use_optuna = True` + `to_optuna_plots()` pattern with the high-level `bn.run(fn, optimise=30)` API across all optimization examples
- Update the meta-generator (`generate_meta_optimization.py`) so regenerated examples use the new pattern
- Simplify `example_optuna.py` by removing manual optuna setup and using `bn.run(optimise=30)`
- Net deletion of 43 lines across 10 files

## Test plan
- [x] `pixi run generate-docs` regenerates examples correctly
- [x] `pixi run ci` passes (871 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify optimization examples to use the high-level optimisation API in bencher instead of manual Optuna configuration.

Enhancements:
- Refactor the Rastrigin Optuna example to call bn.run with an optimise parameter instead of managing Optuna studies and plots directly.
- Update the meta-optimization generator so newly generated optimization examples invoke bn.run with optimise set and no longer append Optuna-specific plots manually.
- Regenerate all optimization example scripts to align with the new high-level optimisation pattern and remove explicit Optuna plot handling.