### PR TITLE
perf: lazy Cartesian product in setup_dataset()

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -698,7 +698,7 @@ class Bench(BenchPlotServer):
 
     def setup_dataset(
         self, bench_cfg: BenchCfg, time_src: datetime | str
-    ) -> tuple[BenchResult, list[tuple], list[str]]:
+    ) -> tuple[BenchResult, zip, list[str], int]:
         """Initialize n-dimensional xarray dataset for storing benchmark results."""
         return self._collector.setup_dataset(bench_cfg, time_src)
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -741,7 +741,7 @@ class Bench(BenchPlotServer):
             timings = SweepTimings()
 
         with phase_timer() as elapsed:
-            bench_res, func_inputs, dims_name = self.setup_dataset(bench_cfg, time_src)
+            bench_res, func_inputs, dims_name, total_jobs = self.setup_dataset(bench_cfg, time_src)
             # Adjust only the sampling traversal; leave dims/plotting unchanged
             if sample_order == SampleOrder.REVERSED:
                 total_dims = len(dims_name)
@@ -792,7 +792,7 @@ class Bench(BenchPlotServer):
                 job.setup_hashes()
                 jobs.append(job)
 
-                jid = f"{bench_res.bench_cfg.title}:call {callcount}/{len(func_inputs)}"
+                jid = f"{bench_res.bench_cfg.title}:call {callcount}/{total_jobs}"
                 worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
                 cache_jobs.append(
                     Job(

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -83,7 +83,7 @@ class ResultCollector:
 
     def setup_dataset(
         self, bench_cfg: BenchCfg, time_src: datetime | str
-    ) -> tuple[BenchResult, list[tuple], list[str]]:
+    ) -> tuple[BenchResult, zip, list[str], int]:
         """Initialize an n-dimensional xarray dataset from benchmark configuration parameters.
 
         This function creates the data structures needed to store benchmark results based on
@@ -96,10 +96,11 @@ class ResultCollector:
             time_src (datetime | str): Timestamp or event name for the benchmark run
 
         Returns:
-            tuple[BenchResult, list[tuple], list[str]]:
+            tuple[BenchResult, zip, list[str], int]:
                 - A BenchResult object with the initialized dataset
-                - A list of function input tuples (index, value pairs)
+                - A lazy iterator of function input tuples (index, value pairs)
                 - A list of dimension names for the dataset
+                - The total number of jobs (Cartesian product size)
         """
         if time_src is None:
             time_src = datetime.now()
@@ -111,9 +112,10 @@ class ResultCollector:
             logger.info(i.sampling_str())
 
         dims_cfg = DimsCfg(bench_cfg)
-        function_inputs = list(
-            zip(product(*dims_cfg.dim_ranges_index), product(*dims_cfg.dim_ranges))
-        )
+        total_jobs = 1
+        for s in dims_cfg.dims_size:
+            total_jobs *= s
+        function_inputs = zip(product(*dims_cfg.dim_ranges_index), product(*dims_cfg.dim_ranges))
         # xarray stores K N-dimensional arrays of data.
         # Each array is named and in this case we have an ND array for each result variable
         data_vars = {}
@@ -143,7 +145,7 @@ class ResultCollector:
         bench_res.dataset_list = dataset_list
         bench_res.setup_object_index()
 
-        return bench_res, function_inputs, dims_cfg.dims_name
+        return bench_res, function_inputs, dims_cfg.dims_name, total_jobs
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -7,6 +7,7 @@ including xarray dataset operations, caching, and metadata management.
 from __future__ import annotations
 
 import logging
+import math
 from datetime import datetime
 from itertools import product
 from typing import Any
@@ -112,9 +113,7 @@ class ResultCollector:
             logger.info(i.sampling_str())
 
         dims_cfg = DimsCfg(bench_cfg)
-        total_jobs = 1
-        for s in dims_cfg.dims_size:
-            total_jobs *= s
+        total_jobs = math.prod(dims_cfg.dims_size)
         function_inputs = zip(product(*dims_cfg.dim_ranges_index), product(*dims_cfg.dim_ranges))
         # xarray stores K N-dimensional arrays of data.
         # Each array is named and in this case we have an ND array for each result variable

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -44,12 +44,15 @@ class TestResultCollector(unittest.TestCase):
             repeats=2,
         )
 
-        bench_res, _, dims_name = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, dims_name, total_jobs = self.collector.setup_dataset(
+            bench_cfg, datetime(2024, 1, 1)
+        )
 
         self.assertIsNotNone(bench_res)
         self.assertIsNotNone(bench_res.ds)
         self.assertIn("theta", dims_name)
         self.assertIn("repeat", dims_name)
+        self.assertGreater(total_jobs, 0)
 
     def test_setup_dataset_result_vars_scalar(self):
         """Test ResultVar creates float data_vars."""
@@ -65,7 +68,7 @@ class TestResultCollector(unittest.TestCase):
             repeats=1,
         )
 
-        bench_res, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
 
         self.assertIn("out_sin", bench_res.ds.data_vars)
         self.assertEqual(bench_res.ds["out_sin"].dtype, np.float64)
@@ -134,7 +137,7 @@ class TestResultCollector(unittest.TestCase):
             repeats=1,
         )
 
-        bench_res, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
 
         # Should not raise any errors
         self.collector.report_results(bench_res, print_xarray=False, print_pandas=False)
@@ -197,7 +200,7 @@ class TestCacheOperations(unittest.TestCase):
             repeats=1,
         )
 
