### PR TITLE
Add viewer_version parameter to rrd_file_to_pane

### DIFF
--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -58,7 +58,12 @@ def publish_and_view_rrd(
     return rrd_to_pane(publish_path, version=version)
 
 
-def rrd_file_to_pane(file_path, width: int = 300, height: int = 300):  # pragma: no cover
+def rrd_file_to_pane(  # pragma: no cover
+    file_path,
+    width: int = 300,
+    height: int = 300,
+    viewer_version: str | None = None,
+):
     """Create a rerun viewer pane from an .rrd file path.
 
     Uses an HTML iframe to display the .rrd file.  If the ``rerun-sdk``
@@ -68,6 +73,23 @@ def rrd_file_to_pane(file_path, width: int = 300, height: int = 300):  # pragma:
     so the hosted viewer can fetch the file from localhost).
 
     The file must be located under ``cachedir/rrd/``.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the .rrd file (must be under ``cachedir/rrd/``).
+    width:
+        Width of the viewer iframe in pixels.
+    height:
+        Height of the viewer iframe in pixels.
+    viewer_version:
+        When set, uses a self-contained viewer page loaded from the
+        ``@rerun-io/web-viewer`` CDN at this exact version instead of the
+        locally installed ``rerun-sdk``.  This is useful when the .rrd was
+        recorded with a different SDK version than the one installed (e.g.
+        a C++ SDK at 0.30.x while the Python SDK is 0.26.x).  The viewer
+        page is written to ``cachedir/rrd/`` and served from the same
+        HTTP origin as the .rrd files, avoiding mixed-content issues.
     """
     rrd_path = Path(file_path).resolve()
     cache_root = Path("cachedir/rrd").resolve()
@@ -79,15 +101,18 @@ def rrd_file_to_pane(file_path, width: int = 300, height: int = 300):  # pragma:
         ) from None
     rrd_url = f"http://localhost:{PANEL_PORT}/rrd_static/{relative}"
 
-    # Prefer the local rerun viewer when the SDK is available.
-    try:
-        from .utils_rerun import _ensure_rerun_viewer
+    if viewer_version is not None:
+        viewer_url = _cdn_viewer_url(relative, viewer_version)
+    else:
+        # Prefer the local rerun viewer when the SDK is available.
+        try:
+            from .utils_rerun import _ensure_rerun_viewer
 
-        _ensure_rerun_viewer()
-        viewer_url = f"http://localhost:{_RERUN_VIEWER_PORT}/?url={rrd_url}"
-    except (ImportError, ModuleNotFoundError):
-        version = _get_rerun_version()
-        viewer_url = f"https://app.rerun.io/version/{version}/?url={rrd_url}"
+            _ensure_rerun_viewer()
+            viewer_url = f"http://localhost:{_RERUN_VIEWER_PORT}/?url={rrd_url}"
+        except (ImportError, ModuleNotFoundError):
+            version = _get_rerun_version()
+            viewer_url = f"https://app.rerun.io/version/{version}/?url={rrd_url}"
 
     return pn.pane.HTML(
         f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
@@ -95,3 +120,56 @@ def rrd_file_to_pane(file_path, width: int = 300, height: int = 300):  # pragma:
         width=width,
         height=height,
     )
+
+
+# --- CDN viewer support ---
+
+_CDN_VIEWER_TEMPLATE = """\
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"/>
+<style>html,body{{margin:0;padding:0;width:100%;height:100%;overflow:hidden}}</style>
+</head><body>
+<div id="c" style="width:100vw;height:100vh"></div>
+<div id="e" style="color:red;padding:20px;font-family:monospace;white-space:pre-wrap"></div>
+<script type="module">
+try {{
+  const p = new URLSearchParams(location.search);
+  const url = p.get("url");
+  if (!url) throw new Error("Missing ?url= parameter");
+  const {{WebViewer}} = await import(
+    "https://cdn.jsdelivr.net/npm/@rerun-io/web-viewer@{version}/+esm"
+  );
+  const v = new WebViewer();
+  await v.start(new URL(url, location.origin).href,
+                document.getElementById("c"),
+                {{hide_welcome_screen:true,width:"100%",height:"100%"}});
+}} catch(e) {{
+  document.getElementById("e").textContent = e.message + "\\n" + e.stack;
+}}
+</script></body></html>
+"""
+
+# Cache of generated viewer HTML pages keyed by version.
+_cdn_viewer_versions: dict[str, str] = {}
+
+
+def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
+    """Return the iframe URL for a CDN-based viewer at the given version.
+
+    Writes a ``viewer_<version>.html`` page into ``cachedir/rrd/`` (served
+    by the Panel server at ``/rrd_static/``) that loads the rerun web viewer
+    from the jsDelivr CDN.  Both the viewer page and the .rrd are on the
+    same HTTP origin, avoiding mixed-content blocks.
+    """
+    if version not in _cdn_viewer_versions:
+        html = _CDN_VIEWER_TEMPLATE.format(version=version)
+        filename = f"viewer_{version}.html"
+        viewer_path = Path("cachedir/rrd").resolve() / filename
+        viewer_path.parent.mkdir(parents=True, exist_ok=True)
+        if not viewer_path.exists() or viewer_path.read_text() != html:
+            viewer_path.write_text(html)
+        _cdn_viewer_versions[version] = filename
+
+    filename = _cdn_viewer_versions[version]
+    rrd_url = f"/rrd_static/{rrd_relative}"
+    return f"http://localhost:{PANEL_PORT}/rrd_static/{filename}?url={rrd_url}"

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -11,8 +11,10 @@ See ``utils_rerun.py`` for functions that require the rerun Python SDK
 """
 
 import logging
+import re
 from importlib.metadata import PackageNotFoundError, version as get_package_version
 from pathlib import Path
+from urllib.parse import quote
 
 import panel as pn
 
@@ -23,6 +25,12 @@ PANEL_PORT = 8051
 
 # Port for the local rerun web viewer server (when rerun-sdk is available).
 _RERUN_VIEWER_PORT = 9090
+
+# Root directory for cached .rrd files and viewer pages.
+_RRD_CACHE_DIR = Path("cachedir/rrd")
+
+# Pattern for valid viewer version strings (semver-like, e.g. "0.30.1", "0.30.0-alpha.1").
+_VERSION_RE = re.compile(r"^[0-9A-Za-z._-]+$")
 
 
 def _get_rerun_version() -> str:
@@ -92,14 +100,20 @@ def rrd_file_to_pane(  # pragma: no cover
         HTTP origin as the .rrd files, avoiding mixed-content issues.
     """
     rrd_path = Path(file_path).resolve()
