### PR TITLE
git_time_event: use --short for SHA, fall back to unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.72.2] - 2026-03-23
+
+### Changed
+- `git_time_event()` now uses wall-clock time (`datetime.now()`) instead of commit date, producing labels like `"2024-06-15 14:59 abc1234"` so multiple runs on the same commit get distinct over_time labels
+- `git_time_event()` uses `git rev-parse --short HEAD` for the canonical abbreviated SHA instead of hardcoded `[:8]` slicing
+- `git_time_event()` falls back to `"<timestamp> unknown"` instead of just the timestamp when git is unavailable, keeping the label format consistent
+- Removed the second subprocess call (`git log`) from `git_time_event()`, making it lighter for fork-sensitive environments
+- Increased `wrap_long_time_labels` wrap width from 20 to 30 characters to accommodate the longer time-event label format
+- Docstring documents the recommended import-time caching pattern for fork-safety in threaded environments (ROS 2, DDS, etc.)
+
+### Performance
+- Skip redundant dataset copy in `to_dataset()` for REDUCE/MINMAX paths (#826)
+- Single-pass reduction avoids `xr.merge()` in `to_dataset()` (#824)
+- Replace DataFrame groupby with xarray sel in curve overlay (#822)
+- Batch cross-process hash tests into 2 subprocess invocations (#820)
+- Add comprehensive `.save()` performance benchmark and report (#825)
+
 ## [1.72.1] - 2026-03-22
 
 ### Changed

--- a/bencher/git_info.py
+++ b/bencher/git_info.py
@@ -23,7 +23,7 @@ def _run_git(args: list[str], repo_path: str | None = None) -> str:
 def git_time_event(repo_path: str | None = None) -> str:
     """Return a time-event label combining wall-clock time and short commit hash.
 
-    Example return value: ``"2024-06-15 14:59 abc1234d"``
+    Example return value: ``"2024-06-15 14:59 abc1234"``
 
     Intended to be used with ``BenchRunCfg(over_time=True, time_event=...)``
     so the over-time slider shows *when* and *which commit* produced the data.
@@ -36,12 +36,10 @@ def git_time_event(repo_path: str | None = None) -> str:
 
         _TIME_EVENT = bn.git_time_event()  # safe: no threads yet
 
-    Falls back to just the timestamp if not inside a git repository.
+    Falls back to ``"<timestamp> unknown"`` if not inside a git repository
+    or git is unavailable, keeping the label format consistent.
     """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
 
-    commit = _run_git(["rev-parse", "HEAD"], repo_path)
-    if not commit:
-        return timestamp
-    short = commit[:8]
+    short = _run_git(["rev-parse", "--short", "HEAD"], repo_path) or "unknown"
     return f"{timestamp} {short}"

--- a/bencher/git_info.py
+++ b/bencher/git_info.py
@@ -25,6 +25,10 @@ def git_time_event(repo_path: str | None = None) -> str:
 
     Example return value: ``"2024-06-15 14:59 abc1234"``
 
+    The SHA portion is git's canonical abbreviated hash (``rev-parse --short``),
+    which is typically 7 characters but may be longer in large repositories
+    to avoid ambiguity.
+
     Intended to be used with ``BenchRunCfg(over_time=True, time_event=...)``
     so the over-time slider shows *when* and *which commit* produced the data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.72.1"
+version = "1.72.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_git_info.py
+++ b/test/test_git_info.py
@@ -8,10 +8,10 @@ from bencher.git_info import git_time_event
 
 
 class TestGitTimeEvent(unittest.TestCase):
-    def test_returns_timestamp_and_hash(self):
+    def test_returns_timestamp_and_short_hash(self):
         def fake(cmd, **_kwargs):
             if "rev-parse" in cmd:
-                return b"abc1234def5678901234567890abcdef12345678\n"
+                return b"abc1234\n"
             return b""
 
         with (
@@ -20,23 +20,23 @@ class TestGitTimeEvent(unittest.TestCase):
         ):
             mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
             result = git_time_event()
-        self.assertEqual(result, "2024-06-15 14:59 abc1234d")
+        self.assertEqual(result, "2024-06-15 14:59 abc1234")
 
-    def test_returns_timestamp_outside_repo(self):
+    def test_returns_unknown_outside_repo(self):
         with (
             mock.patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "")),
             mock.patch("bencher.git_info.datetime") as mock_dt,
         ):
             mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
-            self.assertEqual(git_time_event(), "2024-06-15 14:59")
+            self.assertEqual(git_time_event(), "2024-06-15 14:59 unknown")
 
-    def test_returns_timestamp_when_git_not_installed(self):
+    def test_returns_unknown_when_git_not_installed(self):
         with (
             mock.patch("subprocess.check_output", side_effect=FileNotFoundError),
             mock.patch("bencher.git_info.datetime") as mock_dt,
         ):
             mock_dt.now.return_value.strftime.return_value = "2024-06-15 14:59"
-            self.assertEqual(git_time_event(), "2024-06-15 14:59")
+            self.assertEqual(git_time_event(), "2024-06-15 14:59 unknown")
 
     def test_used_as_time_src(self):
         """git_time_event() works as time_src in plot_sweep."""
@@ -52,7 +52,7 @@ class TestGitTimeEvent(unittest.TestCase):
             plot_callbacks=False,
         )
         over_time_val = str(res.ds.coords["over_time"].values[0])
-        self.assertRegex(over_time_val, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} [0-9a-f]{8}")
+        self.assertRegex(over_time_val, r"\d{4}-\d{2}-\d{2} \d{2}:\d{2} [0-9a-f]{7,}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Use `git rev-parse --short HEAD` instead of `rev-parse HEAD` + `[:8]`. `--short` returns git's canonical abbreviated SHA (default 7 chars, ambiguity-aware), matching `git log --oneline` and GitHub UI.
- Fall back to `"unknown"` instead of omitting the SHA when git is unavailable, keeping the `"<timestamp> <token>"` format consistent for downstream display/parsing.

## Test plan
- [x] Unit tests updated for new short hash and `"unknown"` fallback
- [x] Integration test regex updated to accept 7+ char hashes
- [x] Full CI passes (`pixi run ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update git_time_event labels to use Git’s canonical short commit hash and provide a consistent fallback when Git data is unavailable.

Bug Fixes:
- Ensure git_time_event always returns a label including a second token by falling back to an "unknown" placeholder when Git is unavailable.

Enhancements:
- Use git rev-parse --short to generate canonical abbreviated commit hashes in git_time_event and align tests with variable-length short hashes.