### PR TITLE
Suppress matplotlib Axes3D import warning in bencher __init__

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -1,3 +1,7 @@
+import warnings
+
+warnings.filterwarnings("ignore", message="Unable to import Axes3D", category=UserWarning)
+
 from .bencher import Bench, BenchCfg, BenchRunCfg
 from .bench_runner import BenchRunner
 from .example.benchmark_data import ExampleBenchCfg


### PR DESCRIPTION
Holoviews/panel transitively imports matplotlib which triggers a
UserWarning about Axes3D when multiple matplotlib versions are
installed. Users who don't use the matplotlib backend were seeing
this warning unnecessarily. Filter it out at import time.

https://claude.ai/code/session_019St9w3rtxrzDXMPaF3WshP

## Summary by Sourcery

Bug Fixes:
- Filter out the Axes3D-related UserWarning triggered by transitive matplotlib imports so users not using the matplotlib backend no longer see this warning.