### PR TITLE
Bump version to 1.73.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.73.2] - 2026-03-29
+
+### Added
+- Restore rerun integration with Panel-served .rrd files (#855)
+- New rerun examples: `example_rerun.py` and `example_rerun2.py`
+- SDK-free .rrd utilities in `utils_rrd.py` that work without rerun-sdk dependency
+- Architecture documentation for rerun integration
+- HTTP file server using stdlib `http.server` to replace Flask dependency
+
+### Changed  
+- Auto-initialize rerun recording, removing need for manual `rr.init()` in examples
+- Split rerun code so `.rrd` utilities work without rerun-sdk
+- Replace Flask file server with stdlib `http.server` for better maintainability
+- Refactor rerun examples and clean up unused imports
+
+### Fixed
+- Restore working rerun viewer functionality 
+- Remove hardcoded branch names in examples
+- Clean up unused imports and fix example formatting
+
 ## [1.73.1] - 2026-03-27
 
 ### Fixed

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -196,6 +196,8 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path, pag
     run_cfg.repeats = run_kwargs.get("repeats", 1)
     if "use_optuna" in run_kwargs:
         run_cfg.use_optuna = run_kwargs["use_optuna"]
+    if "over_time" in run_kwargs:
+        run_cfg.over_time = run_kwargs["over_time"]
     optimise = run_kwargs.get("optimise", 0)
     print(f"Running {py_file}...")
     bench = example_fn(run_cfg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.73.1"
+version = "1.73.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
Version bump from 1.73.1 to 1.73.2

## Changes
- Updated version in pyproject.toml from 1.73.1 to 1.73.2  
- Added changelog entry for version 1.73.2

This is a routine version bump for the next release cycle.

## Summary by Sourcery

Bump project version for a new patch release.

Build:
- Update project version in pyproject.toml for release 1.73.2.

Documentation:
- Add changelog entry documenting version 1.73.2 release.