### PR TITLE
Restore example_levels.py for level sampling demo

### DIFF
--- a/bencher/example/example_all.py
+++ b/bencher/example/example_all.py
@@ -1,6 +1,7 @@
 import bencher as bn
 
 from bencher.example.example_simple_float import example_simple_float
+from bencher.example.example_levels import example_levels
 from bencher.example.optuna.example_optuna import optuna_rastrigin
 from bencher.example.example_sample_cache import example_sample_cache
 
@@ -11,6 +12,7 @@ if __name__ == "__main__":
     bench_runner = bn.BenchRunner("bencher_examples", run_cfg=run_cfg)
 
     bench_runner.add(example_simple_float)
+    bench_runner.add(example_levels)
     bench_runner.add(optuna_rastrigin)
     bench_runner.add(example_sample_cache)
 

--- a/bencher/example/example_levels.py
+++ b/bencher/example/example_levels.py
@@ -1,0 +1,21 @@
+import bencher as bn
+from bencher.example.meta.example_meta import BenchMeta
+
+
+def example_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    bench = BenchMeta().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Using Levels to define sample density",
+        description="Sample levels let you perform parameter sweeps without having to decide how many samples to take when defining the class.  If you perform a sweep at level 2, then all the points are reused when sampling at level 3.  The higher levels reuse the points from lower levels to avoid having to recompute potentially expensive samples. The other advantage is that it enables a workflow where you can quickly see the results of the sweep at a low resolution to sense check the code, and then run it at a high level to get the fidelity you want.  When calling a sweep at a high level, you can publish the intermediate lower level results as the computiation continues so that you can track the progress of the computation and end the sweep early when you have sufficient resolution",
+        input_vars=[
+            bn.p("float_vars", [1, 2]),
+            bn.p("level", [2, 3, 4, 5]),
+        ],
+        const_vars=dict(categorical_vars=0),
+    )
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_levels)

--- a/bencher/example/generated/levels/levels_sample_density.py
+++ b/bencher/example/generated/levels/levels_sample_density.py
@@ -1,11 +1,11 @@
-"""Auto-generated example: Sampling: Levels."""
+"""Auto-generated example: Level System: Sample Density."""
 
 import bencher as bn
 from bencher.example.meta.example_meta import BenchMeta
 
 
