### PR TITLE
perf: skip redundant dataset copy in to_dataset() for REDUCE/MINMAX

### DIFF
--- a/PERFORMANCE_PLAN.md
+++ b/PERFORMANCE_PLAN.md
@@ -644,10 +644,10 @@ Every change in this plan must pass:
 | **P0** | 1.3 Default `max_slider_points` to 20 | Trivial | Low | **High** — prevents superlinear embed cost for long histories | **DONE** (v1.72.1, default=10) |
 | **P1** | 1.5 Profile Panel embed hotspots | Medium | None | **Critical** — informs all other report.save() optimizations | |
 | **P1** | 1.4 Use `embed_json` for external patch files | Medium | Medium | **High** — reduces HTML size and may improve serialization speed | |
-| **P1** | 1.6 Skip Spread on per-time-point renders | Low | Low | **Moderate** — reduces per-slider-position render cost | |
+| **P1** | 1.6 Skip Spread on per-time-point renders | Low | Low | **Moderate** — reduces per-slider-position render cost | **Won't do** — Spread bands on per-time-point renders provide useful information |
 | **P1** | 2.1 Deduplicate `plot_sweep()` copies | Low | Low | Moderate | **DONE** (single-copy pattern in place) |
 | **P1** | 2.5 Filter-then-copy kwargs | Low | Low | High for large sweeps | **DONE** (PR #816) |
-| **P1** | 4.1 Avoid dataset copy in `to_dataset()` | Medium | High | High | |
+| **P1** | 4.1 Avoid dataset copy in `to_dataset()` | Medium | High | High | **DONE** — skip copy for REDUCE/MINMAX (reductions create new arrays); deep copy only for SQUEEZE/NONE |
 | **P2** | 2.2 Single copy in `BenchRunner.run()` | Medium | Medium | Moderate | |
 | **P2** | 2.3 Lazy Cartesian product | Low | Low-Med | High for large sweeps | **DONE** (PR #811) |
 | **P2** | 3.1 Reuse cache instances | Low | Low | Moderate | **DONE** (PR #813) |

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -221,7 +221,11 @@ class BenchResultBase:
         if reduce == ReduceType.AUTO:
             reduce = ReduceType.REDUCE if self.bench_cfg.repeats > 1 else ReduceType.SQUEEZE
 
-        ds_out = self.ds.copy()
+        # Avoid an upfront copy for REDUCE/MINMAX — those reductions (.mean(),
+        # .std(), .min(), .max()) always allocate new arrays, so the copy is
+        # wasted.  SQUEEZE and NONE still need a copy because the returned
+        # dataset may share memory with self.ds.
+        ds_out = self.ds
 
         if result_var is not None:
             if isinstance(result_var, Parameter):
@@ -269,10 +273,12 @@ class BenchResultBase:
                     and "repeat" in ds_out.dims
                     and ds_out.sizes["repeat"] == 1
                 ):
-                    # Only squeeze repeat, preserving over_time even if it's length 1
-                    ds_out = ds_out.squeeze("repeat", drop=True)
+                    ds_out = ds_out.squeeze("repeat", drop=True).copy(deep=True)
                 else:
-                    ds_out = ds_out.squeeze(drop=True)
+                    ds_out = ds_out.squeeze(drop=True).copy(deep=True)
+            case _:
+                # ReduceType.NONE — deep copy for mutation safety
+                ds_out = ds_out.copy(deep=True)
 
         # Optional aggregation across non-repeat dimensions (e.g., categorical)
         if agg_over_dims:

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -469,6 +469,23 @@ class TestBenchResultBase(unittest.TestCase):
         title = res.title_from_ds(da, rv)
         self.assertIsInstance(title, str)
 
+    def test_to_dataset_mutation_safety(self):
+        """Mutating the returned dataset must not affect the source self.ds."""
+        res = self._make_1d_result(repeats=2)
+        original_values = res.ds["distance"].values.copy()
+
+        for reduce in (ReduceType.REDUCE, ReduceType.MINMAX, ReduceType.SQUEEZE, ReduceType.NONE):
+            ds = res.to_dataset(reduce=reduce)
+            # Mutate the returned dataset in-place
+            for var in ds.data_vars:
+                ds[var].values[:] = -999.0
+            # Verify source is unaffected
+            np.testing.assert_array_equal(
+                res.ds["distance"].values,
+                original_values,
+                err_msg=f"self.ds mutated after to_dataset(reduce={reduce.name})",
+            )
+
     def test_result_samples(self):
         res = self._make_1d_result()
         samples = res.result_samples()


### PR DESCRIPTION
## Summary
- Skip the upfront `self.ds.copy()` in `to_dataset()` for `REDUCE` and `MINMAX` paths — reductions (`.mean()`, `.std()`, `.min()`, `.max()`) always allocate new arrays, so the copy was wasted
- Fix pre-existing shallow-copy bug: old code used `xr.Dataset.copy()` (defaults to `deep=False`), meaning callers mutating returned values could corrupt `self.ds`. Now `SQUEEZE`/`NONE` use `copy(deep=True)`
- Add mutation safety test covering all `ReduceType` variants
- Update PERFORMANCE_PLAN.md: mark item 4.1 as DONE, item 1.6 as Won't do

## Test plan
- [x] Mutation safety test verifies `self.ds` is unaffected after `to_dataset()` + in-place mutation for all 4 reduce types
- [x] All 917 existing tests pass
- [x] Linting/formatting clean (pylint 10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize bench result dataset conversion by avoiding unnecessary copies for reduction paths while ensuring mutation safety for all reduce modes.

Bug Fixes:
- Ensure to_dataset() returns deep copies for SQUEEZE and NONE reduce modes so mutations do not affect the source dataset.

Enhancements:
- Skip redundant dataset copying for REDUCE and MINMAX reduce types in to_dataset() to improve performance.

Documentation:
- Update PERFORMANCE_PLAN to reflect completed dataset copy optimization and a decision not to skip Spread on per-time-point renders.

Tests:
- Add a mutation safety test that verifies self.ds remains unchanged after mutating datasets returned from to_dataset() across all ReduceType variants.