### PR TITLE
perf: batch cross-process hash tests (26 → 2 subprocesses)

### DIFF
--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -303,50 +303,29 @@ class TestBenchCfgHashStability:
 # This preserves the cross-process guarantee while cutting ~95s of import overhead.
 # ---------------------------------------------------------------------------
 
-# Class names tested for cross-process hash stability
-_CROSS_PROCESS_CLASSES = [
-    "ResultVar",
-    "ResultBool",
-    "ResultVec",
-    "ResultHmap",
-    "ResultPath",
-    "ResultVideo",
-    "ResultImage",
-    "ResultString",
-    "ResultContainer",
-    "ResultReference",
-    "ResultDataSet",
-    "ResultVolume",
-]
+# Class names tested for cross-process hash stability — derived from auto-discovery
+# so new Result* classes are automatically included.
+_CROSS_PROCESS_CLASSES = sorted(cls.__name__ for cls in ALL_DISCOVERED_CLASSES)
 
 _BATCH_HASH_SCRIPT = textwrap.dedent("""\
+    import inspect
     import json
-    from bencher.variables.results import (
-        ResultVar, ResultBool, ResultVec, ResultHmap, ResultPath,
-        ResultVideo, ResultImage, ResultString, ResultContainer,
-        ResultReference, ResultDataSet, ResultVolume,
-    )
+    import param
+    import bencher.variables.results as results_module
+    from bencher.variables.results import ResultVec, ResultVar, ResultImage
     from bencher.bench_cfg import BenchCfg
 
     hashes = {}
 
-    # Individual result classes — same args as the previous per-class tests
-    cases = [
-        ("ResultVar", ResultVar(units="ul", doc="test")),
-        ("ResultBool", ResultBool(units="ratio", doc="test")),
-        ("ResultVec", ResultVec(size=3, units="ul", doc="test")),
-        ("ResultHmap", ResultHmap(doc="test")),
-        ("ResultPath", ResultPath(doc="test")),
-        ("ResultVideo", ResultVideo(doc="test")),
-        ("ResultImage", ResultImage(doc="test")),
-        ("ResultString", ResultString(doc="test")),
-        ("ResultContainer", ResultContainer(doc="test")),
-        ("ResultReference", ResultReference(doc="test")),
-        ("ResultDataSet", ResultDataSet(doc="test")),
-        ("ResultVolume", ResultVolume(doc="test")),
-    ]
-    for name, instance in cases:
-        hashes[name] = instance.hash_persistent()
+    # Auto-discover all Result* classes (mirrors parent process discovery)
+    for name, cls in inspect.getmembers(results_module, inspect.isclass):
+        if (
+            name.startswith("Result")
+            and issubclass(cls, param.Parameter)
+            and cls.__module__ == results_module.__name__
+        ):
+            instance = cls(size=3, units="ul", doc="test") if cls is ResultVec else cls(doc="test")
+            hashes[name] = instance.hash_persistent()
 
     # BenchCfg composite hash
     cfg = BenchCfg()
@@ -403,14 +382,21 @@ class TestCrossProcessDeterminism:
     """
 
     @pytest.mark.parametrize("cls_name", _CROSS_PROCESS_CLASSES)
-    def test_hash_stable_across_two_processes(self, cross_process_hashes, cls_name):
+    def test_hash_stable_across_two_processes(
+        self,
+        cross_process_hashes,  # pylint: disable=redefined-outer-name
+        cls_name,
+    ):
         hashes_a, hashes_b = cross_process_hashes
         assert hashes_a[cls_name] == hashes_b[cls_name], (
             f"{cls_name}.hash_persistent() differs across processes: "
             f"{hashes_a[cls_name]!r} != {hashes_b[cls_name]!r}"
         )
 
-    def test_bench_cfg_hash_stable_across_processes(self, cross_process_hashes):
+    def test_bench_cfg_hash_stable_across_processes(
+        self,
+        cross_process_hashes,  # pylint: disable=redefined-outer-name
+    ):
         """End-to-end: BenchCfg cache key must be identical across processes."""
         hashes_a, hashes_b = cross_process_hashes
         assert hashes_a["BenchCfg"] == hashes_b["BenchCfg"], (

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -14,6 +14,7 @@ Key guarantees enforced by these tests:
 """
 
 import inspect
+import json
 import subprocess
 import sys
 import textwrap
@@ -294,33 +295,98 @@ class TestBenchCfgHashStability:
         ), "BenchCfg hash should not change when only excluded obj fields differ"
 
 
-# Script template for cross-process tests. Each subprocess imports the class,
-# constructs an instance, and prints its hash. The parent compares hashes from
-# two independent processes to verify they match.
-_SUBPROCESS_HASH_SCRIPT = textwrap.dedent("""\
-    from bencher.variables.results import {cls_name}
-    {extra}
-    r = {cls_name}({args})
-    print(r.hash_persistent())
+# ---------------------------------------------------------------------------
+# Cross-process hash tests — batched for performance
+#
+# Instead of spawning 2 subprocesses per result class (26 total), we spawn
+# exactly 2 subprocesses that each compute ALL hashes and return them as JSON.
+# This preserves the cross-process guarantee while cutting ~95s of import overhead.
+# ---------------------------------------------------------------------------
+
+# Class names tested for cross-process hash stability
+_CROSS_PROCESS_CLASSES = [
+    "ResultVar",
+    "ResultBool",
+    "ResultVec",
+    "ResultHmap",
+    "ResultPath",
+    "ResultVideo",
+    "ResultImage",
+    "ResultString",
+    "ResultContainer",
+    "ResultReference",
+    "ResultDataSet",
+    "ResultVolume",
+]
+
+_BATCH_HASH_SCRIPT = textwrap.dedent("""\
+    import json
+    from bencher.variables.results import (
+        ResultVar, ResultBool, ResultVec, ResultHmap, ResultPath,
+        ResultVideo, ResultImage, ResultString, ResultContainer,
+        ResultReference, ResultDataSet, ResultVolume,
+    )
+    from bencher.bench_cfg import BenchCfg
+
+    hashes = {}
+
+    # Individual result classes — same args as the previous per-class tests
+    cases = [
+        ("ResultVar", ResultVar(units="ul", doc="test")),
+        ("ResultBool", ResultBool(units="ratio", doc="test")),
+        ("ResultVec", ResultVec(size=3, units="ul", doc="test")),
+        ("ResultHmap", ResultHmap(doc="test")),
+        ("ResultPath", ResultPath(doc="test")),
+        ("ResultVideo", ResultVideo(doc="test")),
+        ("ResultImage", ResultImage(doc="test")),
+        ("ResultString", ResultString(doc="test")),
+        ("ResultContainer", ResultContainer(doc="test")),
+        ("ResultReference", ResultReference(doc="test")),
+        ("ResultDataSet", ResultDataSet(doc="test")),
+        ("ResultVolume", ResultVolume(doc="test")),
+    ]
+    for name, instance in cases:
+        hashes[name] = instance.hash_persistent()
+
+    # BenchCfg composite hash
+    cfg = BenchCfg()
+    cfg.bench_name = "test_bench"
+    cfg.title = "Test"
+    cfg.over_time = False
+    cfg.repeats = 1
+    cfg.tag = ""
+    cfg.input_vars = []
+    cfg.result_vars = [ResultVar(units="m/s", doc="speed"), ResultImage(doc="img")]
+    cfg.const_vars = []
+    hashes["BenchCfg"] = cfg.hash_persistent(include_repeats=True)
+
+    print(json.dumps(hashes))
 """)
 
 
-def _hash_in_subprocess(cls_name, args="doc='test'", extra=""):
-    """Spawn a fresh Python process and return the hash_persistent() value."""
-    script = _SUBPROCESS_HASH_SCRIPT.format(
-        cls_name=cls_name,
-        args=args,
-        extra=extra,
-    )
+def _all_hashes_in_subprocess():
+    """Spawn a fresh Python process that computes hashes for all result classes + BenchCfg."""
     result = subprocess.run(
-        [sys.executable, "-c", script],
+        [sys.executable, "-c", _BATCH_HASH_SCRIPT],
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=60,
         check=False,
     )
-    assert result.returncode == 0, f"Subprocess failed for {cls_name}:\n{result.stderr}"
-    return result.stdout.strip()
+    assert result.returncode == 0, f"Batch hash subprocess failed:\n{result.stderr}"
+    return json.loads(result.stdout.strip())
+
+
+@pytest.fixture(scope="class")
+def cross_process_hashes():
+    """Run two independent subprocesses and return both hash dicts.
+
+    Scoped to the class so the 2 subprocess invocations are shared across all
+    parametrized test methods in TestCrossProcessDeterminism.
+    """
+    hashes_a = _all_hashes_in_subprocess()
+    hashes_b = _all_hashes_in_subprocess()
+    return hashes_a, hashes_b
 
 
 class TestCrossProcessDeterminism:
@@ -330,59 +396,24 @@ class TestCrossProcessDeterminism:
     a key, process B must compute the same key to find it. In-process tests cannot
     catch bugs where str(obj) includes the memory address, because the address is
     stable within a single process.
+
+    All hashes are computed in a single batched subprocess call per process,
+    reducing 26 subprocess invocations to 2 while preserving the cross-process
+    guarantee.
     """
 
-    @pytest.mark.parametrize(
-        "cls_name,args",
-        [
-            ("ResultVar", "units='ul', doc='test'"),
-            ("ResultBool", "units='ratio', doc='test'"),
-            ("ResultVec", "size=3, units='ul', doc='test'"),
-            ("ResultHmap", "doc='test'"),
-            ("ResultPath", "doc='test'"),
-            ("ResultVideo", "doc='test'"),
-            ("ResultImage", "doc='test'"),
-            ("ResultString", "doc='test'"),
-            ("ResultContainer", "doc='test'"),
-            ("ResultReference", "doc='test'"),
-            ("ResultDataSet", "doc='test'"),
-            ("ResultVolume", "doc='test'"),
-        ],
-    )
-    def test_hash_stable_across_two_processes(self, cls_name, args):
-        hash_a = _hash_in_subprocess(cls_name, args)
-        hash_b = _hash_in_subprocess(cls_name, args)
-        assert hash_a == hash_b, (
-            f"{cls_name}.hash_persistent() differs across processes: {hash_a!r} != {hash_b!r}"
+    @pytest.mark.parametrize("cls_name", _CROSS_PROCESS_CLASSES)
+    def test_hash_stable_across_two_processes(self, cross_process_hashes, cls_name):
+        hashes_a, hashes_b = cross_process_hashes
+        assert hashes_a[cls_name] == hashes_b[cls_name], (
+            f"{cls_name}.hash_persistent() differs across processes: "
+            f"{hashes_a[cls_name]!r} != {hashes_b[cls_name]!r}"
         )
 
-    def test_bench_cfg_hash_stable_across_processes(self):
+    def test_bench_cfg_hash_stable_across_processes(self, cross_process_hashes):
         """End-to-end: BenchCfg cache key must be identical across processes."""
-        script = textwrap.dedent("""\
-            from bencher.variables.results import ResultImage, ResultVar
-            from bencher.bench_cfg import BenchCfg
-            cfg = BenchCfg()
-            cfg.bench_name = "test_bench"
-            cfg.title = "Test"
-            cfg.over_time = False
-            cfg.repeats = 1
-            cfg.tag = ""
-            cfg.input_vars = []
-            cfg.result_vars = [ResultVar(units="m/s", doc="speed"), ResultImage(doc="img")]
-            cfg.const_vars = []
-            print(cfg.hash_persistent(include_repeats=True))
-        """)
-        hashes = []
-        for _ in range(2):
-            result = subprocess.run(
-                [sys.executable, "-c", script],
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=False,
-            )
-            assert result.returncode == 0, f"Subprocess failed:\n{result.stderr}"
-            hashes.append(result.stdout.strip())
-        assert hashes[0] == hashes[1], (
-            f"BenchCfg.hash_persistent() differs across processes: {hashes[0]!r} != {hashes[1]!r}"
+        hashes_a, hashes_b = cross_process_hashes
+        assert hashes_a["BenchCfg"] == hashes_b["BenchCfg"], (
+            f"BenchCfg.hash_persistent() differs across processes: "
+            f"{hashes_a['BenchCfg']!r} != {hashes_b['BenchCfg']!r}"
         )


### PR DESCRIPTION
## Summary
- The 13 `TestCrossProcessDeterminism` tests were spawning **26 separate Python subprocesses** (2 per test), each paying ~4s of import overhead (panel, holoviews, optuna, xarray) to compute a hash that takes <1ms. This accounted for **~105s (54%) of the total 194s test suite time**.
- Replace with a **single batch script** that computes all 12 Result class hashes + BenchCfg hash in one subprocess call, invoked twice via a `@pytest.fixture(scope="class")`. Reduces subprocess invocations from 26 → 2.
- Cross-process correctness guarantee is fully preserved: two independent Python processes still produce and compare hashes. Individual parametrized test methods still report failures per Result class.

## Test plan
- [x] `pixi run pytest test/test_hash_persistent.py -v` — all 85 tests pass (84 passed, 1 skipped)
- [x] `pixi run pytest` — full suite passes (896 passed, 5 skipped, 1 pre-existing flask port-conflict failure)
- [x] `pixi run format && pixi run ruff-lint` — clean
- [ ] CI performance report should show ~90s reduction in cross-process hash test time

🤖 Generated with [Claude Code](https://claude.com/claude-code)