### PR TITLE
Fix LaTeX sweep summary dropping spaces in time_event values

### DIFF
--- a/bencher/results/laxtex_result.py
+++ b/bencher/results/laxtex_result.py
@@ -19,12 +19,20 @@ def format_values_list(values: list[Any], max_display: int = 5) -> list[Any]:
     return [values[i] for i in [0, 1, 0, -2, -1]]
 
 
+def latex_value(val: Any) -> str:
+    """Format a single value for LaTeX, wrapping strings that contain spaces in \\text{}."""
+    s = str(val)
+    if " " in s:
+        return r"\text{" + s.replace("_", " ") + "}"
+    return s
+
+
 def create_matrix_array(values: list[Any]) -> str:
     """Create a LaTeX matrix array from values."""
     displayed_vals = format_values_list(values)
     if len(values) > 5:
         displayed_vals[2] = "⋮"
-    return r"\\ ".join([str(val) for val in displayed_vals])
+    return r"\\ ".join([latex_value(val) for val in displayed_vals])
 
 
 def input_var_to_latex(input_var) -> str:

--- a/test/test_latex_result.py
+++ b/test/test_latex_result.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import pytest
 from bencher.results.laxtex_result import (
     latex_text,
+    latex_value,
     format_values_list,
     create_matrix_array,
     input_var_to_latex,
@@ -39,6 +40,14 @@ def test_format_values_list():
 
     assert format_values_list(short_list) == short_list
     assert format_values_list(long_list) == [1, 2, 1, 6, 7]
+
+
+def test_latex_value():
+    assert latex_value(42) == "42"
+    assert latex_value(3.14) == "3.14"
+    assert latex_value("no_spaces") == "no_spaces"
+    assert latex_value("2024-06-15 14:59 abc1234") == r"\text{2024-06-15 14:59 abc1234}"
+    assert latex_value("has_under score") == r"\text{has under score}"
 
 
 def test_create_matrix_array():
@@ -96,3 +105,17 @@ def test_input_var_sizes(name, values, expected_size):
     var = MockVar(name=name, _values=values)
     result = input_var_to_latex(var)
     assert f"{expected_size}\\times1" in result
+
+
+def test_time_event_values_preserve_spaces():
+    """Time event values like '2024-06-15 14:59 abc1234' must keep spaces in LaTeX."""
+    var = MockVar(name="over_time", _values=["2024-06-15 14:59 abc1234"])
+    result = input_var_to_latex(var)
+    assert r"\text{2024-06-15 14:59 abc1234}" in result
+
+
+def test_create_matrix_array_with_time_events():
+    vals = ["2024-06-15 14:59 abc1234", "2024-06-16 10:00 def5678"]
+    result = create_matrix_array(vals)
+    assert r"\text{2024-06-15 14:59 abc1234}" in result
+    assert r"\text{2024-06-16 10:00 def5678}" in result


### PR DESCRIPTION
## Summary
- In LaTeX math mode, spaces are ignored, so `git_time_event()` values like `"2024-06-15 14:59 abc1234"` rendered as `"2024-06-1514:59abc1234"` with no separation between the timestamp and git SHA
- Added `latex_value()` helper that wraps values containing spaces in `\text{}` to preserve them in the rendered output
- Added tests covering the new helper and time_event rendering

## Test plan
- [x] All existing LaTeX tests pass
- [x] New `test_latex_value` verifies numbers, strings without spaces, and strings with spaces
- [x] New `test_time_event_values_preserve_spaces` verifies end-to-end rendering
- [x] New `test_create_matrix_array_with_time_events` verifies multiple time events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure LaTeX result rendering preserves spaces in time event values by introducing a dedicated value formatter and updating matrix array output.

New Features:
- Add a latex_value helper to format values for LaTeX, wrapping space-containing strings in \text{}.

Bug Fixes:
- Fix LaTeX rendering of time event values so that spaces between timestamps and SHA strings are preserved.

Tests:
- Add unit tests for latex_value covering numeric values, strings without spaces, and strings with spaces.
- Add tests verifying that time event values and matrix arrays with time events preserve spaces in the LaTeX output.