### PR TITLE
fix: prevent example functions from overwriting caller's run_cfg values

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -358,6 +358,17 @@ class BenchRunCfg(BenchPlotSrvCfg):
     def deep(self):
         return deepcopy(self)
 
+    @classmethod
+    def with_defaults(cls, run_cfg=None, **defaults):
+        """Return *run_cfg* unchanged if provided, otherwise create a new instance.
+
+        Use this in example functions to set preferred defaults that yield to
+        caller-provided values::
+
+            run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5, level=4)
+        """
+        return run_cfg if run_cfg is not None else cls(**defaults)
+
 
 class BenchCfg(BenchRunCfg):
     """Complete configuration for a benchmark protocol.

--- a/bencher/example/example_agg_over_time.py
+++ b/bencher/example/example_agg_over_time.py
@@ -21,10 +21,8 @@ from bencher.example.meta.example_meta import BenchableObject
 
 
 def example_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, level=4)
     run_cfg.over_time = True
-    run_cfg.level = 4
 
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/example_bool_result.py
+++ b/bencher/example/example_bool_result.py
@@ -48,11 +48,7 @@ def example_bool_result_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     Returns:
         bn.Bench: The benchmark object with results
     """
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
-
-    # Explicitly set repeats to 1 to avoid averaging
-    run_cfg.repeats = 1
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=1)
 
     bench = SimpleBoolBenchmark().to_bench(run_cfg)
     bench.plot_sweep(
@@ -85,11 +81,7 @@ def example_bool_result_categorical_no_repeats(run_cfg: bn.BenchRunCfg | None = 
         bn.Bench: The benchmark object with results
     """
 
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
-
-    # Explicitly set repeats to 1 to avoid averaging
-    run_cfg.repeats = 1
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=1)
 
     bench = ProgrammingBenchmark().to_bench(run_cfg)
     bench.plot_sweep(

--- a/bencher/example/example_cat2_scatter_jitter.py
+++ b/bencher/example/example_cat2_scatter_jitter.py
@@ -80,7 +80,7 @@ def example_2_cat_in_4_out_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.
         bn.Bench: The benchmark object
     """
 
-    run_cfg.repeats = 15  # Run multiple times to get statistical significance
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=15)
     bench = ProgrammingBenchmark().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["language", "environment"],

--- a/bencher/example/example_float_cat.py
+++ b/bencher/example/example_float_cat.py
@@ -62,13 +62,10 @@ def example_float_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
 
 def run_example_float_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
-    run_cfg.repeats = 2
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2, level=3)
     run_cfg.over_time = True
     run_cfg.clear_cache = True
     run_cfg.clear_history = True
-    run_cfg.level = 3
 
     example_float_cat(run_cfg)
 

--- a/bencher/example/example_git_time_event.py
+++ b/bencher/example/example_git_time_event.py
@@ -49,9 +49,8 @@ def example_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """
 
     random.seed(42)
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
     run_cfg.over_time = True
-    run_cfg.repeats = 5
 
     benchable = ServerLatency()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/example_over_time.py
+++ b/bencher/example/example_over_time.py
@@ -40,10 +40,8 @@ def _run_over_time(bench, benchable, run_cfg, input_vars, title, result_vars=Non
 
 def example_over_time_0D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> bn.Bench:
     """Demo: over_time with 0 input vars — produces a time-series line chart."""
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, level=4)
     run_cfg.over_time = True
-    run_cfg.level = 4
 
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg, report=report)
@@ -53,10 +51,8 @@ def example_over_time_0D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> 
 
 def example_over_time_1D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> bn.Bench:
     """Demo: over_time with 1 float input — slider scrubs through phase-shifted curves."""
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, level=4)
     run_cfg.over_time = True
-    run_cfg.level = 4
 
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg, report=report)
@@ -66,10 +62,8 @@ def example_over_time_1D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> 
 
 def example_over_time_2D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> bn.Bench:
     """Demo: over_time with 2 float inputs — slider scrubs through 2D heatmaps."""
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, level=4)
     run_cfg.over_time = True
-    run_cfg.level = 4
 
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg, report=report)
@@ -79,10 +73,8 @@ def example_over_time_2D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> 
 
 def example_over_time_3D(run_cfg: bn.BenchRunCfg | None = None, report=None) -> bn.Bench:
     """Demo: over_time with 3 float inputs — slider scrubs through 3D heatmaps."""
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, level=4)
     run_cfg.over_time = True
-    run_cfg.level = 4
 
     benchable = BenchableObject()
     bench = benchable.to_bench(run_cfg, report=report)

--- a/bencher/example/example_pareto.py
+++ b/bencher/example/example_pareto.py
@@ -96,15 +96,10 @@ def example_pareto(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     Returns:
         Bench: Benchmark object with results
     """