-def example_sampling_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Sampling: Levels."""
+def example_levels_sample_density(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Level System: Sample Density."""
     bench = BenchMeta().to_bench(run_cfg)
     bench.plot_sweep(
         title="Using Levels to define sample density",
@@ -22,4 +22,4 @@ def example_sampling_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
 
 if __name__ == "__main__":
-    bn.run(example_sampling_levels)
+    bn.run(example_levels_sample_density)

--- a/bencher/example/generated/sampling/sampling_levels.py
+++ b/bencher/example/generated/sampling/sampling_levels.py
@@ -1,41 +1,25 @@
 """Auto-generated example: Sampling: Levels."""
 
-from typing import Any
-
-import math
 import bencher as bn
-
-
-class LevelDemo(bn.ParametrizedSweep):
-    """Demonstrates how sampling level affects resolution."""
-
-    resolution = bn.IntSweep(default=2, bounds=(2, 5), doc="Sampling resolution level")
-    points = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Sample point")
-
-    value = bn.ResultVar(units="ul")
-
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-        self.value = math.sin(self.points * math.pi * self.resolution) + self.resolution * 0.1
-        return super().__call__()
+from bencher.example.meta.example_meta import BenchMeta
 
 
 def example_sampling_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Sampling: Levels."""
-    bench = LevelDemo().to_bench(run_cfg)
+    bench = BenchMeta().to_bench(run_cfg)
     bench.plot_sweep(
-        title="Level-based sampling resolution",
+        title="Using Levels to define sample density",
         input_vars=[
-            "points",
-            bn.p("resolution", [2, 3, 4, 5]),
+            bn.p("float_vars", [1, 2]),
+            bn.p("level", [2, 3, 4, 5]),
         ],
-        result_vars=["value"],
+        const_vars=dict(categorical_vars=0),
         description="Sample levels let you perform parameter sweeps without having to decide how many samples to take when defining the class. If you perform a sweep at level 2, all those points are reused when sampling at level 3. Higher levels reuse the points from lower levels to avoid recomputing potentially expensive samples. This enables a workflow where you quickly see results at low resolution to sense-check the code, then run at a high level for full fidelity. When calling a sweep at a high level you can publish intermediate lower-level results as computation continues, letting you track progress and end the sweep early when you have sufficient resolution.",
-        post_description="Each column shows the same function sampled at a different resolution level. Notice how lower-level sample points are a subset of higher-level points -- no work is wasted.",
+        post_description="Each panel shows the benchmark sampled at a different level. Higher levels produce more sample points. Notice how lower-level sample points are a subset of higher-level points -- no work is wasted.",
     )
 
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_sampling_levels, level=3)
+    bn.run(example_sampling_levels)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -110,6 +110,7 @@ def generate_python_files():
     )
     from bencher.example.meta.generate_meta_plot_types import example_meta_plot_types
     from bencher.example.meta.generate_meta_result_types import example_meta_result_types
+    from bencher.example.meta.generate_meta_levels import example_meta_levels
     from bencher.example.meta.generate_meta_sampling import example_meta_sampling
     from bencher.example.meta.generate_meta_statistics import example_meta_statistics
     from bencher.example.meta.generate_meta_workflows import example_meta_workflows
@@ -126,6 +127,7 @@ def generate_python_files():
     example_meta_image_video()
     example_meta_composable()
     example_meta_plot_types()
+    example_meta_levels()
     example_meta_sampling()
     example_meta_statistics()
     example_meta_const_vars()
@@ -415,6 +417,7 @@ SECTION_GROUPS = [
             ("Result Types", "result_types"),
             ("Plot Types", "plot_types"),
             ("Bool Plot Types", "bool_plot_types"),
+            ("Level System", "levels"),
             ("Sampling Strategies", "sampling"),
             ("Composable Containers", "composable_containers"),
             ("Aggregation", "aggregation"),

--- a/bencher/example/meta/generate_meta_levels.py
+++ b/bencher/example/meta/generate_meta_levels.py
@@ -1,0 +1,76 @@
+"""Meta-generator: Level System.
+
+Demonstrates how the level parameter controls sampling density.
+"""
+
+from typing import Any
+
+import bencher as bn
+from bencher.example.meta.meta_generator_base import MetaGeneratorBase
+
+OUTPUT_DIR = "levels"
+
+
+class MetaLevels(MetaGeneratorBase):
+    """Generate Python example demonstrating the level sampling system."""
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+
+        imports = "import bencher as bn\nfrom bencher.example.meta.example_meta import BenchMeta"
+        levels_desc = (
+            "Sample levels let you perform parameter sweeps without "
+            "having to decide how many samples to take when defining the class. "
+            "If you perform a sweep at level 2, all those points are reused when "
+            "sampling at level 3. Higher levels reuse the points from lower "
+            "levels to avoid recomputing potentially expensive samples. This "
+            "enables a workflow where you quickly see results at low resolution "
+            "to sense-check the code, then run at a high level for full "
+            "fidelity. When calling a sweep at a high level you can publish "
+            "intermediate lower-level results as computation continues, letting "
+            "you track progress and end the sweep early when you have "
+            "sufficient resolution."
+        )
+        levels_post = (
+            "Each panel shows the benchmark sampled at a different level. "
+            "Higher levels produce more sample points. Notice how lower-level "
+            "sample points are a subset of higher-level points -- no work is wasted."
+        )
+        body = (
+            "bench = BenchMeta().to_bench(run_cfg)\n"
+            "bench.plot_sweep(\n"
+            '    title="Using Levels to define sample density",\n'
+            "    input_vars=[\n"
+            '        bn.p("float_vars", [1, 2]),\n'
+            '        bn.p("level", [2, 3, 4, 5]),\n'
+            "    ],\n"
+            "    const_vars=dict(categorical_vars=0),\n"
+            f"    description={levels_desc!r},\n"
+            f"    post_description={levels_post!r},\n"
+            ")\n"
+        )
+        self.generate_example(
+            title="Level System: Sample Density",
+            output_dir=OUTPUT_DIR,
+            filename="levels_sample_density",
+            function_name="example_levels_sample_density",
+            imports=imports,
+            body=body,
+            class_code="",
+        )
+
+        return super().__call__()
+
+
+def example_meta_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    bench = MetaLevels().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Level System",
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_meta_levels)

--- a/bencher/example/meta/generate_meta_sampling.py
+++ b/bencher/example/meta/generate_meta_sampling.py
@@ -40,19 +40,7 @@ class CustomSampler(bn.ParametrizedSweep):
         self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
         return super().__call__()'''
 
-_LEVELS_CLASS_CODE = '''\
-class LevelDemo(bn.ParametrizedSweep):
-    """Demonstrates how sampling level affects resolution."""
-
-    resolution = bn.IntSweep(default=2, bounds=(2, 5), doc="Sampling resolution level")
-    points = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0], doc="Sample point")
-
-    value = bn.ResultVar(units="ul")
-
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.value = math.sin(self.points * math.pi * self.resolution) + self.resolution * 0.1
-        return super().__call__()'''
+_LEVELS_CLASS_CODE = ""  # Uses BenchMeta from example_meta instead
 
 _INT_FLOAT_CLASS_CODE = '''\
 class IntFloatCompare(bn.ParametrizedSweep):
@@ -145,7 +133,9 @@ class MetaSampling(MetaGeneratorBase):
                 run_kwargs={"level": 3},
             )
         elif self.strategy == "levels":
-            imports = "import math\nimport bencher as bn"
+            imports = (
+                "import bencher as bn\nfrom bencher.example.meta.example_meta import BenchMeta"
+            )
             levels_desc = (
                 "Sample levels let you perform parameter sweeps without "
                 "having to decide how many samples to take when defining the class. "
@@ -160,19 +150,19 @@ class MetaSampling(MetaGeneratorBase):
                 "sufficient resolution."
             )
             levels_post = (
-                "Each column shows the same function sampled at "
-                "a different resolution level. Notice how lower-level sample "
-                "points are a subset of higher-level points -- no work is wasted."
+                "Each panel shows the benchmark sampled at a different level. "
+                "Higher levels produce more sample points. Notice how lower-level "
+                "sample points are a subset of higher-level points -- no work is wasted."
             )
             body = (
-                "bench = LevelDemo().to_bench(run_cfg)\n"
+                "bench = BenchMeta().to_bench(run_cfg)\n"
                 "bench.plot_sweep(\n"
-                '    title="Level-based sampling resolution",\n'
+                '    title="Using Levels to define sample density",\n'
                 "    input_vars=[\n"
-                '        "points",\n'
-                '        bn.p("resolution", [2, 3, 4, 5]),\n'
+                '        bn.p("float_vars", [1, 2]),\n'
+                '        bn.p("level", [2, 3, 4, 5]),\n'
                 "    ],\n"
-                '    result_vars=["value"],\n'
+                "    const_vars=dict(categorical_vars=0),\n"
                 f"    description={levels_desc!r},\n"
                 f"    post_description={levels_post!r},\n"
                 ")\n"
@@ -184,8 +174,7 @@ class MetaSampling(MetaGeneratorBase):
                 function_name=function_name,
                 imports=imports,
                 body=body,
-                class_code=_LEVELS_CLASS_CODE,
-                run_kwargs={"level": 3},
+                class_code="",
             )
         else:  # int_vs_float
             self.generate_sweep_example(

--- a/bencher/example/meta/generate_meta_sampling.py
+++ b/bencher/example/meta/generate_meta_sampling.py
@@ -1,6 +1,6 @@
 """Meta-generator: Sampling Strategies.
 
-Shows uniform bounds, custom sample_values, level-based sampling, and Int vs Float.
+Shows uniform bounds, custom sample_values, and Int vs Float.
 """
 
 from typing import Any
@@ -10,7 +10,7 @@ from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
 OUTPUT_DIR = "sampling"
 
-STRATEGIES = ["uniform", "custom_values", "levels", "int_vs_float"]
+STRATEGIES = ["uniform", "custom_values", "int_vs_float"]
 
 # -- Inline class definitions for self-contained examples -----------------------
 
@@ -39,8 +39,6 @@ class CustomSampler(bn.ParametrizedSweep):
         self.update_params_from_kwargs(**kwargs)
         self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
         return super().__call__()'''
-
-_LEVELS_CLASS_CODE = ""  # Uses BenchMeta from example_meta instead
 
 _INT_FLOAT_CLASS_CODE = '''\
 class IntFloatCompare(bn.ParametrizedSweep):
@@ -131,50 +129,6 @@ class MetaSampling(MetaGeneratorBase):
                 body=body,
                 class_code=_CUSTOM_CLASS_CODE,
                 run_kwargs={"level": 3},
-            )
-        elif self.strategy == "levels":
-            imports = (
-                "import bencher as bn\nfrom bencher.example.meta.example_meta import BenchMeta"
-            )
-            levels_desc = (
-                "Sample levels let you perform parameter sweeps without "
-                "having to decide how many samples to take when defining the class. "
-                "If you perform a sweep at level 2, all those points are reused when "
-                "sampling at level 3. Higher levels reuse the points from lower "
-                "levels to avoid recomputing potentially expensive samples. This "
-                "enables a workflow where you quickly see results at low resolution "
-                "to sense-check the code, then run at a high level for full "
-                "fidelity. When calling a sweep at a high level you can publish "
-                "intermediate lower-level results as computation continues, letting "
-                "you track progress and end the sweep early when you have "
-                "sufficient resolution."
-            )
-            levels_post = (
-                "Each panel shows the benchmark sampled at a different level. "
-                "Higher levels produce more sample points. Notice how lower-level "
-                "sample points are a subset of higher-level points -- no work is wasted."
-            )
-            body = (
-                "bench = BenchMeta().to_bench(run_cfg)\n"
-                "bench.plot_sweep(\n"
-                '    title="Using Levels to define sample density",\n'
-                "    input_vars=[\n"
-                '        bn.p("float_vars", [1, 2]),\n'
-                '        bn.p("level", [2, 3, 4, 5]),\n'
-                "    ],\n"
-                "    const_vars=dict(categorical_vars=0),\n"
-                f"    description={levels_desc!r},\n"
-                f"    post_description={levels_post!r},\n"
-                ")\n"
-            )
-            self.generate_example(
-                title=title,
-                output_dir=OUTPUT_DIR,
-                filename=filename,
-                function_name=function_name,
-                imports=imports,
-                body=body,
-                class_code="",
             )
         else:  # int_vs_float
             self.generate_sweep_example(

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -188,6 +188,9 @@ This enables a natural workflow: start at a low level for quick iteration, then 
 publication-quality results. Because higher levels are strict supersets of lower ones, cached
 results from earlier runs are reused automatically — you only pay for the new midpoints.
 
+See the [Level System gallery](reference/meta/levels/index) for an interactive demo showing how
+increasing the level progressively refines the sample grid.
+
 ## Connections to Related Ideas
 
 Bencher sits at the intersection of several established concepts:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -159,7 +159,7 @@ Bencher includes a composable container system for combining visual outputs. See
 
 ## Sampling and Level System
 
-The `level` parameter controls sampling density across all dimensions with a single knob. Higher levels are strict supersets of lower ones, so cached results are reused automatically. See [The Level System](concepts.md#the-level-system) for details and the [Sampling Strategies](reference/meta/sampling/index) gallery.
+The `level` parameter controls sampling density across all dimensions with a single knob. Higher levels are strict supersets of lower ones, so cached results are reused automatically. See [The Level System](concepts.md#the-level-system) for the conceptual explanation, the [Level System](reference/meta/levels/index) gallery for an interactive demo, and the [Sampling Strategies](reference/meta/sampling/index) gallery for related sampling techniques.
 
 ## Running Examples
 


### PR DESCRIPTION
## Summary
- Restores `bencher/example/example_levels.py` which was incorrectly deleted in PR #823
- The generated replacement (`sampling_levels.py`) did not actually demonstrate the built-in level sampling system — it used a fake `IntSweep` called `resolution` instead of sweeping `BenchMeta`'s `level` parameter
- Fixes the generated `sampling_levels.py` and its meta-generator (`generate_meta_sampling.py`) to use `BenchMeta` with `bn.p("level", [2, 3, 4, 5])`
- Re-adds `example_levels` to `example_all.py`

## Test plan
- [x] `pixi run ci` passes (926 passed, 1 pre-existing flask failure)
- [ ] Verify `pixi run python bencher/example/example_levels.py` renders the level sweep correctly
- [ ] Verify `pixi run generate-docs` produces correct sampling_levels output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore and improve the level sampling demo by reintroducing a dedicated example and gallery, and wiring it into the example and docs generation pipeline.

New Features:
- Add a standalone example_levels benchmark demonstrating level-based sampling density using BenchMeta.
- Introduce a level system meta-generator and corresponding generated gallery example under reference/meta/levels.

Enhancements:
- Remove the obsolete levels strategy from the generic sampling meta-generator to avoid duplicative or misleading examples.
- Register the new level system examples in the meta example generation pipeline and navigation index.
- Clarify documentation to link both the conceptual explanation and the new Level System gallery for the level parameter overview.

Documentation:
- Update conceptual and introductory docs to reference the new Level System gallery as the primary interactive demo for level-based sampling.