### PR TITLE
Add show_aggregate_plots toggle to BenchRunCfg

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -63,6 +63,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
         max_time_events (int): Maximum number of over_time events to retain. None means unlimited.
         max_slider_points (int): Maximum time points in the over_time slider. None means all.
         show_aggregated_time_tab (bool): Show the aggregated tab for over_time plots.
+        show_aggregate_plots (bool): Show aggregated BandResult plots when aggregate is set.
         print_pandas (bool): Print a pandas summary of the results to the console
         print_xarray (bool): Print an xarray summary of the results to the console
         serve_pandas (bool): Serve a pandas summary on the results webpage
@@ -247,6 +248,13 @@ class BenchRunCfg(BenchPlotSrvCfg):
         True,
         doc="When over_time is active, show an 'All Time Points (aggregated)' tab "
         "alongside the per-time-point slider. Set False to skip the aggregation "
+        "computation and extra render, improving performance.",
+    )
+
+    show_aggregate_plots: bool = param.Boolean(
+        True,
+        doc="When aggregate is set on plot_sweep, show the aggregated BandResult "
+        "plots in the auto-plots view. Set False to skip the aggregation "
         "computation and extra render, improving performance.",
     )
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -211,7 +211,7 @@ class BenchResult(
         """
         plot_cols = pn.Column()
         plot_cols.append(self.to_sweep_summary(name="Plots View"))
-        if self.bench_cfg.agg_over_dims:
+        if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:
             dims = ", ".join(self.bench_cfg.agg_over_dims)
             plot_cols.append(
                 pn.pane.Markdown(

--- a/test/test_resolve_aggregate.py
+++ b/test/test_resolve_aggregate.py
@@ -168,3 +168,27 @@ class TestResolveAggregateIntegration(unittest.TestCase):
             aggregate=1,
         )
         self.assertEqual(res.bench_cfg.agg_over_dims, ["float2"])
+
+    def test_show_aggregate_plots_false_skips_band_result(self):
+        """show_aggregate_plots=False suppresses aggregate section in to_auto_plots."""
+        import panel as pn
+
+        import bencher as bn
+        from bencher.example.meta.example_meta import BenchableObject
+
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "agg_disabled",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=2, auto_plot=False, show_aggregate_plots=False),
+            aggregate=True,
+        )
+        # agg_over_dims is still set on the config
+        self.assertIsNotNone(res.bench_cfg.agg_over_dims)
+        plots = res.to_auto_plots()
+        # The "Aggregated View" markdown should not appear
+        md_texts = [
+            p.object for p in plots if isinstance(p, pn.pane.Markdown) and "Aggregated View" in str(getattr(p, "object", ""))
+        ]
+        self.assertEqual(len(md_texts), 0, "Aggregated View section should be suppressed")

--- a/test/test_resolve_aggregate.py
+++ b/test/test_resolve_aggregate.py
@@ -195,3 +195,27 @@ class TestResolveAggregateIntegration(unittest.TestCase):
             and "Aggregated View" in str(getattr(p, "object", ""))
         ]
         self.assertEqual(len(md_texts), 0, "Aggregated View section should be suppressed")
+
+    def test_show_aggregate_plots_true_renders_band_result(self):
+        """show_aggregate_plots=True (default) renders the aggregate section."""
+        import panel as pn
+
+        import bencher as bn
+        from bencher.example.meta.example_meta import BenchableObject
+
+        bench = BenchableObject().to_bench()
+        res = bench.plot_sweep(
+            "agg_enabled",
+            input_vars=[BenchableObject.param.float1, BenchableObject.param.float2],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=2, auto_plot=False),
+            aggregate=True,
+        )
+        plots = res.to_auto_plots()
+        md_texts = [
+            p.object
+            for p in plots
+            if isinstance(p, pn.pane.Markdown)
+            and "Aggregated View" in str(getattr(p, "object", ""))
+        ]
+        self.assertGreater(len(md_texts), 0, "Aggregated View section should be present")

--- a/test/test_resolve_aggregate.py
+++ b/test/test_resolve_aggregate.py
@@ -189,6 +189,9 @@ class TestResolveAggregateIntegration(unittest.TestCase):
         plots = res.to_auto_plots()
         # The "Aggregated View" markdown should not appear
         md_texts = [
-            p.object for p in plots if isinstance(p, pn.pane.Markdown) and "Aggregated View" in str(getattr(p, "object", ""))
+            p.object
+            for p in plots
+            if isinstance(p, pn.pane.Markdown)
+            and "Aggregated View" in str(getattr(p, "object", ""))
         ]
         self.assertEqual(len(md_texts), 0, "Aggregated View section should be suppressed")


### PR DESCRIPTION
## Summary
- Adds `show_aggregate_plots` boolean to `BenchRunCfg` (default `True`) that controls whether the aggregated BandResult section renders in `to_auto_plots()`
- When set to `False`, the expensive aggregation computation and rendering is skipped, restoring performance for downstream users who pass `aggregate=True`
- Mirrors the existing `show_aggregated_time_tab` pattern for over-time plots

## Test plan
- [x] New test `test_show_aggregate_plots_false_skips_band_result` verifies the flag suppresses the aggregate view while preserving `agg_over_dims` on the config
- [x] All 897 existing tests pass
- [x] CI green (format, lint, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configuration flag to control rendering of aggregated BandResult plots and update auto-plot generation accordingly.

New Features:
- Introduce a show_aggregate_plots boolean option on BenchRunCfg to toggle aggregated BandResult plots in auto-plots.

Tests:
- Add a regression test ensuring show_aggregate_plots=False skips the aggregated view while preserving agg_over_dims.