### PR TITLE
Increase Bokeh session token expiration to 1 hour

### DIFF
--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -141,6 +141,7 @@ class BenchPlotServer:
             address="0.0.0.0",
             websocket_origin=["*"],
             extra_patterns=extra,
+            session_token_expiration=3600,
         )
         if port is not None:
             serve_kwargs["port"] = port


### PR DESCRIPTION
## Summary
- Add `session_token_expiration=3600` to the `pn.serve()` kwargs in `BenchPlotServer.serve()`
- The default Bokeh session token expiration (300s) is too short when the server takes time to initialize panels, causing "Token is expired" errors on first page load
- Setting to 3600s (1 hour) prevents the WebSocket connection from failing due to token expiry

## Test plan
- [ ] Start a bench plot server with `serve()` and verify no "Token is expired" errors on first page load
- [ ] Confirm the WebSocket connects successfully without needing a manual browser refresh

## Summary by Sourcery

Enhancements:
- Configure the bench plot server's Panel/Bokeh serve call to use a longer (1 hour) session token expiration for WebSocket connections.