### PR TITLE
perf: filter-then-deepcopy kwargs, remove unused hash

### DIFF
--- a/PERFORMANCE_PLAN.md
+++ b/PERFORMANCE_PLAN.md
@@ -416,22 +416,22 @@ Every change in this plan must pass:
 
 ## 6. Implementation Priority
 
-| Priority | Item | Effort | Risk | Impact |
-|----------|------|--------|------|--------|
-| **P0** | 4.1 Profile baseline | Low | None | Enables all other work |
-| **P1** | 1.1 Deduplicate `plot_sweep()` copies | Low | Low | Moderate |
-| **P1** | 1.5 Filter-then-copy kwargs | Low | Low | High for large sweeps |
-| **P1** | 3.1 Avoid dataset copy in `to_dataset()` | Medium | High | High |
-| **P2** | 1.2 Single copy in `BenchRunner.run()` | Medium | Medium | Moderate |
-| **P2** | 1.3 Lazy Cartesian product | Low | Low-Med | High for large sweeps |
-| **P2** | 2.1 Reuse cache instances | Low | Low | Moderate |
-| **P2** | 2.4 Lazy hash computation | Low | Low | Low-Moderate |
-| **P2** | 3.4 Single-pass reduction | Medium | Medium | Moderate |
-| **P2** | 3.5 Memoize `to_dataset()` | Medium | Low-Med | High for many plots |
-| **P3** | 1.4 Deduplicate reversed product | Low | Low | Low |
-| **P3** | 1.6 Streaming parallel results | Medium | Medium | High for parallel |
-| **P3** | 2.2 FanoutCache for parallel | Low | Low | Moderate for parallel |
-| **P3** | 2.3 Batch cache lookups | High | Medium | High for large sweeps |
-| **P3** | 2.5 `__getstate__` for results | Medium | Medium | Low |
-| **P3** | 3.2 DynamicMap for over_time | Medium | Low-Med | Moderate |
-| **P3** | 3.3 Pre-filter before to_dataframe | Low | Low | Low |
+| Priority | Item | Effort | Risk | Impact | Status |
+|----------|------|--------|------|--------|--------|
+| **P0** | 4.1 Profile baseline | Low | None | Enables all other work | DONE (PR #787 — SweepTimings + perf workflow) |
+| **P1** | 1.1 Deduplicate `plot_sweep()` copies | Low | Low | Moderate | DONE (single-copy pattern in place) |
+| **P1** | 1.5 Filter-then-copy kwargs | Low | Low | High for large sweeps | |
+| **P1** | 3.1 Avoid dataset copy in `to_dataset()` | Medium | High | High | |
+| **P2** | 1.2 Single copy in `BenchRunner.run()` | Medium | Medium | Moderate | |
+| **P2** | 1.3 Lazy Cartesian product | Low | Low-Med | High for large sweeps | DONE (PR #811) |
+| **P2** | 2.1 Reuse cache instances | Low | Low | Moderate | DONE (PR #813) |
+| **P2** | 2.4 Lazy hash computation | Low | Low | Low-Moderate | |
+| **P2** | 3.4 Single-pass reduction | Medium | Medium | Moderate | |
+| **P2** | 3.5 Memoize `to_dataset()` | Medium | Low-Med | High for many plots | |
+| **P3** | 1.4 Deduplicate reversed product | Low | Low | Low | |
+| **P3** | 2.3 Batch cache lookups | High | Medium | High for large sweeps | |
+| **P3** | 2.5 `__getstate__` for results | Medium | Medium | Low | |
+| **P3** | 3.2 DynamicMap for over_time | Medium | Low-Med | Moderate | PARTIAL (PR #814 — eliminated DataFrame conversion in common over_time path) |
+| **P3** | 3.3 Pre-filter before to_dataframe | Low | Low | Low | PARTIAL (PR #814 — heatmap + line no longer use DataFrame for common path) |
+| **P4** | 1.6 Streaming parallel results | Medium | Medium | High for parallel | Deprioritized — parallel execution rarely used |
+| **P4** | 2.2 FanoutCache for parallel | Low | Low | Moderate for parallel | Deprioritized — parallel execution rarely used |

--- a/PERFORMANCE_PLAN.md
+++ b/PERFORMANCE_PLAN.md
@@ -222,12 +222,13 @@ Test with cache clearing mid-run to verify race condition handling.
 **File**: `bencher/utils.py:94-107`, `bencher/worker_job.py:48-69`
 
 **Problem**: Each job computes two SHA1 hashes: `function_input_signature_pure` and
-`function_input_signature_benchmark_context`. The pure hash is always computed even when not needed
-(only used when `only_hash_tag` is False).
+`function_input_signature_benchmark_context`. The context hash was never read anywhere in the
+codebase (dead code). The pure hash is always computed even when not needed (only used when
+`only_hash_tag` is False).
 
-**Proposed fix**: Lazily compute hashes — only compute `function_input_signature_benchmark_context`
-when needed (i.e., when `only_hash_tag` is True, skip the context hash). Use `@property` with
-caching (`functools.cached_property`).
+**Status**: `function_input_signature_benchmark_context` removed in PR #816 (dead code). Remaining
+opportunity: lazily compute `function_input_signature_pure` only when `only_hash_tag` is False,
+using `@property` with caching (`functools.cached_property`).
 
 **Correctness risk**: LOW. Hash values are read-only after construction. Lazy evaluation produces
 identical results.
@@ -420,12 +421,12 @@ Every change in this plan must pass:
 |----------|------|--------|------|--------|--------|
 | **P0** | 4.1 Profile baseline | Low | None | Enables all other work | DONE (PR #787 — SweepTimings + perf workflow) |
 | **P1** | 1.1 Deduplicate `plot_sweep()` copies | Low | Low | Moderate | DONE (single-copy pattern in place) |
-| **P1** | 1.5 Filter-then-copy kwargs | Low | Low | High for large sweeps | |
+| **P1** | 1.5 Filter-then-copy kwargs | Low | Low | High for large sweeps | DONE (PR #816) |
 | **P1** | 3.1 Avoid dataset copy in `to_dataset()` | Medium | High | High | |
 | **P2** | 1.2 Single copy in `BenchRunner.run()` | Medium | Medium | Moderate | |
 | **P2** | 1.3 Lazy Cartesian product | Low | Low-Med | High for large sweeps | DONE (PR #811) |
 | **P2** | 2.1 Reuse cache instances | Low | Low | Moderate | DONE (PR #813) |
-| **P2** | 2.4 Lazy hash computation | Low | Low | Low-Moderate | |
+| **P2** | 2.4 Lazy hash computation | Low | Low | Low-Moderate | PARTIAL (PR #816 — removed dead `function_input_signature_benchmark_context` hash) |
 | **P2** | 3.4 Single-pass reduction | Medium | Medium | Moderate | |
 | **P2** | 3.5 Memoize `to_dataset()` | Medium | Low-Med | High for many plots | |
 | **P3** | 1.4 Deduplicate reversed product | Low | Low | Low | |

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -19,14 +19,19 @@ from bencher.variables.parametrised_sweep import ParametrizedSweep
 # Default cache size for benchmark results (100 GB)
 DEFAULT_CACHE_SIZE_BYTES = int(100e9)
 
+# Metadata keys that must never be forwarded to the worker function.
+_META_KEYS = frozenset({"over_time", "time_event"})
+
 logger = logging.getLogger(__name__)
 
 
 def worker_kwargs_wrapper(worker: Callable, bench_cfg: BenchCfg, **kwargs) -> dict:
     """Prepare keyword arguments and pass them to a worker function.
 
-    This wrapper helps filter out metadata parameters that should not be passed
-    to the worker function (like 'repeat', 'over_time', and 'time_event').
+    This wrapper filters out metadata parameters that should not be passed
+    to the worker function (like 'repeat', 'over_time', and 'time_event'),
+    then deep-copies the filtered dict for mutation safety before calling
+    the worker.
 
     Args:
         worker (Callable): The worker function to call
@@ -36,14 +41,12 @@ def worker_kwargs_wrapper(worker: Callable, bench_cfg: BenchCfg, **kwargs) -> di
     Returns:
         dict: The result from the worker function
     """
-    function_input_deep = deepcopy(kwargs)
-    if not bench_cfg.pass_repeat:
-        function_input_deep.pop("repeat")
-    if "over_time" in function_input_deep:
-        function_input_deep.pop("over_time")
-    if "time_event" in function_input_deep:
-        function_input_deep.pop("time_event")
-    return worker(**function_input_deep)
+    filtered = {
+        k: v
+        for k, v in kwargs.items()
+        if k not in _META_KEYS and (k != "repeat" or bench_cfg.pass_repeat)
+    }
+    return worker(**deepcopy(filtered))
 
 
 class SweepExecutor:

--- a/bencher/worker_job.py
+++ b/bencher/worker_job.py
@@ -25,7 +25,6 @@ class WorkerJob:
         canonical_input (tuple[Any]): Canonical representation of inputs for caching
         fn_inputs_sorted (list[tuple[str, Any]]): Sorted representation of function inputs
         function_input_signature_pure (str): Hash of the function inputs and tag
-        function_input_signature_benchmark_context (str): Comprehensive hash including benchmark context
         found_in_cache (bool): Whether this job result was found in cache
         msgs (list[str]): Messages related to this job's execution
     """
@@ -41,7 +40,6 @@ class WorkerJob:
     canonical_input: tuple[Any] | None = None
     fn_inputs_sorted: list[tuple[str, Any]] | None = None
     function_input_signature_pure: str | None = None
-    function_input_signature_benchmark_context: str | None = None
     found_in_cache: bool = False
     msgs: list[str] = field(default_factory=list)
 
@@ -63,7 +61,3 @@ class WorkerJob:
         # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
         self.fn_inputs_sorted = sorted(self.function_input.items())
         self.function_input_signature_pure = hash_sha1((self.fn_inputs_sorted, self.tag))
-
-        self.function_input_signature_benchmark_context = hash_sha1(
-            (self.function_input_signature_pure, self.bench_cfg_sample_hash)
-        )

--- a/test/test_sweep_executor.py
+++ b/test/test_sweep_executor.py
@@ -282,6 +282,92 @@ class TestWorkerKwargsWrapper(unittest.TestCase):
         self.assertNotIn("time_event", call_log[0])
         self.assertIn("theta", call_log[0])
 
+    def test_does_not_mutate_original_kwargs(self):
+        """Verify that the original kwargs dict is not mutated by filtering."""
+
+        def my_worker(**_kwargs):
+            return {"result": 1}
+
+        bench_cfg = BenchCfg(
+            input_vars=[],
+            result_vars=[],
+            const_vars=[],
+            bench_name="test",
+            title="test",
+            pass_repeat=False,
+        )
+
+        original = {"theta": 1.0, "repeat": 1, "over_time": "2024-01-01", "time_event": "ev1"}
+        snapshot = dict(original)
+
+        worker_kwargs_wrapper(my_worker, bench_cfg, **original)
+
+        self.assertEqual(original, snapshot)
+
+    def test_worker_mutation_of_mutable_value_does_not_leak(self):
+        """Verify deepcopy prevents worker mutations of mutable values from leaking back."""
+        shared_list = [1, 2, 3]
+
+        def mutating_worker(**kwargs):
+            kwargs["data"].append(999)
+            return {"result": 1}
+
+        bench_cfg = BenchCfg(
+            input_vars=[],
+            result_vars=[],
+            const_vars=[],
+            bench_name="test",
+            title="test",
+            pass_repeat=False,
+        )
+
+        original = {"data": shared_list, "repeat": 1}
+        worker_kwargs_wrapper(mutating_worker, bench_cfg, **original)
+
+        self.assertEqual(shared_list, [1, 2, 3])
+
+    def test_no_meta_keys_present(self):
+        """Test behavior when no metadata keys are in kwargs."""
+        call_log = []
+
+        def my_worker(**kwargs):
+            call_log.append(kwargs)
+            return {"result": 1}
+
+        bench_cfg = BenchCfg(
+            input_vars=[],
+            result_vars=[],
+            const_vars=[],
+            bench_name="test",
+            title="test",
+            pass_repeat=True,
+        )
+
+        worker_kwargs_wrapper(my_worker, bench_cfg, theta=1.0, phi=2.0)
+
+        self.assertEqual(call_log[0], {"theta": 1.0, "phi": 2.0})
+
+    def test_only_meta_keys(self):
+        """Test that worker receives empty dict when only metadata keys are present."""
+        call_log = []
+
+        def my_worker(**kwargs):
+            call_log.append(kwargs)
+            return {"result": 1}
+
+        bench_cfg = BenchCfg(
+            input_vars=[],
+            result_vars=[],
+            const_vars=[],
+            bench_name="test",
+            title="test",
+            pass_repeat=False,
+        )
+
+        worker_kwargs_wrapper(my_worker, bench_cfg, repeat=1, over_time="t", time_event="e")
+
+        self.assertEqual(call_log[0], {})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- **Item 1.5**: `worker_kwargs_wrapper` now filters metadata keys (`repeat`, `over_time`, `time_event`) via dict comprehension *before* `deepcopy()`, so the copy operates on a smaller dict instead of copying everything then popping three keys. Deepcopy is retained for downstream mutation safety.
- **Item 2.4**: Removed `function_input_signature_benchmark_context` from `WorkerJob` — it was computed via `hash_sha1()` on every job but never read anywhere in the codebase (dead code).
- Updated `PERFORMANCE_PLAN.md`: marked 4 completed items, deprioritized parallel-only items (1.6, 2.2) to P4.

## Test plan
- [x] 4 new tests in `TestWorkerKwargsWrapper`: dict isolation, mutable-value mutation safety, no-meta-keys edge case, only-meta-keys edge case
- [x] All 901 existing tests pass (`pixi run coverage`)
- [x] Hash stability: `test_hash_persistent.py` — all 82 tests pass
- [x] Cache integrity: `test_sample_cache.py` — hit/miss counts unchanged
- [x] Mutation safety: `test_plot_sweep_mutation.py` — all 8 tests pass
- [x] Lint clean: pylint 10/10, ruff, ty all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)