### PR TITLE
perf: fix over_time rendering regression (v1.72.0)

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -61,6 +61,8 @@ class BenchRunCfg(BenchPlotSrvCfg):
                                    every time it is called
         clear_history (bool): Clear historical results
         max_time_events (int): Maximum number of over_time events to retain. None means unlimited.
+        max_slider_points (int): Maximum time points in the over_time slider. None means all.
+        show_aggregated_time_tab (bool): Show the aggregated tab for over_time plots.
         print_pandas (bool): Print a pandas summary of the results to the console
         print_xarray (bool): Print an xarray summary of the results to the console
         serve_pandas (bool): Serve a pandas summary on the results webpage
@@ -230,6 +232,22 @@ class BenchRunCfg(BenchPlotSrvCfg):
         bounds=[1, None],
         allow_None=True,
         doc="Maximum number of over_time events to retain. Oldest events are trimmed. None means unlimited.",
+    )
+
+    max_slider_points: int | None = param.Integer(
+        None,
+        bounds=[2, None],
+        allow_None=True,
+        doc="Maximum number of time points shown in the over_time slider. "
+        "Evenly subsampled (first and last always included). "
+        "The aggregated tab still uses all data. None means no subsampling.",
+    )
+
+    show_aggregated_time_tab: bool = param.Boolean(
+        True,
+        doc="When over_time is active, show an 'All Time Points (aggregated)' tab "
+        "alongside the per-time-point slider. Set False to skip the aggregation "
+        "computation and extra render, improving performance.",
     )
 
     time_event: str | None = param.String(

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -635,11 +635,13 @@ class Bench(BenchPlotServer):
             bench_res.post_setup()
         timings.post_setup_ms = elapsed()
 
+        if bench_cfg.auto_plot:
+            with phase_timer() as elapsed:
+                self.report.append_result(bench_res)
+            timings.render_ms = elapsed()
+
         timings.total_ms = timings.compute_total()
         bench_res.timings = timings
-
-        if bench_cfg.auto_plot:
-            self.report.append_result(bench_res)
 
         self.results.append(bench_res)
         return bench_res

--- a/bencher/results/holoview_results/heatmap_result.py
+++ b/bencher/results/holoview_results/heatmap_result.py
@@ -153,8 +153,8 @@ class HeatmapResult(HoloviewResult):
 
                 def make_heatmap(ds_t):
                     da_t = ds_t[C]
-                    df_t = da_t.to_dataframe().reset_index()
-                    return hv.HeatMap(df_t, kdims=[x, y], vdims=[C]).opts(
+                    hvds = hv.Dataset(da_t)
+                    return hvds.to(hv.HeatMap, kdims=[x, y], vdims=[C]).opts(
                         cmap="plasma", title=title, xrotation=30, **kwargs
                     )
 

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -295,8 +295,7 @@ class HoloviewResult(VideoResult):
         times = dataset.coords["over_time"].values
         n_time = len(times)
 
-        max_slider = getattr(self.bench_cfg, "max_slider_points", None)
-        slider_indices = self.subsample_indices(n_time, max_slider)
+        slider_indices = self.subsample_indices(n_time, self.bench_cfg.max_slider_points)
 
         kdims = self._over_time_kdims()
         holomap = hv.HoloMap(kdims=kdims)
@@ -308,8 +307,7 @@ class HoloviewResult(VideoResult):
 
         slider_pane = self._holomap_with_slider_bottom(holomap)
 
-        show_agg = getattr(self.bench_cfg, "show_aggregated_time_tab", True)
-        if n_time > 1 and show_agg:
+        if n_time > 1 and self.bench_cfg.show_aggregated_time_tab:
             ds_agg = self._mean_over_time(dataset, result_var_name)
             agg_plot = make_plot_fn(ds_agg)
             return pn.Tabs(
@@ -333,8 +331,7 @@ class HoloviewResult(VideoResult):
         times = da.coords["over_time"].values
         n_time = len(times)
 
-        max_slider = getattr(self.bench_cfg, "max_slider_points", None)
-        slider_indices = self.subsample_indices(n_time, max_slider)
+        slider_indices = self.subsample_indices(n_time, self.bench_cfg.max_slider_points)
 
         kdims = self._over_time_kdims()
         holomap = hv.HoloMap(kdims=kdims)
@@ -346,8 +343,7 @@ class HoloviewResult(VideoResult):
 
         slider_pane = self._holomap_with_slider_bottom(holomap)
 
-        show_agg = getattr(self.bench_cfg, "show_aggregated_time_tab", True)
-        if n_time > 1 and show_agg:
+        if n_time > 1 and self.bench_cfg.show_aggregated_time_tab:
             agg_plot = make_plot_fn(da)
             return pn.Tabs(
                 ("Per Time Point", slider_pane),

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import panel as pn
 import holoviews as hv
+import numpy as np
 from param import Parameter
 from functools import partial
 import hvplot.xarray  # noqa pylint: disable=duplicate-code,unused-import
@@ -201,6 +202,11 @@ class HoloviewResult(VideoResult):
         automatically.  This is used by both the curve renderer and the
         line renderer (for aggregated data that gained ``_std`` from
         ``_mean_over_time``).
+
+        Performance: avoids ``to_dataframe()`` when there are no categorical
+        groupby dimensions by constructing ``hv.Dataset`` directly from the
+        xarray Dataset.  The heavier DataFrame path is only used when manual
+        groupby is required.
         """
         var = result_var.name
         std_var = f"{var}_std"
@@ -212,12 +218,11 @@ class HoloviewResult(VideoResult):
         kdims = [d for d in ds_dims if d in float_names] or ds_dims[:1]
         groupby = [d for d in ds_dims if d not in kdims]
 
-        df = dataset.to_dataframe().reset_index()
-
         vdims = [var, std_var] if has_spread else [var]
-        hvds = hv.Dataset(df, kdims=kdims + groupby, vdims=vdims)
 
         if not groupby:
+            # Fast path: build hv.Dataset directly from xarray (no DataFrame conversion)
+            hvds = hv.Dataset(dataset, kdims=kdims, vdims=vdims)
             pt = hv.Overlay()
             pt *= hv.Curve(hvds, kdims=kdims, vdims=var, label=var).opts(
                 title=title, xrotation=30, **kwargs
@@ -226,6 +231,8 @@ class HoloviewResult(VideoResult):
                 pt *= hv.Spread(hvds, kdims=kdims, vdims=[var, std_var])
             return pt.opts(legend_position="right")
 
+        # Groupby path: DataFrame needed for manual group iteration
+        df = dataset.to_dataframe().reset_index()
         pt = hv.Overlay()
         for key, group_df in df.groupby(groupby):
             label = str(key) if not isinstance(key, tuple) else ", ".join(str(k) for k in key)
@@ -258,8 +265,19 @@ class HoloviewResult(VideoResult):
             new_ds[std_var] = var_of_means**0.5
         return new_ds
 
+    @staticmethod
+    def subsample_indices(n, max_points):
+        """Return evenly-spaced indices into a length-*n* array.
+
+        Always includes the first and last index.  When *max_points* is
+        ``None`` or >= *n*, returns ``range(n)`` (no subsampling).
+        """
+        if max_points is None or n <= max_points:
+            return range(n)
+        return np.unique(np.linspace(0, n - 1, max_points, dtype=int)).tolist()
+
     def _build_time_holomap(self, dataset, result_var_name, make_plot_fn):
-        """Build per-time-point HoloMap + a static aggregated plot.
+        """Build per-time-point HoloMap + optional aggregated plot.
 
         ``make_plot_fn`` receives a Dataset *without* the ``over_time``
         dimension.  The aggregated dataset produced by ``_mean_over_time``
@@ -267,24 +285,31 @@ class HoloviewResult(VideoResult):
         ``_std``-aware (e.g. delegating to ``_build_curve_overlay``) will
         automatically render spread bands on the aggregated tab.
 
-        Returns ``pn.Tabs`` with two tabs:
+        When ``bench_cfg.max_slider_points`` is set, only that many
+        evenly-spaced time points are rendered for the slider (first and
+        last always included).  The aggregated tab still uses all data.
 
-        1. **Per Time Point** — *N*-entry HoloMap with a time slider.
-        2. **All Time Points (aggregated)** — data averaged over every snapshot.
+        When ``bench_cfg.show_aggregated_time_tab`` is ``False``, the
+        aggregation is skipped entirely for faster rendering.
         """
         times = dataset.coords["over_time"].values
         n_time = len(times)
 
+        max_slider = getattr(self.bench_cfg, "max_slider_points", None)
+        slider_indices = self.subsample_indices(n_time, max_slider)
+
         kdims = self._over_time_kdims()
         holomap = hv.HoloMap(kdims=kdims)
 
-        for t in times:
+        for idx in slider_indices:
+            t = times[idx]
             ds_t = dataset.sel(over_time=t)
             holomap[t] = make_plot_fn(ds_t)
 
         slider_pane = self._holomap_with_slider_bottom(holomap)
 
-        if n_time > 1:
+        show_agg = getattr(self.bench_cfg, "show_aggregated_time_tab", True)
+        if n_time > 1 and show_agg:
             ds_agg = self._mean_over_time(dataset, result_var_name)
             agg_plot = make_plot_fn(ds_agg)
             return pn.Tabs(
@@ -295,31 +320,34 @@ class HoloviewResult(VideoResult):
         return slider_pane
 
     def _build_time_holomap_raw(self, da, make_plot_fn):
-        """Build per-time-point HoloMap + a static aggregated plot for distributions.
+        """Build per-time-point HoloMap + optional aggregated plot for distributions.
 
         *make_plot_fn* receives a DataArray that **retains** the ``over_time``
         dimension (a single-element slice for per-time-point entries, or the
         full array for the aggregated tab).  Callers should flatten via
         ``.to_dataframe().reset_index()`` or equivalent.
 
-        Returns ``pn.Tabs`` with two tabs:
-
-        1. **Per Time Point** — HoloMap with a time slider (shown by default).
-        2. **All Time Points (aggregated)** — all samples pooled.
+        Respects ``bench_cfg.max_slider_points`` and
+        ``bench_cfg.show_aggregated_time_tab``.
         """
         times = da.coords["over_time"].values
         n_time = len(times)
 
+        max_slider = getattr(self.bench_cfg, "max_slider_points", None)
+        slider_indices = self.subsample_indices(n_time, max_slider)
+
         kdims = self._over_time_kdims()
         holomap = hv.HoloMap(kdims=kdims)
 
-        for i, t in enumerate(times):
-            da_t = da.isel(over_time=slice(i, i + 1))
+        for idx in slider_indices:
+            t = times[idx]
+            da_t = da.isel(over_time=slice(idx, idx + 1))
             holomap[t] = make_plot_fn(da_t)
 
         slider_pane = self._holomap_with_slider_bottom(holomap)
 
-        if n_time > 1:
+        show_agg = getattr(self.bench_cfg, "show_aggregated_time_tab", True)
+        if n_time > 1 and show_agg:
             agg_plot = make_plot_fn(da)
             return pn.Tabs(
                 ("Per Time Point", slider_pane),

--- a/bencher/sweep_timings.py
+++ b/bencher/sweep_timings.py
@@ -23,6 +23,7 @@ class SweepTimings:
     job_execution_ms: float = 0.0  #: Job submission, execution, and result storage
     history_merge_ms: float = 0.0
     post_setup_ms: float = 0.0
+    render_ms: float = 0.0  #: Time spent generating plots (to_auto_plots / plot callbacks)
     total_ms: float = 0.0  #: Sum of all phase timings above
 
     def compute_total(self) -> float:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1270,7 +1270,7 @@ packages:
 - pypi: ./
   name: holobench
   version: 1.71.0
-  sha256: 513637b4b3b004cd818f8c5dd2c0892973edf6aa50acfd050d0970bcce478c8b
+  sha256: a8c6654fbf09868a5c69e0089de5d6ecf0ac7e68d2d467cd5e9c490906e5561e
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.71.0"
+version = "1.72.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -252,3 +252,157 @@ class TestOverTimeWidgetIsDiscreteSlider:
             assert not isinstance(widget, pn.widgets.Select), (
                 "over_time widget must not be a Select dropdown"
             )
+
+
+def _run_over_time_cfg(benchable, input_vars, result_vars, repeats=1, snapshots=3, **cfg_kwargs):
+    """Helper that accepts extra BenchRunCfg keyword overrides."""
+    run_cfg = bn.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = repeats
+    for k, v in cfg_kwargs.items():
+        setattr(run_cfg, k, v)
+    bench = benchable.to_bench(run_cfg)
+    base_time = datetime(2000, 1, 1)
+
+    for i in range(snapshots):
+        benchable.offset = i * 0.5
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "over_time_test",
+            input_vars=input_vars,
+            result_vars=result_vars,
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+    return res
+
+
+class TestShowAggregatedTimeTab:
+    """Tests for the show_aggregated_time_tab config parameter."""
+
+    def _count_agg_tabs(self, plots, depth=0):
+        """Count pn.Tabs instances that contain the aggregated title."""
+        count = 0
+        if depth > 10:
+            return 0
+        if isinstance(plots, pn.Tabs):
+            for title in plots._names:  # pylint: disable=protected-access
+                if "aggregated" in title.lower():
+                    count += 1
+        try:
+            for child in plots:
+                count += self._count_agg_tabs(child, depth + 1)
+        except TypeError:
+            pass
+        return count
+
+    def test_aggregated_tab_present_by_default(self):
+        """With default config, aggregated tab should appear."""
+        benchable = SimpleBench()
+        res = _run_over_time_cfg(benchable, ["backend"], ["latency"], repeats=1, snapshots=3)
+        plots = res.to_auto_plots()
+        assert self._count_agg_tabs(plots) > 0
+
+    def test_aggregated_tab_absent_when_disabled(self):
+        """With show_aggregated_time_tab=False, no aggregated tabs."""
+        benchable = SimpleBench()
+        res = _run_over_time_cfg(
+            benchable,
+            ["backend"],
+            ["latency"],
+            repeats=1,
+            snapshots=3,
+            show_aggregated_time_tab=False,
+        )
+        plots = res.to_auto_plots()
+        assert self._count_agg_tabs(plots) == 0
+
+    def test_curve_aggregated_tab_absent_when_disabled(self):
+        """Curve plots also respect show_aggregated_time_tab=False."""
+        benchable = FloatBench()
+        res = _run_over_time_cfg(
+            benchable,
+            ["size", "backend"],
+            ["time"],
+            repeats=3,
+            snapshots=3,
+            show_aggregated_time_tab=False,
+        )
+        plots = res.to_auto_plots()
+        assert self._count_agg_tabs(plots) == 0
+
+
+class TestMaxSliderPoints:
+    """Tests for the max_slider_points config parameter."""
+
+    def test_slider_subsampled(self):
+        """With max_slider_points=2 and 5 snapshots, slider should have 2 entries."""
+        benchable = SimpleBench()
+        res = _run_over_time_cfg(
+            benchable,
+            ["backend"],
+            ["latency"],
+            repeats=1,
+            snapshots=5,
+            max_slider_points=2,
+        )
+        plots = res.to_auto_plots()
+        widgets = _find_all_over_time_widgets(plots)
+        for widget in widgets:
+            if hasattr(widget, "options"):
+                opts = list(
+                    widget.options.values() if isinstance(widget.options, dict) else widget.options
+                )
+                assert len(opts) == 2, f"Expected 2 slider options, got {len(opts)}"
+
+    def test_no_subsampling_by_default(self):
+        """With default config, slider should have all time points."""
+        benchable = SimpleBench()
+        res = _run_over_time_cfg(
+            benchable,
+            ["backend"],
+            ["latency"],
+            repeats=1,
+            snapshots=5,
+        )
+        plots = res.to_auto_plots()
+        widgets = _find_all_over_time_widgets(plots)
+        for widget in widgets:
+            if hasattr(widget, "options"):
+                opts = list(
+                    widget.options.values() if isinstance(widget.options, dict) else widget.options
+                )
+                assert len(opts) == 5, f"Expected 5 slider options, got {len(opts)}"
+
+
+class TestSubsampleIndices:
+    """Unit tests for subsample_indices static method."""
+
+    def test_no_subsampling_when_none(self):
+        from bencher.results.holoview_results.holoview_result import HoloviewResult
+
+        result = list(HoloviewResult.subsample_indices(10, None))
+        assert result == list(range(10))
+
+    def test_no_subsampling_when_n_within_limit(self):
+        from bencher.results.holoview_results.holoview_result import HoloviewResult
+
+        result = list(HoloviewResult.subsample_indices(5, 10))
+        assert result == list(range(5))
+
+    def test_subsampling_includes_first_and_last(self):
+        from bencher.results.holoview_results.holoview_result import HoloviewResult
+
+        result = list(HoloviewResult.subsample_indices(20, 3))
+        assert result[0] == 0
+        assert result[-1] == 19
+        assert len(result) == 3
+
+    def test_subsampling_correct_count(self):
+        from bencher.results.holoview_results.holoview_result import HoloviewResult
+
+        result = list(HoloviewResult.subsample_indices(100, 5))
+        assert len(result) == 5
+        assert result[0] == 0
+        assert result[-1] == 99

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -41,11 +41,16 @@ class FloatBench(bn.ParametrizedSweep):
         return super().__call__()
 
 
-def _run_over_time(benchable, input_vars, result_vars, repeats=1, snapshots=3):
-    """Helper to run a benchmark over multiple time points."""
+def _run_over_time(benchable, input_vars, result_vars, repeats=1, snapshots=3, **cfg_kwargs):
+    """Helper to run a benchmark over multiple time points.
+
+    Extra keyword arguments are forwarded as BenchRunCfg attribute overrides.
+    """
     run_cfg = bn.BenchRunCfg()
     run_cfg.over_time = True
     run_cfg.repeats = repeats
+    for k, v in cfg_kwargs.items():
+        setattr(run_cfg, k, v)
     bench = benchable.to_bench(run_cfg)
     base_time = datetime(2000, 1, 1)
 
@@ -254,30 +259,6 @@ class TestOverTimeWidgetIsDiscreteSlider:
             )
 
 
-def _run_over_time_cfg(benchable, input_vars, result_vars, repeats=1, snapshots=3, **cfg_kwargs):
-    """Helper that accepts extra BenchRunCfg keyword overrides."""
-    run_cfg = bn.BenchRunCfg()
-    run_cfg.over_time = True
-    run_cfg.repeats = repeats
-    for k, v in cfg_kwargs.items():
-        setattr(run_cfg, k, v)
-    bench = benchable.to_bench(run_cfg)
-    base_time = datetime(2000, 1, 1)
-
-    for i in range(snapshots):
-        benchable.offset = i * 0.5
-        run_cfg.clear_cache = True
-        run_cfg.clear_history = i == 0
-        res = bench.plot_sweep(
-            "over_time_test",
-            input_vars=input_vars,
-            result_vars=result_vars,
-            run_cfg=run_cfg,
-            time_src=base_time + timedelta(seconds=i),
-        )
-    return res
-
-
 class TestShowAggregatedTimeTab:
     """Tests for the show_aggregated_time_tab config parameter."""
 
@@ -300,14 +281,14 @@ class TestShowAggregatedTimeTab:
     def test_aggregated_tab_present_by_default(self):
         """With default config, aggregated tab should appear."""
         benchable = SimpleBench()
-        res = _run_over_time_cfg(benchable, ["backend"], ["latency"], repeats=1, snapshots=3)
+        res = _run_over_time(benchable, ["backend"], ["latency"], repeats=1, snapshots=3)
         plots = res.to_auto_plots()
         assert self._count_agg_tabs(plots) > 0
 
     def test_aggregated_tab_absent_when_disabled(self):
         """With show_aggregated_time_tab=False, no aggregated tabs."""
         benchable = SimpleBench()
-        res = _run_over_time_cfg(
+        res = _run_over_time(
             benchable,
             ["backend"],
             ["latency"],
@@ -321,7 +302,7 @@ class TestShowAggregatedTimeTab:
     def test_curve_aggregated_tab_absent_when_disabled(self):
         """Curve plots also respect show_aggregated_time_tab=False."""
         benchable = FloatBench()
-        res = _run_over_time_cfg(
+        res = _run_over_time(
             benchable,
             ["size", "backend"],
             ["time"],
@@ -339,7 +320,7 @@ class TestMaxSliderPoints:
     def test_slider_subsampled(self):
         """With max_slider_points=2 and 5 snapshots, slider should have 2 entries."""
         benchable = SimpleBench()
-        res = _run_over_time_cfg(
+        res = _run_over_time(
             benchable,
             ["backend"],
             ["latency"],
@@ -359,7 +340,7 @@ class TestMaxSliderPoints:
     def test_no_subsampling_by_default(self):
         """With default config, slider should have all time points."""
         benchable = SimpleBench()
-        res = _run_over_time_cfg(
+        res = _run_over_time(
             benchable,
             ["backend"],
             ["latency"],


### PR DESCRIPTION
## Summary

- **Eliminate DataFrame conversion** in `_build_curve_overlay` for the common no-groupby path — builds `hv.Dataset` directly from xarray instead of calling `to_dataframe().reset_index()` per time point
- **Eliminate DataFrame conversion** in heatmap per-time-point renders (same pattern)
- **Add `max_slider_points`** param to subsample HoloMap slider entries (evenly spaced, aggregated tab still uses all data)
- **Add `show_aggregated_time_tab`** param to skip aggregation computation and extra render when not needed
- **Add `render_ms`** timing instrumentation to `SweepTimings` for detecting future render regressions
- **Bump version** to 1.72.0

## Context

Holobench 1.71.0 introduced an aggregated tab feature for `over_time` plots that caused a **6.6x slowdown** in downstream benchmark tests (5.4 min → 36 min). Even with `max_time_events=15`, rendering was still **2x the 1.70.4 baseline** (11 min vs 5.4 min), proving the per-render cost itself had doubled.

Root causes:
1. `_build_curve_overlay()` converted xarray→DataFrame + manual pandas groupby for **every** per-time-point render
2. Aggregated tab was always computed (N+1 renders instead of N)
3. `embed=True` in `report.save()` pre-computes ALL slider positions

## Downstream usage

Users experiencing the regression can now tune:
```python
run_cfg.max_slider_points = 8            # cap slider pre-renders
run_cfg.show_aggregated_time_tab = False  # skip aggregation entirely
```

## Test plan

- [x] All existing over_time tests pass (bar, curve, line, heatmap, distribution, histogram)
- [x] New tests for `show_aggregated_time_tab` (present by default, absent when disabled)
- [x] New tests for `max_slider_points` (subsampled vs full slider)
- [x] Unit tests for `subsample_indices` algorithm
- [x] Full CI: 901 passed, 5 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)