-        bench_res, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
 
         # Start with empty list
         bench_cfg_hashes = []
@@ -222,7 +225,7 @@ class TestCacheOperations(unittest.TestCase):
             repeats=1,
         )
 
-        bench_res, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
 
         # Set object_index to something non-empty
         bench_res.object_index = ["obj-1", "obj-2"]
@@ -266,7 +269,7 @@ class TestCacheOperations(unittest.TestCase):
             repeats=1,
         )
 
-        bench_res, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        bench_res, _, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
 
         # Add metadata for theta input
         self.collector.add_metadata_to_dataset(bench_res, instance.param.theta)
@@ -434,6 +437,73 @@ class TestDTypeIncompatibleHistory(unittest.TestCase):
             any("Discarding incompatible historical data" in msg for msg in captured_logs.output)
         )
         self.assertTrue(result.equals(ds_datetime))
+
+
+class TestLazyCartesianProduct(unittest.TestCase):
+    """Tests for lazy Cartesian product in setup_dataset (plan item 1.3)."""
+
+    def setUp(self):
+        self.collector = ResultCollector()
+
+    def _make_bench_cfg(self, n_theta_samples=3, repeats=2):
+        instance = ExampleBenchCfg()
+        instance.param.theta.samples = n_theta_samples
+        return BenchCfg(
+            input_vars=[instance.param.theta],
+            result_vars=[instance.param.out_sin],
+            const_vars=[],
+            bench_name="test_lazy",
+            title="test_lazy",
+            repeats=repeats,
+        )
+
+    def test_setup_dataset_returns_lazy_iterator(self):
+        """function_inputs should be a lazy zip, not a list."""
+        bench_cfg = self._make_bench_cfg()
+        _, func_inputs, _, total_jobs = self.collector.setup_dataset(
+            bench_cfg, datetime(2024, 1, 1)
+        )
+        self.assertNotIsInstance(func_inputs, list)
+        self.assertIsInstance(func_inputs, zip)
+        self.assertEqual(total_jobs, 3 * 2)  # theta_samples * repeats
+
+    def test_total_jobs_matches_iterator_length(self):
+        """total_jobs count must match the number of items yielded by the iterator."""
+        bench_cfg = self._make_bench_cfg(n_theta_samples=5, repeats=3)
+        _, func_inputs, _, total_jobs = self.collector.setup_dataset(
+            bench_cfg, datetime(2024, 1, 1)
+        )
+        items = list(func_inputs)
+        self.assertEqual(len(items), total_jobs)
+
+    def test_iterator_yields_correct_values(self):
+        """Materialized iterator should match the expected Cartesian product."""
+        bench_cfg = self._make_bench_cfg(n_theta_samples=3, repeats=2)
+        _, func_inputs, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        items = list(func_inputs)
+        # Each item is (index_tuple, value_tuple)
+        # With 3 theta samples and 2 repeats, expect 6 items
+        self.assertEqual(len(items), 6)
+        # First element should be indices, second should be values
+        for idx_tuple, val_tuple in items:
+            self.assertIsInstance(idx_tuple, tuple)
+            self.assertIsInstance(val_tuple, tuple)
+            self.assertEqual(len(idx_tuple), 2)  # theta dim + repeat dim
+            self.assertEqual(len(val_tuple), 2)
+
+    def test_iteration_does_not_mutate_bench_cfg(self):
+        """Consuming the iterator must not change bench_cfg."""
+        bench_cfg = self._make_bench_cfg()
+        input_vars_before = list(bench_cfg.input_vars)
+        all_vars_before = list(bench_cfg.all_vars) if bench_cfg.all_vars else None
+
+        _, func_inputs, _, _ = self.collector.setup_dataset(bench_cfg, datetime(2024, 1, 1))
+        # Consume the iterator fully
+        _ = list(func_inputs)
+
+        self.assertEqual(bench_cfg.input_vars, input_vars_before)
+        if all_vars_before is not None:
+            self.assertEqual(list(bench_cfg.all_vars), all_vars_before)
 
 
 class TestSetXarrayMultidim(unittest.TestCase):


### PR DESCRIPTION
## Summary
- **Plan item 1.3** from #788: `setup_dataset()` now returns a lazy `zip` iterator instead of eagerly materializing `list(zip(product(...), product(...)))`.
- For large sweeps (e.g. 5 dims × 10 values = 100k tuples), this avoids allocating the full Cartesian product upfront.
- A separate `total_jobs` integer is returned alongside the iterator for the progress display that previously relied on `len()`.

## Test plan
- [x] 4 new tests in `TestLazyCartesianProduct`: verifies lazy type, correct count, correct values, and mutation safety
- [x] Existing `test_result_collector.py` tests updated to unpack 4-tuple return
- [x] `test_sample_order.py` passes — both INORDER and REVERSED produce identical datasets
- [x] Full CI green (`pixi run ci`): 877 passed, 94% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make setup_dataset() use a lazy Cartesian product iterator and expose the total job count to callers.

New Features:
- Expose a total_jobs count from setup_dataset() for use in progress reporting.

Enhancements:
- Switch setup_dataset() to return a lazy iterator of function inputs instead of an eagerly materialized list to reduce memory usage on large sweeps.

Tests:
- Add TestLazyCartesianProduct to validate laziness, correctness, and non-mutation of benchmark configuration.
- Update existing tests and call sites to handle the extended setup_dataset() return signature including total_jobs.