-    cache_root = Path("cachedir/rrd").resolve()
+    cache_root = _RRD_CACHE_DIR.resolve()
     try:
         relative = rrd_path.relative_to(cache_root)
     except ValueError:
         raise ValueError(
             f"rrd_file_to_pane expects files under {cache_root}, got {rrd_path}"
         ) from None
-    rrd_url = f"http://localhost:{PANEL_PORT}/rrd_static/{relative}"
+    rrd_url = f"http://localhost:{PANEL_PORT}/rrd_static/{relative.as_posix()}"
+
+    if viewer_version is not None and not _VERSION_RE.match(viewer_version):
+        raise ValueError(
+            f"Invalid viewer_version {viewer_version!r}: "
+            "must match [0-9A-Za-z._-]+"
+        )
 
     if viewer_version is not None:
         viewer_url = _cdn_viewer_url(relative, viewer_version)
@@ -164,12 +178,12 @@ def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
     if version not in _cdn_viewer_versions:
         html = _CDN_VIEWER_TEMPLATE.format(version=version)
         filename = f"viewer_{version}.html"
-        viewer_path = Path("cachedir/rrd").resolve() / filename
+        viewer_path = _RRD_CACHE_DIR.resolve() / filename
         viewer_path.parent.mkdir(parents=True, exist_ok=True)
         if not viewer_path.exists() or viewer_path.read_text() != html:
             viewer_path.write_text(html)
         _cdn_viewer_versions[version] = filename
 
     filename = _cdn_viewer_versions[version]
-    rrd_url = f"/rrd_static/{rrd_relative}"
+    rrd_url = quote(f"/rrd_static/{rrd_relative.as_posix()}", safe="/:")
     return f"http://localhost:{PANEL_PORT}/rrd_static/{filename}?url={rrd_url}"

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -12,6 +12,7 @@ See ``utils_rerun.py`` for functions that require the rerun Python SDK
 
 import logging
 import re
+import shutil
 from importlib.metadata import PackageNotFoundError, version as get_package_version
 from pathlib import Path
 from urllib.parse import quote
@@ -71,6 +72,7 @@ def rrd_file_to_pane(  # pragma: no cover
     width: int = 300,
     height: int = 300,
     viewer_version: str | None = None,
+    report_dir: str | Path | None = None,
 ):
     """Create a rerun viewer pane from an .rrd file path.
 
@@ -98,8 +100,23 @@ def rrd_file_to_pane(  # pragma: no cover
         a C++ SDK at 0.30.x while the Python SDK is 0.26.x).  The viewer
         page is written to ``cachedir/rrd/`` and served from the same
         HTTP origin as the .rrd files, avoiding mixed-content issues.
+    report_dir:
+        When set (together with ``viewer_version``), copies the .rrd and
+        viewer HTML into this directory and uses relative URLs in the iframe.
+        This makes the report portable — it works when served from any HTTP
+        origin (e.g. CI report hosting on GCS/S3) without a live Panel
+        server.  When ``None``, files stay in ``cachedir/rrd/`` and are
+        served by the Panel server at ``/rrd_static/``.
     """
     rrd_path = Path(file_path).resolve()
