### PR TITLE
Gracefully skip optimization when no targets found

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -938,7 +938,7 @@ class Bench(BenchPlotServer):
         tag: str = "",
         run_cfg: BenchRunCfg | None = None,
         plot: bool = True,
-    ) -> OptimizeResult:
+    ) -> OptimizeResult | None:
         """Run optuna optimization directly — no full grid sweep required.
 
         Args:
@@ -994,10 +994,12 @@ class Bench(BenchPlotServer):
         # --- determine optimisation directions --------------------------
         targets = bench_cfg.optuna_targets(as_var=True)
         if not targets:
-            raise ValueError(
+            logging.warning(
                 "No result variables with an optimization direction found. "
-                "Set direction=OptDir.minimize or OptDir.maximize on your ResultVar."
+                "Skipping optimization. Set direction=OptDir.minimize or "
+                "OptDir.maximize on your ResultVar to enable optimization."
             )
+            return None
         directions = [t.direction for t in targets]
         target_names = [t.name for t in targets]
 

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -82,8 +82,8 @@ def run(
 
         def _with_optimise(run_cfg: BenchRunCfg | None = None) -> "Bench":
             bench = _original_target(run_cfg)
-            bench.optimize(n_trials=optimise, plot=False)
-            if bench.results:
+            result = bench.optimize(n_trials=optimise, plot=False)
+            if result is not None and bench.results:
                 bench.report.append(bench.results[-1].to_optuna_plots())
             return bench
 


### PR DESCRIPTION
## Summary
- When `.run(optimise=N)` is called but all result variables have `direction=OptDir.none`, the optimizer now logs a warning and skips instead of raising a `ValueError`
- `optimize()` return type updated to `OptimizeResult | None`
- `run.py` handles `None` return so no optuna plots are appended when optimization was skipped

## Test plan
- [x] All 922 existing tests pass
- [ ] Verify that a sweep with `optimise=10` and all `OptDir.none` result vars logs a warning and completes without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle cases where optimization is requested but no optimizable targets are configured by skipping the optimization instead of raising an error.

Bug Fixes:
- Avoid crashing when optimization is requested but no result variables have an optimization direction by skipping optimization and logging a warning instead.

Enhancements:
- Update the optimize() API to return an optional result to represent skipped optimization and propagate this through the sweep helper so reports and plots are only generated when optimization actually ran.