### PR TITLE
fix: include time event in over_time panel labels and default to last

### DIFF
--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -10,6 +10,8 @@ import tempfile
 from threading import Thread
 from dataclasses import dataclass
 
+import numpy as np
+import pandas as pd
 import panel as pn
 from bencher.results.bench_result import BenchResult
 from bencher.bench_plot_server import BenchPlotServer
@@ -63,15 +65,37 @@ class BenchReport(BenchPlotServer):
             col = pn.Column(pane, name=pane.name)
         self.pane.append(col)
 
+    @staticmethod
+    def _time_event_label(bench_res: BenchResult) -> str | None:
+        """Extract a human-readable label for the latest time event from a result."""
+        if not bench_res.bench_cfg.over_time or "over_time" not in bench_res.ds.coords:
+            return None
+        time_vals = bench_res.ds.coords["over_time"].values
+        if len(time_vals) == 0:
+            return None
+        last = time_vals[-1]
+        if isinstance(last, (np.datetime64,)):
+            label = pd.Timestamp(last).strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            label = str(last).replace("\n", " ")
+        if len(label) > 60:
+            label = label[:57] + "..."
+        return label
+
     def append_result(self, bench_res: BenchResult) -> None:
         self.bench_results.append(bench_res)
-        self.append_tab(bench_res.plot(), bench_res.bench_cfg.title)
+        title = bench_res.bench_cfg.title
+        label = self._time_event_label(bench_res)
+        if label:
+            title = f"{title} [{label}]"
+        self.append_tab(bench_res.plot(), title)
 
     def append_tab(self, pane: pn.panel, name: str | None = None) -> None:
         if pane is not None:
             if name is None:
                 name = pane.name
             self.pane.append(pn.Column(pane, name=name))
+            self.pane.active = len(self.pane) - 1
 
     def save_index(self, directory: str = "", filename: str = "index.html") -> Path:
         """Saves the result to index.html in the root folder so that it can be displayed by github pages.
@@ -157,15 +181,16 @@ class BenchReport(BenchPlotServer):
     @staticmethod
     def _write_iframe_index(index_path: Path, tab_files: list) -> None:
         """Write a lightweight HTML index with tab buttons and an iframe."""
+        last_idx = len(tab_files) - 1
         buttons = ""
         for i, (name, path) in enumerate(tab_files):
-            active = " active" if i == 0 else ""
+            active = " active" if i == last_idx else ""
             escaped_name = html.escape(name)
             buttons += (
                 f'<button class="tab-btn{active}" '
                 f"onclick=\"switchTab(this, '{path}')\">{escaped_name}</button>\n"
             )
-        first_src = tab_files[0][1] if tab_files else ""
+        first_src = tab_files[last_idx][1] if tab_files else ""
         page = f"""\
 <!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Report</title>


### PR DESCRIPTION
## Summary
- Over_time examples call `plot_sweep` multiple times, creating report tabs that all share the same title (e.g. "over_time"). Now each tab label includes the latest time event (e.g. `over_time [2000-01-01 00:00:02]` or `PR Benchmark [PR-112-add-cache]`).
- The default active panel is now the last (most recent) time event instead of the first, both in the iframe-based HTML report and in live Panel serving.

## Test plan
- [ ] Run an over_time example (`pixi run python bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py`) and verify tab labels are distinct
- [ ] Run a time_event example (`pixi run python bencher/example/generated/advanced/advanced_time_event.py`) and verify tab labels show PR names
- [ ] Verify the last tab is active by default in saved HTML output
- [ ] Run `pixi run ci` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update benchmark reports to include the latest time event in panel labels and make the most recent panel active by default in both live and HTML iframe reports.

New Features:
- Add human-readable labels for the latest time event to over_time benchmark report panel titles.

Enhancements:
- Change panel selection so the most recent benchmark result tab is active by default in live Panel views and generated HTML iframe indices.