### PR TITLE
Improve optuna result report readability and insight

### DIFF
--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -9,6 +9,8 @@ from optuna.visualization import (
     plot_param_importances,
     plot_pareto_front,
     plot_optimization_history,
+    plot_parallel_coordinate,
+    plot_slice,
 )
 
 from bencher.bench_cfg import BenchCfg
@@ -53,39 +55,48 @@ def optuna_grid_search(bench_cfg: BenchCfg, trial_vars: list | None = None) -> o
 
 
 # BENCH_CFG
-def param_importance(bench_cfg: BenchCfg, study: optuna.Study) -> pn.Row:
+def param_importance(bench_cfg: BenchCfg, study: optuna.Study) -> pn.Column:
     col_importance = pn.Column()
-    for tgt in bench_cfg.optuna_targets():
+    for idx, tgt in enumerate(bench_cfg.optuna_targets()):
+
+        def target(t, i=idx):
+            return t.values[i]
+
         col_importance.append(
             pn.Column(
-                pn.pane.Markdown(f"## Parameter importance for: {tgt}"),
-                plot_param_importances(study, target=lambda t: t.values[0], target_name=tgt),
+                pn.pane.Markdown(f"### Parameter importance for: {tgt}"),
+                plot_param_importances(study, target=target, target_name=tgt),
             )
         )
     return col_importance
 
 
 # BENCH_CFG
-def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> list[str]:
-    """Given a trial produce a string summary of the best results
+def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> str:
+    """Given a trial produce a markdown summary of the best results.
 
     Args:
         trial (optuna.trial): trial to summarise
         bench_cfg (BenchCfg): info about the trial
 
     Returns:
