### PR TITLE
Use softbounds for sweep ranges and add callable sweep API

### DIFF
--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -107,9 +107,9 @@ def sweep_var_to_optuna_dist(var: param.Parameter) -> optuna.distributions.BaseD
     """
 
     if isinstance(var, IntSweep):
-        return optuna.distributions.IntDistribution(var.bounds[0], var.bounds[1])
+        return optuna.distributions.IntDistribution(var.sweep_bounds[0], var.sweep_bounds[1])
     if isinstance(var, FloatSweep):
-        return optuna.distributions.FloatDistribution(var.bounds[0], var.bounds[1])
+        return optuna.distributions.FloatDistribution(var.sweep_bounds[0], var.sweep_bounds[1])
     if isinstance(var, (EnumSweep, StringSweep)):
         return optuna.distributions.CategoricalDistribution(var.objects)
     if isinstance(var, BoolSweep):
@@ -138,9 +138,9 @@ def sweep_var_to_suggest(iv: ParametrizedSweep, trial: optuna.trial) -> object:
     iv_type = type(iv)
 
     if iv_type == IntSweep:
-        return trial.suggest_int(iv.name, iv.bounds[0], iv.bounds[1])
+        return trial.suggest_int(iv.name, iv.sweep_bounds[0], iv.sweep_bounds[1])
     if iv_type == FloatSweep:
-        return trial.suggest_float(iv.name, iv.bounds[0], iv.bounds[1])
+        return trial.suggest_float(iv.name, iv.sweep_bounds[0], iv.sweep_bounds[1])
     if iv_type in (EnumSweep, StringSweep):
         return trial.suggest_categorical(iv.name, iv.objects)
     if iv_type in (TimeSnapshot, TimeEvent):

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -464,6 +465,10 @@ class IntSweep(Integer, SweepBase):
         **params,
     ):
         SweepBase.__init__(self)
+        # Redirect bounds -> softbounds so param doesn't hard-enforce them
+        user_bounds = params.pop("bounds", None)
+        if user_bounds is not None:
+            params["softbounds"] = user_bounds
         Integer.__init__(self, **params)
 
         self.units = units
@@ -471,9 +476,9 @@ class IntSweep(Integer, SweepBase):
 
         if sample_values is None:
             if samples is None:
-                if self.bounds is None:
+                if self.sweep_bounds is None:
                     raise RuntimeError("You must define bounds for integer types")
-                self.samples = 1 + self.bounds[1] - self.bounds[0]
+                self.samples = 1 + self.sweep_bounds[1] - self.sweep_bounds[0]
             else:
                 self.samples = samples
             self.sample_values = None
@@ -495,7 +500,7 @@ class IntSweep(Integer, SweepBase):
         sample_values = (
             self.sample_values
             if self.sample_values is not None
-            else list(range(int(self.bounds[0]), int(self.bounds[1] + 1)))
+            else list(range(int(self.sweep_bounds[0]), int(self.sweep_bounds[1] + 1)))
         )
 
         return self.indices_to_samples(self.samples, sample_values)
@@ -545,6 +550,10 @@ class FloatSweep(Number, SweepBase):
         **params,
     ):
         SweepBase.__init__(self)
+        # Redirect bounds -> softbounds so param doesn't hard-enforce them
+        user_bounds = params.pop("bounds", None)
+        if user_bounds is not None:
+            params["softbounds"] = user_bounds
         Number.__init__(self, step=step, **params)
 
         self.units = units
@@ -571,9 +580,9 @@ class FloatSweep(Number, SweepBase):
         samps = self.samples
         if self.sample_values is None:
             if self.step is None:
-                return np.linspace(self.bounds[0], self.bounds[1], samps)
+                return np.linspace(self.sweep_bounds[0], self.sweep_bounds[1], samps)
 
-            return np.arange(self.bounds[0], self.bounds[1], self.step)
+            return np.arange(self.sweep_bounds[0], self.sweep_bounds[1], self.step)
         return self.sample_values
 
 
@@ -597,28 +606,40 @@ def box(name: str, center: float, width: float) -> FloatSweep:
 
 
 def p(
-    name: str,
+    name: str | SweepBase,
     values: list[Any] | None = None,
     samples: int | None = None,
     max_level: int | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | SweepBase:
     """
-    Create a parameter dictionary with optional values, samples, and max_level.
+    Create a parameter specification for use in plot_sweep input_vars.
+
+    Accepts either a string parameter name (returns a dict for deferred lookup)
+    or a SweepBase parameter object (returns a configured sweep directly).
 
     Args:
-        name (str): The name of the parameter.
+        name: The parameter name (str) or a param object (e.g. ``Cfg.param.theta``).
         values (list[Any], optional): A list of values for the parameter. Defaults to None.
         samples (int, optional): The number of samples. Must be greater than 0 if provided. Defaults to None.
         max_level (int, optional): The maximum level. Must be greater than 0 if provided. Defaults to None.
 
     Returns:
