### PR TITLE
feat: add over_time parameter to bn.run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `atexit` handler to stop Panel servers on exit, preventing process hangs after `bn.run(show=True)` (#841)
 - Interactive prompt in terminal mode — press Enter to stop servers after viewing results (#841)
 - SIGTERM handler chaining — lazily installed only when servers are created, chains to previous handler instead of calling `sys.exit()` (#841)
+- `over_time` parameter on `bn.run()` and `BenchRunner.run()` — enables time-series benchmarking without manually creating a `BenchRunCfg` (#848)
+- 2-float 2-categorical aggregation example (`agg_list_2_cat`) demonstrating `aggregate=["direction", "scale"]` on a `GradientSurface` class (#845)
 
 ### Changed
 - `FloatSweep`/`IntSweep` now store user-supplied bounds as param `softbounds` instead of hard bounds, so values outside the defined sweep range are no longer rejected by `update_params_from_kwargs` (#838)
 - `BenchRunCfg.with_defaults()` returns a deep copy and merges defaults into caller-provided configs instead of ignoring them (#840)
 - `BenchRunCfg.with_defaults()` raises `ValueError` for unknown parameter names to catch typos early (#840)
 - Rename `test/test_bn_p.py` to `test/test_sweep_helper.py` to match new `bn.sweep()` API
+- Generated over_time examples now pass `over_time=True` via `bn.run()` kwargs instead of setting `run_cfg.over_time` inside the function body (#848)
 
 ### Fixed
 - `bn.p()` now raises `ValueError` when `max_level` is used with `SweepBase` objects, which require `run_cfg.level` at execution time (#838)
@@ -28,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server shutdown is exception-safe — a failing shutdown on one runner no longer prevents cleanup of remaining runners (#841)
 - Shutdown errors are logged to stderr instead of silently swallowed (#841)
 - Interactive prompt delayed to appear after async server startup logs (#841)
+- Optuna plot failures now show diagnostic `Markdown` panels instead of silently swallowing exceptions (#847)
+- `to_optuna_plots()` in `bn.run()` shows a diagnostic when `optimize()` returns `None` (#847)
+- `logging.warning` when `dropna` removes all rows from optuna trial data (#847)
 
 ## [1.72.3] - 2026-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.73.0] - 2026-03-26
+
+### Added
+- `bn.sweep()` API with `bounds=(low, high)` support as the unified replacement for `bn.p()` — `bn.p()` still works but emits a `DeprecationWarning` (#838)
+- `SweepBase.__call__()` for concise, type-safe sweep configuration: `Cfg.param.theta([0, 0.5, 1.0])` or `Cfg.param.theta(samples=5)` (#838)
+- `SweepBase.with_bounds()` for overriding sweep ranges immutably (#838)
+- Dict and inline-dict shorthand for `input_vars` in `plot_sweep`: `{"theta": [0, 0.5, 1.0]}`, `{"theta": 5}`, `{"theta": None}` (#842)
+- `atexit` handler to stop Panel servers on exit, preventing process hangs after `bn.run(show=True)` (#841)
+- Interactive prompt in terminal mode — press Enter to stop servers after viewing results (#841)
+- SIGTERM handler chaining — lazily installed only when servers are created, chains to previous handler instead of calling `sys.exit()` (#841)
+
+### Changed
+- `FloatSweep`/`IntSweep` now store user-supplied bounds as param `softbounds` instead of hard bounds, so values outside the defined sweep range are no longer rejected by `update_params_from_kwargs` (#838)
+- `BenchRunCfg.with_defaults()` returns a deep copy and merges defaults into caller-provided configs instead of ignoring them (#840)
+- `BenchRunCfg.with_defaults()` raises `ValueError` for unknown parameter names to catch typos early (#840)
+- Rename `test/test_bn_p.py` to `test/test_sweep_helper.py` to match new `bn.sweep()` API
+
+### Fixed
+- `bn.p()` now raises `ValueError` when `max_level` is used with `SweepBase` objects, which require `run_cfg.level` at execution time (#838)
+- `bn.sweep()` / `__call__()` reject combining explicit `values` with `bounds`/`samples` to prevent ambiguous configurations (#838)
+- Server shutdown is exception-safe — a failing shutdown on one runner no longer prevents cleanup of remaining runners (#841)
+- Shutdown errors are logged to stderr instead of silently swallowed (#841)
+- Interactive prompt delayed to appear after async server startup logs (#841)
+
 ## [1.72.3] - 2026-03-24
 
 ### Fixed

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -109,7 +109,10 @@ class BenchRunner:
 
     @staticmethod
     def setup_run_cfg(
-        run_cfg: BenchRunCfg | None = None, level: int = 2, cache_results: bool = True
+        run_cfg: BenchRunCfg | None = None,
+        level: int = 2,
+        cache_results: bool = True,
+        over_time: bool = False,
     ) -> BenchRunCfg:
         """Configure benchmark run settings with reasonable defaults.
 
@@ -120,6 +123,7 @@ class BenchRunner:
             run_cfg (BenchRunCfg, optional): Base configuration to modify. Defaults to None.
             level (int, optional): Benchmark sampling resolution level. Defaults to 2.
             cache_results (bool, optional): Whether to enable result caching. Defaults to True.
+            over_time (bool, optional): Enable time-series benchmarking. Defaults to False.
 
         Returns:
             BenchRunCfg: A new configuration object with the specified settings
@@ -128,6 +132,8 @@ class BenchRunner:
         run_cfg_out.cache_samples = cache_results
         run_cfg_out.only_hash_tag = cache_results
         run_cfg_out.level = level
+        if over_time:
+            run_cfg_out.over_time = True
         return run_cfg_out
 
     @staticmethod
@@ -265,6 +271,7 @@ class BenchRunner:
         save: bool = False,
         grouped: bool = False,
         cache_results: bool = True,
+        over_time: bool = False,
     ) -> list[BenchCfg]:
         """Unified interface for running benchmarks.
 
@@ -290,6 +297,7 @@ class BenchRunner:
             save (bool, optional): save the results to disk in index.html. Defaults to False.
             grouped (bool, optional): Produce a single html page with all the benchmarks included. Defaults to False.
             cache_results (bool, optional): Use the sample cache to reused previous results. Defaults to True.
+            over_time (bool, optional): Enable time-series benchmarking. Defaults to False.
 
         Returns:
             list[BenchCfg]: A list of benchmark configuration objects with results
@@ -315,7 +323,9 @@ class BenchRunner:
 
         if run_cfg is None:
             run_cfg = deepcopy(self.run_cfg)
-        run_cfg = BenchRunner.setup_run_cfg(run_cfg, cache_results=cache_results)
+        run_cfg = BenchRunner.setup_run_cfg(
+            run_cfg, cache_results=cache_results, over_time=over_time
+        )
 
         # Set up level and repeat ranges
         min_level = level

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -112,7 +112,7 @@ class BenchRunner:
         run_cfg: BenchRunCfg | None = None,
         level: int = 2,
         cache_results: bool = True,
-        over_time: bool = False,
+        over_time: bool | None = None,
     ) -> BenchRunCfg:
         """Configure benchmark run settings with reasonable defaults.
 
@@ -123,7 +123,7 @@ class BenchRunner:
             run_cfg (BenchRunCfg, optional): Base configuration to modify. Defaults to None.
             level (int, optional): Benchmark sampling resolution level. Defaults to 2.
             cache_results (bool, optional): Whether to enable result caching. Defaults to True.
-            over_time (bool, optional): Enable time-series benchmarking. Defaults to False.
+            over_time (bool, optional): Enable time-series benchmarking. None preserves run_cfg value.
 
         Returns:
             BenchRunCfg: A new configuration object with the specified settings
@@ -132,8 +132,8 @@ class BenchRunner:
         run_cfg_out.cache_samples = cache_results
         run_cfg_out.only_hash_tag = cache_results
         run_cfg_out.level = level
-        if over_time:
-            run_cfg_out.over_time = True
+        if over_time is not None:
+            run_cfg_out.over_time = over_time
         return run_cfg_out
 
     @staticmethod
@@ -271,7 +271,7 @@ class BenchRunner:
         save: bool = False,
         grouped: bool = False,
         cache_results: bool = True,
-        over_time: bool = False,
+        over_time: bool | None = None,
     ) -> list[BenchCfg]:
         """Unified interface for running benchmarks.
 
@@ -297,7 +297,7 @@ class BenchRunner:
             save (bool, optional): save the results to disk in index.html. Defaults to False.
             grouped (bool, optional): Produce a single html page with all the benchmarks included. Defaults to False.
             cache_results (bool, optional): Use the sample cache to reused previous results. Defaults to True.
-            over_time (bool, optional): Enable time-series benchmarking. Defaults to False.
+            over_time (bool, optional): Enable time-series benchmarking. None preserves run_cfg value.
 
         Returns:
             list[BenchCfg]: A list of benchmark configuration objects with results

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
@@ -24,7 +24,8 @@ class BaselineCheck(bn.ParametrizedSweep):
 
 def example_sweep_0_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 0 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = BaselineCheck()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
@@ -25,7 +25,6 @@ class BaselineCheck(bn.ParametrizedSweep):
 def example_sweep_0_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 0 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = BaselineCheck()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -47,4 +46,4 @@ def example_sweep_0_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_0_cat_over_time, level=4)
+    bn.run(example_sweep_0_float_0_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
@@ -26,7 +26,8 @@ class CacheBackend(bn.ParametrizedSweep):
 
 def example_sweep_0_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 1 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = CacheBackend()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
@@ -27,7 +27,6 @@ class CacheBackend(bn.ParametrizedSweep):
 def example_sweep_0_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 1 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = CacheBackend()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -49,4 +48,4 @@ def example_sweep_0_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_1_cat_over_time, level=4)
+    bn.run(example_sweep_0_float_1_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
@@ -29,7 +29,6 @@ class NetworkConfig(bn.ParametrizedSweep):
 def example_sweep_0_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 2 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = NetworkConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -51,4 +50,4 @@ def example_sweep_0_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_2_cat_over_time, level=4)
+    bn.run(example_sweep_0_float_2_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
@@ -28,7 +28,8 @@ class NetworkConfig(bn.ParametrizedSweep):
 
 def example_sweep_0_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 2 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = NetworkConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
@@ -30,7 +30,8 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
 def example_sweep_0_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 3 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = DeploymentConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
@@ -31,7 +31,6 @@ class DeploymentConfig(bn.ParametrizedSweep):
 def example_sweep_0_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """0 Float, 3 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = DeploymentConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -53,4 +52,4 @@ def example_sweep_0_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_3_cat_over_time, level=4)
+    bn.run(example_sweep_0_float_3_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
@@ -27,7 +27,6 @@ def example_sweep_0_float_0_cat_over_time_repeats(
 ) -> bn.Bench:
     """0 Float, 0 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = BaselineCheck()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -49,4 +48,4 @@ def example_sweep_0_float_0_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_0_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_0_float_0_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
@@ -29,7 +29,6 @@ def example_sweep_0_float_1_cat_over_time_repeats(
 ) -> bn.Bench:
     """0 Float, 1 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = CacheBackend()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -51,4 +50,4 @@ def example_sweep_0_float_1_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_1_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_0_float_1_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
@@ -31,7 +31,6 @@ def example_sweep_0_float_2_cat_over_time_repeats(
 ) -> bn.Bench:
     """0 Float, 2 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = NetworkConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -53,4 +52,4 @@ def example_sweep_0_float_2_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_2_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_0_float_2_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
@@ -33,7 +33,6 @@ def example_sweep_0_float_3_cat_over_time_repeats(
 ) -> bn.Bench:
     """0 Float, 3 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = DeploymentConfig()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -55,4 +54,4 @@ def example_sweep_0_float_3_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_0_float_3_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_0_float_3_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
@@ -28,7 +28,6 @@ class SortBenchmark(bn.ParametrizedSweep):
 def example_sweep_1_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 0 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = SortBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -50,4 +49,4 @@ def example_sweep_1_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_0_cat_over_time, level=4)
+    bn.run(example_sweep_1_float_0_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
@@ -27,7 +27,8 @@ class SortBenchmark(bn.ParametrizedSweep):
 
 def example_sweep_1_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 0 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = SortBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
@@ -30,7 +30,6 @@ class SortComparison(bn.ParametrizedSweep):
 def example_sweep_1_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 1 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = SortComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -52,4 +51,4 @@ def example_sweep_1_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_1_cat_over_time, level=4)
+    bn.run(example_sweep_1_float_1_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
@@ -29,7 +29,8 @@ class SortComparison(bn.ParametrizedSweep):
 
 def example_sweep_1_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 1 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = SortComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
@@ -33,7 +33,8 @@ class SortAnalysis(bn.ParametrizedSweep):
 
 def example_sweep_1_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 2 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = SortAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
@@ -34,7 +34,6 @@ class SortAnalysis(bn.ParametrizedSweep):
 def example_sweep_1_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 2 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = SortAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -56,4 +55,4 @@ def example_sweep_1_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_2_cat_over_time, level=4)
+    bn.run(example_sweep_1_float_2_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
@@ -41,7 +41,6 @@ class SortFullMatrix(bn.ParametrizedSweep):
 def example_sweep_1_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 3 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = SortFullMatrix()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -63,4 +62,4 @@ def example_sweep_1_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_3_cat_over_time, level=4)
+    bn.run(example_sweep_1_float_3_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
@@ -40,7 +40,8 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
 def example_sweep_1_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """1 Float, 3 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = SortFullMatrix()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
@@ -30,7 +30,6 @@ def example_sweep_1_float_0_cat_over_time_repeats(
 ) -> bn.Bench:
     """1 Float, 0 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = SortBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -52,4 +51,4 @@ def example_sweep_1_float_0_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_0_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_1_float_0_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
@@ -32,7 +32,6 @@ def example_sweep_1_float_1_cat_over_time_repeats(
 ) -> bn.Bench:
     """1 Float, 1 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = SortComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -54,4 +53,4 @@ def example_sweep_1_float_1_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_1_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_1_float_1_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
@@ -36,7 +36,6 @@ def example_sweep_1_float_2_cat_over_time_repeats(
 ) -> bn.Bench:
     """1 Float, 2 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = SortAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -58,4 +57,4 @@ def example_sweep_1_float_2_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_2_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_1_float_2_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
@@ -43,7 +43,6 @@ def example_sweep_1_float_3_cat_over_time_repeats(
 ) -> bn.Bench:
     """1 Float, 3 Categorical (over time repeats)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = SortFullMatrix()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -65,4 +64,4 @@ def example_sweep_1_float_3_cat_over_time_repeats(
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_1_float_3_cat_over_time_repeats, level=4)
+    bn.run(example_sweep_1_float_3_cat_over_time_repeats, level=4, over_time=True)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
@@ -29,7 +29,6 @@ class CompressionBench(bn.ParametrizedSweep):
 def example_sweep_2_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 0 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = CompressionBench()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -51,4 +50,4 @@ def example_sweep_2_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_2_float_0_cat_over_time, level=4)
+    bn.run(example_sweep_2_float_0_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
@@ -28,7 +28,8 @@ class CompressionBench(bn.ParametrizedSweep):
 
 def example_sweep_2_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 0 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = CompressionBench()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
@@ -33,7 +33,6 @@ class CompressionCodec(bn.ParametrizedSweep):
 def example_sweep_2_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 1 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = CompressionCodec()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -55,4 +54,4 @@ def example_sweep_2_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_2_float_1_cat_over_time, level=4)
+    bn.run(example_sweep_2_float_1_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
@@ -32,7 +32,8 @@ class CompressionCodec(bn.ParametrizedSweep):
 
 def example_sweep_2_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 1 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = CompressionCodec()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
@@ -38,7 +38,6 @@ class CompressionSuite(bn.ParametrizedSweep):
 def example_sweep_2_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 2 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = CompressionSuite()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -60,4 +59,4 @@ def example_sweep_2_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_2_float_2_cat_over_time, level=4)
+    bn.run(example_sweep_2_float_2_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
@@ -37,7 +37,8 @@ class CompressionSuite(bn.ParametrizedSweep):
 
 def example_sweep_2_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """2 Float, 2 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = CompressionSuite()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
@@ -35,7 +35,6 @@ class HashBenchmark(bn.ParametrizedSweep):
 def example_sweep_3_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 0 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = HashBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -57,4 +56,4 @@ def example_sweep_3_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_3_float_0_cat_over_time, level=4)
+    bn.run(example_sweep_3_float_0_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
@@ -34,7 +34,8 @@ class HashBenchmark(bn.ParametrizedSweep):
 
 def example_sweep_3_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 0 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = HashBenchmark()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
@@ -38,7 +38,6 @@ class HashComparison(bn.ParametrizedSweep):
 def example_sweep_3_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 1 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = HashComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -60,4 +59,4 @@ def example_sweep_3_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_3_float_1_cat_over_time, level=4)
+    bn.run(example_sweep_3_float_1_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
@@ -37,7 +37,8 @@ class HashComparison(bn.ParametrizedSweep):
 
 def example_sweep_3_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 1 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = HashComparison()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
@@ -41,7 +41,6 @@ class HashAnalysis(bn.ParametrizedSweep):
 def example_sweep_3_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 2 Categorical (over time)."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = HashAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -63,4 +62,4 @@ def example_sweep_3_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_sweep_3_float_2_cat_over_time, level=4)
+    bn.run(example_sweep_3_float_2_cat_over_time, level=4, over_time=True)

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
@@ -40,7 +40,8 @@ class HashAnalysis(bn.ParametrizedSweep):
 
 def example_sweep_3_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """3 Float, 2 Categorical (over time)."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = HashAnalysis()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -39,7 +39,6 @@ class ThermalPlate(bn.ParametrizedSweep):
 def example_advanced_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
 
     benchable = ThermalPlate()
     bench = benchable.to_bench(run_cfg)
@@ -64,4 +63,4 @@ def example_advanced_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.
 
 
 if __name__ == "__main__":
-    bn.run(example_advanced_agg_over_time, level=4)
+    bn.run(example_advanced_agg_over_time, level=4, over_time=True)

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -38,7 +38,8 @@ class ThermalPlate(bn.ParametrizedSweep):
 
 def example_advanced_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
 
     benchable = ThermalPlate()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/advanced/advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/advanced_git_time_event.py
@@ -26,9 +26,6 @@ class ServerLatency(bn.ParametrizedSweep):
 
 def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Git Time Event — date + commit hash slider labels."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
-
     bench = ServerLatency().to_bench(run_cfg)
 
     # git_time_event() returns a string like "2024-06-15 abc1234d".
@@ -47,4 +44,4 @@ def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn
 
 
 if __name__ == "__main__":
-    bn.run(example_advanced_git_time_event, level=3)
+    bn.run(example_advanced_git_time_event, level=3, over_time=True)

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -30,7 +30,8 @@ class LatencyMonitor(bn.ParametrizedSweep):
 
 def example_advanced_max_time_events(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Max Time Events — cap over_time history."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
 
     # Keep only the 3 most recent time slices in the cache.
     # Without this, every call to plot_sweep appends a new slice and the

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -31,7 +31,6 @@ class LatencyMonitor(bn.ParametrizedSweep):
 def example_advanced_max_time_events(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Max Time Events — cap over_time history."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
 
     # Keep only the 3 most recent time slices in the cache.
     # Without this, every call to plot_sweep appends a new slice and the
@@ -62,4 +61,4 @@ def example_advanced_max_time_events(run_cfg: bn.BenchRunCfg | None = None) -> b
 
 
 if __name__ == "__main__":
-    bn.run(example_advanced_max_time_events, level=3)
+    bn.run(example_advanced_max_time_events, level=3, over_time=True)

--- a/bencher/example/generated/advanced/advanced_time_event.py
+++ b/bencher/example/generated/advanced/advanced_time_event.py
@@ -29,7 +29,8 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
 
 def example_advanced_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Time Events — track metrics across discrete events."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
 
     benchable = PullRequestBenchmark()
     bench = benchable.to_bench(run_cfg)

--- a/bencher/example/generated/advanced/advanced_time_event.py
+++ b/bencher/example/generated/advanced/advanced_time_event.py
@@ -30,7 +30,6 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
 def example_advanced_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Time Events — track metrics across discrete events."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
 
     benchable = PullRequestBenchmark()
     bench = benchable.to_bench(run_cfg)
@@ -56,4 +55,4 @@ def example_advanced_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Ben
 
 
 if __name__ == "__main__":
-    bn.run(example_advanced_time_event, level=3)
+    bn.run(example_advanced_time_event, level=3, over_time=True)

--- a/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
@@ -33,7 +33,6 @@ class ServerOptimizer(bn.ParametrizedSweep):
 def example_optim_over_time_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise Over Time: 1D input."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = ServerOptimizer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -56,4 +55,4 @@ def example_optim_over_time_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Benc
 
 
 if __name__ == "__main__":
-    bn.run(example_optim_over_time_1d, level=2, optimise=30)
+    bn.run(example_optim_over_time_1d, level=2, optimise=30, over_time=True)

--- a/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
@@ -33,7 +33,6 @@ class ServerOptimizer(bn.ParametrizedSweep):
 def example_optim_over_time_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Optimise Over Time: 2D input."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)
-    run_cfg.over_time = True
     benchable = ServerOptimizer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -56,4 +55,4 @@ def example_optim_over_time_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Benc
 
 
 if __name__ == "__main__":
-    bn.run(example_optim_over_time_2d, level=2, optimise=30)
+    bn.run(example_optim_over_time_2d, level=2, optimise=30, over_time=True)

--- a/bencher/example/generated/performance/perf_self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/perf_self_benchmark_over_time.py
@@ -68,7 +68,8 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
 
 def example_perf_self_benchmark_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Bencher self-introspection: overhead tracked over time."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     run_cfg.auto_plot = False
     time_src = bn.git_time_event()
     bench = BencherSelfBenchmark().to_bench(run_cfg)

--- a/bencher/example/generated/performance/perf_self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/perf_self_benchmark_over_time.py
@@ -69,7 +69,6 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
 def example_perf_self_benchmark_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Bencher self-introspection: overhead tracked over time."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     run_cfg.auto_plot = False
     time_src = bn.git_time_event()
     bench = BencherSelfBenchmark().to_bench(run_cfg)
@@ -90,4 +89,4 @@ def example_perf_self_benchmark_over_time(run_cfg: bn.BenchRunCfg | None = None)
 
 
 if __name__ == "__main__":
-    bn.run(example_perf_self_benchmark_over_time)
+    bn.run(example_perf_self_benchmark_over_time, over_time=True)

--- a/bencher/example/generated/regression/regression_percentage.py
+++ b/bencher/example/generated/regression/regression_percentage.py
@@ -29,7 +29,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
 def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Regression detection — percentage threshold over time."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
-    run_cfg.over_time = True
     run_cfg.regression_detection = True
     run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
@@ -69,4 +68,4 @@ def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.B
 
 
 if __name__ == "__main__":
-    bn.run(example_regression_percentage)
+    bn.run(example_regression_percentage, over_time=True)

--- a/bencher/example/generated/result_types/result_image/result_image_over_time.py
+++ b/bencher/example/generated/result_types/result_image/result_image_over_time.py
@@ -50,7 +50,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
 def example_result_image_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """ResultImage: Over Time Slider."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-    run_cfg.over_time = True
     benchable = PolygonRenderer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
@@ -70,4 +69,4 @@ def example_result_image_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.
 
 
 if __name__ == "__main__":
-    bn.run(example_result_image_over_time, level=3)
+    bn.run(example_result_image_over_time, level=3, over_time=True)

--- a/bencher/example/generated/result_types/result_image/result_image_over_time.py
+++ b/bencher/example/generated/result_types/result_image/result_image_over_time.py
@@ -49,7 +49,8 @@ class PolygonRenderer(bn.ParametrizedSweep):
 
 def example_result_image_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """ResultImage: Over Time Slider."""
-    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
     benchable = PolygonRenderer()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -515,12 +515,16 @@ class BenchMetaGen(bn.ParametrizedSweep):
                 time_offset=True,
             )
 
-            defaults_kw = ""
             if self.sample_with_repeats > 1:
-                defaults_kw = f", repeats={self.sample_with_repeats}"
+                cfg_line = (
+                    f"run_cfg = bn.BenchRunCfg.with_defaults"
+                    f"(run_cfg, repeats={self.sample_with_repeats})\n"
+                )
+            else:
+                cfg_line = "if run_cfg is None:\n    run_cfg = bn.BenchRunCfg()\n"
 
             body = (
-                f"run_cfg = bn.BenchRunCfg.with_defaults(run_cfg{defaults_kw})\n"
+                f"{cfg_line}"
                 f"benchable = {info['class_name']}()\n"
                 f"bench = benchable.to_bench(run_cfg)\n"
                 f"_base_time = datetime(2000, 1, 1)\n"

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -521,7 +521,6 @@ class BenchMetaGen(bn.ParametrizedSweep):
 
             body = (
                 f"run_cfg = bn.BenchRunCfg.with_defaults(run_cfg{defaults_kw})\n"
-                "run_cfg.over_time = True\n"
                 f"benchable = {info['class_name']}()\n"
                 f"bench = benchable.to_bench(run_cfg)\n"
                 f"_base_time = datetime(2000, 1, 1)\n"
@@ -549,7 +548,7 @@ class BenchMetaGen(bn.ParametrizedSweep):
                 imports=imports,
                 body=body,
                 class_code=class_code,
-                run_kwargs={"level": 4},
+                run_kwargs={"level": 4, "over_time": True},
             )
         else:
             noise_val = 0.15 if self.sample_with_repeats > 1 else 0.0

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -132,7 +132,6 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
         return super().__call__()'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-run_cfg.over_time = True
 
 benchable = PullRequestBenchmark()
 bench = benchable.to_bench(run_cfg)
@@ -162,7 +161,7 @@ for i, event_name in enumerate(events):
             imports=imports,
             body=body,
             class_code=class_code,
-            run_kwargs={"level": 3},
+            run_kwargs={"level": 3, "over_time": True},
         )
 
     def _generate_git_time_event(self):
@@ -189,9 +188,6 @@ class ServerLatency(bn.ParametrizedSweep):
         self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
         return super().__call__()'''
         body = """\
-run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-run_cfg.over_time = True
-
 bench = ServerLatency().to_bench(run_cfg)
 
 # git_time_event() returns a string like "2024-06-15 abc1234d".
@@ -214,7 +210,7 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             class_code=class_code,
-            run_kwargs={"level": 3},
+            run_kwargs={"level": 3, "over_time": True},
         )
 
     def _generate_max_time_events(self):
@@ -244,7 +240,6 @@ class LatencyMonitor(bn.ParametrizedSweep):
         return super().__call__()'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-run_cfg.over_time = True
 
 # Keep only the 3 most recent time slices in the cache.
 # Without this, every call to plot_sweep appends a new slice and the
@@ -279,7 +274,7 @@ for i in range(5):
             imports=imports,
             body=body,
             class_code=class_code,
-            run_kwargs={"level": 3},
+            run_kwargs={"level": 3, "over_time": True},
         )
 
     def _generate_report_save(self):
@@ -360,7 +355,6 @@ class ThermalPlate(bn.ParametrizedSweep):
         return super().__call__()'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-run_cfg.over_time = True
 
 benchable = ThermalPlate()
 bench = benchable.to_bench(run_cfg)
@@ -389,7 +383,7 @@ for i, offset in enumerate(time_offsets):
             imports=imports,
             body=body,
             class_code=class_code,
-            run_kwargs={"level": 4},
+            run_kwargs={"level": 4, "over_time": True},
         )
 
 

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -131,7 +131,8 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
         self.throughput = base + self._event_idx * 30
         return super().__call__()'''
         body = """\
-run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
 
 benchable = PullRequestBenchmark()
 bench = benchable.to_bench(run_cfg)
@@ -239,7 +240,8 @@ class LatencyMonitor(bn.ParametrizedSweep):
         self.latency = base + self._drift + random.gauss(0, 5)
         return super().__call__()'''
         body = """\
-run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
 
 # Keep only the 3 most recent time slices in the cache.
 # Without this, every call to plot_sweep appends a new slice and the
@@ -354,7 +356,8 @@ class ThermalPlate(bn.ParametrizedSweep):
         )
         return super().__call__()'''
         body = """\
-run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
 
 benchable = ThermalPlate()
 bench = benchable.to_bench(run_cfg)

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -262,7 +262,6 @@ class MetaImageVideoRich(MetaGeneratorBase):
         )
         body = (
             "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)\n"
-            "run_cfg.over_time = True\n"
             "benchable = PolygonRenderer()\n"
             "bench = benchable.to_bench(run_cfg)\n"
             "_base_time = datetime(2000, 1, 1)\n"
@@ -286,7 +285,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
             imports=imports,
             body=body,
             class_code=_IMAGE_CLASS_CODE,
-            run_kwargs={"level": 3},
+            run_kwargs={"level": 3, "over_time": True},
         )
 
     # -- Composable container video from images ------------------------------

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -261,7 +261,8 @@ class MetaImageVideoRich(MetaGeneratorBase):
             ["import bencher as bn", "from datetime import datetime, timedelta"] + _EXTRA_IMPORTS
         )
         body = (
-            "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)\n"
+            "if run_cfg is None:\n"
+            "    run_cfg = bn.BenchRunCfg()\n"
             "benchable = PolygonRenderer()\n"
             "bench = benchable.to_bench(run_cfg)\n"
             "_base_time = datetime(2000, 1, 1)\n"

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -183,7 +183,6 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
 
         body_lines = [
             "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)",
-            "run_cfg.over_time = True",
             "benchable = ServerOptimizer()",
             "bench = benchable.to_bench(run_cfg)",
             "_base_time = datetime(2000, 1, 1)",
@@ -214,7 +213,7 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
             ),
             body="\n".join(body_lines) + "\n",
             class_code=CLASS_CODE_OVERTIME,
-            run_kwargs={"level": 2, "optimise": 30},
+            run_kwargs={"level": 2, "optimise": 30, "over_time": True},
         )
 
         return super().__call__()
@@ -248,7 +247,6 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
 
             body_lines = [
                 "run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=3)",
-                "run_cfg.over_time = True",
                 "benchable = AlgorithmBench()",
                 "bench = benchable.to_bench(run_cfg)",
                 "_base_time = datetime(2000, 1, 1)",
@@ -277,7 +275,7 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 ),
                 body="\n".join(body_lines) + "\n",
                 class_code=CLASS_CODE_AGG,
-                run_kwargs={"level": 3, "optimise": 30},
+                run_kwargs={"level": 3, "optimise": 30, "over_time": True},
             )
         else:
             filename = "optim_aggregated"

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -72,7 +72,8 @@ bench.plot_sweep(
         imports = "import bencher as bn"
 
         body = """\
-run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
 run_cfg.auto_plot = False
 time_src = bn.git_time_event()
 bench = BencherSelfBenchmark().to_bench(run_cfg)

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -73,7 +73,6 @@ bench.plot_sweep(
 
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)
-run_cfg.over_time = True
 run_cfg.auto_plot = False
 time_src = bn.git_time_event()
 bench = BencherSelfBenchmark().to_bench(run_cfg)
@@ -99,6 +98,7 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             class_code=_get_shared_class_code(),
+            run_kwargs={"over_time": True},
         )
 
 

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -53,7 +53,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
         return super().__call__()'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
-run_cfg.over_time = True
 run_cfg.regression_detection = True
 run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False
@@ -97,6 +96,7 @@ if report is not None:
             imports=imports,
             body=body,
             class_code=class_code,
+            run_kwargs={"over_time": True},
         )
 
 

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
         body_lines = []
         if run_cfg_lines:
-            body_lines.append("run_cfg = bn.BenchRunCfg.with_defaults(run_cfg)")
+            body_lines.append("if run_cfg is None:\n    run_cfg = bn.BenchRunCfg()")
             body_lines.extend(run_cfg_lines)
 
         body_lines.append(f"bench = {benchable_class}().to_bench(run_cfg)")

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -70,7 +70,7 @@ def run(
     publish: bool = False,
     grouped: bool = False,
     cache_results: bool = True,
-    over_time: bool = False,
+    over_time: bool | None = None,
     optimise: int | bool = 0,
 ) -> list[BenchCfg]:
     """Run a benchmark target with sensible defaults.
@@ -94,7 +94,7 @@ def run(
         publish: Publish results. Defaults to False.
         grouped: Produce a single HTML page with all benchmarks. Defaults to False.
         cache_results: Use sample cache for previous results. Defaults to True.
-        over_time: Enable time-series benchmarking. Defaults to False.
+        over_time: Enable time-series benchmarking. None preserves run_cfg value.
         optimise: When > 0, appends optuna analysis plots (parameter importance,
             with/without repeats comparison, best parameters) from the sweep results
             to the report. Defaults to 0 (no optimisation analysis).

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -70,6 +70,7 @@ def run(
     publish: bool = False,
     grouped: bool = False,
     cache_results: bool = True,
+    over_time: bool = False,
     optimise: int | bool = 0,
 ) -> list[BenchCfg]:
     """Run a benchmark target with sensible defaults.
@@ -93,6 +94,7 @@ def run(
         publish: Publish results. Defaults to False.
         grouped: Produce a single HTML page with all benchmarks. Defaults to False.
         cache_results: Use sample cache for previous results. Defaults to True.
+        over_time: Enable time-series benchmarking. Defaults to False.
         optimise: When > 0, appends optuna analysis plots (parameter importance,
             with/without repeats comparison, best parameters) from the sweep results
             to the report. Defaults to 0 (no optimisation analysis).
@@ -145,6 +147,7 @@ def run(
         publish=publish,
         grouped=grouped,
         cache_results=cache_results,
+        over_time=over_time,
     )
     if show and br.servers:
         # Always register so atexit/SIGTERM can clean up as a safety net.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -89,7 +89,13 @@ Bencher assumes your function is a stochastic pure function — given the same i
 
 ## Tracking Over Time
 
-Track how results change across successive runs by calling `plot_sweep()` multiple times with different `time_src` values:
+Enable `over_time` to record time-series snapshots that can be scrubbed via a slider:
+
+```python
+bn.run(MyBench, level=3, repeats=3, over_time=True)
+```
+
+For multi-snapshot tracking (e.g. CI pipelines), call `plot_sweep()` in a loop with different `time_src` values:
 
 ```python
 run_cfg = bn.BenchRunCfg(over_time=True, repeats=3)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.72.5"
+version = "1.73.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Add `over_time` as a top-level keyword argument to `bn.run()` and `BenchRunner.run()`, so users can write `bn.run(MyBench, over_time=True)` instead of manually creating a `BenchRunCfg`
- Update `docs/intro.md` to show the new one-liner alongside the existing manual loop pattern
- Update all meta-generators to pass `over_time` via `run_kwargs` instead of setting `run_cfg.over_time = True` inside generated function bodies, and regenerate all 30+ over_time examples

## Test plan
- [x] `pixi run ci` passes (format, lint, pylint, type check, tests with coverage)
- [x] All generated examples regenerated and verified
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)