### PR TITLE
fix: render tally marks at constant pixel size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ are:
 | `publish_` | `publishing/` | example |
 | `rerun_` | `rerun/` | example |
 | `agg_` | `aggregation/` | aggregation form, agg_fn |
+| `cartesian_` | `cartesian_animation/` | (single example) |
 
 **Rules for adding new generators:**
 1. Pick a short, unique section prefix that does not collide with existing prefixes.

--- a/bencher/example/generated/cartesian_animation/cartesian_animation.py
+++ b/bencher/example/generated/cartesian_animation/cartesian_animation.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Cartesian Product Animations — Visual exploration of parameter spaces."""
+"""Auto-generated example: Cartesian Product Animation — Visual exploration of parameter spaces."""
 
 from typing import Any
 
@@ -67,8 +67,8 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
         return super().__call__()
 
 
-def example_advanced_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Cartesian Product Animations — Visual exploration of parameter spaces."""
+def example_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Cartesian Product Animation — Visual exploration of parameter spaces."""
     bench = CartesianAnimationSweep().to_bench(run_cfg)
 
     bench.plot_sweep(
@@ -79,14 +79,17 @@ def example_advanced_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) 
             bn.sweep("time_steps", [0, 1, 6, 30]),
         ],
         result_vars=["animation"],
-        description="Demonstrates advanced animation generation by visualizing Cartesian product "
-        "exploration across different dimensionality combinations. Each animation shows how the "
-        "parameter space grid changes with varying spatial dimensions, repeat counts, and time steps.",
-        post_description="The animations illustrate the complexity scaling of parameter sweeps "
-        "and provide visual insight into multi-dimensional benchmark design patterns.",
+        description="Visualizes Cartesian product parameter spaces as animated "
+        "dimensional extrusions. Each animation shows how the parameter space "
+        "grid builds up: point to line to grid to 3D stack, with repeats shown "
+        "as tally marks and time steps as a film strip.",
+        post_description="The animations illustrate the complexity scaling of "
+        "parameter sweeps and provide visual insight into multi-dimensional "
+        "benchmark design patterns.",
     )
+
     return bench
 
 
 if __name__ == "__main__":
-    bn.run(example_advanced_cartesian_animation, level=4, cache_results=False)
+    bn.run(example_cartesian_animation, level=4, cache_results=False)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -121,6 +121,9 @@ def generate_python_files():
     from bencher.example.meta.generate_meta_publish import example_meta_publish
     from bencher.example.meta.generate_meta_rerun import example_meta_rerun
     from bencher.example.meta.generate_meta_aggregation import example_meta_aggregation
+    from bencher.example.meta.generate_meta_cartesian_animation import (
+        example_meta_cartesian_animation,
+    )
 
     example_meta()
     example_meta_result_types()
@@ -143,6 +146,7 @@ def generate_python_files():
     example_meta_publish()
     example_meta_rerun()
     example_meta_aggregation()
+    example_meta_cartesian_animation()
 
     # Write __init__.py files so generated examples are importable
     for d in GENERATED_DIR.rglob("*"):
@@ -428,6 +432,7 @@ SECTION_GROUPS = [
             ("Statistics", "statistics"),
             ("Workflows", "workflows"),
             ("YAML Sweeps", "yaml"),
+            ("Cartesian Animation", "cartesian_animation"),
             ("Advanced Patterns", "advanced"),
             ("Regression Detection", "regression"),
             ("Performance", "performance"),

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -18,7 +18,6 @@ ADVANCED_EXAMPLES = [
     "max_time_events",
     "report_save",
     "agg_over_time",
-    "cartesian_animation",
 ]
 
 
@@ -42,9 +41,6 @@ class MetaAdvanced(MetaGeneratorBase):
             self._generate_report_save()
         elif self.example == "agg_over_time":
             self._generate_agg_over_time()
-        elif self.example == "cartesian_animation":
-            self._generate_cartesian_animation()
-
         return super().__call__()
 
     def _generate_cache_patterns(self):
@@ -390,90 +386,6 @@ for i, offset in enumerate(time_offsets):
             body=body,
             class_code=class_code,
             run_kwargs={"level": 4, "over_time": True},
-        )
-
-    def _generate_cartesian_animation(self):
-        """Generate Cartesian product animations across dimensionality combinations."""
-        imports = "import bencher as bn\nfrom bencher.results.manim_cartesian import CartesianProductCfg, SweepVar, render_animation"
-        class_code = '''class CartesianAnimationSweep(bn.ParametrizedSweep):
-    """Renders animations of Cartesian product exploration across dimensions.
-    
-    Demonstrates advanced animation capabilities by sweeping across:
-    - spatial_dims: Number of spatial dimensions (1-4)
-    - repeats: Number of repeat dimensions 
-    - time_steps: Number of time steps for over_time dimension
-    
-    Each combination produces a unique animation showing how the Cartesian
-    product grid changes with different dimensionality patterns.
-    """
-    spatial_dims = bn.IntSweep(default=1, bounds=(1, 5), doc="Number of spatial dimensions")
-    repeats = bn.IntSweep(default=0, bounds=(0, 100), doc="Number of repeats (0 = no repeat dim)")
-    time_steps = bn.IntSweep(
-        default=0, bounds=(0, 10), doc="Number of time steps (0 = no over_time dim)"
-    )
-
-    # Strobe tunables
-    strobe_pad = 12
-    strobe_border_radius = 4
-    strobe_mark_size = 2
-    strobe_mark_gap = 4
-
-    animation = bn.ResultImage()
-
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
-        all_spatial = [
-            SweepVar("dim_1", [0, 1, 2]),
-            SweepVar("dim_2", [0, 1, 2]),
-            SweepVar("dim_3", [0, 1]),
-            SweepVar("dim_4", [0, 1]),
-            SweepVar("dim_5", [0, 1]),
-        ]
-        sweep_vars = list(all_spatial[: self.spatial_dims])
-
-        if self.repeats > 0:
-            sweep_vars.append(SweepVar("repeat", list(range(1, self.repeats + 1))))
-        if self.time_steps > 0:
-            sweep_vars.append(SweepVar("over_time", [f"t{i}" for i in range(self.time_steps)]))
-
-        cfg = CartesianProductCfg(
-            all_vars=sweep_vars,
-            result_names=["result"],
-            strobe_pad=self.strobe_pad,
-            strobe_mark_size=self.strobe_mark_size,
-            strobe_mark_gap=self.strobe_mark_gap,
-            strobe_border_radius=self.strobe_border_radius,
-        )
-
-        animation_path = render_animation(
-            cfg,
-            width=320,
-            height=200,
-        )
-        self.animation = animation_path
-        return super().__call__()'''
-        body = """bench = CartesianAnimationSweep().to_bench(run_cfg)
-
-bench.plot_sweep(
-    "Cartesian Product Animations",
-    input_vars=["spatial_dims", bn.sweep("repeats", [0, 1, 6, 100]), bn.sweep("time_steps", [0, 1, 6, 30])],
-    result_vars=["animation"],
-    description="Demonstrates advanced animation generation by visualizing Cartesian product "
-    "exploration across different dimensionality combinations. Each animation shows how the "
-    "parameter space grid changes with varying spatial dimensions, repeat counts, and time steps.",
-    post_description="The animations illustrate the complexity scaling of parameter sweeps "
-    "and provide visual insight into multi-dimensional benchmark design patterns.",
-)"""
-        self.generate_example(
-            title="Cartesian Product Animations — Visual exploration of parameter spaces",
-            output_dir=OUTPUT_DIR,
-            filename="advanced_cartesian_animation",
-            function_name="example_advanced_cartesian_animation",
-            imports=imports,
-            body=body,
-            class_code=class_code,
-            run_kwargs={"level": 4, "cache_results": False},
         )
 
 

--- a/bencher/example/meta/generate_meta_cartesian_animation.py
+++ b/bencher/example/meta/generate_meta_cartesian_animation.py
@@ -1,0 +1,139 @@
+"""Meta-generator: Cartesian product animation example.
+
+Generates an example that visualizes Cartesian product parameter spaces as
+animated dimensional extrusions — showing how each dimension builds on the
+last (point → line → grid → stack → repeats → film strip).
+"""
+
+from typing import Any
+
+import bencher as bn
+from bencher.example.meta.meta_generator_base import MetaGeneratorBase
+
+OUTPUT_DIR = "cartesian_animation"
+
+
+class MetaCartesianAnimation(MetaGeneratorBase):
+    """Generate the Cartesian product animation example."""
+
+    def __call__(self, **kwargs: Any) -> Any:
+        self.update_params_from_kwargs(**kwargs)
+        self._generate_cartesian_animation()
+        return super().__call__()
+
+    def _generate_cartesian_animation(self):
+        """Generate Cartesian product animations across dimensionality combinations."""
+        imports = (
+            "import bencher as bn\n"
+            "from bencher.results.manim_cartesian import "
+            "CartesianProductCfg, SweepVar, render_animation"
+        )
+        class_code = '''\
+class CartesianAnimationSweep(bn.ParametrizedSweep):
+    """Renders animations of Cartesian product exploration across dimensions.
+
+    Demonstrates advanced animation capabilities by sweeping across:
+    - spatial_dims: Number of spatial dimensions (1-4)
+    - repeats: Number of repeat dimensions
+    - time_steps: Number of time steps for over_time dimension
+
+    Each combination produces a unique animation showing how the Cartesian
+    product grid changes with different dimensionality patterns.
+    """
+
+    spatial_dims = bn.IntSweep(default=1, bounds=(1, 5), doc="Number of spatial dimensions")
+    repeats = bn.IntSweep(
+        default=0, bounds=(0, 100), doc="Number of repeats (0 = no repeat dim)"
+    )
+    time_steps = bn.IntSweep(
+        default=0, bounds=(0, 10), doc="Number of time steps (0 = no over_time dim)"
+    )
+
+    # Strobe tunables
+    strobe_pad = 12
+    strobe_border_radius = 4
+    strobe_mark_size = 2
+    strobe_mark_gap = 4
+
+    animation = bn.ResultImage()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+
+        all_spatial = [
+            SweepVar("dim_1", [0, 1, 2]),
+            SweepVar("dim_2", [0, 1, 2]),
+            SweepVar("dim_3", [0, 1]),
+            SweepVar("dim_4", [0, 1]),
+            SweepVar("dim_5", [0, 1]),
+        ]
+        sweep_vars = list(all_spatial[: self.spatial_dims])
+
+        if self.repeats > 0:
+            sweep_vars.append(SweepVar("repeat", list(range(1, self.repeats + 1))))
+        if self.time_steps > 0:
+            sweep_vars.append(
+                SweepVar("over_time", [f"t{i}" for i in range(self.time_steps)])
+            )
+
+        cfg = CartesianProductCfg(
+            all_vars=sweep_vars,
+            result_names=["result"],
+            strobe_pad=self.strobe_pad,
+            strobe_mark_size=self.strobe_mark_size,
+            strobe_mark_gap=self.strobe_mark_gap,
+            strobe_border_radius=self.strobe_border_radius,
+        )
+
+        animation_path = render_animation(
+            cfg,
+            width=320,
+            height=200,
+        )
+        self.animation = animation_path
+        return super().__call__()'''
+        body = """\
+bench = CartesianAnimationSweep().to_bench(run_cfg)
+
+bench.plot_sweep(
+    "Cartesian Product Animations",
+    input_vars=[
+        "spatial_dims",
+        bn.sweep("repeats", [0, 1, 6, 100]),
+        bn.sweep("time_steps", [0, 1, 6, 30]),
+    ],
+    result_vars=["animation"],
+    description="Visualizes Cartesian product parameter spaces as animated "
+    "dimensional extrusions. Each animation shows how the parameter space "
+    "grid builds up: point to line to grid to 3D stack, with repeats shown "
+    "as tally marks and time steps as a film strip.",
+    post_description="The animations illustrate the complexity scaling of "
+    "parameter sweeps and provide visual insight into multi-dimensional "
+    "benchmark design patterns.",
+)
+"""
+        self.generate_example(
+            title="Cartesian Product Animation — Visual exploration of parameter spaces",
+            output_dir=OUTPUT_DIR,
+            filename="cartesian_animation",
+            function_name="example_cartesian_animation",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"level": 4, "cache_results": False},
+        )
+
+
+def example_meta_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    bench = MetaCartesianAnimation().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Cartesian Animation",
+        input_vars=[],
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_meta_cartesian_animation)

--- a/bencher/results/manim_cartesian/cartesian_product_scene.py
+++ b/bencher/results/manim_cartesian/cartesian_product_scene.py
@@ -491,6 +491,15 @@ class StrobeShape(Shape):
         c = self.cfg
         return (iw + 2 * c.strobe_pad, ih + 2 * c.strobe_pad)
 
+    def draw_without_tally(self, img: ImageDraw.ImageDraw, x: int, y: int) -> None:
+        """Draw the shape without tallies, preserving previous state."""
+        prev = self._skip_tally
+        self._skip_tally = True
+        try:
+            self.draw(img, x, y)
+        finally:
+            self._skip_tally = prev
+
     def draw_tally_overlay(
         self, img: ImageDraw.ImageDraw, anchor_x: int, anchor_y: int, avail_w: int
     ):
@@ -498,6 +507,23 @@ class StrobeShape(Shape):
         c = self.cfg
         mark_color = tuple(int(v) for v in c.strobe_color)
         self._draw_tally(img, anchor_x, anchor_y, avail_w, mark_color, c)
+
+    def draw_tally_overlay_for_box(
+        self, img: ImageDraw.ImageDraw, box_x: int, box_y: int, box_w: int, box_h: int
+    ) -> None:
+        """Draw fixed-size tally overlay below a rendered box.
+
+        Spacing is derived from cfg fields so layout stays consistent
+        when configuration changes.
+        """
+        c = self.cfg
+        v_gap = c.strobe_mark_row_h // 2
+        tally_margin = 2 * c.strobe_pad
+        tally_min_w = 4 * c.strobe_pad
+        tally_y = box_y + box_h + v_gap
+        tally_avail_w = max(box_w - tally_margin, tally_min_w)
+        tally_x = box_x + (box_w - tally_avail_w) // 2
+        self.draw_tally_overlay(img, tally_x, tally_y, tally_avail_w)
 
     def _deep_copy(self) -> "Shape":
         return StrobeShape(self.inner._deep_copy(), self.count, self.cfg, self.flash)  # pylint: disable=protected-access
@@ -590,12 +616,11 @@ def render_animation(
         # Detect top-level StrobeShape for fixed-size tally overlay
         strobe_overlay = isinstance(shape, StrobeShape) and not isinstance(shape, TimelineShape)
         if strobe_overlay:
-            shape._skip_tally = True  # pylint: disable=protected-access
             # Use content box (no tally row) for scale — reserve fixed space for overlay
             sw, sh = shape.content_box_size()
-            tally_h = shape.cfg.strobe_mark_row_h + 6
+            tally_reserve = shape.cfg.strobe_mark_row_h + shape.cfg.strobe_mark_row_h // 2
             avail_w = width - 40
-            avail_h = height - shape_area_top - 10 - tally_h
+            avail_h = height - shape_area_top - 10 - tally_reserve
         else:
             sw, sh = shape.size()
             avail_w = width - 40
@@ -606,7 +631,10 @@ def render_animation(
         if scale < 1.0:
             big = Image.new("RGB", (sw + 40, sh + 10), BG_COLOR)
             big_draw = ImageDraw.Draw(big)
-            shape.draw(big_draw, 20, 5)
+            if strobe_overlay:
+                shape.draw_without_tally(big_draw, 20, 5)
+            else:
+                shape.draw(big_draw, 20, 5)
             new_w = int(big.width * scale)
             new_h = int(big.height * scale)
             big = big.resize((new_w, new_h), Image.Resampling.LANCZOS)
@@ -614,22 +642,15 @@ def render_animation(
             paste_y = shape_area_top + (avail_h - big.height) // 2
             img.paste(big, (paste_x, paste_y))
             if strobe_overlay:
-                tally_y = paste_y + new_h + 6
-                tally_avail_w = max(new_w - 20, 40)
-                tally_x = paste_x + (new_w - tally_avail_w) // 2
-                shape.draw_tally_overlay(draw, tally_x, tally_y, tally_avail_w)
+                shape.draw_tally_overlay_for_box(draw, paste_x, paste_y, new_w, new_h)
         else:
             sx = (width - sw) // 2 + x_offset
             sy = shape_area_top + (avail_h - sh) // 2
-            shape.draw(draw, sx, sy)
             if strobe_overlay:
-                tally_y = sy + sh + 6
-                tally_avail_w = sw - 2 * shape.cfg.strobe_pad
-                tally_x = sx + shape.cfg.strobe_pad
-                shape.draw_tally_overlay(draw, tally_x, tally_y, tally_avail_w)
-
-        if strobe_overlay:
-            shape._skip_tally = False  # pylint: disable=protected-access
+                shape.draw_without_tally(draw, sx, sy)
+                shape.draw_tally_overlay_for_box(draw, sx, sy, sw, sh)
+            else:
+                shape.draw(draw, sx, sy)
 
         # Line 1: dimension name (always visible)
         if current_dim_label:

--- a/bencher/results/manim_cartesian/cartesian_product_scene.py
+++ b/bencher/results/manim_cartesian/cartesian_product_scene.py
@@ -375,6 +375,7 @@ class StrobeShape(Shape):
         self.count = count
         self.cfg = cfg
         self.flash = flash
+        self._skip_tally = False  # when True, draw() skips tallies (overlay mode)
         super().__init__(children=None, direction="right", depth=0)
 
     @property
@@ -419,11 +420,12 @@ class StrobeShape(Shape):
             blended = Image.blend(region, overlay, fill_alpha)
             base_img.paste(blended, (x, y))
 
-        # Tally marks + count label below
-        marks_y = y + box_h + 6
-        mark_color = tuple(int(v * alpha) for v in c.strobe_color)
-        avail_w = total_w - 2 * c.strobe_pad
-        self._draw_tally(img, x + c.strobe_pad, marks_y, avail_w, mark_color, c)
+        # Tally marks + count label below (skipped when drawn as fixed-size overlay)
+        if not self._skip_tally:
+            marks_y = y + box_h + 6
+            mark_color = tuple(int(v * alpha) for v in c.strobe_color)
+            avail_w = total_w - 2 * c.strobe_pad
+            self._draw_tally(img, x + c.strobe_pad, marks_y, avail_w, mark_color, c)
 
     def _draw_tally(self, img, mx0, my, avail_w, color, c):
         """Proper tally marks (vertical lines, diagonal strike every 5) + xN label.
