### PR TITLE
Fix aggregate=True to collapse to 1-D instead of scalar

### DIFF
--- a/bencher/example/generated/aggregation/agg_all.py
+++ b/bencher/example/generated/aggregation/agg_all.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Aggregate All (True)."""
+"""Auto-generated example: Aggregate to 1-D (True)."""
 
 from typing import Any
 
@@ -25,13 +25,13 @@ class SortComparison(bn.ParametrizedSweep):
 
 
 def example_agg_all(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Aggregate All (True)."""
+    """Aggregate to 1-D (True)."""
     bench = SortComparison().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["array_size", "algorithm"],
         result_vars=["time"],
-        description="Setting aggregate=True collapses every input dimension, giving a single scalar summary. Useful when you want one headline number from a multi-dimensional sweep.",
-        post_description="The aggregated view collapses all inputs into a single mean ± std. The non-aggregated view below shows the full detail.",
+        description="Setting aggregate=True collapses all but the first input dimension, reducing the sweep to a 1-D plot. Useful when you want a simple curve from a multi-dimensional sweep.",
+        post_description="The aggregated view collapses all inputs except the first into a single mean ± std curve. The non-aggregated view below shows the full detail.",
         aggregate=True,
     )
 

--- a/bencher/example/meta/generate_meta_aggregation.py
+++ b/bencher/example/meta/generate_meta_aggregation.py
@@ -42,11 +42,11 @@ def example_meta_aggregation():
         run_kwargs={"level": 4, "repeats": 3},
     )
 