-        dict[str, Any]: A dictionary containing the parameter details.
+        dict[str, Any] | SweepBase: A parameter dict (for string names) or configured sweep object.
     """
     if max_level is not None and max_level <= 0:
         raise ValueError("max_level must be greater than 0")
 
     if samples is not None and samples <= 0:
         raise ValueError("samples must be greater than 0")
+
+    # If a SweepBase param object is passed, delegate to its callable API
+    if isinstance(name, SweepBase):
+        if values is not None:
+            return name.with_sample_values(values)
+        if samples is not None:
+            return name.with_samples(samples)
+        return deepcopy(name)
+
     return {"name": name, "values": values, "max_level": max_level, "samples": samples}
 
 

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -634,6 +634,11 @@ def p(
 
     # If a SweepBase param object is passed, delegate to its callable API
     if isinstance(name, SweepBase):
+        if max_level is not None:
+            raise ValueError(
+                "max_level is not supported when passing a SweepBase object to p(). "
+                "Use the string-based API instead: p('param_name', max_level=N)"
+            )
         if values is not None:
             return name.with_sample_values(values)
         if samples is not None:

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -54,6 +54,22 @@ class SweepBase(param.Parameter):
     # slots = ["units", "samples"]
     # __slots__ = shared_slots
 
+    @property
+    def sweep_bounds(self) -> tuple | None:
+        """Return the sweep range (low, high).
+
+        FloatSweep/IntSweep store user-supplied bounds as param softbounds
+        (not hard bounds) so that values outside the range are not rejected.
+        This property provides a single access point.
+        """
+        sb = getattr(self, "softbounds", None)
+        if sb is not None:
+            return tuple(sb)
+        b = getattr(self, "bounds", None)
+        if b is not None:
+            return tuple(b)
+        return None
+
     def values(
         self,
     ) -> list[Any]:
@@ -95,12 +111,11 @@ class SweepBase(param.Parameter):
         name_tuple = (self.name, self.name)
 
         params = {}
-        if hasattr(self, "bounds") and self.bounds is not None:
+        if self.sweep_bounds is not None:
             if compute_values:
                 params["values"] = self.values()
-                # params["range"] = tuple(self.bounds)
             else:
-                params["range"] = tuple(self.bounds)
+                params["range"] = tuple(self.sweep_bounds)
                 params["default"] = self.default
 
         else:
@@ -144,6 +159,27 @@ class SweepBase(param.Parameter):
             output.objects = sample_values  # pylint: disable = attribute-defined-outside-init
         output.samples = len(sample_values)  # pylint: disable = attribute-defined-outside-init
         return output
+
+    def __call__(self, values: list | None = None, *, samples: int | None = None) -> SweepBase:
+        """Shorthand for creating a sweep with specific values or sample count.
+
+        Usage::
+
+            Cfg.param.theta([0, 0.5, 1.0])   # explicit values
+            Cfg.param.theta(samples=5)         # override sample count
+
+        Args:
+            values: Explicit list of values to sweep through.
+            samples: Number of samples to take from the sweep range.
+
+        Returns:
+            SweepBase: A copy of this sweep with the specified values or sample count.
+        """
+        if values is not None:
+            return self.with_sample_values(values)
+        if samples is not None:
+            return self.with_samples(samples)
+        return deepcopy(self)
 
     def with_const(self, const_value: Any) -> tuple[SweepBase, Any]:
         """Create a new instance of SweepBase with a constant value.

--- a/test/test_sweep_base.py
+++ b/test/test_sweep_base.py
@@ -200,6 +200,29 @@ class TestSweepBase(unittest.TestCase):
     #     var_int = bn.IntSweep(default=start, bounds=(start, start + var_range))
     #     self.sweep_up_to(var_int, int, level=5)
 
+    def test_callable_sweep_values(self):
+        vals = AllSweepVars.param.var_float([0, 1, 5]).values()
+        self.assertEqual(vals, [0, 1, 5])
+
+    def test_callable_sweep_samples(self):
+        sampled = AllSweepVars.param.var_float(samples=3).values()
+        self.assertEqual(len(sampled), 3)
+
+    def test_callable_sweep_no_args(self):
+        original = AllSweepVars.param.var_float.values()
+        copy = AllSweepVars.param.var_float().values()
+        self.assertEqual(str(original), str(copy))
+
+    def test_p_with_param_object(self):
+        result = bn.p(AllSweepVars.param.var_float, [0, 1, 5])
+        self.assertIsInstance(result, bn.SweepBase)
+        self.assertEqual(result.values(), [0, 1, 5])
+
+    def test_p_with_param_object_samples(self):
+        result = bn.p(AllSweepVars.param.var_float, samples=3)
+        self.assertIsInstance(result, bn.SweepBase)
+        self.assertEqual(len(result.values()), 3)
+
 
 if __name__ == "__main__":
     # TestSweepBase().test_override_defaults()

--- a/test/test_sweep_vars.py
+++ b/test/test_sweep_vars.py
@@ -182,9 +182,9 @@ class TestVarSweeps(unittest.TestCase):
         self.assertEqual(fs.sweep_bounds, (0, 1))
         self.assertIsNone(fs.bounds)
 