@@ -482,6 +484,20 @@ class StrobeShape(Shape):
             tw = bbox[2] - bbox[0]
             lx = mx0 + (avail_w - tw) // 2
             img.text((lx, my - 1), label, fill=color, font=font)
+
+    def content_box_size(self) -> tuple[int, int]:
+        """Size of border + inner shape, excluding the tally mark row."""
+        iw, ih = self.inner.size()
+        c = self.cfg
+        return (iw + 2 * c.strobe_pad, ih + 2 * c.strobe_pad)
+
+    def draw_tally_overlay(
+        self, img: ImageDraw.ImageDraw, anchor_x: int, anchor_y: int, avail_w: int
+    ):
+        """Draw tally marks at fixed pixel size on the final frame."""
+        c = self.cfg
+        mark_color = tuple(int(v) for v in c.strobe_color)
+        self._draw_tally(img, anchor_x, anchor_y, avail_w, mark_color, c)
 
     def _deep_copy(self) -> "Shape":
         return StrobeShape(self.inner._deep_copy(), self.count, self.cfg, self.flash)  # pylint: disable=protected-access
@@ -570,9 +586,21 @@ def render_animation(
 
         # Reserve top 55px for text
         shape_area_top = 55
-        sw, sh = shape.size()
-        avail_w = width - 40
-        avail_h = height - shape_area_top - 10
+
+        # Detect top-level StrobeShape for fixed-size tally overlay
+        strobe_overlay = isinstance(shape, StrobeShape) and not isinstance(shape, TimelineShape)
+        if strobe_overlay:
+            shape._skip_tally = True  # pylint: disable=protected-access
+            # Use content box (no tally row) for scale — reserve fixed space for overlay
+            sw, sh = shape.content_box_size()
+            tally_h = shape.cfg.strobe_mark_row_h + 6
+            avail_w = width - 40
+            avail_h = height - shape_area_top - 10 - tally_h
+        else:
+            sw, sh = shape.size()
+            avail_w = width - 40
+            avail_h = height - shape_area_top - 10
+
         scale = min(avail_w / max(sw, 1), avail_h / max(sh, 1), 1.0)
 
         if scale < 1.0:
@@ -585,10 +613,23 @@ def render_animation(
             paste_x = (width - big.width) // 2 + x_offset
             paste_y = shape_area_top + (avail_h - big.height) // 2
             img.paste(big, (paste_x, paste_y))
+            if strobe_overlay:
+                tally_y = paste_y + new_h + 6
+                tally_avail_w = max(new_w - 20, 40)
+                tally_x = paste_x + (new_w - tally_avail_w) // 2
+                shape.draw_tally_overlay(draw, tally_x, tally_y, tally_avail_w)
         else:
             sx = (width - sw) // 2 + x_offset
             sy = shape_area_top + (avail_h - sh) // 2
             shape.draw(draw, sx, sy)
+            if strobe_overlay:
+                tally_y = sy + sh + 6
+                tally_avail_w = sw - 2 * shape.cfg.strobe_pad
+                tally_x = sx + shape.cfg.strobe_pad
+                shape.draw_tally_overlay(draw, tally_x, tally_y, tally_avail_w)
+
+        if strobe_overlay:
+            shape._skip_tally = False  # pylint: disable=protected-access
 
         # Line 1: dimension name (always visible)
         if current_dim_label:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -92,6 +92,10 @@ evaluations is `s1 * s2 * ... * sN * repeats`. Each combination is represented a
 index tuple (for storage in the N-D array) and a value tuple (for passing to the benchmark
 function).
 
+See the [Cartesian Animation](reference/meta/cartesian_animation/index) gallery for an
+animated visualization of how each dimension builds on the last — from a single point to a
+line, grid, 3D stack, repeated measurements, and time-series film strip.
+
 ### Execution
 
 Each parameter combination is hashed to produce a persistent cache key. Results are stored

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -67,7 +67,7 @@ As you add input parameters, Bencher automatically adapts the visualization:
 | 2 floats | [Heatmap](reference/meta/2_float/no_repeats/index) |
 | Categories only | [Bar chart](reference/meta/0_float/no_repeats/index) |
 
-No code changes to plotting logic are needed — the type signature of your parameters drives the selection. See [Automatic Plot Selection](concepts.md#automatic-plot-selection) for how this works.
+No code changes to plotting logic are needed — the type signature of your parameters drives the selection. See [Automatic Plot Selection](concepts.md#automatic-plot-selection) for how this works, and the [Cartesian Animation](reference/meta/cartesian_animation/index) gallery for an animated visualization of how each dimension builds on the last.
 
 ## Repeats and Statistics
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -129,7 +129,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -286,7 +286,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -445,7 +445,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -602,7 +602,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -758,7 +758,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/89/182ef62bff3d9f190dd2e024b28cf0513ac7a83bc15b979e052c46c41f64/rerun_sdk-0.30.2-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -1204,8 +1204,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.75.0
-  sha256: 30c530292a44cdc7d633a69291103e5b38e8b2ad2abeb822ab6bbf2835792f19
+  version: 1.75.1
+  sha256: f27edd50e49ae639e968511f4a087386891b309190c35dc580e7a3a7ba093a02
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -3585,10 +3585,10 @@ packages:
   - rpds-py>=0.7.0
   - typing-extensions>=4.4.0 ; python_full_version < '3.13'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
   name: requests
-  version: 2.33.0
-  sha256: 3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b
+  version: 2.33.1
+  sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
   requires_dist:
   - charset-normalizer>=2,<4
   - idna>=2.5,<4
@@ -3596,12 +3596,6 @@ packages:
   - certifi>=2023.5.7
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
   - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
-  - pytest-httpbin==2.1.0 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - pysocks>=1.5.6,!=1.5.7 ; extra == 'test'
-  - pytest>=3 ; extra == 'test'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ca/e9/3d70642af4ade1a0fa1fa7d7967ff6b25db727f455c83376381c18f265ee/rerun_notebook-0.30.2-py2.py3-none-any.whl
   name: rerun-notebook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.75.0"
+version = "1.75.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary

- Tally marks in the cartesian product animation were drawn inside `StrobeShape` as part of the shape tree, causing them to scale down when the shape exceeded the canvas size
- Now tallies are rendered as a fixed-size overlay on the final frame (the same way headings are drawn), so they remain legible at a constant pixel size regardless of shape complexity
- Added `content_box_size()` and `draw_tally_overlay()` methods to `StrobeShape`, and refactored `make_frame()` to use two-pass rendering when a top-level `StrobeShape` is detected
- Moved cartesian animation example out of "Advanced Patterns" into its own "Cartesian Animation" gallery section with a dedicated generator
- Added references from `concepts.md` (Design section) and `intro.md` (Adding Dimensions section) so the animation is discoverable from the docs

## Test plan

- [x] `pixi run ci` passes (1122 passed, 1 unrelated flake)
- [ ] Visually inspect rendered cartesian animations to confirm tallies render at heading-consistent scale
- [ ] Run `pixi run generate-docs` to verify the new gallery section generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)