### PR TITLE
fix: show diagnostic panels for optuna plot failures

### DIFF
--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1129,7 +1129,7 @@ class Bench(BenchPlotServer):
                     study.add_trials(trials)
                     added += len(trials)
             except Exception:  # pylint: disable=broad-except
-                pass
+                logging.debug("Failed to warm-start from result", exc_info=True)
         return added
 
     def _warm_from_sample_cache(
@@ -1194,7 +1194,7 @@ class Bench(BenchPlotServer):
                     study.add_trial(trial)
                     added += 1
                 except Exception:  # pylint: disable=broad-except
-                    pass
+                    logging.debug("Failed to warm-start trial from cache", exc_info=True)
 
         return added
 

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -169,6 +169,8 @@ def _append_safe(row, plot_fn, *args, **kwargs):
         row.append(plot_fn(*args, **kwargs))
     except Exception as e:  # pylint: disable=broad-except
         logging.exception(e)
+        fn_name = getattr(plot_fn, "__name__", str(plot_fn))
+        row.append(pn.pane.Markdown(f"**Plot failed** (`{fn_name}`): {e}"))
 
 
 def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
@@ -180,3 +182,5 @@ def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
         row.append(fig)
     except Exception as e:  # pylint: disable=broad-except
         logging.exception(e)
+        fn_name = getattr(plot_fn, "__name__", str(plot_fn))
+        row.append(pn.pane.Markdown(f"**Plot failed** (`{fn_name}`): {e}"))

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import logging
 from copy import deepcopy
 from itertools import product as iter_product
 
@@ -156,7 +157,14 @@ class OptunaResult(BenchResultBase):
             df = _aggregate_non_optimized(df, opt_vars, non_opt_vars, target_names)
             trial_vars = opt_vars
 
+        rows_before = len(df)
         df.dropna(inplace=True)
+        rows_after = len(df)
+        if rows_after == 0 and rows_before > 0:
+            logging.warning(
+                "All %d rows dropped due to NaN values — optuna study will have no trials",
+                rows_before,
+            )
 
         distributions = {}
         for i in trial_vars:
@@ -238,11 +246,19 @@ class OptunaResult(BenchResultBase):
             pn.pane.panel: A panel with optuna visualisations.
         """
 
-        self.studies = [self.bench_result_to_study(True)]
+        try:
+            self.studies = [self.bench_result_to_study(True)]
+        except Exception as e:  # pylint: disable=broad-except
+            logging.exception(e)
+            return pn.Column(pn.pane.Markdown(f"**Optuna study creation failed**: {e}"))
         tab_names = ["Analysis"]
         if self.bench_cfg.repeats > 1:
-            self.studies.append(self.bench_result_to_study(False))
-            tab_names = ["With Repeats", "Without Repeats"]
+            try:
+                self.studies.append(self.bench_result_to_study(False))
+                tab_names = ["With Repeats", "Without Repeats"]
+            except Exception as e:  # pylint: disable=broad-except
+                logging.exception(e)
+                tab_names = ["Analysis (without-repeats study failed)"]
 
         plot_w = self.bench_cfg.plot_width or self.bench_cfg.plot_size or 600
         target_names = self.bench_cfg.optuna_targets()
@@ -299,9 +315,9 @@ class OptunaResult(BenchResultBase):
                         target_names=target_names[:3],
                         include_dominated_trials=False,
                     )
-                    if pareto_width is not None:
+                    if pareto_width is not None and hasattr(study_pane[-1], "width"):
                         study_pane[-1].width = pareto_width
-                    if pareto_height is not None:
+                    if pareto_height is not None and hasattr(study_pane[-1], "height"):
                         study_pane[-1].height = pareto_height
 
                 param_str.append(
@@ -319,7 +335,14 @@ class OptunaResult(BenchResultBase):
                 )
 
                 if _study_has_multiple_params(study):
-                    study_pane.append(plot_param_importances(study, target_name=target_names[0]))
+                    try:
+                        study_pane.append(
+                            plot_param_importances(study, target_name=target_names[0])
+                        )
+                    except RuntimeError as e:
+                        study_pane.append(
+                            pn.pane.Markdown(f"**Parameter importance unavailable**: {e}")
+                        )
 
                 param_str.extend(summarise_trial(study.best_trial, self.bench_cfg))
 

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -123,10 +123,27 @@ def run(
         _original_target = target
 
         def _with_optimise(run_cfg: BenchRunCfg | None = None) -> "Bench":
+            import logging as _log
+            import panel as _pn
+
             bench = _original_target(run_cfg)
             result = bench.optimize(n_trials=optimise, plot=False)
-            if result is not None and bench.results:
-                bench.report.append(bench.results[-1].to_optuna_plots())
+            if result is None:
+                bench.report.append(
+                    _pn.pane.Markdown(
+                        "**Optimisation skipped**: no result variables have an optimization "
+                        "direction. Set `direction=OptDir.minimize` or `OptDir.maximize` "
+                        "on your `ResultVar`."
+                    )
+                )
+            elif bench.results:
+                try:
+                    bench.report.append(bench.results[-1].to_optuna_plots())
+                except Exception as e:  # pylint: disable=broad-except
+                    _log.exception(e)
+                    bench.report.append(
+                        _pn.pane.Markdown(f"**Optuna plot generation failed**: {e}")
+                    )
             return bench
 
         _with_optimise.__name__ = getattr(_original_target, "__name__", "optimised")


### PR DESCRIPTION
## Summary
- Replace silent `except` handlers in optuna plotting with visible `pn.pane.Markdown` error panels so users see **why** their optimization reports are missing or incomplete
- Guard study creation, single-objective param importance, and pareto size assignment in `optuna_result.py` to degrade gracefully instead of crashing
- Add `logging.warning` when `dropna` removes all rows from trial data, and `logging.debug` in warm-start helpers (previously bare `pass`)
- Wrap `to_optuna_plots()` in `run.py` and show a diagnostic when `optimize()` returns `None` (no result vars have optimization direction)

## Test plan
- [x] `pixi run ci` passes (968 tests, lint, format all green)
- [x] `pixi run python bencher/example/generated/optimization/optim_1_objective_1d.py` renders plots correctly
- [ ] Manual: trigger a failure (e.g. all-NaN results) and verify the error markdown panel appears in the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)