-        ist = IntSweep(bounds=(0, 10))
-        self.assertEqual(ist.sweep_bounds, (0, 10))
-        self.assertIsNone(ist.bounds)
+        int_sw = IntSweep(bounds=(0, 10))
+        self.assertEqual(int_sw.sweep_bounds, (0, 10))
+        self.assertIsNone(int_sw.bounds)
 
     def test_float_sweep_out_of_bounds(self):
         class Cfg(ParametrizedSweep):

--- a/test/test_sweep_vars.py
+++ b/test/test_sweep_vars.py
@@ -2,6 +2,8 @@ import unittest
 from hypothesis import given, strategies as st  # pylint: disable=unused-import
 import pytest
 from bencher.variables.inputs import IntSweep, EnumSweep, StringSweep, BoolSweep, FloatSweep
+from bencher.variables.parametrised_sweep import ParametrizedSweep
+from bencher.variables.results import ResultVar
 from enum import auto
 from strenum import StrEnum
 
@@ -174,3 +176,36 @@ class TestVarSweeps(unittest.TestCase):
         int_sweep = IntSweep(bounds=[0, 10], samples=samples)
         self.assertEqual(int_sweep.default, 0)
         self.assertEqual(len(int_sweep.values()), samples)
+
+    def test_sweep_bounds_property(self):
+        fs = FloatSweep(bounds=(0, 1))
+        self.assertEqual(fs.sweep_bounds, (0, 1))
+        self.assertIsNone(fs.bounds)
+
+        ist = IntSweep(bounds=(0, 10))
+        self.assertEqual(ist.sweep_bounds, (0, 10))
+        self.assertIsNone(ist.bounds)
+
+    def test_float_sweep_out_of_bounds(self):
+        class Cfg(ParametrizedSweep):
+            theta = FloatSweep(default=0.5, bounds=(0, 1), samples=3)
+            result = ResultVar()
+
+        cfg = Cfg()
+        cfg.update_params_from_kwargs(theta=1.5)
+        self.assertEqual(cfg.theta, 1.5)
+
+        cfg.update_params_from_kwargs(theta=-0.5)
+        self.assertEqual(cfg.theta, -0.5)
+
+    def test_int_sweep_out_of_bounds(self):
+        class Cfg(ParametrizedSweep):
+            count = IntSweep(default=3, bounds=(0, 10))
+            result = ResultVar()
+
+        cfg = Cfg()
+        cfg.update_params_from_kwargs(count=15)
+        self.assertEqual(cfg.count, 15)
+
+        cfg.update_params_from_kwargs(count=-5)
+        self.assertEqual(cfg.count, -5)


### PR DESCRIPTION
## Summary
- **Soft bounds migration:** `FloatSweep`/`IntSweep` now store user-supplied `bounds` as param `softbounds` (not hard bounds), so `update_params_from_kwargs` no longer rejects values outside the defined sweep range. This unblocks overriding sweep values via `bn.p()` or `with_sample_values()` beyond the original bounds.
- **Callable sweep API:** Added `SweepBase.__call__` so sweep parameters can be used directly — `Cfg.param.theta([0, 0.5, 1.5])` or `Cfg.param.theta(samples=5)` — providing a concise, type-safe alternative to `bn.p("theta", ...)`.
- **`bn.p()` accepts param objects:** `bn.p(Cfg.param.theta, [0, 0.5, 1.5])` now works alongside the existing string-based form.

## Test plan
- [x] Added `test_sweep_bounds_property` — verifies `sweep_bounds` returns user-supplied bounds and `bounds` is `None`
- [x] Added `test_float_sweep_out_of_bounds` / `test_int_sweep_out_of_bounds` — verifies values outside bounds no longer crash
- [x] Added `test_callable_sweep_values` / `test_callable_sweep_samples` / `test_callable_sweep_no_args` — verifies `__call__` API
- [x] Added `test_p_with_param_object` / `test_p_with_param_object_samples` — verifies `bn.p()` with param objects
- [x] Full CI passes: 938 tests passed, pylint 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow sweep parameters to use soft bounds, add a callable sweep API, and support passing parameter objects to the bn.p helper.

New Features:
- Introduce a sweep_bounds property to expose the effective sweep range regardless of whether it is stored as bounds or softbounds.
- Add a callable interface to SweepBase so sweep parameters can be configured via direct calls with values or samples.
- Allow bn.p to accept SweepBase parameter objects and return configured sweeps directly.

Bug Fixes:
- Prevent update_params_from_kwargs from rejecting FloatSweep and IntSweep values that fall outside the original bounds by storing user bounds as softbounds instead of hard bounds.

Enhancements:
- Update IntSweep and FloatSweep to derive ranges and sample values from sweep_bounds for consistent handling of soft bounds.
- Align Optuna conversion utilities to use sweep_bounds instead of bounds when constructing distributions and suggestions.

Tests:
- Add tests covering sweep_bounds behavior, out-of-bounds updates for float and int sweeps, the callable sweep API, and bn.p usage with parameter objects.