### PR TITLE
chore: release v1.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.73.0] - 2026-03-26
+
+### Added
+- `bn.sweep()` API with `bounds=(low, high)` support as the unified replacement for `bn.p()` — `bn.p()` still works but emits a `DeprecationWarning` (#838)
+- `SweepBase.__call__()` for concise, type-safe sweep configuration: `Cfg.param.theta([0, 0.5, 1.0])` or `Cfg.param.theta(samples=5)` (#838)
+- `SweepBase.with_bounds()` for overriding sweep ranges immutably (#838)
+- Dict and inline-dict shorthand for `input_vars` in `plot_sweep`: `{"theta": [0, 0.5, 1.0]}`, `{"theta": 5}`, `{"theta": None}` (#842)
+- `atexit` handler to stop Panel servers on exit, preventing process hangs after `bn.run(show=True)` (#841)
+- Interactive prompt in terminal mode — press Enter to stop servers after viewing results (#841)
+- SIGTERM handler chaining — lazily installed only when servers are created, chains to previous handler instead of calling `sys.exit()` (#841)
+
+### Changed
+- `FloatSweep`/`IntSweep` now store user-supplied bounds as param `softbounds` instead of hard bounds, so values outside the defined sweep range are no longer rejected by `update_params_from_kwargs` (#838)
+- `BenchRunCfg.with_defaults()` returns a deep copy and merges defaults into caller-provided configs instead of ignoring them (#840)
+- `BenchRunCfg.with_defaults()` raises `ValueError` for unknown parameter names to catch typos early (#840)
+- Rename `test/test_bn_p.py` to `test/test_sweep_helper.py` to match new `bn.sweep()` API
+
+### Fixed
+- `bn.p()` now raises `ValueError` when `max_level` is used with `SweepBase` objects, which require `run_cfg.level` at execution time (#838)
+- `bn.sweep()` / `__call__()` reject combining explicit `values` with `bounds`/`samples` to prevent ambiguous configurations (#838)
+- Server shutdown is exception-safe — a failing shutdown on one runner no longer prevents cleanup of remaining runners (#841)
+- Shutdown errors are logged to stderr instead of silently swallowed (#841)
+- Interactive prompt delayed to appear after async server startup logs (#841)
+
 ## [1.72.3] - 2026-03-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.72.5"
+version = "1.73.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Bump version from 1.72.5 to 1.73.0
- Add changelog entry covering all changes since v1.72.5

## Changelog

### Added
- `bn.sweep()` API with `bounds=(low, high)` support as the unified replacement for `bn.p()` (#838)
- `SweepBase.__call__()` for concise, type-safe sweep configuration (#838)
- `SweepBase.with_bounds()` for overriding sweep ranges immutably (#838)
- Dict and inline-dict shorthand for `input_vars` in `plot_sweep` (#842)
- `atexit` handler + interactive prompt + SIGTERM chaining for Panel server lifecycle (#841)

### Changed
- `FloatSweep`/`IntSweep` bounds stored as `softbounds` instead of hard bounds (#838)
- `BenchRunCfg.with_defaults()` returns a deep copy and validates unknown keys (#840)

### Fixed
- `bn.p()` raises `ValueError` for `max_level` + `SweepBase` (#838)
- Server shutdown exception safety and error logging (#841)

## Test plan
- [x] `pixi run ci` passes (format, lint, test with coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release version 1.73.0 with updated changelog entries and packaging metadata.

New Features:
- Document new bn.sweep() API, SweepBase helpers, and additional input shorthands for plot_sweep.
- Document improved Panel server lifecycle handling, including atexit cleanup, interactive prompt, and SIGTERM handler chaining.

Enhancements:
- Describe changes to sweep bounds handling and BenchRunCfg.with_defaults() behavior in the changelog, including stricter validation and deep-copy merging.
- Rename a sweep-related test module to align with the new bn.sweep() API name.

Documentation:
- Add a 1.73.0 section to the changelog summarizing all user-facing additions, changes, and fixes since 1.72.5.

Chores:
- Bump the project version from 1.72.5 to 1.73.0 in packaging configuration.