-    # ---- 2) aggregate=True: 1 float + 1 cat → all dims collapsed → bar ----
+    # ---- 2) aggregate=True: 1 float + 1 cat → collapse to 1-D (keep first) ----
     info = INLINE_CLASSES[(1, 1)]
     class_code = _build_class_code(info, 1, 1, noise_val=0.15)
     gen.generate_sweep_example(
-        title="Aggregate All (True)",
+        title="Aggregate to 1-D (True)",
         output_dir="aggregation",
         filename="agg_all",
         function_name="example_agg_all",
@@ -57,13 +57,14 @@ def example_meta_aggregation():
         class_code=class_code,
         extra_imports=["import random", "import math"],
         description=(
-            "Setting aggregate=True collapses every input dimension, giving a "
-            "single scalar summary. Useful when you want one headline number "
-            "from a multi-dimensional sweep."
+            "Setting aggregate=True collapses all but the first input dimension, "
+            "reducing the sweep to a 1-D plot. Useful when you want a simple "
+            "curve from a multi-dimensional sweep."
         ),
         post_description=(
-            "The aggregated view collapses all inputs into a single mean ± std. "
-            "The non-aggregated view below shows the full detail."
+            "The aggregated view collapses all inputs except the first into a "
+            "single mean ± std curve. The non-aggregated view below shows the "
+            "full detail."
         ),
         aggregate=True,
         run_kwargs={"level": 4, "repeats": 3},

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -212,14 +212,49 @@ class BenchResult(
         if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:
             dims = ", ".join(self.bench_cfg.agg_over_dims)
             plot_cols.append(pn.pane.Markdown(f"### Aggregated View\nAggregated over: **{dims}**"))
-            agg_kwargs = {k: v for k, v in kwargs.items() if k not in ("agg_over_dims", "agg_fn")}
-            plot_cols.append(
-                self.to_auto(
-                    agg_over_dims=self.bench_cfg.agg_over_dims,
-                    agg_fn=self.bench_cfg.agg_fn,
-                    **agg_kwargs,
+            # Check whether ALL input dims are being aggregated (scalar result)
+            all_input_names = {iv.name for iv in self.bench_cfg.input_vars}
+            agg_set = set(self.bench_cfg.agg_over_dims)
+            if all_input_names <= agg_set:
+                # Fully-aggregated scalar: render a summary table instead of
+                # trying to_auto (no plotter handles 0-dimensional data).
+                plot_cols.append(self._scalar_aggregate_summary())
+            else:
+                agg_kwargs = {
+                    k: v for k, v in kwargs.items() if k not in ("agg_over_dims", "agg_fn")
+                }
+                plot_cols.append(
+                    self.to_auto(
+                        agg_over_dims=self.bench_cfg.agg_over_dims,
+                        agg_fn=self.bench_cfg.agg_fn,
+                        **agg_kwargs,
+                    )
                 )
-            )
         plot_cols.append(self.to_auto(**kwargs))
         plot_cols.append(self.bench_cfg.to_post_description())
         return plot_cols
+
+    def _scalar_aggregate_summary(self) -> pn.pane.Markdown:
+        """Render a Markdown table for a fully-aggregated (scalar) result."""
+        ds = self.to_dataset(
+            reduce=ReduceType.REDUCE,
+            agg_over_dims=self.bench_cfg.agg_over_dims,
+            agg_fn=self.bench_cfg.agg_fn,
+        )
+        rows = []
+        for rv in self.bench_cfg.result_vars:
+            name = rv.name
+            if name not in ds.data_vars:
+                continue
+            val = float(ds[name].values)
+            std_name = f"{name}_std"
+            units = getattr(rv, "units", "")
+            if std_name in ds.data_vars:
+                std = float(ds[std_name].values)
+                rows.append(f"| {name} | {val:.4g} ± {std:.4g} | {units} |")
+            else:
+                rows.append(f"| {name} | {val:.4g} | {units} |")
+        header = "| Result | Value | Units |\n|---|---|---|"
+        return pn.pane.Markdown(
+            f"{header}\n" + "\n".join(rows) if rows else "No result variables found."
+        )

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -596,9 +596,28 @@ class BenchResultBase:
             repeats_range=repeats_range,
             input_range=input_range,
         )
-        matches_res = plot_filter.matches_result(
-            self.plt_cnt_cfg, callable_name(plot_callback), override
-        )
+        # When aggregating, adjust variable counts to reflect post-aggregation
+        # dimensions so plot type filters correctly reject impossible combos
+        # (e.g. curve with 0 kdims after collapsing all inputs).
+        check_cfg = self.plt_cnt_cfg
+        if agg_over_dims:
+            agg_set = set(agg_over_dims)
+            adj_float = [fv for fv in self.plt_cnt_cfg.float_vars if fv.name not in agg_set]
+            adj_cat = [cv for cv in self.plt_cnt_cfg.cat_vars if cv.name not in agg_set]
+            check_cfg = PltCntCfg(
+                float_vars=adj_float,
+                float_cnt=len(adj_float),
+                cat_vars=adj_cat,
+                cat_cnt=len(adj_cat),
+                vector_len=self.plt_cnt_cfg.vector_len,
+                result_vars=self.plt_cnt_cfg.result_vars,
+                panel_vars=list(self.plt_cnt_cfg.panel_vars),
+                panel_cnt=self.plt_cnt_cfg.panel_cnt,
+                repeats=self.plt_cnt_cfg.repeats,
+                inputs_cnt=len(adj_float) + len(adj_cat),
+                print_debug=self.plt_cnt_cfg.print_debug,
+            )
+        matches_res = plot_filter.matches_result(check_cfg, callable_name(plot_callback), override)
         if matches_res.overall:
             # Compute aggregated dataset once (if requested) so all plotters benefit
             if hv_dataset is None:

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -216,6 +216,8 @@ class HoloviewResult(VideoResult):
 
         float_names = [fv.name for fv in self.plt_cnt_cfg.float_vars]
         ds_dims = list(dataset.dims)
+        if not ds_dims:
+            return None
         kdims = [d for d in ds_dims if d in float_names] or ds_dims[:1]
         groupby = [d for d in ds_dims if d not in kdims]
 

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -298,7 +298,9 @@ def resolve_aggregate(
     Args:
         aggregate: Aggregation specification.
             - None / False: no aggregation
-            - True: aggregate all input dims (requires input_var_names)
+            - True: aggregate all but the first input dim, collapsing data
+              to 1-D (the minimum for meaningful plots). With 0 or 1 input
+              vars there is nothing to aggregate and None is returned.
             - int N: aggregate last N input dims (requires input_var_names)
             - list[str]: aggregate exactly these dims (validated only when
               input_var_names is provided)
@@ -319,7 +321,10 @@ def resolve_aggregate(
     if aggregate is True:
         if input_var_names is None:
             raise ValueError("aggregate=True requires input_var_names")
-        return list(input_var_names)
+        if len(input_var_names) <= 1:
+            return None
+        # Keep the first input dim (x-axis) and aggregate the rest
+        return list(input_var_names[1:])
     if isinstance(aggregate, int):
         if input_var_names is None:
             raise ValueError("aggregate=<int> requires input_var_names")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.72.3"
+version = "1.72.4"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_generated_examples.py
+++ b/test/test_generated_examples.py
@@ -43,6 +43,6 @@ def test_generated_example(example_path):
 
     run_cfg = bn.BenchRunCfg()
     run_cfg.level = 2
-    run_cfg.repeats = 1
+    run_cfg.repeats = 2
     result = example_fns[0](run_cfg)
     assert result is not None

--- a/test/test_resolve_aggregate.py
+++ b/test/test_resolve_aggregate.py
@@ -20,19 +20,19 @@ class TestResolveAggregate(unittest.TestCase):
     def test_false_returns_none(self):
         self.assertIsNone(resolve_aggregate(False, self.vars3))
 
-    # --- True: aggregate all ---
+    # --- True: collapse to 1-D (aggregate all but first) ---
 
-    def test_true_all_3(self):
-        self.assertEqual(resolve_aggregate(True, self.vars3), ["x", "y", "z"])
+    def test_true_3_keeps_first(self):
+        self.assertEqual(resolve_aggregate(True, self.vars3), ["y", "z"])
 
-    def test_true_all_2(self):
-        self.assertEqual(resolve_aggregate(True, self.vars2), ["x", "y"])
+    def test_true_2_keeps_first(self):
+        self.assertEqual(resolve_aggregate(True, self.vars2), ["y"])
 
-    def test_true_all_1(self):
-        self.assertEqual(resolve_aggregate(True, self.vars1), ["x"])
+    def test_true_1_nothing_to_aggregate(self):
+        self.assertIsNone(resolve_aggregate(True, self.vars1))
 
-    def test_true_empty(self):
-        self.assertEqual(resolve_aggregate(True, self.vars0), [])
+    def test_true_empty_nothing_to_aggregate(self):
+        self.assertIsNone(resolve_aggregate(True, self.vars0))
 
     # --- int: last N dims ---
 
@@ -144,9 +144,9 @@ class TestResolveAggregateIntegration(unittest.TestCase):
         )
 
     def test_aggregate_true_sets_agg_over_dims(self):
-        """aggregate=True should resolve to all input dim names on BenchCfg."""
+        """aggregate=True should resolve to all but the first input dim on BenchCfg."""
         cfg = self.res_agg_true.bench_cfg
-        self.assertEqual(cfg.agg_over_dims, ["float1", "float2"])
+        self.assertEqual(cfg.agg_over_dims, ["float2"])
 
     def test_no_aggregate_has_none(self):
         """Without aggregate, agg_over_dims should be None."""


### PR DESCRIPTION
## Summary
- **`aggregate=True` now collapses to 1-D** (keeps first input dim) instead of collapsing all dims to an unplottable scalar
- **Plot type filter accounts for aggregation** — adjusted `PltCntCfg` counts in `filter()` so plotters like Curve/Line are correctly rejected when their required dims are aggregated away
- **Defensive guard** in `_build_curve_overlay` for empty dataset dims
- **Scalar summary fallback** in `to_auto_plots` for the edge case where all dims are explicitly aggregated via `list[str]`
- **CI test repeats bumped to 2** so curve/distribution code paths are exercised

## Test plan
- [x] `pixi run pytest test/test_resolve_aggregate.py` — all 29 tests pass
- [x] `pixi run pytest test/test_generated_examples.py -k agg` — all 6 aggregation examples pass
- [x] `pixi run ci` — full CI green
- [x] `agg_all.py` example runs without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust aggregation behavior to preserve a 1-D input dimension for plotting while handling fully aggregated scalars more robustly in filters, plot generation, examples, and tests.

New Features:
- Add a scalar aggregate Markdown summary view when all input dimensions are explicitly aggregated.

Bug Fixes:
- Change aggregate=True resolution to aggregate all but the first input dimension, avoiding fully scalar results that cannot be plotted.
- Update plot type filtering to account for dimensions removed by aggregation so incompatible plotters are rejected.
- Prevent curve overlay construction from running on datasets with no dimensions.

Enhancements:
- Revise aggregation example metadata and generated example descriptions to reflect 1-D aggregation behavior.
- Increase default test repeats in generated example tests to better exercise curve and distribution paths.

Tests:
- Update aggregation resolution tests and generated example tests to cover the new aggregate=True semantics and increased repeats.