### PR TITLE
fix: set over_time on run_cfg in doc generator

### DIFF
--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -196,6 +196,8 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path, pag
     run_cfg.repeats = run_kwargs.get("repeats", 1)
     if "use_optuna" in run_kwargs:
         run_cfg.use_optuna = run_kwargs["use_optuna"]
+    if run_kwargs.get("over_time"):
+        run_cfg.over_time = True
     optimise = run_kwargs.get("optimise", 0)
     print(f"Running {py_file}...")
     bench = example_fn(run_cfg)


### PR DESCRIPTION
## Summary

- The doc generator (`generate_examples.py`) extracts `run_kwargs` from each example's `bn.run()` call but never applied the `over_time` flag to the `run_cfg` passed into the example function
- This meant `plot_sweep` ran with `over_time=False`, so history cache loading was skipped and the `over_time` coordinate was not assembled correctly in generated reports
- Adds `run_cfg.over_time = True` when `over_time` is present in the extracted `run_kwargs`

## Context

PR #848 (`beb6b87`) moved `over_time` from being set inside generated function bodies (`run_cfg.over_time = True`) to being passed as a kwarg to `bn.run()`. The generated examples now have `bn.run(example_fn, level=4, over_time=True)` in their `__main__` block, but the doc generator calls `example_fn(run_cfg)` directly — bypassing `bn.run()` — so the `over_time=True` kwarg was never applied.

## Test plan

- [ ] Verify `pixi run generate-docs` produces correct over_time reports with time sliders
- [ ] Run `pixi run ci` to confirm no regressions

https://claude.ai/code/session_01GL8TBGCBC5emR5JVhjAs8g

## Summary by Sourcery

Bug Fixes:
- Apply the extracted over_time flag from example run kwargs to the run_cfg used by the doc generator to fix missing over-time coordinates and history loading in generated reports.