-        list[str]: Summary of trial
+        str: Markdown-formatted summary of the trial
     """
-    sep = "    "
-    output = []
-    output.append(f"Trial id:{trial.number}:")
-    output.append(f"{sep}Inputs:")
+    lines = [f"#### Trial {trial.number}", ""]
+    lines.append("| Parameter | Value |")
+    lines.append("|-----------|-------|")
     for k, v in trial.params.items():
-        output.append(f"{sep}{sep}{k}:{v}")
-    output.append(f"{sep}Results:")
+        lines.append(f"| {k} | {v} |")
+    lines.append("")
+    lines.append("| Result | Value |")
+    lines.append("|--------|-------|")
     for it, rv in enumerate(bench_cfg.optuna_targets()):
-        output.append(f"{sep}{sep}{rv}:{trial.values[it]}")
-    return output
+        val = trial.values[it]
+        if isinstance(val, float):
+            lines.append(f"| {rv} | {val:.6g} |")
+        else:
+            lines.append(f"| {rv} | {val} |")
+    return "\n".join(lines)
 
 
 def sweep_var_to_optuna_dist(var: param.Parameter) -> optuna.distributions.BaseDistribution:
@@ -158,6 +169,15 @@ def cfg_from_optuna_trial(
     return cfg
 
 
+def _make_target(idx: int):
+    """Create a target function that extracts the idx-th objective value from a trial."""
+
+    def target(t):
+        return t.values[idx]
+
+    return target
+
+
 def _append_safe(row, plot_fn, *args, **kwargs):
     """Append a plot to *row*, logging any exception instead of propagating."""
     try:
@@ -166,30 +186,75 @@ def _append_safe(row, plot_fn, *args, **kwargs):
         logging.exception(e)
 
 
-def summarise_optuna_study(study: optuna.study.Study) -> pn.pane.panel:
-    """Summarise an optuna study in a panel format"""
-    row = pn.Column(name="Optimisation Results")
+def summarise_optuna_study(
+    study: optuna.study.Study, target_names: list[str] | None = None
+) -> pn.pane.panel:
+    """Summarise an optuna study in a panel format.
+
+    Args:
+        study: The optuna study to summarise.
+        target_names: Optional names for each objective. Falls back to "Objective N".
+    """
+    col = pn.Column(name="Optimisation Results")
     n_objectives = len(study.directions)
     is_multi = n_objectives >= 2
 
+    col.append(pn.pane.Markdown("## Optimization History"))
     if is_multi:
         for idx in range(n_objectives):
-            target_name = f"Objective {idx}"
-
-            def target(t, i=idx):
-                return t.values[i]
-
+            name = target_names[idx] if target_names and idx < len(target_names) else f"Obj {idx}"
             _append_safe(
-                row, plot_optimization_history, study, target=target, target_name=target_name
+                col, plot_optimization_history, study, target=_make_target(idx), target_name=name
             )
-            _append_safe(row, plot_param_importances, study, target=target, target_name=target_name)
-
-        _append_safe(row, plot_pareto_front, study)
-        summary = f"Pareto-front size: {len(study.best_trials)}"
     else:
-        _append_safe(row, plot_optimization_history, study)
-        _append_safe(row, plot_param_importances, study)
-        summary = f"Best value: {study.best_value}\nParams: {study.best_params}"
+        _append_safe(col, plot_optimization_history, study)
 
-    row.append(pn.pane.Markdown(f"```\n{summary}```"))
-    return row
+    col.append(pn.pane.Markdown("## Parameter Importance"))
+    if is_multi:
+        for idx in range(n_objectives):
+            name = target_names[idx] if target_names and idx < len(target_names) else f"Obj {idx}"
+            _append_safe(
+                col, plot_param_importances, study, target=_make_target(idx), target_name=name
+            )
+    else:
+        _append_safe(col, plot_param_importances, study)
+
+    # Parameter interactions
+    n_params = len(study.trials[0].params) if study.trials else 0
+    if n_params >= 2:
+        col.append(pn.pane.Markdown("## Parameter Interactions"))
+        if is_multi:
+            for idx in range(n_objectives):
+                name = (
+                    target_names[idx] if target_names and idx < len(target_names) else f"Obj {idx}"
+                )
+                _append_safe(
+                    col,
+                    plot_parallel_coordinate,
+                    study,
+                    target=_make_target(idx),
+                    target_name=name,
+                )
+                _append_safe(col, plot_slice, study, target=_make_target(idx), target_name=name)
+        else:
+            _append_safe(col, plot_parallel_coordinate, study)
+            _append_safe(col, plot_slice, study)
+
+    if is_multi:
+        _append_safe(col, plot_pareto_front, study)
+
+    # Summary section
+    col.append(pn.pane.Markdown("## Summary"))
+    if is_multi:
+        col.append(pn.pane.Markdown(f"**Pareto-front size:** {len(study.best_trials)}"))
+    else:
+        summary_lines = [
+            "| Parameter | Value |",
+            "|-----------|-------|",
+        ]
+        for k, v in study.best_params.items():
+            summary_lines.append(f"| {k} | {v} |")
+        summary_lines.append("")
+        summary_lines.append(f"**Best objective value:** {study.best_value}")
+        col.append(pn.pane.Markdown("\n".join(summary_lines)))
+    return col

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import numbers
 
 import optuna
 import panel as pn
@@ -58,14 +59,10 @@ def optuna_grid_search(bench_cfg: BenchCfg, trial_vars: list | None = None) -> o
 def param_importance(bench_cfg: BenchCfg, study: optuna.Study) -> pn.Column:
     col_importance = pn.Column()
     for idx, tgt in enumerate(bench_cfg.optuna_targets()):
-
-        def target(t, i=idx):
-            return t.values[i]
-
         col_importance.append(
             pn.Column(
                 pn.pane.Markdown(f"### Parameter importance for: {tgt}"),
-                plot_param_importances(study, target=target, target_name=tgt),
+                plot_param_importances(study, target=_make_target(idx), target_name=tgt),
             )
         )
     return col_importance
@@ -92,7 +89,7 @@ def summarise_trial(trial: optuna.trial, bench_cfg: BenchCfg) -> str:
     lines.append("|--------|-------|")
     for it, rv in enumerate(bench_cfg.optuna_targets()):
         val = trial.values[it]
-        if isinstance(val, float):
+        if isinstance(val, numbers.Real):
             lines.append(f"| {rv} | {val:.6g} |")
         else:
             lines.append(f"| {rv} | {val} |")
@@ -199,6 +196,10 @@ def summarise_optuna_study(
     n_objectives = len(study.directions)
     is_multi = n_objectives >= 2
 
+    if not study.trials:
+        col.append(pn.pane.Markdown("*No completed trials to summarise.*"))
+        return col
+
     col.append(pn.pane.Markdown("## Optimization History"))
     if is_multi:
         for idx in range(n_objectives):
@@ -220,7 +221,7 @@ def summarise_optuna_study(
         _append_safe(col, plot_param_importances, study)
 
     # Parameter interactions
-    n_params = len(study.trials[0].params) if study.trials else 0
+    n_params = len({k for t in study.trials for k in t.params}) if study.trials else 0
     if n_params >= 2:
         col.append(pn.pane.Markdown("## Parameter Interactions"))
         if is_multi:

--- a/bencher/results/optimize_result.py
+++ b/bencher/results/optimize_result.py
@@ -66,7 +66,7 @@ class OptimizeResult:
 
     def to_panel(self) -> pn.pane.panel:
         """Panel visualization reusing the existing ``summarise_optuna_study`` helper."""
-        return summarise_optuna_study(self.study)
+        return summarise_optuna_study(self.study, target_names=self.target_names)
 
     # ------------------------------------------------------------------
     # Text summary

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -10,14 +10,17 @@ import panel as pn
 from optuna.visualization import (
     plot_param_importances,
     plot_pareto_front,
+    plot_optimization_history,
+    plot_contour,
+    plot_parallel_coordinate,
 )
 from bencher.utils import hmap_canonical_input
 from bencher.variables.time import TimeSnapshot, TimeEvent
 from bencher.variables.inputs import BoolSweep
 from bencher.results.bench_result_base import BenchResultBase, ReduceType
-
-# from bencher.results.bench_result_base import BenchResultBase
 from bencher.optuna_conversions import (
+    _append_safe,
+    _make_target,
     sweep_var_to_optuna_dist,
     summarise_trial,
     param_importance,
@@ -224,91 +227,132 @@ class OptunaResult(BenchResultBase):
 
     def collect_optuna_plots(
         self, pareto_width: float | None = None, pareto_height: float | None = None
-    ) -> list[pn.pane.panel]:
-        """Use optuna to plot various summaries of the optimisation
-
-        Args:
-            study (optuna.Study): The study to plot
-            bench_cfg (BenchCfg): Benchmark config with options used to generate the study
+    ) -> pn.pane.panel:
+        """Use optuna to plot various summaries of the optimisation.
 
         Returns:
-            list[pn.pane.Pane]: A list of plots
+            pn.pane.panel: A panel widget (Column or Tabs) with optuna visualisations.
         """
 
         self.studies = [self.bench_result_to_study(True)]