-    run_cfg.repeats = 5  # Multiple repeats to demonstrate randomness effects
-    run_cfg.level = 4
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5, level=4)
 
     # Set up Optuna for multi-objective optimization
     run_cfg.use_optuna = True
-
-    # Important: Set multiple repeats to demonstrate the effect of randomness
-    # The framework will automatically calculate and plot both individual runs and averages
-    run_cfg.repeats = 5
 
     # Create problem definition and benchmark
     bench = EngineeringDesignProblem().to_bench(run_cfg)

--- a/bencher/example/example_regression.py
+++ b/bencher/example/example_regression.py
@@ -39,9 +39,8 @@ def example_regression(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     Stable releases are followed by progressively worse degradation so the
     aggregated trend curve clearly shows when metrics go outside bounds.
     """
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.over_time = True
-    run_cfg.repeats = 2
     run_cfg.regression_detection = True
     run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False

--- a/bencher/example/example_self_benchmark.py
+++ b/bencher/example/example_self_benchmark.py
@@ -77,6 +77,7 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
 
 def example_self_benchmark(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Benchmark bencher's own overhead across problem sizes."""
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
     bench = BencherSelfBenchmark().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["num_samples"],
@@ -105,7 +106,7 @@ def example_self_benchmark_over_time(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """Track bencher's overhead over time, accumulating results across commits."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
     run_cfg.over_time = True
     run_cfg.auto_plot = False
 
@@ -133,4 +134,4 @@ def example_self_benchmark_over_time(
 
 
 if __name__ == "__main__":
-    bn.run(example_self_benchmark)
+    bn.run(example_self_benchmark, level=5, repeats=20)

--- a/bencher/example/example_time_event.py
+++ b/bencher/example/example_time_event.py
@@ -34,9 +34,7 @@ def example_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
 
 def run_example_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    if run_cfg is None:
-        run_cfg = bn.BenchRunCfg()
-    run_cfg.repeats = 1
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=1)
     run_cfg.print_pandas = True
     run_cfg.over_time = True
 

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
@@ -24,7 +24,7 @@ class BaselineCheck(bn.ParametrizedSweep):
 
 def example_sweep_0_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 0 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = BaselineCheck()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
@@ -26,7 +26,7 @@ class CacheBackend(bn.ParametrizedSweep):
 
 def example_sweep_0_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 1 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = CacheBackend()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
@@ -28,7 +28,7 @@ class NetworkConfig(bn.ParametrizedSweep):
 
 def example_sweep_0_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 2 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = NetworkConfig()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
@@ -30,7 +30,7 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
 def example_sweep_0_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 3 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = DeploymentConfig()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
@@ -26,9 +26,8 @@ def example_sweep_0_float_0_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """0 Float, 0 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = BaselineCheck()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
@@ -28,9 +28,8 @@ def example_sweep_0_float_1_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """0 Float, 1 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = CacheBackend()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
@@ -30,9 +30,8 @@ def example_sweep_0_float_2_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """0 Float, 2 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = NetworkConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
@@ -32,9 +32,8 @@ def example_sweep_0_float_3_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """0 Float, 3 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = DeploymentConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
@@ -27,7 +27,7 @@ class SortBenchmark(bn.ParametrizedSweep):
 
 def example_sweep_1_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 0 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = SortBenchmark()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
@@ -29,7 +29,7 @@ class SortComparison(bn.ParametrizedSweep):
 
 def example_sweep_1_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 1 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = SortComparison()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
@@ -33,7 +33,7 @@ class SortAnalysis(bn.ParametrizedSweep):
 
 def example_sweep_1_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 2 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = SortAnalysis()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
@@ -40,7 +40,7 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
 def example_sweep_1_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 3 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = SortFullMatrix()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
@@ -29,9 +29,8 @@ def example_sweep_1_float_0_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """1 Float, 0 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = SortBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
@@ -31,9 +31,8 @@ def example_sweep_1_float_1_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """1 Float, 1 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = SortComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
@@ -35,9 +35,8 @@ def example_sweep_1_float_2_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """1 Float, 2 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = SortAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
@@ -42,9 +42,8 @@ def example_sweep_1_float_3_cat_over_time_repeats(
     run_cfg: bn.BenchRunCfg | None = None,
 ) -> bn.Bench:
     """1 Float, 3 Categorical (over time repeats)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = SortFullMatrix()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
@@ -28,7 +28,7 @@ class CompressionBench(bn.ParametrizedSweep):
 
 def example_sweep_2_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 0 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = CompressionBench()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
@@ -32,7 +32,7 @@ class CompressionCodec(bn.ParametrizedSweep):
 
 def example_sweep_2_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 1 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = CompressionCodec()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
@@ -37,7 +37,7 @@ class CompressionSuite(bn.ParametrizedSweep):
 
 def example_sweep_2_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 2 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = CompressionSuite()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
@@ -34,7 +34,7 @@ class HashBenchmark(bn.ParametrizedSweep):
 
 def example_sweep_3_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 0 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = HashBenchmark()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
@@ -37,7 +37,7 @@ class HashComparison(bn.ParametrizedSweep):
 
 def example_sweep_3_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 1 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = HashComparison()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
@@ -40,7 +40,7 @@ class HashAnalysis(bn.ParametrizedSweep):
 
 def example_sweep_3_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 2 Categorical (over time)."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = HashAnalysis()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -38,7 +38,7 @@ class ThermalPlate(bn.ParametrizedSweep):
 
 def example_advanced_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
 
     benchable = ThermalPlate()

--- a/bencher/example/generated/advanced/advanced_cache_patterns.py
+++ b/bencher/example/generated/advanced/advanced_cache_patterns.py
@@ -33,7 +33,7 @@ class NoisySensor(bn.ParametrizedSweep):
 
 def example_advanced_cache_patterns(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Cache Patterns — run_tag and cache_samples."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
 
     # run_tag partitions the cache so different experiment runs don't collide.
     run_cfg.run_tag = "sensor_v1"
@@ -42,7 +42,6 @@ def example_advanced_cache_patterns(run_cfg: bn.BenchRunCfg | None = None) -> bn
     # benchmarks that might be interrupted.
     run_cfg.cache_samples = True
     run_cfg.clear_sample_cache = True
-    run_cfg.repeats = 5
 
     bench = NoisySensor().to_bench(run_cfg)
     bench.plot_sweep(

--- a/bencher/example/generated/advanced/advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/advanced_git_time_event.py
@@ -26,7 +26,7 @@ class ServerLatency(bn.ParametrizedSweep):
 
 def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Git Time Event — date + commit hash slider labels."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
 
     bench = ServerLatency().to_bench(run_cfg)

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -30,7 +30,7 @@ class LatencyMonitor(bn.ParametrizedSweep):
 
 def example_advanced_max_time_events(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Max Time Events — cap over_time history."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
 
     # Keep only the 3 most recent time slices in the cache.

--- a/bencher/example/generated/advanced/advanced_time_event.py
+++ b/bencher/example/generated/advanced/advanced_time_event.py
@@ -29,7 +29,7 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
 
 def example_advanced_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Time Events — track metrics across discrete events."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
 
     benchable = PullRequestBenchmark()

--- a/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
@@ -32,9 +32,8 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optim_over_time_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise Over Time: 1D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = ServerOptimizer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
@@ -32,9 +32,8 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
 def example_optim_over_time_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise Over Time: 2D input."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
     run_cfg.over_time = True
-    run_cfg.repeats = 3
     benchable = ServerOptimizer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/performance/perf_self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/perf_self_benchmark_over_time.py
@@ -68,7 +68,7 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
 
 def example_perf_self_benchmark_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Bencher self-introspection: overhead tracked over time."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     run_cfg.auto_plot = False
     time_src = bn.git_time_event()

--- a/bencher/example/generated/regression/regression_percentage.py
+++ b/bencher/example/generated/regression/regression_percentage.py
@@ -28,9 +28,8 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
 def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Regression detection — percentage threshold over time."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.over_time = True
-    run_cfg.repeats = 2
     run_cfg.regression_detection = True
     run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False

--- a/bencher/example/generated/result_types/result_image/result_image_over_time.py
+++ b/bencher/example/generated/result_types/result_image/result_image_over_time.py
@@ -49,7 +49,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
 
 def example_result_image_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """ResultImage: Over Time Slider."""
-    run_cfg = run_cfg or bn.BenchRunCfg()
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
     run_cfg.over_time = True
     benchable = PolygonRenderer()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -425,12 +425,13 @@ class BenchMetaGen(bn.ParametrizedSweep):
                 time_offset=True,
             )
 
-            run_cfg_lines = ["run_cfg.over_time = True"]
+            defaults_kw = ""
             if self.sample_with_repeats > 1:
-                run_cfg_lines.append(f"run_cfg.repeats = {self.sample_with_repeats}")
+                defaults_kw = f", repeats={self.sample_with_repeats}"
 
             body = (
-                "run_cfg = run_cfg or bn.BenchRunCfg()\n" + "\n".join(run_cfg_lines) + "\n"
+                f"run_cfg = bn.BenchRunCfg.with_defaults(run_cfg{defaults_kw})\n"
+                "run_cfg.over_time = True\n"
                 f"benchable = {info['class_name']}()\n"
                 f"bench = benchable.to_bench(run_cfg)\n"
                 f"_base_time = datetime(2000, 1, 1)\n"

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -71,7 +71,7 @@ class NoisySensor(bn.ParametrizedSweep):
             self.reading += random.gauss(0, self.noise_scale)
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
 
 # run_tag partitions the cache so different experiment runs don't collide.
 run_cfg.run_tag = "sensor_v1"
@@ -80,7 +80,6 @@ run_cfg.run_tag = "sensor_v1"
 # benchmarks that might be interrupted.
 run_cfg.cache_samples = True
 run_cfg.clear_sample_cache = True
-run_cfg.repeats = 5
 
 bench = NoisySensor().to_bench(run_cfg)
 bench.plot_sweep(
@@ -132,7 +131,7 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
         self.throughput = base + self._event_idx * 30
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
 run_cfg.over_time = True
 
 benchable = PullRequestBenchmark()
@@ -190,7 +189,7 @@ class ServerLatency(bn.ParametrizedSweep):
         self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
 run_cfg.over_time = True
 
 bench = ServerLatency().to_bench(run_cfg)
@@ -244,7 +243,7 @@ class LatencyMonitor(bn.ParametrizedSweep):
         self.latency = base + self._drift + random.gauss(0, 5)
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
 run_cfg.over_time = True
 
 # Keep only the 3 most recent time slices in the cache.
@@ -360,7 +359,7 @@ class ThermalPlate(bn.ParametrizedSweep):
         )
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
 run_cfg.over_time = True
 
 benchable = ThermalPlate()

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -261,7 +261,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
             ["import bencher as bn", "from datetime import datetime, timedelta"] + _EXTRA_IMPORTS
         )
         body = (
-            "run_cfg = run_cfg or bn.BenchRunCfg()\n"
+            "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)\n"
             "run_cfg.over_time = True\n"
             "benchable = PolygonRenderer()\n"
             "bench = benchable.to_bench(run_cfg)\n"

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -182,9 +182,8 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
         )
 
         body_lines = [
-            "run_cfg = run_cfg or bn.BenchRunCfg()",
+            "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)",
             "run_cfg.over_time = True",
-            "run_cfg.repeats = 3",
             "benchable = ServerOptimizer()",
             "bench = benchable.to_bench(run_cfg)",
             "_base_time = datetime(2000, 1, 1)",
@@ -248,9 +247,8 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
             )
 
             body_lines = [
-                "run_cfg = run_cfg or bn.BenchRunCfg()",
+                "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)",
                 "run_cfg.over_time = True",
-                "run_cfg.repeats = 3",
                 "benchable = AlgorithmBench()",
                 "bench = benchable.to_bench(run_cfg)",
                 "_base_time = datetime(2000, 1, 1)",

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -72,7 +72,7 @@ bench.plot_sweep(
         imports = "import bencher as bn"
 
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
 run_cfg.over_time = True
 run_cfg.auto_plot = False
 time_src = bn.git_time_event()

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -52,9 +52,8 @@ class ServerBenchmark(bn.ParametrizedSweep):
         self.throughput = 1000.0 / self.response_time
         return super().__call__()'''
         body = """\
-run_cfg = run_cfg or bn.BenchRunCfg()
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.over_time = True
-run_cfg.repeats = 2
 run_cfg.regression_detection = True
 run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 
         body_lines = []
         if run_cfg_lines:
-            body_lines.append("run_cfg = run_cfg or bn.BenchRunCfg()")
+            body_lines.append("run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)")
             body_lines.extend(run_cfg_lines)
 
         body_lines.append(f"bench = {benchable_class}().to_bench(run_cfg)")


### PR DESCRIPTION
## Summary
- Add `BenchRunCfg.with_defaults(run_cfg, **defaults)` classmethod that returns `run_cfg` unchanged if provided, or creates a new instance with the given defaults
- Fix bug where `bn.run(example_fn, repeats=20)` had its `repeats=20` silently overwritten by example functions that hardcoded `run_cfg.repeats = 5`
- Update 12 hand-written examples, 7 code generators, and regenerate all ~40 generated examples to use the new pattern

## Details

**Before (bug):**
```python
def example_self_benchmark(run_cfg=None):
    run_cfg = run_cfg or bn.BenchRunCfg()
    run_cfg.repeats = 5  # always overwrites caller's value
```

**After (fix):**
```python
def example_self_benchmark(run_cfg=None):
    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)  # respects caller
```

Required settings like `run_cfg.over_time = True` remain as unconditional assignments since they're necessary for functionality — only "soft defaults" (repeats, level) use `with_defaults`.

## Test plan
- [x] `pixi run ci` passes (897 tests, 0 failures)
- [x] `pixi run generate-docs` regenerates all examples successfully
- [x] Verified generated files use new `with_defaults` pattern
- [x] No old `run_cfg = run_cfg or bn.BenchRunCfg()` pattern remains in generated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)