### PR TITLE
Fix aggregate plot type selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ are:
 | `yaml_` | `yaml/` | format |
 | `publish_` | `publishing/` | example |
 | `rerun_` | `rerun/` | example |
+| `agg_` | `aggregation/` | aggregation form, agg_fn |
 
 **Rules for adding new generators:**
 1. Pick a short, unique section prefix that does not collide with existing prefixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.72.3] - 2026-03-24
 
 ### Fixed
-- `aggregate` parameter in `plot_sweep` now produces the correct plot type for remaining dimensions (e.g. heatmap for 2 remaining floats) instead of always forcing a 1D band plot that collapsed all non-x dimensions
+- `aggregate` parameter in `plot_sweep` now produces the correct plot type for remaining dimensions (e.g. heatmap for 2 remaining floats) instead of always forcing a 1D band plot, collapsing all non-x dimensions
 
 ## [1.72.2] - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.72.3] - 2026-03-24
+
+### Fixed
+- `aggregate` parameter in `plot_sweep` now produces the correct plot type for remaining dimensions (e.g. heatmap for 2 remaining floats) instead of always forcing a 1D band plot that collapsed all non-x dimensions
+
 ## [1.72.2] - 2026-03-23
 
 ### Changed

--- a/bencher/example/generated/aggregation/agg_all.py
+++ b/bencher/example/generated/aggregation/agg_all.py
@@ -1,0 +1,35 @@
+"""Auto-generated example: Aggregate All (True)."""
+
+from typing import Any
+
+import random
+import math
+
+import bencher as bn
+
+class SortComparison(bn.ParametrizedSweep):
+    """Compares sort duration across array sizes and algorithms."""
+
+    array_size = bn.FloatSweep(default=100, bounds=[10, 10000], doc="Array length")
+    algorithm = bn.StringSweep(["quicksort", "mergesort", "heapsort"], doc="Sort algorithm")
+
+    time = bn.ResultVar(units="ms", doc="Sort duration")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
+        self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
+        self.time += random.gauss(0, 0.15 * self.time)
+        return super().__call__()
+
+
+def example_agg_all(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Aggregate All (True)."""
+    bench = SortComparison().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=['array_size', 'algorithm'], result_vars=['time'], description='Setting aggregate=True collapses every input dimension, giving a single scalar summary. Useful when you want one headline number from a multi-dimensional sweep.', post_description='The aggregated view collapses all inputs into a single mean ± std. The non-aggregated view below shows the full detail.', aggregate=True)
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_agg_all, level=4, repeats=3)

--- a/bencher/example/generated/aggregation/agg_all.py
+++ b/bencher/example/generated/aggregation/agg_all.py
@@ -7,6 +7,7 @@ import math
 
 import bencher as bn
 
+
 class SortComparison(bn.ParametrizedSweep):
     """Compares sort duration across array sizes and algorithms."""
 
@@ -26,7 +27,13 @@ class SortComparison(bn.ParametrizedSweep):
 def example_agg_all(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate All (True)."""
     bench = SortComparison().to_bench(run_cfg)
-    bench.plot_sweep(input_vars=['array_size', 'algorithm'], result_vars=['time'], description='Setting aggregate=True collapses every input dimension, giving a single scalar summary. Useful when you want one headline number from a multi-dimensional sweep.', post_description='The aggregated view collapses all inputs into a single mean ± std. The non-aggregated view below shows the full detail.', aggregate=True)
+    bench.plot_sweep(
+        input_vars=["array_size", "algorithm"],
+        result_vars=["time"],
+        description="Setting aggregate=True collapses every input dimension, giving a single scalar summary. Useful when you want one headline number from a multi-dimensional sweep.",
+        post_description="The aggregated view collapses all inputs into a single mean ± std. The non-aggregated view below shows the full detail.",
+        aggregate=True,
+    )
 
     return bench
 

--- a/bencher/example/generated/aggregation/agg_fn_max.py
+++ b/bencher/example/generated/aggregation/agg_fn_max.py
@@ -7,6 +7,7 @@ import math
 
 import bencher as bn
 
+
 class CompressionCodec(bn.ParametrizedSweep):
     """Compression ratio across block size, entropy, and codec."""
 
@@ -19,7 +20,9 @@ class CompressionCodec(bn.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
-        self.ratio = codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        self.ratio = (
+            codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        )
         self.ratio += random.gauss(0, 0.15 * 0.3)
         return super().__call__()
 
@@ -27,7 +30,14 @@ class CompressionCodec(bn.ParametrizedSweep):
 def example_agg_fn_max(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate with Max."""
     bench = CompressionCodec().to_bench(run_cfg)
-    bench.plot_sweep(input_vars=['block_size', 'entropy', 'codec'], result_vars=['ratio'], description='Combine aggregate=["codec"] with agg_fn="max" to show the best-case (maximum) compression ratio across codecs for each (block_size, entropy) combination.', post_description='Unlike the default mean aggregation, agg_fn="max" picks the best codec at every point. Other options: "min", "sum", "median".', aggregate=['codec'], agg_fn='max')
+    bench.plot_sweep(
+        input_vars=["block_size", "entropy", "codec"],
+        result_vars=["ratio"],
+        description='Combine aggregate=["codec"] with agg_fn="max" to show the best-case (maximum) compression ratio across codecs for each (block_size, entropy) combination.',
+        post_description='Unlike the default mean aggregation, agg_fn="max" picks the best codec at every point. Other options: "min", "sum", "median".',
+        aggregate=["codec"],
+        agg_fn="max",
+    )
 
     return bench
 

--- a/bencher/example/generated/aggregation/agg_fn_max.py
+++ b/bencher/example/generated/aggregation/agg_fn_max.py
@@ -1,0 +1,36 @@
+"""Auto-generated example: Aggregate with Max."""
+
+from typing import Any
+
+import random
+import math
+
+import bencher as bn
+
+class CompressionCodec(bn.ParametrizedSweep):
+    """Compression ratio across block size, entropy, and codec."""
+
+    block_size = bn.FloatSweep(default=4096, bounds=[512, 65536], doc="Block size in bytes")
+    entropy = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Input data entropy")
+    codec = bn.StringSweep(["zlib", "lz4", "zstd"], doc="Compression codec")
+
+    ratio = bn.ResultVar(units="x", doc="Compression ratio")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
+        self.ratio = codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        self.ratio += random.gauss(0, 0.15 * 0.3)
+        return super().__call__()
+
+
+def example_agg_fn_max(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Aggregate with Max."""
+    bench = CompressionCodec().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=['block_size', 'entropy', 'codec'], result_vars=['ratio'], description='Combine aggregate=["codec"] with agg_fn="max" to show the best-case (maximum) compression ratio across codecs for each (block_size, entropy) combination.', post_description='Unlike the default mean aggregation, agg_fn="max" picks the best codec at every point. Other options: "min", "sum", "median".', aggregate=['codec'], agg_fn='max')
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_agg_fn_max, level=4, repeats=3)

--- a/bencher/example/generated/aggregation/agg_int.py
+++ b/bencher/example/generated/aggregation/agg_int.py
@@ -1,0 +1,37 @@
+"""Auto-generated example: Aggregate Last N (int)."""
+
+from typing import Any
+
+import random
+import math
+
+import bencher as bn
+
+class SortAnalysis(bn.ParametrizedSweep):
+    """Sort analysis across size, algorithm, and data distribution."""
+
+    array_size = bn.FloatSweep(default=100, bounds=[10, 10000], doc="Array length")
+    algorithm = bn.StringSweep(["quicksort", "mergesort", "heapsort"], doc="Sort algorithm")
+    distribution = bn.StringSweep(["uniform", "sorted", "reversed"], doc="Data distribution")
+
+    time = bn.ResultVar(units="ms", doc="Sort duration")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
+        dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
+        self.time = algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
+        self.time += random.gauss(0, 0.15 * self.time)
+        return super().__call__()
+
+
+def example_agg_int(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Aggregate Last N (int)."""
+    bench = SortAnalysis().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=['array_size', 'algorithm', 'distribution'], result_vars=['time'], description='Setting aggregate=1 collapses the last 1 input dimension (distribution). The remaining dimensions (array_size, algorithm) produce a line plot faceted by algorithm.', post_description='The aggregated view averages over the distribution dimension. Use aggregate=N to collapse the last N dimensions in the input variable list.', aggregate=1)
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_agg_int, level=4, repeats=3)

--- a/bencher/example/generated/aggregation/agg_int.py
+++ b/bencher/example/generated/aggregation/agg_int.py
@@ -7,6 +7,7 @@ import math
 
 import bencher as bn
 
+
 class SortAnalysis(bn.ParametrizedSweep):
     """Sort analysis across size, algorithm, and data distribution."""
 
@@ -20,7 +21,9 @@ class SortAnalysis(bn.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
-        self.time = algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
+        self.time = (
+            algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
+        )
         self.time += random.gauss(0, 0.15 * self.time)
         return super().__call__()
 
@@ -28,7 +31,13 @@ class SortAnalysis(bn.ParametrizedSweep):
 def example_agg_int(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate Last N (int)."""
     bench = SortAnalysis().to_bench(run_cfg)
-    bench.plot_sweep(input_vars=['array_size', 'algorithm', 'distribution'], result_vars=['time'], description='Setting aggregate=1 collapses the last 1 input dimension (distribution). The remaining dimensions (array_size, algorithm) produce a line plot faceted by algorithm.', post_description='The aggregated view averages over the distribution dimension. Use aggregate=N to collapse the last N dimensions in the input variable list.', aggregate=1)
+    bench.plot_sweep(
+        input_vars=["array_size", "algorithm", "distribution"],
+        result_vars=["time"],
+        description="Setting aggregate=1 collapses the last 1 input dimension (distribution). The remaining dimensions (array_size, algorithm) produce a line plot faceted by algorithm.",
+        post_description="The aggregated view averages over the distribution dimension. Use aggregate=N to collapse the last N dimensions in the input variable list.",
+        aggregate=1,
+    )
 
     return bench
 

--- a/bencher/example/generated/aggregation/agg_list_1_cat.py
+++ b/bencher/example/generated/aggregation/agg_list_1_cat.py
@@ -7,6 +7,7 @@ import math
 
 import bencher as bn
 
+
 class CompressionCodec(bn.ParametrizedSweep):
     """Compression ratio across block size, entropy, and codec."""
 
@@ -19,7 +20,9 @@ class CompressionCodec(bn.ParametrizedSweep):
     def __call__(self, **kwargs: Any) -> Any:
         self.update_params_from_kwargs(**kwargs)
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
-        self.ratio = codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        self.ratio = (
+            codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        )
         self.ratio += random.gauss(0, 0.15 * 0.3)
         return super().__call__()
 
@@ -27,7 +30,13 @@ class CompressionCodec(bn.ParametrizedSweep):
 def example_agg_list_1_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate by Name (list)."""
     bench = CompressionCodec().to_bench(run_cfg)
-    bench.plot_sweep(input_vars=['block_size', 'entropy', 'codec'], result_vars=['ratio'], description='Aggregate a specific dimension by name using aggregate=["codec"]. The codec categorical is averaged out, leaving a 2D heatmap of block_size vs entropy. This is the most explicit form — you list exactly which dimensions to collapse.', post_description='The aggregated view shows a heatmap because two float dimensions remain after collapsing codec. The non-aggregated view below shows the full faceted heatmaps (one per codec).', aggregate=['codec'])
+    bench.plot_sweep(
+        input_vars=["block_size", "entropy", "codec"],
+        result_vars=["ratio"],
+        description='Aggregate a specific dimension by name using aggregate=["codec"]. The codec categorical is averaged out, leaving a 2D heatmap of block_size vs entropy. This is the most explicit form — you list exactly which dimensions to collapse.',
+        post_description="The aggregated view shows a heatmap because two float dimensions remain after collapsing codec. The non-aggregated view below shows the full faceted heatmaps (one per codec).",
+        aggregate=["codec"],
+    )
 
     return bench
 

--- a/bencher/example/generated/aggregation/agg_list_1_cat.py
+++ b/bencher/example/generated/aggregation/agg_list_1_cat.py
@@ -1,0 +1,36 @@
+"""Auto-generated example: Aggregate by Name (list)."""
+
+from typing import Any
+
+import random
+import math
+
+import bencher as bn
+
+class CompressionCodec(bn.ParametrizedSweep):
+    """Compression ratio across block size, entropy, and codec."""
+
+    block_size = bn.FloatSweep(default=4096, bounds=[512, 65536], doc="Block size in bytes")
+    entropy = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Input data entropy")
+    codec = bn.StringSweep(["zlib", "lz4", "zstd"], doc="Compression codec")
+
+    ratio = bn.ResultVar(units="x", doc="Compression ratio")
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
+        self.ratio = codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
+        self.ratio += random.gauss(0, 0.15 * 0.3)
+        return super().__call__()
+
+
+def example_agg_list_1_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Aggregate by Name (list)."""
+    bench = CompressionCodec().to_bench(run_cfg)
+    bench.plot_sweep(input_vars=['block_size', 'entropy', 'codec'], result_vars=['ratio'], description='Aggregate a specific dimension by name using aggregate=["codec"]. The codec categorical is averaged out, leaving a 2D heatmap of block_size vs entropy. This is the most explicit form — you list exactly which dimensions to collapse.', post_description='The aggregated view shows a heatmap because two float dimensions remain after collapsing codec. The non-aggregated view below shows the full faceted heatmaps (one per codec).', aggregate=['codec'])
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_agg_list_1_cat, level=4, repeats=3)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -119,6 +119,7 @@ def generate_python_files():
     from bencher.example.meta.generate_meta_performance import example_meta_performance
     from bencher.example.meta.generate_meta_publish import example_meta_publish
     from bencher.example.meta.generate_meta_rerun import example_meta_rerun
+    from bencher.example.meta.generate_meta_aggregation import example_meta_aggregation
 
     example_meta()
     example_meta_result_types()
@@ -139,6 +140,7 @@ def generate_python_files():
     example_meta_performance()
     example_meta_publish()
     example_meta_rerun()
+    example_meta_aggregation()
 
     # Write __init__.py files so generated examples are importable
     for d in GENERATED_DIR.rglob("*"):
@@ -415,6 +417,7 @@ SECTION_GROUPS = [
             ("Bool Plot Types", "bool_plot_types"),
             ("Sampling Strategies", "sampling"),
             ("Composable Containers", "composable_containers"),
+            ("Aggregation", "aggregation"),
             ("Constant Variables", "const_vars"),
             ("Statistics", "statistics"),
             ("Workflows", "workflows"),

--- a/bencher/example/meta/generate_meta_aggregation.py
+++ b/bencher/example/meta/generate_meta_aggregation.py
@@ -1,0 +1,127 @@
+"""Meta-generator for aggregation examples.
+
+Produces examples that demonstrate the ``aggregate`` parameter of ``plot_sweep``
+in its various forms (list of dim names, True, int) and with different ``agg_fn``
+options. Each example reuses a class definition from the main sweep registry.
+"""
+
+from bencher.example.meta.meta_generator_base import MetaGeneratorBase
+from bencher.example.meta.generate_meta import INLINE_CLASSES, _build_class_code
+
+
+def example_meta_aggregation():
+    """Generate aggregation example files."""
+    gen = MetaGeneratorBase()
+
+    # ---- 1) aggregate=["codec"]: 2 float + 1 cat → heatmap (codec averaged out) ----
+    info = INLINE_CLASSES[(2, 1)]
+    class_code = _build_class_code(info, 2, 1, noise_val=0.15)
+    gen.generate_sweep_example(
+        title="Aggregate by Name (list)",
+        output_dir="aggregation",
+        filename="agg_list_1_cat",
+        function_name="example_agg_list_1_cat",
+        benchable_class=info["class_name"],
+        benchable_module=None,
+        input_vars="['block_size', 'entropy', 'codec']",
+        result_vars="['ratio']",
+        class_code=class_code,
+        extra_imports=["import random", "import math"],
+        description=(
+            "Aggregate a specific dimension by name using aggregate=[\"codec\"]. "
+            "The codec categorical is averaged out, leaving a 2D heatmap of "
+            "block_size vs entropy. This is the most explicit form — you list "
+            "exactly which dimensions to collapse."
+        ),
+        post_description=(
+            "The aggregated view shows a heatmap because two float dimensions "
+            "remain after collapsing codec. The non-aggregated view below "
+            "shows the full faceted heatmaps (one per codec)."
+        ),
+        aggregate=["codec"],
+        run_kwargs={"level": 4, "repeats": 3},
+    )
+
+    # ---- 2) aggregate=True: 1 float + 1 cat → all dims collapsed → bar ----
+    info = INLINE_CLASSES[(1, 1)]
+    class_code = _build_class_code(info, 1, 1, noise_val=0.15)
+    gen.generate_sweep_example(
+        title="Aggregate All (True)",
+        output_dir="aggregation",
+        filename="agg_all",
+        function_name="example_agg_all",
+        benchable_class=info["class_name"],
+        benchable_module=None,
+        input_vars="['array_size', 'algorithm']",
+        result_vars="['time']",
+        class_code=class_code,
+        extra_imports=["import random", "import math"],
+        description=(
+            "Setting aggregate=True collapses every input dimension, giving a "
+            "single scalar summary. Useful when you want one headline number "
+            "from a multi-dimensional sweep."
+        ),
+        post_description=(
+            "The aggregated view collapses all inputs into a single mean ± std. "
+            "The non-aggregated view below shows the full detail."
+        ),
+        aggregate=True,
+        run_kwargs={"level": 4, "repeats": 3},
+    )
+
+    # ---- 3) aggregate=1: 1 float + 2 cat → last cat collapsed → line + 1 cat ----
+    info = INLINE_CLASSES[(1, 2)]
+    class_code = _build_class_code(info, 1, 2, noise_val=0.15)
+    gen.generate_sweep_example(
+        title="Aggregate Last N (int)",
+        output_dir="aggregation",
+        filename="agg_int",
+        function_name="example_agg_int",
+        benchable_class=info["class_name"],
+        benchable_module=None,
+        input_vars="['array_size', 'algorithm', 'distribution']",
+        result_vars="['time']",
+        class_code=class_code,
+        extra_imports=["import random", "import math"],
+        description=(
+            "Setting aggregate=1 collapses the last 1 input dimension "
+            "(distribution). The remaining dimensions (array_size, algorithm) "
+            "produce a line plot faceted by algorithm."
+        ),
+        post_description=(
+            "The aggregated view averages over the distribution dimension. "
+            "Use aggregate=N to collapse the last N dimensions in the input "
+            "variable list."
+        ),
+        aggregate=1,
+        run_kwargs={"level": 4, "repeats": 3},
+    )
+
+    # ---- 4) aggregate + agg_fn="max": 2 float + 1 cat → heatmap of max ----
+    info = INLINE_CLASSES[(2, 1)]
+    class_code = _build_class_code(info, 2, 1, noise_val=0.15)
+    gen.generate_sweep_example(
+        title="Aggregate with Max",
+        output_dir="aggregation",
+        filename="agg_fn_max",
+        function_name="example_agg_fn_max",
+        benchable_class=info["class_name"],
+        benchable_module=None,
+        input_vars="['block_size', 'entropy', 'codec']",
+        result_vars="['ratio']",
+        class_code=class_code,
+        extra_imports=["import random", "import math"],
+        description=(
+            "Combine aggregate=[\"codec\"] with agg_fn=\"max\" to show the "
+            "best-case (maximum) compression ratio across codecs for each "
+            "(block_size, entropy) combination."
+        ),
+        post_description=(
+            "Unlike the default mean aggregation, agg_fn=\"max\" picks the "
+            "best codec at every point. Other options: \"min\", \"sum\", "
+            "\"median\"."
+        ),
+        aggregate=["codec"],
+        agg_fn="max",
+        run_kwargs={"level": 4, "repeats": 3},
+    )

--- a/bencher/example/meta/generate_meta_aggregation.py
+++ b/bencher/example/meta/generate_meta_aggregation.py
@@ -28,7 +28,7 @@ def example_meta_aggregation():
         class_code=class_code,
         extra_imports=["import random", "import math"],
         description=(
-            "Aggregate a specific dimension by name using aggregate=[\"codec\"]. "
+            'Aggregate a specific dimension by name using aggregate=["codec"]. '
             "The codec categorical is averaged out, leaving a 2D heatmap of "
             "block_size vs entropy. This is the most explicit form — you list "
             "exactly which dimensions to collapse."
@@ -112,14 +112,14 @@ def example_meta_aggregation():
         class_code=class_code,
         extra_imports=["import random", "import math"],
         description=(
-            "Combine aggregate=[\"codec\"] with agg_fn=\"max\" to show the "
+            'Combine aggregate=["codec"] with agg_fn="max" to show the '
             "best-case (maximum) compression ratio across codecs for each "
             "(block_size, entropy) combination."
         ),
         post_description=(
-            "Unlike the default mean aggregation, agg_fn=\"max\" picks the "
-            "best codec at every point. Other options: \"min\", \"sum\", "
-            "\"median\"."
+            'Unlike the default mean aggregation, agg_fn="max" picks the '
+            'best codec at every point. Other options: "min", "sum", '
+            '"median".'
         ),
         aggregate=["codec"],
         agg_fn="max",

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -90,6 +90,8 @@ if __name__ == "__main__":
         extra_imports=None,
         run_kwargs=None,
         module_docstring=None,
+        aggregate=None,
+        agg_fn=None,
     ):
         """Build imports + body and call generate_example() for a standard sweep.
 
@@ -163,6 +165,10 @@ if __name__ == "__main__":
             sweep_parts.append(f"description={description!r}")
         if post_description:
             sweep_parts.append(f"post_description={post_description!r}")
+        if aggregate is not None:
+            sweep_parts.append(f"aggregate={aggregate!r}")
+        if agg_fn is not None:
+            sweep_parts.append(f"agg_fn={agg_fn!r}")
         sweep_args = ", ".join(sweep_parts)
 
         use_res = post_sweep_line is not None

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -213,11 +213,7 @@ class BenchResult(
         plot_cols.append(self.to_sweep_summary(name="Plots View"))
         if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:
             dims = ", ".join(self.bench_cfg.agg_over_dims)
-            plot_cols.append(
-                pn.pane.Markdown(
-                    f"### Aggregated View\nAggregated over: **{dims}**"
-                )
-            )
+            plot_cols.append(pn.pane.Markdown(f"### Aggregated View\nAggregated over: **{dims}**"))
             plot_cols.append(
                 self.to_auto(
                     agg_over_dims=self.bench_cfg.agg_over_dims,

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -195,9 +195,7 @@ class BenchResult(
 
         self.plt_cnt_cfg.print_debug = True
         if len(row.pane) == 0:
-            row.append(
-                pn.pane.Markdown("No Plotters are able to represent these results", **kwargs)
-            )
+            row.append(pn.pane.Markdown("No Plotters are able to represent these results"))
         return row.pane
 
     def to_auto_plots(self, **kwargs) -> pn.panel:
@@ -214,11 +212,12 @@ class BenchResult(
         if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:
             dims = ", ".join(self.bench_cfg.agg_over_dims)
             plot_cols.append(pn.pane.Markdown(f"### Aggregated View\nAggregated over: **{dims}**"))
+            agg_kwargs = {k: v for k, v in kwargs.items() if k not in ("agg_over_dims", "agg_fn")}
             plot_cols.append(
                 self.to_auto(
                     agg_over_dims=self.bench_cfg.agg_over_dims,
                     agg_fn=self.bench_cfg.agg_fn,
-                    **kwargs,
+                    **agg_kwargs,
                 )
             )
         plot_cols.append(self.to_auto(**kwargs))

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -215,10 +215,16 @@ class BenchResult(
             dims = ", ".join(self.bench_cfg.agg_over_dims)
             plot_cols.append(
                 pn.pane.Markdown(
-                    f"### Aggregated View\nMean and percentile bands aggregated over: **{dims}**"
+                    f"### Aggregated View\nAggregated over: **{dims}**"
                 )
             )
-            plot_cols.append(self.to(BandResult, aggregate=self.bench_cfg.agg_over_dims))
+            plot_cols.append(
+                self.to_auto(
+                    agg_over_dims=self.bench_cfg.agg_over_dims,
+                    agg_fn=self.bench_cfg.agg_fn,
+                    **kwargs,
+                )
+            )
         plot_cols.append(self.to_auto(**kwargs))
         plot_cols.append(self.bench_cfg.to_post_description())
         return plot_cols

--- a/pixi.lock
+++ b/pixi.lock
@@ -157,7 +157,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/5c/2c189d18d495dd0fa3f27ccc60762bbc787eed95b9b0147266e72bb76585/xyzservices-2025.11.0-py3-none-any.whl
@@ -322,7 +322,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/5c/2c189d18d495dd0fa3f27ccc60762bbc787eed95b9b0147266e72bb76585/xyzservices-2025.11.0-py3-none-any.whl
@@ -485,7 +485,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/5c/2c189d18d495dd0fa3f27ccc60762bbc787eed95b9b0147266e72bb76585/xyzservices-2025.11.0-py3-none-any.whl
@@ -648,7 +648,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/5c/2c189d18d495dd0fa3f27ccc60762bbc787eed95b9b0147266e72bb76585/xyzservices-2025.11.0-py3-none-any.whl
@@ -810,7 +810,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/5c/2c189d18d495dd0fa3f27ccc60762bbc787eed95b9b0147266e72bb76585/xyzservices-2025.11.0-py3-none-any.whl
@@ -1269,8 +1269,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.72.1
-  sha256: 5216f411cc19fd6b54943627388c4aa3c6ef230834061c5549908b2bd253b3d6
+  version: 1.72.3
+  sha256: 32635dde1d541cb3ee44f821e5c02e5fdfe98622e673a40a7db7a3c14d1b26ac
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -2035,6 +2035,7 @@ packages:
   constrains:
   - binutils_impl_linux-64 2.45.1
   license: GPL-3.0-only
+  license_family: GPL
   purls: []
   size: 728002
   timestamp: 1774197446916
@@ -4479,10 +4480,10 @@ packages:
   name: webencodings
   version: 0.5.1
   sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
-- pypi: https://files.pythonhosted.org/packages/4d/ec/d58832f89ede95652fd01f4f24236af7d32b70cab2196dfcc2d2fd13c5c2/werkzeug-3.1.6-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7f/b2/0bba9bbb4596d2d2f285a16c2ab04118f6b957d8441566e1abb892e6a6b2/werkzeug-3.1.7-py3-none-any.whl
   name: werkzeug
-  version: 3.1.6
-  sha256: 7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131
+  version: 3.1.7
+  sha256: 4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f
   requires_dist:
   - markupsafe>=2.1.1
   - watchdog>=2.3 ; extra == 'watchdog'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.72.2"
+version = "1.72.3"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- **Bug:** `aggregate=["codec"]` in `plot_sweep` always produced a 1D `BandResult` that collapsed *all* non-x dimensions (including non-aggregated floats like `entropy`), instead of only the requested dims
- **Fix:** Route the aggregated view through `to_auto()` with `agg_over_dims` so the correct plot type is selected based on remaining dimensions (e.g. heatmap for 2 remaining floats, curve for 1, bar for 0)
- Add 4 new aggregation examples demonstrating all `aggregate` parameter forms:
  - `agg_list_1_cat` — `aggregate=["codec"]` (list of dim names) → heatmap
  - `agg_all` — `aggregate=True` (collapse all) → scalar summary
  - `agg_int` — `aggregate=1` (last N dims) → line + facets
  - `agg_fn_max` — `aggregate=["codec"]` + `agg_fn="max"` → heatmap with max
- Add `aggregate`/`agg_fn` support to `generate_sweep_example` in meta generator base
- Register new "Aggregation" gallery section
- Bump version to 1.72.3

## Test plan
- [ ] Run `pixi run python bencher/example/generated/aggregation/agg_list_1_cat.py` — should produce a heatmap (block_size × entropy) with codec averaged out
- [ ] Run `pixi run python bencher/example/generated/aggregation/agg_all.py` — should collapse all dims
- [ ] Run `pixi run python bencher/example/generated/aggregation/agg_int.py` — should collapse last dim only
- [ ] Run `pixi run python bencher/example/generated/aggregation/agg_fn_max.py` — should use max instead of mean
- [ ] Run `pixi run ci` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)