+
+    if report_dir is not None and viewer_version is not None:
+        if not _VERSION_RE.match(viewer_version):
+            raise ValueError(
+                f"Invalid viewer_version {viewer_version!r}: must match [0-9A-Za-z._-]+"
+            )
+        return _portable_rrd_pane(rrd_path, viewer_version, Path(report_dir), width, height)
+
     cache_root = _RRD_CACHE_DIR.resolve()
     try:
         relative = rrd_path.relative_to(cache_root)
@@ -151,7 +168,7 @@ try {{
     "https://cdn.jsdelivr.net/npm/@rerun-io/web-viewer@{version}/+esm"
   );
   const v = new WebViewer();
-  await v.start(new URL(url, location.origin).href,
+  await v.start(new URL(url, location.href).href,
                 document.getElementById("c"),
                 {{hide_welcome_screen:true,width:"100%",height:"100%"}});
 }} catch(e) {{
@@ -184,3 +201,45 @@ def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
     filename = _cdn_viewer_versions[version]
     rrd_url = quote(f"/rrd_static/{rrd_relative.as_posix()}", safe="/:")
     return f"http://localhost:{PANEL_PORT}/rrd_static/{filename}?url={rrd_url}"
+
+
+def _get_cdn_viewer_html(version: str) -> str:
+    """Return the viewer HTML string for a given rerun version (cached)."""
+    if version not in _cdn_viewer_versions:
+        _cdn_viewer_versions[version] = _CDN_VIEWER_TEMPLATE.format(version=version)
+    return _cdn_viewer_versions[version]
+
+
+def _portable_rrd_pane(
+    rrd_path: Path,
+    version: str,
+    report_dir: Path,
+    width: int,
+    height: int,
+) -> pn.pane.HTML:
+    """Create a self-contained pane with files copied into the report directory.
+
+    Copies the .rrd and a CDN viewer HTML page into ``report_dir/rrd/`` and
+    returns an iframe with a relative URL.  The resulting report can be served
+    from any HTTP origin without a live Panel server.
+    """
+    rrd_subdir = report_dir / "rrd"
+    rrd_subdir.mkdir(parents=True, exist_ok=True)
+
+    # Copy .rrd
+    rrd_dest = rrd_subdir / rrd_path.name
+    shutil.copy2(rrd_path, rrd_dest)
+
+    # Write viewer HTML (idempotent)
+    html = _get_cdn_viewer_html(version)
+    viewer_path = rrd_subdir / "viewer.html"
+    if not viewer_path.exists() or viewer_path.read_text() != html:
+        viewer_path.write_text(html)
+
+    viewer_url = f"rrd/viewer.html?url={quote(rrd_path.name)}"
+    return pn.pane.HTML(
+        f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
+        f' frameborder="0" allowfullscreen></iframe>',
+        width=width,
+        height=height,
+    )

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -110,10 +110,7 @@ def rrd_file_to_pane(  # pragma: no cover
     rrd_url = f"http://localhost:{PANEL_PORT}/rrd_static/{relative.as_posix()}"
 
     if viewer_version is not None and not _VERSION_RE.match(viewer_version):
-        raise ValueError(
-            f"Invalid viewer_version {viewer_version!r}: "
-            "must match [0-9A-Za-z._-]+"
-        )
+        raise ValueError(f"Invalid viewer_version {viewer_version!r}: must match [0-9A-Za-z._-]+")
 
     if viewer_version is not None:
         viewer_url = _cdn_viewer_url(relative, viewer_version)


### PR DESCRIPTION
## Summary
- Add optional `viewer_version` parameter to `rrd_file_to_pane()`
- When set, uses a CDN-loaded `@rerun-io/web-viewer` at the specified version instead of the locally installed `rerun-sdk`
- The viewer HTML page is served from the same HTTP origin as the `.rrd` files, avoiding mixed-content browser blocks

## Motivation
When the `.rrd` file is recorded with a different rerun SDK version than the one installed (e.g. C++ SDK 0.30.x while the Python SDK is 0.26.x), the local viewer cannot render data or blueprints correctly. This happens in kinisi_ros where the C++ rerun bridge uses 0.30.1 but the Python environment has 0.26.x pinned due to numpy constraints.

## Usage
```python
# Use version-matched viewer instead of locally installed SDK
rrd_file_to_pane(path, viewer_version="0.30.1")
```

When `viewer_version` is not set, behavior is unchanged (uses local SDK viewer or hosted fallback).

## Test plan
- [ ] Existing `rrd_file_to_pane()` calls without `viewer_version` work as before
- [ ] `rrd_file_to_pane(path, viewer_version="0.30.1")` renders .rrd files correctly with the CDN viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for rendering .rrd files with a version-pinned web viewer loaded from a CDN while preserving existing behavior by default.

New Features:
- Introduce an optional viewer_version parameter to rrd_file_to_pane to select a specific web viewer version for .rrd rendering.
- Generate and serve a per-version HTML viewer page from cachedir/rrd that loads the @rerun-io/web-viewer package from the jsDelivr CDN on the same HTTP origin as the .rrd files.