-        titles = ["# Analysis"]
+        tab_names = ["Analysis"]
         if self.bench_cfg.repeats > 1:
             self.studies.append(self.bench_result_to_study(False))
-            titles = [
-                "# Parameter Importance With Repeats",
-                "# Parameter Importance Without Repeats",
-            ]
+            tab_names = ["With Repeats", "Without Repeats"]
 
-        study_repeats_pane = pn.Row()
-        for study, title in zip(self.studies, titles):
+        study_panes = []
+        for study, tab_name in zip(self.studies, tab_names):
             study_pane = pn.Column()
             target_names = self.bench_cfg.optuna_targets()
-            param_str = []
+            n_inputs = len(self.bench_cfg.input_vars)
 
-            study_pane.append(pn.pane.Markdown(title))
+            # --- Optimization Overview ---
+            study_pane.append(pn.pane.Markdown(f"# {tab_name}"))
 
             if len(target_names) > 1:
+                study_pane.append(pn.pane.Markdown("## Pareto Front"))
                 if len(target_names) <= 3:
-                    study_pane.append(
-                        plot_pareto_front(
-                            study,
-                            target_names=target_names,
-                            include_dominated_trials=False,
-                        )
+                    _append_safe(
+                        study_pane,
+                        plot_pareto_front,
+                        study,
+                        target_names=target_names,
+                        include_dominated_trials=False,
                     )
                 else:
-                    print("plotting pareto front of first 3 result variables")
-                    study_pane.append(
-                        plot_pareto_front(
-                            study,
-                            targets=lambda t: (t.values[0], t.values[1], t.values[2]),
-                            target_names=target_names[:3],
-                            include_dominated_trials=False,
-                        )
+                    _append_safe(
+                        study_pane,
+                        plot_pareto_front,
+                        study,
+                        targets=lambda t: (t.values[0], t.values[1], t.values[2]),
+                        target_names=target_names[:3],
+                        include_dominated_trials=False,
                     )
                     if pareto_width is not None:
                         study_pane[-1].width = pareto_width
                     if pareto_height is not None:
                         study_pane[-1].height = pareto_height
+
+                # Optimization history per objective
+                study_pane.append(pn.pane.Markdown("## Optimization History"))
+                for idx, tgt in enumerate(target_names):
+                    _append_safe(
+                        study_pane,
+                        plot_optimization_history,
+                        study,
+                        target=_make_target(idx),
+                        target_name=tgt,
+                    )
+
+                # Parameter importance
+                study_pane.append(pn.pane.Markdown("## Parameter Importance"))
                 try:
                     study_pane.append(param_importance(self.bench_cfg, study))
-                    param_str.append(
-                        f"    Number of trials on the Pareto front: {len(study.best_trials)}"
-                    )
                 except RuntimeError as e:
-                    study_pane.append(f"Error generating parameter importance: {str(e)}")
-
-                for t in study.best_trials:
-                    param_str.extend(summarise_trial(t, self.bench_cfg))
+                    study_pane.append(
+                        pn.pane.Markdown(f"*Error generating parameter importance: {e}*")
+                    )
 
             else:
-                # cols.append(plot_optimization_history(study)) #TODO, maybe more clever when this is plotted?
+                # Single objective
+                study_pane.append(pn.pane.Markdown("## Optimization History"))
+                _append_safe(study_pane, plot_optimization_history, study)
 
-                # If there is only 1 parameter then there is no point is plotting relative importance.  Only worth plotting if there are multiple repeats of the same value so that you can compare the parameter vs to repeat to get a sense of the how much chance affects the results
-                # if bench_cfg.repeats > 1 and len(bench_cfg.input_vars) > 1:  #old code, not sure if its right
-                if len(self.bench_cfg.input_vars) > 1:
-                    study_pane.append(plot_param_importances(study, target_name=target_names[0]))
+                if n_inputs > 1:
+                    study_pane.append(pn.pane.Markdown("## Parameter Importance"))
+                    _append_safe(
+                        study_pane,
+                        plot_param_importances,
+                        study,
+                        target_name=target_names[0],
+                    )
 
-                param_str.extend(summarise_trial(study.best_trial, self.bench_cfg))
+            # --- Parameter Interactions ---
+            if n_inputs >= 2:
+                study_pane.append(pn.pane.Markdown("## Parameter Interactions"))
+                if len(target_names) > 1:
+                    for idx, tgt in enumerate(target_names):
+                        _append_safe(
+                            study_pane,
+                            plot_parallel_coordinate,
+                            study,
+                            target=_make_target(idx),
+                            target_name=tgt,
+                        )
+                        _append_safe(
+                            study_pane,
+                            plot_contour,
+                            study,
+                            target=_make_target(idx),
+                            target_name=tgt,
+                        )
+                else:
+                    _append_safe(study_pane, plot_parallel_coordinate, study)
+                    _append_safe(study_pane, plot_contour, study)
 
-            kwargs = {"height": 500, "scroll": True} if len(param_str) > 30 else {}
+            # --- Best Parameters ---
+            study_pane.append(pn.pane.Markdown("## Best Parameters"))
 
-            param_str = "\n".join(param_str)
-            study_pane.append(
-                pn.Row(
-                    pn.pane.Markdown(f"## Best Parameters\n```text\n{param_str}"),
-                    **kwargs,
-                ),
-            )
+            if len(target_names) > 1:
+                best_trials = study.best_trials
+                study_pane.append(pn.pane.Markdown(f"**Pareto front size:** {len(best_trials)}"))
+                display_trials = best_trials[:10]
+                trial_md = "\n\n".join(summarise_trial(t, self.bench_cfg) for t in display_trials)
+                if len(best_trials) > 10:
+                    trial_md += f"\n\n*... and {len(best_trials) - 10} more trials*"
+                study_pane.append(pn.pane.Markdown(trial_md))
+            else:
+                study_pane.append(
+                    pn.pane.Markdown(summarise_trial(study.best_trial, self.bench_cfg))
+                )
 
-            study_repeats_pane.append(study_pane)
+            study_panes.append(study_pane)
 
-        return study_repeats_pane
+        if len(study_panes) == 1:
+            return study_panes[0]
+        return pn.Tabs(
+            *((name, pane) for name, pane in zip(tab_names, study_panes)),
+        )
 
     # def extract_study_to_dataset(study: optuna.Study, bench_cfg: BenchCfg) -> BenchCfg:
     #     """Extract an optuna study into an xarray dataset for easy plotting

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -67,11 +67,11 @@ def _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names):
 
 
 class OptunaResult(BenchResultBase):
-    def to_optuna_plots(self, **kwargs) -> list[pn.pane.panel]:
-        """Create an optuna summary from the benchmark results
+    def to_optuna_plots(self, **kwargs) -> pn.pane.panel:
+        """Create an optuna summary from the benchmark results.
 
         Returns:
-            list[pn.pane.panel]: A list of optuna plot summarising the benchmark process
+            pn.pane.panel: A panel widget with optuna visualisations.
         """
 
         return self.collect_optuna_plots(**kwargs)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -205,7 +205,7 @@ class TestSummariseOptunaStudy:
         # Find Markdown panes and check their content
         md_texts = [obj.object for obj in panel.objects if isinstance(obj, pn.pane.Markdown)]
         combined = " ".join(md_texts)
-        assert "Best value" in combined
+        assert "Best objective value" in combined
 
     def test_multi_objective_panel_no_best_value_error(self):
         """Multi-objective panel should not call study.best_value (which raises)."""

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -249,9 +249,9 @@ class TestSummariseTrial(unittest.TestCase):
         study.optimize(lambda trial: trial.suggest_float("float_var", 0, 1), n_trials=3)
         trial = study.best_trial
         output = summarise_trial(trial, res.bench_cfg)
-        self.assertIsInstance(output, list)
-        self.assertTrue(len(output) > 0)
-        self.assertIn("Trial id:", output[0])
+        self.assertIsInstance(output, str)
+        self.assertIn("Trial", output)
+        self.assertIn("|", output)  # markdown table markers
 
 
 class TestOptunaGridSearch(unittest.TestCase):

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -82,15 +82,15 @@ class TestOptunaResult(unittest.TestCase):
 
     def test_collect_optuna_plots_single_result(self):
         plots = self.res_2d.collect_optuna_plots()
-        self.assertIsInstance(plots, pn.Row)
+        self.assertIsInstance(plots, pn.Column)
 
     def test_to_optuna_plots(self):
         plots = self.res_2d.to_optuna_plots()
-        self.assertIsInstance(plots, pn.Row)
+        self.assertIsInstance(plots, pn.Column)
 
     def test_collect_optuna_plots_with_repeats(self):
         plots = self.res_2d_r2.collect_optuna_plots()
-        self.assertIsInstance(plots, pn.Row)
+        self.assertIsInstance(plots, pn.Tabs)
 
 
 class _AggCfg(bn.ParametrizedSweep):


### PR DESCRIPTION
## Summary

- **Fix bug**: `param_importance()` closure always used `t.values[0]` for all targets in multi-objective studies — now correctly indexes each objective
- **Add new visualizations**: optimization history, parallel coordinate, and contour plots for both grid-search and direct-optimization reports
- **Improve layout**: use tabs instead of side-by-side row for with/without repeats comparison; add clear section headers (Pareto Front, Optimization History, Parameter Importance, Parameter Interactions, Best Parameters)
- **Better summaries**: rewrite `summarise_trial()` to use markdown tables instead of raw indented text; structured summary in `summarise_optuna_study()` with real target names
- **Pass target_names** through `OptimizeResult.to_panel()` so direct optimization uses actual objective names instead of "Objective 0"

## Test plan

- [x] All 868 existing tests pass (`pixi run ci`)
- [x] Updated test assertions for new return types (`pn.Column`/`pn.Tabs` instead of `pn.Row`)
- [x] Updated `summarise_trial` test for new markdown table format
- [x] Updated `test_single_objective_panel_shows_best_value` for new text
- [ ] Visual check: `pixi run python bencher/example/optuna/example_optuna.py`
- [ ] Visual check: `pixi run python bencher/example/example_pareto.py`

## Review notes

- `param_importance()` still uses inline `def target(t, i=idx)` while other functions use `_make_target(idx)` factory — both are correct, could be unified for consistency
- `_append_safe` and `_make_target` are underscore-prefixed but imported cross-module — intentional internal API between tightly coupled modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Revamp Optuna-based result panels to provide clearer, more informative optimization reports for both grid search and direct optimization.

New Features:
- Expose richer Optuna visualizations including optimization history, parameter importance, parallel coordinate, contour, and Pareto-front plots in a structured panel layout.
- Add tabbed comparison between studies with and without repeats in Optuna result panels.
- Include markdown-formatted trial summaries and a structured study summary section with real objective names where available.

Bug Fixes:
- Fix parameter importance for multi-objective studies so each objective uses its own target index instead of always using the first value.
- Avoid accessing best_value for multi-objective studies in the generic Optuna summary panel.

Enhancements:
- Change Optuna result and summary helpers to return a single Column/Tabs panel instead of low-level rows and lists, improving layout consistency.
- Refine headings and section ordering in Optuna summaries (Optimization History, Parameter Importance, Parameter Interactions, Pareto Front, Summary/Best Parameters).
- Format single- and multi-objective best trial information as readable markdown tables, truncating long Pareto fronts for display.
- Propagate objective target names from OptimizeResult into the Optuna summary panel so direct-optimization reports use meaningful names instead of generic placeholders.

Tests:
- Update Optuna-related tests to reflect new panel return types (Column/Tabs) and markdown-based summaries, and to assert on the new best-value label text.