### PR TITLE
Deprecate __call__() and introduce benchmark() method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ To test a specific example: `pixi run python bencher/example/example_simple_floa
 
 ### How to Use Bencher
 See **[docs/how_to_use_bencher.md](docs/how_to_use_bencher.md)** for the complete guide
-on using bencher — sweep types, result types, the `__call__` pattern, plot callbacks,
+on using bencher — sweep types, result types, the `benchmark()` pattern, plot callbacks,
 and common mistakes. **Read this before writing any benchmark or example.**
 
 ### Updating Examples & Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Deprecated `__call__()` in favor of `benchmark()`**: `ParametrizedSweep` subclasses should now override `benchmark()` instead of `__call__()`. The new method removes the need for `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` boilerplate. The old `__call__()` pattern still works but emits a `DeprecationWarning`.
+
 ## [1.74.0] - 2026-03-28
 
 ### Added

--- a/PLAN.md
+++ b/PLAN.md
@@ -171,7 +171,11 @@ Add new tests:
 
 ## Verification
 
-1. After Phase 1: `pixi run ci` — all existing tests pass (backward compat confirmed)
-2. After Phase 2-4: `pixi run ci` — everything passes with new interface
-3. Spot-check: `pixi run python bencher/example/example_simple_float.py` works
-4. Verify deprecation: temporarily revert one example to `__call__` pattern, confirm warning is emitted
+1. After Phase 1: `pixi run ci` — all existing tests pass (backward compat confirmed) ✓
+2. After Phase 2-4: `pixi run ci` — everything passes with new interface ✓
+3. Spot-check: `pixi run python bencher/example/example_simple_float.py` works ✓
+4. Verify deprecation: test_benchmark_method.py confirms warning is emitted ✓
+
+## Status: IMPLEMENTED
+
+All phases complete. 1128 tests pass, 6 new tests added for benchmark() interface.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,40 +1,177 @@
-# Plan: Self-Contained Inline Examples (Completed)
+# Plan: Deprecate `__call__()` and Introduce `benchmark()` Method
 
-## Summary
+## Context
 
-All auto-generated examples are now fully self-contained with inline class definitions.
-No generated example imports from `benchable_objects.py` or `example_meta.py`.
+Every `ParametrizedSweep` subclass currently requires users to override `__call__` with 2 mandatory boilerplate lines that are easy to forget and add no value:
 
-## What Was Done
+```python
+# CURRENT — verbose, error-prone
+class MyBench(bn.ParametrizedSweep):
+    x = bn.FloatSweep(bounds=(0, 1))
+    result = bn.ResultVar()
 
-### Core Infrastructure
-- `meta_generator_base.py`: Added `class_code` parameter to `generate_example()` and
-  `generate_sweep_example()`. Added `generate_inline_example()` convenience method.
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)  # boilerplate
+        self.result = math.sin(self.x)
+        return super().__call__()                  # boilerplate
+```
 
-### Generators Updated
-All generators now produce self-contained examples with inline classes:
+The goal is to replace this with a streamlined `benchmark()` method:
 
-| Generator | Domain Theme | Status |
-|-----------|-------------|--------|
-| `generate_meta.py` | Software ops (sort, compression, hash, cache, network) | Done |
-| `generate_meta_result_types.py` | ResponseTimer, HealthChecker, SystemMetrics, etc. | Done |
-| `generate_meta_plot_types.py` | Data-processing scenarios per plot type | Done |
-| `generate_meta_sampling.py` | UniformSampler, IntFloatCompare, LevelDemo | Done |
-| `generate_meta_statistics.py` | NoisyTimer (request timing with noise) | Done |
-| `generate_meta_const_vars.py` | ServerBenchmark (CPU, memory, disk, cache) | Done |
-| `generate_meta_optimization.py` | ServerOptimizer (performance/cost tradeoff) | Done |
-| `generate_meta_composable.py` | Polygon geometry (self-contained helpers) | Done |
-| `generate_meta_image_video.py` | Polygon renderer/animator (self-contained) | Done |
-| `generate_meta_workflows.py` | DataPipeline, ServerConfig/ServerMetrics | Done |
-| `generate_meta_advanced.py` | NoisySensor, PullRequestBenchmark, QuadraticFit | Done |
-| `generate_meta_flagship.py` | WaveFunction, ServerBenchmark, TerrainSampler | Done |
+```python
+# NEW — clean, no boilerplate
+class MyBench(bn.ParametrizedSweep):
+    x = bn.FloatSweep(bounds=(0, 1))
+    result = bn.ResultVar()
 
-### Cleanup
-- Removed `BenchableRobotArm` and `BenchableMLTrainer` from `benchable_objects.py`
-- All classes at module level (not inside functions) — required for diskcache pickling
-- No robotics or ML themes — all examples use software ops and data processing domains
+    def benchmark(self):
+        self.result = math.sin(self.x)
+```
+
+**Scope**: ~193 files use the pattern (~10 hand-written examples, ~150+ auto-generated, ~30 tests).
+
+---
+
+## Phase 1: Framework Core Changes
+
+### 1a. `bencher/variables/parametrised_sweep.py`
+
+Add `benchmark()` method and update `__call__` dispatch logic:
+
+```python
+def __call__(self, **kwargs) -> dict:
+    if type(self).benchmark is not ParametrizedSweep.benchmark:
+        # New-style: subclass overrides benchmark()
+        self.update_params_from_kwargs(**kwargs)
+        self.benchmark()
+        return self.get_results_values_as_dict()
+    else:
+        # Legacy path: subclass overrides __call__() and handles
+        # update_params_from_kwargs + super().__call__() itself.
+        # Base just returns results dict (called via super().__call__()).
+        return self.get_results_values_as_dict()
+
+def benchmark(self):
+    """Override this with your benchmark logic.
+
+    When called, all sweep parameters (self.x, etc.) are already set.
+    Set result variables (self.result, etc.) directly on self.
+    No need to call update_params_from_kwargs or super().__call__().
+    """
+    pass
+```
+
+**Key insight**: Legacy `__call__` overrides call `super().__call__()` which hits the base — the base method is only ever reached as the *final* step. The detection `type(self).benchmark is not ParametrizedSweep.benchmark` correctly distinguishes new vs legacy code. No double `update_params_from_kwargs` call occurs.
+
+Also update:
+- `plot_hmap` (line 210): works unchanged since `self.__call__(**kwargs)` dispatches correctly
+- `to_dynamic_map` (line 170): works unchanged for same reason
+
+### 1b. `bencher/worker_manager.py` (line 91-93)
+
+Add deprecation warning when a ParametrizedSweep overrides `__call__` but not `benchmark`:
+
+```python
+if isinstance(worker, ParametrizedSweep):
+    self.worker_class_instance = worker
+    self.worker = self.worker_class_instance.__call__
+    if (type(worker).__call__ is not ParametrizedSweep.__call__
+            and type(worker).benchmark is ParametrizedSweep.benchmark):
+        warnings.warn(
+            f"{type(worker).__name__} overrides __call__() which is deprecated. "
+            "Override benchmark() instead.",
+            DeprecationWarning, stacklevel=2
+        )
+```
+
+### 1c. No changes needed to:
+- `bencher/sweep_executor.py` — calls `worker(**kwargs)` which resolves to `__call__`
+- `bencher/bencher.py` — wraps worker in `partial(worker_kwargs_wrapper, ...)`
+- `bencher/results/optuna_result.py` — calls `worker(**kwargs)`, same chain
+- `bencher/bench_runner.py` — `BenchableV1`/`BenchableV2` protocols are for top-level bench functions, not sweep workers
+
+---
+
+## Phase 2: Migrate Hand-Written Examples
+
+Convert `__call__` → `benchmark()` in each file (remove `update_params_from_kwargs` + `super().__call__()`, rename method):
+
+- `bencher/example/example_simple_float.py`
+- `bencher/example/example_workflow.py`
+- `bencher/example/example_image.py`
+- `bencher/example/example_video.py`
+- `bencher/example/example_rerun.py`
+- `bencher/example/example_cartesian_animation.py`
+- `bencher/example/example_self_benchmark.py`
+- `bencher/example/example_tab_bar_sweep.py`
+- `bencher/example/example_sample_cache_context.py`
+- `bencher/example/benchmark_data.py`
+- `bencher/example/yaml_sweep_dict.py`
+- `bencher/example/yaml_sweep_list.py`
+- `bencher/example/optuna/example_optuna.py`
+- `bencher/example/optuna/example_optimize.py`
+
+---
+
+## Phase 3: Migrate Benchable Objects & Meta Generators
+
+### 3a. `bencher/example/meta/benchable_objects.py`
+Convert all 8 benchmark classes (`BenchableBoolResult`, `BenchableVecResult`, etc.) from `__call__` to `benchmark()`.
+
+### 3b. `bencher/example/meta/meta_generator_base.py` (line 45-48)
+Update code generation to emit `benchmark()` instead of `__call__`:
+- Replace the `__call__` type hint rewrite logic
+- Update template to generate `def benchmark(self):` instead of `def __call__(self, **kwargs):`
+- Remove `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` from templates
+
+### 3c. Meta generators that emit `__call__` in class code
+Search all `bencher/example/meta/generate_meta_*.py` files for `__call__` in string templates and convert them.
+
+### 3d. Regenerate all generated examples
+Run `pixi run generate-docs` to regenerate ~150 files in `bencher/example/generated/`.
+
+---
+
+## Phase 4: Migrate Tests
+
+Convert test benchmark classes from `__call__` → `benchmark()` in:
+- `test/test_singleton_parametrised_sweep.py`
+- `test/test_sweep_timings.py`
+- `test/test_time_event_curve.py`
+- `test/test_regression.py`
+- `test/test_result_bool.py`
+- `test/test_sample_order.py`
+- `test/test_job.py`
+- `test/test_multiprocessing_executor.py`
+- `test/test_optimize.py`
+- `test/test_optuna_conversions.py`
+- `test/test_optuna_result.py`
+- `test/test_over_time_repeats.py`
+- `test/test_over_time_save_perf.py`
+- `test/test_cache.py`
+- `test/test_bench_result_base.py`
+- `test/test_sweep_vars.py`
+- `scripts/benchmark_save.py`
+
+Add new tests:
+- Test that `benchmark()` override works correctly (params auto-populated, results auto-collected)
+- Test that legacy `__call__` override still works (backward compat)
+- Test that deprecation warning is emitted for legacy `__call__` override
+- Test that a class with neither override returns empty results
+
+---
+
+## Phase 5: Documentation
+
+- `docs/how_to_use_bencher.md` — Replace `__call__` pattern with `benchmark()`, add migration section
+- `docs/intro.md` — Update examples
+- `CHANGELOG.md` — Add deprecation notice
+
+---
 
 ## Verification
-- `pixi run ci` passes (format, lint, 444 tests)
-- No generated file imports from `benchable_objects` or `example_meta`
-- No class definitions inside function bodies
+
+1. After Phase 1: `pixi run ci` — all existing tests pass (backward compat confirmed)
+2. After Phase 2-4: `pixi run ci` — everything passes with new interface
+3. Spot-check: `pixi run python bencher/example/example_simple_float.py` works
+4. Verify deprecation: temporarily revert one example to `__call__` pattern, confirm warning is emitted

--- a/bencher/example/benchmark_data.py
+++ b/bencher/example/benchmark_data.py
@@ -59,16 +59,13 @@ class ExampleBenchCfg(ParametrizedSweep):
     out_cos = ResultVar(units="v", direction=OptDir.minimize, doc="cos of theta with some noise")
     out_bool = ResultVar(units="%", doc="sin > 0.5")
 
-    def __call__(self, **kwwargs) -> dict:
-        self.update_params_from_kwargs(**kwwargs)
-
+    def benchmark(self):
         noise = self.calculate_noise()
         postprocess_fn = abs if self.postprocess_fn == PostprocessFn.absolute else negate_fn
 
         self.out_sin = postprocess_fn(self.offset + math.sin(self.theta) + noise)
         self.out_cos = postprocess_fn(self.offset + math.cos(self.theta) + noise)
         self.out_bool = self.out_sin > 0.5
-        return self.get_results_values_as_dict()
 
     def calculate_noise(self):
         noise = 0.0
@@ -100,10 +97,8 @@ class AllSweepVars(ParametrizedSweep):
 
     result = ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.var_float + self.var_int
-        return self.get_results_values_as_dict()
 
 
 class SimpleBenchClass(ParametrizedSweep):
@@ -111,10 +106,8 @@ class SimpleBenchClass(ParametrizedSweep):
 
     result = ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.var1
-        return self.get_results_values_as_dict()
 
 
 class SimpleBenchClassFloat(ParametrizedSweep):
@@ -122,7 +115,5 @@ class SimpleBenchClassFloat(ParametrizedSweep):
 
     result = ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.var1
-        return self.get_results_values_as_dict()

--- a/bencher/example/example_cartesian_animation.py
+++ b/bencher/example/example_cartesian_animation.py
@@ -28,9 +28,7 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
 
     animation = bn.ResultImage()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         all_spatial = [
             SweepVar("dim_1", [0, 1, 2]),
             SweepVar("dim_2", [0, 1, 2]),
@@ -60,7 +58,6 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
             height=200,
         )
         self.animation = animation_path
-        return super().__call__()
 
 
 def example_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_image.py
+++ b/bencher/example/example_image.py
@@ -22,8 +22,7 @@ class BenchPolygons(bn.ParametrizedSweep):
     area = bn.ResultVar()
     side_length = bn.ResultVar()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = polygon_points(self.radius, self.sides, self.start_angle)
         filepath = bn.gen_image_path("polygon")
         self.polygon = self.points_to_polygon_png(points, filepath)
@@ -32,7 +31,6 @@ class BenchPolygons(bn.ParametrizedSweep):
 
         self.side_length = 2 * self.radius * math.sin(math.pi / self.sides)
         self.area = (self.sides * self.side_length**2) / (4 * math.tan(math.pi / self.sides))
-        return super().__call__()
 
     def points_to_polygon_png(self, points: list[float], filename: str):
         """Draw a closed polygon and save to png using PIL"""

--- a/bencher/example/example_rerun.py
+++ b/bencher/example/example_rerun.py
@@ -7,12 +7,9 @@ class SweepRerun(bn.ParametrizedSweep):
 
     out_pane = bn.ResultContainer()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rr.log("s1", rr.Boxes2D(half_sizes=[self.theta, 1]))
         self.out_pane = bn.capture_rerun_window(width=600, height=600)
-
-        return super().__call__(**kwargs)
 
 
 def example_rerun(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_self_benchmark.py
+++ b/bencher/example/example_self_benchmark.py
@@ -20,10 +20,8 @@ class TrivialWorkload(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bn.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.x * 2
-        return super().__call__(**kwargs)
 
 
 class BencherSelfBenchmark(bn.ParametrizedSweep):
@@ -46,9 +44,7 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
     sample_cache_init_ms = bn.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bn.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         workload = TrivialWorkload()
         x_sweep = bn.FloatSweep(default=0, bounds=[0, 1], samples=self.num_samples, doc="input")
         x_sweep.name = "x"
@@ -71,8 +67,6 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
         self.cache_check_ms = t.cache_check_ms
         self.sample_cache_init_ms = t.sample_cache_init_ms
         self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
-
-        return super().__call__(**kwargs)
 
 
 def example_self_benchmark(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_simple_float.py
+++ b/bencher/example/example_simple_float.py
@@ -10,10 +10,8 @@ class SimpleFloat(bn.ParametrizedSweep):
     )
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
-        return super().__call__(**kwargs)
 
 
 def example_simple_float(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_tab_bar_sweep.py
+++ b/bencher/example/example_tab_bar_sweep.py
@@ -19,9 +19,7 @@ class TabBarSweep(bn.ParametrizedSweep):
     rows_used = bn.ResultVar(units="rows", doc="How many rows the tabs wrap into")
     overflow = bn.ResultVar(units="bool", doc="1 if tabs exceed max bar height, else 0")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         btn_pad_x = MARKER_SIZE
         btn_pad_y = int(MARKER_SIZE * 0.7)
         char_w = MARKER_SIZE * 0.6
@@ -89,7 +87,6 @@ class TabBarSweep(bn.ParametrizedSweep):
         filepath = bn.gen_image_path("tab_bar")
         img.save(filepath, "PNG")
         self.tab_bar_image = str(filepath)
-        return super().__call__()
 
 
 def example_tab_bar_sweep(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_video.py
+++ b/bencher/example/example_video.py
@@ -62,9 +62,7 @@ class TuringPattern(bn.ParametrizedSweep):
             Z[:, 0] = Z[:, 1]
             Z[:, -1] = Z[:, -2]
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         n = int(self.time / self.dt)
         dx = 2.0 / self.size
 
@@ -88,7 +86,6 @@ class TuringPattern(bn.ParametrizedSweep):
         self.img_extracted = bn.video_writer.VideoWriter.extract_frame(self.video)
         print("img path", self.img_extracted)
         self.score = self.alpha + self.beta
-        return super().__call__()
 
 
 def example_video(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/example_workflow.py
+++ b/bencher/example/example_workflow.py
@@ -34,8 +34,7 @@ class VolumeSweep(bn.ParametrizedSweep):
         "ul", direction=bn.OptDir.maximize, doc="The scalar value of the 3D volume field"
     )
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cur_point = np.array([self.x, self.y, self.z])
         self.p1_dis = np.linalg.norm(p1 - cur_point)
         self.p2_dis = np.linalg.norm(p2 - cur_point)
@@ -49,7 +48,6 @@ class VolumeSweep(bn.ParametrizedSweep):
                 ]
             )
         )
-        return super().__call__()
 
 
 p1 = np.array([0.4, 0.6, 0.0])

--- a/bencher/example/generated/0_float/no_repeats/sweep_0_float_0_cat_no_repeats.py
+++ b/bencher/example/generated/0_float/no_repeats/sweep_0_float_0_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 0 Categorical (no repeats)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -10,10 +8,8 @@ class BaselineCheck(bn.ParametrizedSweep):
 
     baseline = bn.ResultVar(units="ms", doc="Baseline latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.baseline = 42.0
-        return super().__call__()
 
 
 def example_sweep_0_float_0_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/no_repeats/sweep_0_float_1_cat_no_repeats.py
+++ b/bencher/example/generated/0_float/no_repeats/sweep_0_float_1_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 1 Categorical (no repeats)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -12,11 +10,9 @@ class CacheBackend(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Cache lookup latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
         self.latency = base
-        return super().__call__()
 
 
 def example_sweep_0_float_1_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/no_repeats/sweep_0_float_2_cat_no_repeats.py
+++ b/bencher/example/generated/0_float/no_repeats/sweep_0_float_2_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 2 Categorical (no repeats)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -13,12 +11,10 @@ class NetworkConfig(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         self.throughput = region_base * proto_factor
-        return super().__call__()
 
 
 def example_sweep_0_float_2_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/no_repeats/sweep_0_float_3_cat_no_repeats.py
+++ b/bencher/example/generated/0_float/no_repeats/sweep_0_float_3_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 3 Categorical (no repeats)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -14,13 +12,11 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
         self.throughput = region_base * proto_factor * log_penalty
-        return super().__call__()
 
 
 def example_sweep_0_float_3_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_0_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 0 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -14,12 +12,10 @@ class BaselineCheck(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.baseline = 42.0
         self.baseline += random.gauss(0, 0.1 * 5)
         self.baseline += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_1_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 1 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -16,12 +14,10 @@ class CacheBackend(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
         self.latency = base + random.gauss(0, 0.1 * base)
         self.latency += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_2_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 2 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -17,13 +15,11 @@ class NetworkConfig(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         self.throughput = region_base * proto_factor + random.gauss(0, 0.1 * 50)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
+++ b/bencher/example/generated/0_float/over_time/sweep_0_float_3_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 3 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -18,14 +16,12 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
         self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, 0.1 * 50)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_0_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 0 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -14,12 +12,10 @@ class BaselineCheck(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.baseline = 42.0
         self.baseline += random.gauss(0, 0.15 * 5)
         self.baseline += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_0_cat_over_time_repeats(

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_1_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 1 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -16,12 +14,10 @@ class CacheBackend(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
         self.latency = base + random.gauss(0, 0.15 * base)
         self.latency += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_1_cat_over_time_repeats(

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_2_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 2 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -17,13 +15,11 @@ class NetworkConfig(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         self.throughput = region_base * proto_factor + random.gauss(0, 0.15 * 50)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_2_cat_over_time_repeats(

--- a/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/0_float/over_time_repeats/sweep_0_float_3_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 3 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -18,14 +16,12 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
         self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, 0.15 * 50)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_0_float_3_cat_over_time_repeats(

--- a/bencher/example/generated/0_float/with_repeats/sweep_0_float_0_cat_with_repeats.py
+++ b/bencher/example/generated/0_float/with_repeats/sweep_0_float_0_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 0 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 
 import bencher as bn
@@ -12,11 +10,9 @@ class BaselineCheck(bn.ParametrizedSweep):
 
     baseline = bn.ResultVar(units="ms", doc="Baseline latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.baseline = 42.0
         self.baseline += random.gauss(0, 0.15 * 5)
-        return super().__call__()
 
 
 def example_sweep_0_float_0_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/with_repeats/sweep_0_float_1_cat_with_repeats.py
+++ b/bencher/example/generated/0_float/with_repeats/sweep_0_float_1_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 1 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 
 import bencher as bn
@@ -14,11 +12,9 @@ class CacheBackend(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Cache lookup latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.2, "memcached": 1.5, "local": 0.3}[self.backend]
         self.latency = base + random.gauss(0, 0.15 * base)
-        return super().__call__()
 
 
 def example_sweep_0_float_1_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/with_repeats/sweep_0_float_2_cat_with_repeats.py
+++ b/bencher/example/generated/0_float/with_repeats/sweep_0_float_2_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 2 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 
 import bencher as bn
@@ -15,12 +13,10 @@ class NetworkConfig(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         self.throughput = region_base * proto_factor + random.gauss(0, 0.15 * 50)
-        return super().__call__()
 
 
 def example_sweep_0_float_2_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/0_float/with_repeats/sweep_0_float_3_cat_with_repeats.py
+++ b/bencher/example/generated/0_float/with_repeats/sweep_0_float_3_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 0 Float, 3 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 
 import bencher as bn
@@ -16,13 +14,11 @@ class DeploymentConfig(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         proto_factor = {"http": 1.0, "grpc": 1.8}[self.protocol]
         region_base = {"us-east": 500, "eu-west": 420, "ap-south": 350}[self.region]
         log_penalty = {"debug": 0.7, "info": 1.0, "warn": 1.0}[self.log_level]
         self.throughput = region_base * proto_factor * log_penalty + random.gauss(0, 0.15 * 50)
-        return super().__call__()
 
 
 def example_sweep_0_float_3_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/no_repeats/sweep_1_float_0_cat_no_repeats.py
+++ b/bencher/example/generated/1_float/no_repeats/sweep_1_float_0_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 0 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -14,10 +12,8 @@ class SortBenchmark(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
-        return super().__call__()
 
 
 def example_sweep_1_float_0_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/no_repeats/sweep_1_float_1_cat_no_repeats.py
+++ b/bencher/example/generated/1_float/no_repeats/sweep_1_float_1_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 1 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class SortComparison(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
-        return super().__call__()
 
 
 def example_sweep_1_float_1_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/no_repeats/sweep_1_float_2_cat_no_repeats.py
+++ b/bencher/example/generated/1_float/no_repeats/sweep_1_float_2_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 2 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -16,14 +14,12 @@ class SortAnalysis(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         self.time = (
             algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         )
-        return super().__call__()
 
 
 def example_sweep_1_float_2_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/no_repeats/sweep_1_float_3_cat_no_repeats.py
+++ b/bencher/example/generated/1_float/no_repeats/sweep_1_float_3_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 3 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -17,8 +15,7 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         stab_factor = {"stable": 1.1, "unstable": 1.0}[self.stability]
@@ -30,7 +27,6 @@ class SortFullMatrix(bn.ParametrizedSweep):
             * math.log2(self.array_size + 1)
             * 0.001
         )
-        return super().__call__()
 
 
 def example_sweep_1_float_3_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_0_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 0 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -17,12 +15,10 @@ class SortBenchmark(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_1_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 1 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -18,13 +16,11 @@ class SortComparison(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_2_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 2 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -19,8 +17,7 @@ class SortAnalysis(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         self.time = (
@@ -28,7 +25,6 @@ class SortAnalysis(bn.ParametrizedSweep):
         )
         self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
+++ b/bencher/example/generated/1_float/over_time/sweep_1_float_3_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 3 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -20,8 +18,7 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         stab_factor = {"stable": 1.1, "unstable": 1.0}[self.stability]
@@ -35,7 +32,6 @@ class SortFullMatrix(bn.ParametrizedSweep):
         )
         self.time += random.gauss(0, 0.1 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_3_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_0_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 0 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -17,12 +15,10 @@ class SortBenchmark(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.15 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_0_cat_over_time_repeats(

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_1_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 1 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -18,13 +16,11 @@ class SortComparison(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.15 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_1_cat_over_time_repeats(

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_2_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 2 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -19,8 +17,7 @@ class SortAnalysis(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         self.time = (
@@ -28,7 +25,6 @@ class SortAnalysis(bn.ParametrizedSweep):
         )
         self.time += random.gauss(0, 0.15 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_2_cat_over_time_repeats(

--- a/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
+++ b/bencher/example/generated/1_float/over_time_repeats/sweep_1_float_3_cat_over_time_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 3 Categorical (over time repeats)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -20,8 +18,7 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         stab_factor = {"stable": 1.1, "unstable": 1.0}[self.stability]
@@ -35,7 +32,6 @@ class SortFullMatrix(bn.ParametrizedSweep):
         )
         self.time += random.gauss(0, 0.15 * self.time)
         self.time += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_1_float_3_cat_over_time_repeats(

--- a/bencher/example/generated/1_float/with_repeats/sweep_1_float_0_cat_with_repeats.py
+++ b/bencher/example/generated/1_float/with_repeats/sweep_1_float_0_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 0 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -15,11 +13,9 @@ class SortBenchmark(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.time = self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.15 * self.time)
-        return super().__call__()
 
 
 def example_sweep_1_float_0_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/with_repeats/sweep_1_float_1_cat_with_repeats.py
+++ b/bencher/example/generated/1_float/with_repeats/sweep_1_float_1_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 1 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -16,12 +14,10 @@ class SortComparison(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         self.time = algo_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         self.time += random.gauss(0, 0.15 * self.time)
-        return super().__call__()
 
 
 def example_sweep_1_float_1_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/with_repeats/sweep_1_float_2_cat_with_repeats.py
+++ b/bencher/example/generated/1_float/with_repeats/sweep_1_float_2_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 2 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -17,15 +15,13 @@ class SortAnalysis(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         self.time = (
             algo_factor * dist_factor * self.array_size * math.log2(self.array_size + 1) * 0.001
         )
         self.time += random.gauss(0, 0.15 * self.time)
-        return super().__call__()
 
 
 def example_sweep_1_float_2_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/1_float/with_repeats/sweep_1_float_3_cat_with_repeats.py
+++ b/bencher/example/generated/1_float/with_repeats/sweep_1_float_3_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 1 Float, 3 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -18,8 +16,7 @@ class SortFullMatrix(bn.ParametrizedSweep):
 
     time = bn.ResultVar(units="ms", doc="Sort duration")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_factor = {"quicksort": 1.0, "mergesort": 1.2, "heapsort": 1.5}[self.algorithm]
         dist_factor = {"uniform": 1.0, "sorted": 0.6, "reversed": 1.8}[self.distribution]
         stab_factor = {"stable": 1.1, "unstable": 1.0}[self.stability]
@@ -32,7 +29,6 @@ class SortFullMatrix(bn.ParametrizedSweep):
             * 0.001
         )
         self.time += random.gauss(0, 0.15 * self.time)
-        return super().__call__()
 
 
 def example_sweep_1_float_3_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/no_repeats/sweep_2_float_0_cat_no_repeats.py
+++ b/bencher/example/generated/2_float/no_repeats/sweep_2_float_0_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 0 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,10 +13,8 @@ class CompressionBench(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
-        return super().__call__()
 
 
 def example_sweep_2_float_0_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/no_repeats/sweep_2_float_1_cat_no_repeats.py
+++ b/bencher/example/generated/2_float/no_repeats/sweep_2_float_1_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 1 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -16,13 +14,11 @@ class CompressionCodec(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         self.ratio = (
             codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        return super().__call__()
 
 
 def example_sweep_2_float_1_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/no_repeats/sweep_2_float_2_cat_no_repeats.py
+++ b/bencher/example/generated/2_float/no_repeats/sweep_2_float_2_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 2 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -17,8 +15,7 @@ class CompressionSuite(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         effort_mult = {"fast": 0.8, "balanced": 1.0, "max": 1.15}[self.effort]
         self.ratio = (
@@ -27,7 +24,6 @@ class CompressionSuite(bn.ParametrizedSweep):
             * (1.0 - 0.7 * self.entropy)
             * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
-        return super().__call__()
 
 
 def example_sweep_2_float_2_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_0_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 0 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -18,12 +16,10 @@ class CompressionBench(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_2_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_1_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 1 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -19,15 +17,13 @@ class CompressionCodec(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         self.ratio = (
             codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
         self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_2_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
+++ b/bencher/example/generated/2_float/over_time/sweep_2_float_2_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 2 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -20,8 +18,7 @@ class CompressionSuite(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         effort_mult = {"fast": 0.8, "balanced": 1.0, "max": 1.15}[self.effort]
         self.ratio = (
@@ -32,7 +29,6 @@ class CompressionSuite(bn.ParametrizedSweep):
         )
         self.ratio += random.gauss(0, 0.1 * 0.3)
         self.ratio += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_2_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/with_repeats/sweep_2_float_0_cat_with_repeats.py
+++ b/bencher/example/generated/2_float/with_repeats/sweep_2_float_0_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 0 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -16,11 +14,9 @@ class CompressionBench(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.ratio = (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         self.ratio += random.gauss(0, 0.15 * 0.3)
-        return super().__call__()
 
 
 def example_sweep_2_float_0_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/with_repeats/sweep_2_float_1_cat_with_repeats.py
+++ b/bencher/example/generated/2_float/with_repeats/sweep_2_float_1_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 1 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -17,14 +15,12 @@ class CompressionCodec(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         self.ratio = (
             codec_eff * (1.0 - 0.7 * self.entropy) * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
         self.ratio += random.gauss(0, 0.15 * 0.3)
-        return super().__call__()
 
 
 def example_sweep_2_float_1_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/2_float/with_repeats/sweep_2_float_2_cat_with_repeats.py
+++ b/bencher/example/generated/2_float/with_repeats/sweep_2_float_2_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 2 Float, 2 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -18,8 +16,7 @@ class CompressionSuite(bn.ParametrizedSweep):
 
     ratio = bn.ResultVar(units="x", doc="Compression ratio")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         codec_eff = {"zlib": 1.0, "lz4": 0.7, "zstd": 1.1}[self.codec]
         effort_mult = {"fast": 0.8, "balanced": 1.0, "max": 1.15}[self.effort]
         self.ratio = (
@@ -29,7 +26,6 @@ class CompressionSuite(bn.ParametrizedSweep):
             * (1.0 + 0.3 * math.log2(self.block_size / 512))
         )
         self.ratio += random.gauss(0, 0.15 * 0.3)
-        return super().__call__()
 
 
 def example_sweep_2_float_2_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/no_repeats/sweep_3_float_0_cat_no_repeats.py
+++ b/bencher/example/generated/3_float/no_repeats/sweep_3_float_0_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 0 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -16,15 +14,13 @@ class HashBenchmark(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.throughput = (
             500.0
             / (1.0 + 0.5 * math.log2(self.key_size / 8))
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        return super().__call__()
 
 
 def example_sweep_3_float_0_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/no_repeats/sweep_3_float_1_cat_no_repeats.py
+++ b/bencher/example/generated/3_float/no_repeats/sweep_3_float_1_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 1 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -17,8 +15,7 @@ class HashComparison(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         self.throughput = (
             algo_speed
@@ -27,7 +24,6 @@ class HashComparison(bn.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        return super().__call__()
 
 
 def example_sweep_3_float_1_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/no_repeats/sweep_3_float_2_cat_no_repeats.py
+++ b/bencher/example/generated/3_float/no_repeats/sweep_3_float_2_cat_no_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 2 Categorical (no repeats)."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -18,8 +16,7 @@ class HashAnalysis(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         mode_factor = {"stream": 1.0, "block": 0.85}[self.mode]
         self.throughput = (
@@ -30,7 +27,6 @@ class HashAnalysis(bn.ParametrizedSweep):
             / (1.0 + 0.3 * math.log2(self.payload_size / 64))
             * (self.iterations / 100)
         )
-        return super().__call__()
 
 
 def example_sweep_3_float_2_cat_no_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_0_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 0 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -19,8 +17,7 @@ class HashBenchmark(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.throughput = (
             500.0
             / (1.0 + 0.5 * math.log2(self.key_size / 8))
@@ -29,7 +26,6 @@ class HashBenchmark(bn.ParametrizedSweep):
         )
         self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_3_float_0_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_1_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 1 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -20,8 +18,7 @@ class HashComparison(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         self.throughput = (
             algo_speed
@@ -32,7 +29,6 @@ class HashComparison(bn.ParametrizedSweep):
         )
         self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_3_float_1_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
+++ b/bencher/example/generated/3_float/over_time/sweep_3_float_2_cat_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 2 Categorical (over time)."""
 
-from typing import Any
-
 import random
 import math
 import bencher as bn
@@ -21,8 +19,7 @@ class HashAnalysis(bn.ParametrizedSweep):
 
     _time_offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         mode_factor = {"stream": 1.0, "block": 0.85}[self.mode]
         self.throughput = (
@@ -35,7 +32,6 @@ class HashAnalysis(bn.ParametrizedSweep):
         )
         self.throughput += random.gauss(0, 0.1 * 30)
         self.throughput += self._time_offset * 10
-        return super().__call__()
 
 
 def example_sweep_3_float_2_cat_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/with_repeats/sweep_3_float_0_cat_with_repeats.py
+++ b/bencher/example/generated/3_float/with_repeats/sweep_3_float_0_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 0 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -17,8 +15,7 @@ class HashBenchmark(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.throughput = (
             500.0
             / (1.0 + 0.5 * math.log2(self.key_size / 8))
@@ -26,7 +23,6 @@ class HashBenchmark(bn.ParametrizedSweep):
             * (self.iterations / 100)
         )
         self.throughput += random.gauss(0, 0.15 * 30)
-        return super().__call__()
 
 
 def example_sweep_3_float_0_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/with_repeats/sweep_3_float_1_cat_with_repeats.py
+++ b/bencher/example/generated/3_float/with_repeats/sweep_3_float_1_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 1 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -18,8 +16,7 @@ class HashComparison(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         self.throughput = (
             algo_speed
@@ -29,7 +26,6 @@ class HashComparison(bn.ParametrizedSweep):
             * (self.iterations / 100)
         )
         self.throughput += random.gauss(0, 0.15 * 30)
-        return super().__call__()
 
 
 def example_sweep_3_float_1_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/3_float/with_repeats/sweep_3_float_2_cat_with_repeats.py
+++ b/bencher/example/generated/3_float/with_repeats/sweep_3_float_2_cat_with_repeats.py
@@ -1,7 +1,5 @@
 """Auto-generated example: 3 Float, 2 Categorical (with repeats)."""
 
-from typing import Any
-
 import random
 import math
 
@@ -19,8 +17,7 @@ class HashAnalysis(bn.ParametrizedSweep):
 
     throughput = bn.ResultVar(units="MB/s", doc="Hash throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_speed = {"sha256": 1.0, "blake2": 1.4, "md5": 1.8}[self.algorithm]
         mode_factor = {"stream": 1.0, "block": 0.85}[self.mode]
         self.throughput = (
@@ -32,7 +29,6 @@ class HashAnalysis(bn.ParametrizedSweep):
             * (self.iterations / 100)
         )
         self.throughput += random.gauss(0, 0.15 * 30)
-        return super().__call__()
 
 
 def example_sweep_3_float_2_cat_with_repeats(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_agg_over_time.py
+++ b/bencher/example/generated/advanced/advanced_agg_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate Over Time — 2D sweep to scalar curve with error bounds."""
 
-from typing import Any
-
 import math
 import bencher as bn
 from datetime import datetime, timedelta
@@ -23,8 +21,7 @@ class ThermalPlate(bn.ParametrizedSweep):
 
     _time_offset = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         # Hot spot at centre, decaying over time
         self.temperature = (
             100
@@ -33,7 +30,6 @@ class ThermalPlate(bn.ParametrizedSweep):
             * math.exp(-0.3 * self._time_offset)
             + 20
         )
-        return super().__call__()
 
 
 def example_advanced_agg_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_cache_patterns.py
+++ b/bencher/example/generated/advanced/advanced_cache_patterns.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Cache Patterns — run_tag and cache_samples."""
 
-from typing import Any
-
 import math
 import random
 import bencher as bn
@@ -23,12 +21,10 @@ class NoisySensor(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.reading = 0.5 + 0.03 * self.temperature + math.sin(self.temperature * 0.1)
         if self.noise_scale > 0:
             self.reading += random.gauss(0, self.noise_scale)
-        return super().__call__()
 
 
 def example_advanced_cache_patterns(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_cartesian_animation.py
+++ b/bencher/example/generated/advanced/advanced_cartesian_animation.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Cartesian Product Animations — Visual exploration of parameter spaces."""
 
-from typing import Any
-
 import bencher as bn
 from bencher.results.manim_cartesian import CartesianProductCfg, SweepVar, render_animation
 
@@ -32,9 +30,7 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
 
     animation = bn.ResultImage()
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         all_spatial = [
             SweepVar("dim_1", [0, 1, 2]),
             SweepVar("dim_2", [0, 1, 2]),
@@ -64,7 +60,6 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
             height=200,
         )
         self.animation = animation_path
-        return super().__call__()
 
 
 def example_advanced_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/advanced_git_time_event.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Git Time Event — date + commit hash slider labels."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -18,10 +16,8 @@ class ServerLatency(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
-        return super().__call__()
 
 
 def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_max_time_events.py
+++ b/bencher/example/generated/advanced/advanced_max_time_events.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Max Time Events — cap over_time history."""
 
-from typing import Any
-
 import random
 import bencher as bn
 from datetime import datetime, timedelta
@@ -21,11 +19,9 @@ class LatencyMonitor(bn.ParametrizedSweep):
 
     _drift = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"/api/users": 45, "/api/orders": 120}[self.endpoint]
         self.latency = base + self._drift + random.gauss(0, 5)
-        return super().__call__()
 
 
 def example_advanced_max_time_events(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_report_save.py
+++ b/bencher/example/generated/advanced/advanced_report_save.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Report Customization — saving and appending content."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,10 +9,8 @@ class QuadraticFit(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[-2, 2], doc="Input value")
     y = bn.ResultVar(units="ul", doc="Quadratic output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.y = self.x**2 - 1
-        return super().__call__()
 
 
 def example_advanced_report_save(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/advanced/advanced_time_event.py
+++ b/bencher/example/generated/advanced/advanced_time_event.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Time Events — track metrics across discrete events."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -19,12 +17,10 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
 
     _event_idx = 0  # set externally per event
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"light": 1000, "medium": 500, "heavy": 200}[self.workload]
         # Simulate gradual improvement across events
         self.throughput = base + self._event_idx * 30
-        return super().__call__()
 
 
 def example_advanced_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/aggregation/agg_all.py
+++ b/bencher/example/generated/aggregation/agg_all.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate to 1-D (True)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -13,15 +11,13 @@ class GradientScale(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.scale == "linear":
             self.out = self.x
         elif self.scale == "quadratic":
             self.out = self.x**2
         else:
             self.out = self.x**0.5
-        return super().__call__()
 
 
 def example_agg_all(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/aggregation/agg_fn_max.py
+++ b/bencher/example/generated/aggregation/agg_fn_max.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate with Max."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -14,15 +12,13 @@ class GradientDirection(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "diagonal":
             self.out = self.x + self.y
         elif self.direction == "horizontal":
             self.out = self.x
         else:
             self.out = self.y
-        return super().__call__()
 
 
 def example_agg_fn_max(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/aggregation/agg_int.py
+++ b/bencher/example/generated/aggregation/agg_int.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate Last N (int)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -14,8 +12,7 @@ class GradientDirectionScale(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "positive":
             base = self.x
         elif self.direction == "negative":
@@ -28,7 +25,6 @@ class GradientDirectionScale(bn.ParametrizedSweep):
             self.out = base**2
         else:
             self.out = base**0.5
-        return super().__call__()
 
 
 def example_agg_int(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/aggregation/agg_list_1_cat.py
+++ b/bencher/example/generated/aggregation/agg_list_1_cat.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate by Name (list)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -14,15 +12,13 @@ class GradientDirection(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "diagonal":
             self.out = self.x + self.y
         elif self.direction == "horizontal":
             self.out = self.x
         else:
             self.out = self.y
-        return super().__call__()
 
 
 def example_agg_list_1_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/aggregation/agg_list_2_cat.py
+++ b/bencher/example/generated/aggregation/agg_list_2_cat.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregate 2 Categoricals (list)."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -15,8 +13,7 @@ class GradientSurface(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "diagonal":
             base = self.x + self.y
         elif self.direction == "horizontal":
@@ -29,7 +26,6 @@ class GradientSurface(bn.ParametrizedSweep):
             self.out = base**2
         else:
             self.out = base**0.5
-        return super().__call__()
 
 
 def example_agg_list_2_cat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_bar.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_bar.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Bar."""
 
-from typing import Any
-
 import random
 
 import bencher as bn
@@ -14,11 +12,9 @@ class HealthCheckCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
         self.healthy = random.random() < rates[self.backend]
-        return super().__call__()
 
 
 def example_bool_plot_bar(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_box_whisker.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_box_whisker.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Box Whisker."""
 
-from typing import Any
-
 import random
 
 from bencher.results.holoview_results.distribution_result.box_whisker_result import BoxWhiskerResult
@@ -15,11 +13,9 @@ class ReliabilityCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
         self.healthy = random.random() < rates[self.backend]
-        return super().__call__()
 
 
 def example_bool_plot_box_whisker(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_curve.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_curve.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Curve."""
 
-from typing import Any
-
 import math
 import random
 
@@ -15,11 +13,9 @@ class HealthCheckFloatNoisy(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         probability = math.sin(math.pi * self.load)
         self.healthy = random.random() < probability
-        return super().__call__()
 
 
 def example_bool_plot_curve(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_heatmap.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_heatmap.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Heatmap."""
 
-from typing import Any
-
 import math
 import random
 
@@ -16,11 +14,9 @@ class HealthCheck2DNoisy(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         probability = 0.5 + 0.4 * math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
         self.healthy = random.random() < probability
-        return super().__call__()
 
 
 def example_bool_plot_heatmap(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_histogram.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_histogram.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Histogram."""
 
-from typing import Any
-
 import random
 
 from bencher.results.histogram_result import HistogramResult
@@ -15,11 +13,9 @@ class PassRateFloat(bn.ParametrizedSweep):
 
     passed = bn.ResultBool(doc="Whether the test passed")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rate = 1.0 - 0.8 * self.complexity**1.5
         self.passed = random.random() < rate
-        return super().__call__()
 
 
 def example_bool_plot_histogram(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_line.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_line.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Line."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -14,11 +12,9 @@ class HealthCheckFloat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.load)
         self.healthy = score > 0.5
-        return super().__call__()
 
 
 def example_bool_plot_line(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_scatter_jitter.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_scatter_jitter.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Scatter Jitter."""
 
-from typing import Any
-
 import random
 
 from bencher.results.holoview_results.distribution_result.scatter_jitter_result import (
@@ -17,11 +15,9 @@ class ReliabilityCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
         self.healthy = random.random() < rates[self.backend]
-        return super().__call__()
 
 
 def example_bool_plot_scatter_jitter(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_surface.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_surface.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Surface."""
 
-from typing import Any
-
 import math
 import random
 
@@ -16,11 +14,9 @@ class HealthCheck2DNoisy(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         probability = 0.5 + 0.4 * math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
         self.healthy = random.random() < probability
-        return super().__call__()
 
 
 def example_bool_plot_surface(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/bool_plot_types/bool_plot_violin.py
+++ b/bencher/example/generated/bool_plot_types/bool_plot_violin.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bool Plot: Violin."""
 
-from typing import Any
-
 import random
 
 from bencher.results.holoview_results.distribution_result.violin_result import ViolinResult
@@ -15,11 +13,9 @@ class ReliabilityCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
         self.healthy = random.random() < rates[self.backend]
-        return super().__call__()
 
 
 def example_bool_plot_violin(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/composable_containers/composable_all_compose_types.py
+++ b/bencher/example/generated/composable_containers/composable_all_compose_types.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Container: All ComposeTypes Compared."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _ComposeTypeSweep(BenchableImageResult):
@@ -57,8 +53,7 @@ class _ComposeTypeSweep(BenchableImageResult):
     )
     composed_video = bn.ResultVideo(doc="Composed video output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid = bn.ComposableContainerVideo()
         for i in range(5):
             angle = 360.0 * i / 5

--- a/bencher/example/generated/composable_containers/composable_dataset_down.py
+++ b/bencher/example/generated/composable_containers/composable_dataset_down.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Dataset: ComposeType.down."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,17 +9,15 @@ class TimeseriesCollector(bn.ParametrizedSweep):
     duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
     result_ds = bn.ResultDataSet(doc="Collected time-series dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
         import numpy as np
 
-        self.update_params_from_kwargs(**kwargs)
         n = int(self.duration * 10)
         t = np.linspace(0, self.duration, n)
         values = np.sin(2 * np.pi * t / self.duration) * self.duration
         data_array = xr.DataArray(values, dims=["time"], coords={"time": t})
         self.result_ds = bn.ResultDataSet(xr.Dataset({"signal": data_array}).to_pandas())
-        return super().__call__()
 
 
 def example_composable_dataset_down(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/composable_containers/composable_dataset_overlay.py
+++ b/bencher/example/generated/composable_containers/composable_dataset_overlay.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Dataset: ComposeType.overlay."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,17 +9,15 @@ class TimeseriesCollector(bn.ParametrizedSweep):
     duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
     result_ds = bn.ResultDataSet(doc="Collected time-series dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
         import numpy as np
 
-        self.update_params_from_kwargs(**kwargs)
         n = int(self.duration * 10)
         t = np.linspace(0, self.duration, n)
         values = np.sin(2 * np.pi * t / self.duration) * self.duration
         data_array = xr.DataArray(values, dims=["time"], coords={"time": t})
         self.result_ds = bn.ResultDataSet(xr.Dataset({"signal": data_array}).to_pandas())
-        return super().__call__()
 
 
 def example_composable_dataset_overlay(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/composable_containers/composable_dataset_right.py
+++ b/bencher/example/generated/composable_containers/composable_dataset_right.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Dataset: ComposeType.right."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,17 +9,15 @@ class TimeseriesCollector(bn.ParametrizedSweep):
     duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
     result_ds = bn.ResultDataSet(doc="Collected time-series dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
         import numpy as np
 
-        self.update_params_from_kwargs(**kwargs)
         n = int(self.duration * 10)
         t = np.linspace(0, self.duration, n)
         values = np.sin(2 * np.pi * t / self.duration) * self.duration
         data_array = xr.DataArray(values, dims=["time"], coords={"time": t})
         self.result_ds = bn.ResultDataSet(xr.Dataset({"signal": data_array}).to_pandas())
-        return super().__call__()
 
 
 def example_composable_dataset_right(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/composable_containers/composable_dataset_sequence.py
+++ b/bencher/example/generated/composable_containers/composable_dataset_sequence.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Dataset: ComposeType.sequence."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,17 +9,15 @@ class TimeseriesCollector(bn.ParametrizedSweep):
     duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
     result_ds = bn.ResultDataSet(doc="Collected time-series dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
         import numpy as np
 
-        self.update_params_from_kwargs(**kwargs)
         n = int(self.duration * 10)
         t = np.linspace(0, self.duration, n)
         values = np.sin(2 * np.pi * t / self.duration) * self.duration
         data_array = xr.DataArray(values, dims=["time"], coords={"time": t})
         self.result_ds = bn.ResultDataSet(xr.Dataset({"signal": data_array}).to_pandas())
-        return super().__call__()
 
 
 def example_composable_dataset_sequence(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/composable_containers/composable_panel_down.py
+++ b/bencher/example/generated/composable_containers/composable_panel_down.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Panel: ComposeType.down."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _PanelComposeDemo(BenchableImageResult):
@@ -52,8 +48,7 @@ class _PanelComposeDemo(BenchableImageResult):
 
     result_image = bn.ResultImage(doc="Composed panel image")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("panel_compose")

--- a/bencher/example/generated/composable_containers/composable_panel_right.py
+++ b/bencher/example/generated/composable_containers/composable_panel_right.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Panel: ComposeType.right."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _PanelComposeDemo(BenchableImageResult):
@@ -52,8 +48,7 @@ class _PanelComposeDemo(BenchableImageResult):
 
     result_image = bn.ResultImage(doc="Composed panel image")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("panel_compose")

--- a/bencher/example/generated/composable_containers/composable_panel_sequence.py
+++ b/bencher/example/generated/composable_containers/composable_panel_sequence.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Panel: ComposeType.sequence."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _PanelComposeDemo(BenchableImageResult):
@@ -52,8 +48,7 @@ class _PanelComposeDemo(BenchableImageResult):
 
     result_image = bn.ResultImage(doc="Composed panel image")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("panel_compose")

--- a/bencher/example/generated/composable_containers/composable_video_down.py
+++ b/bencher/example/generated/composable_containers/composable_video_down.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Video: ComposeType.down."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _VideoComposeDemo(BenchableImageResult):
@@ -53,8 +49,7 @@ class _VideoComposeDemo(BenchableImageResult):
     num_frames = bn.IntSweep(default=6, bounds=[3, 12], doc="Number of frames")
     composed_video = bn.ResultVideo(doc="Composed video output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid = bn.ComposableContainerVideo()
         for i in range(self.num_frames):
             angle = 360.0 * i / self.num_frames

--- a/bencher/example/generated/composable_containers/composable_video_overlay.py
+++ b/bencher/example/generated/composable_containers/composable_video_overlay.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Video: ComposeType.overlay."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _VideoComposeDemo(BenchableImageResult):
@@ -53,8 +49,7 @@ class _VideoComposeDemo(BenchableImageResult):
     num_frames = bn.IntSweep(default=6, bounds=[3, 12], doc="Number of frames")
     composed_video = bn.ResultVideo(doc="Composed video output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid = bn.ComposableContainerVideo()
         for i in range(self.num_frames):
             angle = 360.0 * i / self.num_frames

--- a/bencher/example/generated/composable_containers/composable_video_right.py
+++ b/bencher/example/generated/composable_containers/composable_video_right.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Video: ComposeType.right."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _VideoComposeDemo(BenchableImageResult):
@@ -53,8 +49,7 @@ class _VideoComposeDemo(BenchableImageResult):
     num_frames = bn.IntSweep(default=6, bounds=[3, 12], doc="Number of frames")
     composed_video = bn.ResultVideo(doc="Composed video output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid = bn.ComposableContainerVideo()
         for i in range(self.num_frames):
             angle = 360.0 * i / self.num_frames

--- a/bencher/example/generated/composable_containers/composable_video_sequence.py
+++ b/bencher/example/generated/composable_containers/composable_video_sequence.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Composable Video: ComposeType.sequence."""
 
-from typing import Any
-
 import math
 import numpy as np
 from PIL import Image, ImageDraw
@@ -34,8 +32,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class _VideoComposeDemo(BenchableImageResult):
@@ -53,8 +49,7 @@ class _VideoComposeDemo(BenchableImageResult):
     num_frames = bn.IntSweep(default=6, bounds=[3, 12], doc="Number of frames")
     composed_video = bn.ResultVideo(doc="Composed video output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid = bn.ComposableContainerVideo()
         for i in range(self.num_frames):
             angle = 360.0 * i / self.num_frames

--- a/bencher/example/generated/const_vars/const_vars_categorical.py
+++ b/bencher/example/generated/const_vars/const_vars_categorical.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Const Vars: Fixing Categorical Parameters."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -19,8 +17,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
     latency = bn.ResultVar(units="ms", doc="Request latency")
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cache_factor = 0.6 if self.cache_enabled else 1.0
         db_base = {"postgres": 1.0, "mysql": 1.1, "sqlite": 0.7}[self.backend]
         log_penalty = {"debug": 1.3, "info": 1.0, "warn": 1.0}[self.log_level]
@@ -36,7 +33,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
             self.latency += random.gauss(0, self.noise_scale * self.latency * 0.1)
             self.throughput = 1000 / max(self.latency, 1)
-        return super().__call__()
 
 
 def example_const_vars_categorical(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/const_vars/const_vars_compare.py
+++ b/bencher/example/generated/const_vars/const_vars_compare.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Const Vars: Comparing Slices."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -19,8 +17,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
     latency = bn.ResultVar(units="ms", doc="Request latency")
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cache_factor = 0.6 if self.cache_enabled else 1.0
         db_base = {"postgres": 1.0, "mysql": 1.1, "sqlite": 0.7}[self.backend]
         log_penalty = {"debug": 1.3, "info": 1.0, "warn": 1.0}[self.log_level]
@@ -36,7 +33,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
             self.latency += random.gauss(0, self.noise_scale * self.latency * 0.1)
             self.throughput = 1000 / max(self.latency, 1)
-        return super().__call__()
 
 
 def example_const_vars_compare(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/const_vars/const_vars_noise.py
+++ b/bencher/example/generated/const_vars/const_vars_noise.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Const Vars: Setting Non-Default Configuration."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -19,8 +17,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
     latency = bn.ResultVar(units="ms", doc="Request latency")
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cache_factor = 0.6 if self.cache_enabled else 1.0
         db_base = {"postgres": 1.0, "mysql": 1.1, "sqlite": 0.7}[self.backend]
         log_penalty = {"debug": 1.3, "info": 1.0, "warn": 1.0}[self.log_level]
@@ -36,7 +33,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
             self.latency += random.gauss(0, self.noise_scale * self.latency * 0.1)
             self.throughput = 1000 / max(self.latency, 1)
-        return super().__call__()
 
 
 def example_const_vars_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/const_vars/const_vars_slice.py
+++ b/bencher/example/generated/const_vars/const_vars_slice.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Const Vars: Slicing a 3D Space."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -19,8 +17,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
     latency = bn.ResultVar(units="ms", doc="Request latency")
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cache_factor = 0.6 if self.cache_enabled else 1.0
         db_base = {"postgres": 1.0, "mysql": 1.1, "sqlite": 0.7}[self.backend]
         log_penalty = {"debug": 1.3, "info": 1.0, "warn": 1.0}[self.log_level]
@@ -36,7 +33,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
             self.latency += random.gauss(0, self.noise_scale * self.latency * 0.1)
             self.throughput = 1000 / max(self.latency, 1)
-        return super().__call__()
 
 
 def example_const_vars_slice(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization/optim_1_objective_1d.py
+++ b/bencher/example/generated/optimization/optim_1_objective_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise 1 objective(s), 1D input."""
 
-from typing import Any
-
 import math
 import random
 
@@ -19,14 +17,12 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.cost = 0.05 * self.cpu_cores + 0.02 * self.memory_gb
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
             self.cost += random.gauss(0, self.noise_scale * 0.1)
-        return super().__call__()
 
 
 def example_optim_1_objective_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization/optim_1_objective_2d.py
+++ b/bencher/example/generated/optimization/optim_1_objective_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise 1 objective(s), 2D input."""
 
-from typing import Any
-
 import math
 import random
 
@@ -19,14 +17,12 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.cost = 0.05 * self.cpu_cores + 0.02 * self.memory_gb
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
             self.cost += random.gauss(0, self.noise_scale * 0.1)
-        return super().__call__()
 
 
 def example_optim_1_objective_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization/optim_2_objectives_1d.py
+++ b/bencher/example/generated/optimization/optim_2_objectives_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise 2 objective(s), 1D input."""
 
-from typing import Any
-
 import math
 import random
 
@@ -19,14 +17,12 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.cost = 0.05 * self.cpu_cores + 0.02 * self.memory_gb
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
             self.cost += random.gauss(0, self.noise_scale * 0.1)
-        return super().__call__()
 
 
 def example_optim_2_objectives_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization/optim_2_objectives_2d.py
+++ b/bencher/example/generated/optimization/optim_2_objectives_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise 2 objective(s), 2D input."""
 
-from typing import Any
-
 import math
 import random
 
@@ -19,14 +17,12 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.cost = 0.05 * self.cpu_cores + 0.02 * self.memory_gb
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
             self.cost += random.gauss(0, self.noise_scale * 0.1)
-        return super().__call__()
 
 
 def example_optim_2_objectives_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization_aggregated/optim_aggregated.py
+++ b/bencher/example/generated/optimization_aggregated/optim_aggregated.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Aggregated Optimisation."""
 
-from typing import Any
-
 import math
 import random
 
@@ -20,13 +18,11 @@ class AlgorithmBench(bn.ParametrizedSweep):
 
     loss = bn.ResultVar("loss", bn.OptDir.minimize, doc="Training loss (minimize)")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         algo_sensitivity = {"gradient_descent": 1.0, "adam": 0.6, "rmsprop": 0.8}
         optimal_lr = 0.01 * algo_sensitivity[self.algorithm]
         self.loss = (math.log10(self.learning_rate) - math.log10(optimal_lr)) ** 2
         self.loss += random.gauss(0, 0.02)
-        return super().__call__()
 
 
 def example_optim_aggregated(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise Over Time: 1D input."""
 
-from typing import Any
-
 import math
 import random
 from datetime import datetime, timedelta
@@ -21,13 +19,11 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     _drift = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.performance *= 1.0 - self._drift * 0.15  # degrade over time
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
-        return super().__call__()
 
 
 def example_optim_over_time_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
+++ b/bencher/example/generated/optimization_over_time/optim_over_time_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Optimise Over Time: 2D input."""
 
-from typing import Any
-
 import math
 import random
 from datetime import datetime, timedelta
@@ -21,13 +19,11 @@ class ServerOptimizer(bn.ParametrizedSweep):
 
     _drift = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10
         self.performance *= 1.0 - self._drift * 0.15  # degrade over time
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale * 5)
-        return super().__call__()
 
 
 def example_optim_over_time_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/performance/perf_self_benchmark.py
+++ b/bencher/example/generated/performance/perf_self_benchmark.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bencher self-introspection: overhead vs problem size."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,10 +9,8 @@ class TrivialWorkload(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bn.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.x * 2
-        return super().__call__(**kwargs)
 
 
 class BencherSelfBenchmark(bn.ParametrizedSweep):
@@ -37,9 +33,7 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
     sample_cache_init_ms = bn.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bn.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         workload = TrivialWorkload()
         x_sweep = bn.FloatSweep(default=0, bounds=[0, 1], samples=self.num_samples, doc="input")
         x_sweep.name = "x"
@@ -62,8 +56,6 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
         self.cache_check_ms = t.cache_check_ms
         self.sample_cache_init_ms = t.sample_cache_init_ms
         self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
-
-        return super().__call__(**kwargs)
 
 
 def example_perf_self_benchmark(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/performance/perf_self_benchmark_over_time.py
+++ b/bencher/example/generated/performance/perf_self_benchmark_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Bencher self-introspection: overhead tracked over time."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -11,10 +9,8 @@ class TrivialWorkload(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[0, 1], samples=2)
     result = bn.ResultVar(units="v", doc="trivial output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.x * 2
-        return super().__call__(**kwargs)
 
 
 class BencherSelfBenchmark(bn.ParametrizedSweep):
@@ -37,9 +33,7 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
     sample_cache_init_ms = bn.ResultVar(units="ms", doc="Sample cache initialization time")
     throughput = bn.ResultVar(units="samples/s", doc="Samples processed per second")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         workload = TrivialWorkload()
         x_sweep = bn.FloatSweep(default=0, bounds=[0, 1], samples=self.num_samples, doc="input")
         x_sweep.name = "x"
@@ -62,8 +56,6 @@ class BencherSelfBenchmark(bn.ParametrizedSweep):
         self.cache_check_ms = t.cache_check_ms
         self.sample_cache_init_ms = t.sample_cache_init_ms
         self.throughput = (self.num_samples / t.total_ms * 1000) if t.total_ms > 0 else 0
-
-        return super().__call__(**kwargs)
 
 
 def example_perf_self_benchmark_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_bar.py
+++ b/bencher/example/generated/plot_types/plot_bar.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Bar."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -12,11 +10,9 @@ class CacheCompare(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Response distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
         self.distance = lookup[self.backend]
-        return super().__call__()
 
 
 def example_plot_bar(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_box_whisker.py
+++ b/bencher/example/generated/plot_types/plot_box_whisker.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Box Whisker."""
 
-from typing import Any
-
 from bencher.results.holoview_results.distribution_result.box_whisker_result import BoxWhiskerResult
 import bencher as bn
 
@@ -16,13 +14,11 @@ class JitterDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Jittered distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
         self.distance = lookup[self.backend]
         if self.noise_scale > 0:
             self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()
 
 
 def example_plot_box_whisker(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_curve.py
+++ b/bencher/example/generated/plot_types/plot_curve.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Curve."""
 
-from typing import Any
-
 import bencher as bn
 
 import math
@@ -16,12 +14,10 @@ class LatencyNoisyProfile(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Latency distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.distance = math.sin(math.pi * self.load) + 0.5
         if self.noise_scale > 0:
             self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()
 
 
 def example_plot_curve(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_heatmap.py
+++ b/bencher/example/generated/plot_types/plot_heatmap.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Heatmap."""
 
-from typing import Any
-
 import bencher as bn
 
 import math
@@ -15,10 +13,8 @@ class HeatmapDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Surface height")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
-        return super().__call__()
 
 
 def example_plot_heatmap(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_line.py
+++ b/bencher/example/generated/plot_types/plot_line.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Line."""
 
-from typing import Any
-
 import bencher as bn
 
 import math
@@ -14,10 +12,8 @@ class LatencyProfile(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Latency distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.distance = math.sin(math.pi * self.load) + 0.5
-        return super().__call__()
 
 
 def example_plot_line(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_scatter.py
+++ b/bencher/example/generated/plot_types/plot_scatter.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Scatter."""
 
-from typing import Any
-
 import bencher as bn
 
 
@@ -12,11 +10,9 @@ class ThroughputCompare(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Throughput distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 5.4, "memcached": 4.1, "local": 8.7}
         self.distance = lookup[self.backend]
-        return super().__call__()
 
 
 def example_plot_scatter(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_scatter_jitter.py
+++ b/bencher/example/generated/plot_types/plot_scatter_jitter.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Scatter Jitter."""
 
-from typing import Any
-
 from bencher.results.holoview_results.distribution_result.scatter_jitter_result import (
     ScatterJitterResult,
 )
@@ -18,13 +16,11 @@ class ScatterJitterDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Jittered distance metric")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
         self.distance = lookup[self.backend]
         if self.noise_scale > 0:
             self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()
 
 
 def example_plot_scatter_jitter(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/plot_types/plot_surface.py
+++ b/bencher/example/generated/plot_types/plot_surface.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Plot Type: Surface."""
 
-from typing import Any
-
 import bencher as bn
 
 import math
@@ -15,10 +13,8 @@ class SurfaceDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Surface height")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
-        return super().__call__()
 
 
 def example_plot_surface(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/publishing/publish_report_gh_pages.py
+++ b/bencher/example/generated/publishing/publish_report_gh_pages.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Publish Report to GitHub Pages."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -14,10 +12,8 @@ class SimpleFloat(bn.ParametrizedSweep):
     )
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
-        return super().__call__(**kwargs)
 
 
 def example_publish_report_gh_pages(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/publishing/publish_runner_gh_pages.py
+++ b/bencher/example/generated/publishing/publish_runner_gh_pages.py
@@ -1,7 +1,5 @@
 """Auto-generated example: BenchRunner Publishing with GithubPagesCfg."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -16,10 +14,8 @@ class WaveBenchmark(bn.ParametrizedSweep):
 
     out_wave = bn.ResultVar(units="v", doc="Wave output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_wave = self.amplitude * math.sin(self.theta)
-        return super().__call__(**kwargs)
 
 
 def example_publish_runner_gh_pages(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/regression/regression_percentage.py
+++ b/bencher/example/generated/regression/regression_percentage.py
@@ -1,6 +1,5 @@
 """Auto-generated example: Regression detection — percentage threshold over time."""
 
-from typing import Any
 from datetime import datetime, timedelta
 
 import bencher as bn
@@ -17,13 +16,11 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
     _time_offset = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
         leak = 1.0 + self._time_offset * 0.12  # memory leak grows per release
         self.response_time = base_rt * leak
         self.throughput = 1000.0 / self.response_time
-        return super().__call__()
 
 
 def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/rerun/rerun_capture_window.py
+++ b/bencher/example/generated/rerun/rerun_capture_window.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Rerun Capture — embed spatial visualizations in sweep reports."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -29,8 +27,7 @@ class RerunSweep(bn.ParametrizedSweep):
 
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
 
         # To capture rerun output as a report panel:
@@ -41,8 +38,6 @@ class RerunSweep(bn.ParametrizedSweep):
         #
         # capture_rerun_window() embeds the data inline (base64) and loads
         # the rerun viewer from CDN — no local file server needed.
-
-        return super().__call__(**kwargs)
 
 
 def example_rerun_capture_window(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/rerun/rerun_rrd_publish.py
+++ b/bencher/example/generated/rerun/rerun_rrd_publish.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Rerun Publishing — share .rrd recordings via git or HTTP."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -36,8 +34,7 @@ class WaveSweep(bn.ParametrizedSweep):
 
     amplitude = bn.ResultVar(units="v", doc="Peak amplitude")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.amplitude = math.sin(self.frequency * math.pi)
 
         # To publish rerun data:
@@ -58,8 +55,6 @@ class WaveSweep(bn.ParametrizedSweep):
         #       content_callback=bn.github_content,
         #   )
         #   pane.show()
-
-        return super().__call__(**kwargs)
 
 
 def example_rerun_rrd_publish(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_bool/result_bool_0d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Bool: 0D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class HealthChecker(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.threshold) * (1.0 - 0.5 * self.difficulty)
         self.healthy = score > 0.5
-        return super().__call__()
 
 
 def example_result_bool_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_bool/result_bool_1d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Bool: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class HealthChecker(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.threshold) * (1.0 - 0.5 * self.difficulty)
         self.healthy = score > 0.5
-        return super().__call__()
 
 
 def example_result_bool_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_bool/result_bool_2d.py
+++ b/bencher/example/generated/result_types/result_bool/result_bool_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Bool: 2D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class HealthChecker(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.threshold) * (1.0 - 0.5 * self.difficulty)
         self.healthy = score > 0.5
-        return super().__call__()
 
 
 def example_result_bool_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Dataset: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,10 +13,9 @@ class TimeseriesCollector(bn.ParametrizedSweep):
 
     result_ds = bn.ResultDataSet(doc="Collected timeseries dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
 
-        self.update_params_from_kwargs(**kwargs)
         n_samples = max(1, int(self.duration * self.sample_rate))
         values = [
             math.sin(2 * math.pi * i / max(n_samples, 1)) * self.duration for i in range(n_samples)
@@ -26,7 +23,6 @@ class TimeseriesCollector(bn.ParametrizedSweep):
         data_array = xr.DataArray(values, dims=["time"], coords={"time": list(range(n_samples))})
         ds = xr.Dataset({"result_ds": data_array})
         self.result_ds = bn.ResultDataSet(ds.to_pandas())
-        return super().__call__()
 
 
 def example_result_dataset_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
+++ b/bencher/example/generated/result_types/result_dataset/result_dataset_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Dataset: 2D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,10 +13,9 @@ class TimeseriesCollector(bn.ParametrizedSweep):
 
     result_ds = bn.ResultDataSet(doc="Collected timeseries dataset")
 
-    def __call__(self, **kwargs: Any) -> Any:
+    def benchmark(self):
         import xarray as xr
 
-        self.update_params_from_kwargs(**kwargs)
         n_samples = max(1, int(self.duration * self.sample_rate))
         values = [
             math.sin(2 * math.pi * i / max(n_samples, 1)) * self.duration for i in range(n_samples)
@@ -26,7 +23,6 @@ class TimeseriesCollector(bn.ParametrizedSweep):
         data_array = xr.DataArray(values, dims=["time"], coords={"time": list(range(n_samples))})
         ds = xr.Dataset({"result_ds": data_array})
         self.result_ds = bn.ResultDataSet(ds.to_pandas())
-        return super().__call__()
 
 
 def example_result_dataset_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_0d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Image: 0D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -34,8 +32,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_1d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Image: 1D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -34,8 +32,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_2d.py
+++ b/bencher/example/generated/result_types/result_image/result_image_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Image: 2D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -34,8 +32,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_composable.py
+++ b/bencher/example/generated/result_types/result_image/result_image_composable.py
@@ -1,7 +1,5 @@
 """Auto-generated example: ResultImage: Composable Container Video from Images."""
 
-from typing import Any
-
 import bencher as bn
 import math
 import numpy as np
@@ -38,8 +36,7 @@ class _ComposableImageDemo(bn.ParametrizedSweep):
     num_frames = bn.IntSweep(default=5, bounds=[2, 20], doc="Frame count")
     polygon_vid = bn.ResultVideo()
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vr = bn.ComposableContainerVideo()
         for i in range(self.num_frames):
             angle = 360.0 * i / self.num_frames

--- a/bencher/example/generated/result_types/result_image/result_image_mixed.py
+++ b/bencher/example/generated/result_types/result_image/result_image_mixed.py
@@ -1,7 +1,5 @@
 """Auto-generated example: ResultImage: Mixed Image and Scalar Results."""
 
-from typing import Any
-
 import bencher as bn
 import math
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -43,7 +40,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_mixed(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_over_time.py
+++ b/bencher/example/generated/result_types/result_image/result_image_over_time.py
@@ -1,7 +1,5 @@
 """Auto-generated example: ResultImage: Over Time Slider."""
 
-from typing import Any
-
 import bencher as bn
 from datetime import datetime, timedelta
 import math
@@ -34,8 +32,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -44,7 +41,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_progressive.py
+++ b/bencher/example/generated/result_types/result_image/result_image_progressive.py
@@ -1,7 +1,5 @@
 """Auto-generated example: ResultImage: Progressive Multi-Parameter Sweep."""
 
-from typing import Any
-
 import bencher as bn
 import math
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -43,7 +40,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_progressive(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_image/result_image_to_video.py
+++ b/bencher/example/generated/result_types/result_image/result_image_to_video.py
@@ -1,7 +1,5 @@
 """Auto-generated example: ResultImage: Image Sweep to Video Grid."""
 
-from typing import Any
-
 import bencher as bn
 import math
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -43,7 +40,6 @@ class PolygonRenderer(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 def example_result_image_to_video(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_path/result_path_0d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Path: 0D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -14,15 +12,13 @@ class ReportExporter(bn.ParametrizedSweep):
 
     file_result = bn.ResultPath(doc="Generated report file")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         filename = bn.gen_path(self.format_type, suffix=".txt")
         line_count = {"summary": 5, "detailed": 20, "raw": 50}[self.format_type]
         with open(filename, "w", encoding="utf-8") as f:
             for i in range(line_count):
                 f.write(f"[{self.format_type}] line {i + 1}: value={math.sin(i):.4f}\n")
         self.file_result = filename
-        return super().__call__()
 
 
 def example_result_path_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_path/result_path_1d.py
+++ b/bencher/example/generated/result_types/result_path/result_path_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Path: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -14,15 +12,13 @@ class ReportExporter(bn.ParametrizedSweep):
 
     file_result = bn.ResultPath(doc="Generated report file")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         filename = bn.gen_path(self.format_type, suffix=".txt")
         line_count = {"summary": 5, "detailed": 20, "raw": 50}[self.format_type]
         with open(filename, "w", encoding="utf-8") as f:
             for i in range(line_count):
                 f.write(f"[{self.format_type}] line {i + 1}: value={math.sin(i):.4f}\n")
         self.file_result = filename
-        return super().__call__()
 
 
 def example_result_path_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_string/result_string_0d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result String: 0D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,12 +13,10 @@ class LogFormatter(bn.ParametrizedSweep):
 
     report = bn.ResultString(doc="Formatted log report")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         detail = int(math.ceil(self.verbosity * 5))
         text = f"Level: {self.level}\n\tVerbosity: {self.verbosity:.2f}\n\tDetail depth: {detail}"
         self.report = bn.tabs_in_markdown(text)
-        return super().__call__()
 
 
 def example_result_string_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_string/result_string_1d.py
+++ b/bencher/example/generated/result_types/result_string/result_string_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result String: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,12 +13,10 @@ class LogFormatter(bn.ParametrizedSweep):
 
     report = bn.ResultString(doc="Formatted log report")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         detail = int(math.ceil(self.verbosity * 5))
         text = f"Level: {self.level}\n\tVerbosity: {self.verbosity:.2f}\n\tDetail depth: {detail}"
         self.report = bn.tabs_in_markdown(text)
-        return super().__call__()
 
 
 def example_result_string_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_var/result_var_0d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Var: 0D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class ResponseTimer(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"api/users": 12.0, "api/orders": 25.0}[self.endpoint]
         self.latency = base + 0.5 * math.log1p(self.concurrency)
-        return super().__call__()
 
 
 def example_result_var_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_var/result_var_1d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Var: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class ResponseTimer(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"api/users": 12.0, "api/orders": 25.0}[self.endpoint]
         self.latency = base + 0.5 * math.log1p(self.concurrency)
-        return super().__call__()
 
 
 def example_result_var_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_var/result_var_2d.py
+++ b/bencher/example/generated/result_types/result_var/result_var_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Var: 2D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,11 +13,9 @@ class ResponseTimer(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"api/users": 12.0, "api/orders": 25.0}[self.endpoint]
         self.latency = base + 0.5 * math.log1p(self.concurrency)
-        return super().__call__()
 
 
 def example_result_var_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_vec/result_vec_1d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Vec: 1D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,13 +13,11 @@ class SystemMetrics(bn.ParametrizedSweep):
 
     metrics = bn.ResultVec(3, "%", doc="CPU, memory, disk utilization")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cpu = 20.0 + 70.0 * math.sin(math.pi * self.load / 2.0)
         mem = 30.0 + 50.0 * self.load * math.log1p(self.instances)
         disk = 10.0 + 40.0 * math.sqrt(self.load * self.instances / 10.0)
         self.metrics = [cpu, mem, disk]
-        return super().__call__()
 
 
 def example_result_vec_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_vec/result_vec_2d.py
+++ b/bencher/example/generated/result_types/result_vec/result_vec_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Vec: 2D input."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,13 +13,11 @@ class SystemMetrics(bn.ParametrizedSweep):
 
     metrics = bn.ResultVec(3, "%", doc="CPU, memory, disk utilization")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cpu = 20.0 + 70.0 * math.sin(math.pi * self.load / 2.0)
         mem = 30.0 + 50.0 * self.load * math.log1p(self.instances)
         disk = 10.0 + 40.0 * math.sqrt(self.load * self.instances / 10.0)
         self.metrics = [cpu, mem, disk]
-        return super().__call__()
 
 
 def example_result_vec_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/result_video_0d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_0d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Video: 0D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid_writer = bn.VideoWriter()
         num_frames = 8
         for i in range(num_frames):
@@ -44,7 +41,6 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
-        return super().__call__()
 
 
 def example_result_video_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/result_video_1d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_1d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Video: 1D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid_writer = bn.VideoWriter()
         num_frames = 8
         for i in range(num_frames):
@@ -44,7 +41,6 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
-        return super().__call__()
 
 
 def example_result_video_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/result_video_2d.py
+++ b/bencher/example/generated/result_types/result_video/result_video_2d.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Result Video: 2D input."""
 
-from typing import Any
-
 import math
 
 import numpy as np
@@ -33,8 +31,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid_writer = bn.VideoWriter()
         num_frames = 8
         for i in range(num_frames):
@@ -44,7 +41,6 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
-        return super().__call__()
 
 
 def example_result_video_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/sampling/sampling_custom_values.py
+++ b/bencher/example/generated/sampling/sampling_custom_values.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Sampling: Custom Values."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -13,10 +11,8 @@ class CustomSampler(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
-        return super().__call__()
 
 
 def example_sampling_custom_values(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/sampling/sampling_int_vs_float.py
+++ b/bencher/example/generated/sampling/sampling_int_vs_float.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Sampling: Int Vs Float."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -15,10 +13,8 @@ class IntFloatCompare(bn.ParametrizedSweep):
 
     output = bn.ResultVar("ul", doc="Computed output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.output = math.sin(self.int_input * 0.3) + math.cos(self.float_input * 0.2)
-        return super().__call__()
 
 
 def example_sampling_int_vs_float(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/sampling/sampling_uniform.py
+++ b/bencher/example/generated/sampling/sampling_uniform.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Sampling: Uniform."""
 
-from typing import Any
-
 import math
 
 import bencher as bn
@@ -14,10 +12,8 @@ class UniformSampler(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
-        return super().__call__()
 
 
 def example_sampling_uniform(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/workflows/workflow_bench_runner.py
+++ b/bencher/example/generated/workflows/workflow_bench_runner.py
@@ -1,7 +1,5 @@
 """Auto-generated example: BenchRunner — run multiple benchmarks in one session."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -12,10 +10,8 @@ class SineWave(bn.ParametrizedSweep):
     theta = bn.FloatSweep(default=0, bounds=[0, math.pi], doc="Input angle", units="rad")
     out_sin = bn.ResultVar(units="V", doc="Sine output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
-        return super().__call__()
 
 
 def example_workflow_bench_runner(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/workflows/workflow_getting_started.py
+++ b/bencher/example/generated/workflows/workflow_getting_started.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Getting Started — progressive bencher tutorial."""
 
-from typing import Any
-
 import math
 import random
 
@@ -27,7 +25,7 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
     """A tutorial benchmark demonstrating core bencher features step by step.
 
     This class defines both inputs (sweep variables) and outputs (result
-    variables) in a single ParametrizedSweep. The __call__ method is the
+    variables) in a single ParametrizedSweep. The benchmark() method is the
     benchmark function -- it must be pure (no side effects) so that repeated
     calls produce statistically valid results.
 
@@ -54,9 +52,7 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
         doc="Algorithm accuracy - the metric we want to optimise",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         self.accuracy = 50 + math.sin(self.intensity) * 5
 
         match self.algo_setting:
@@ -66,8 +62,6 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
                 self.accuracy += 30
             case AlgoSetting.poor:
                 self.accuracy -= 20
-
-        return super().__call__(**kwargs)
 
 
 def example_workflow_getting_started(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/workflows/workflow_input_output_cfg.py
+++ b/bencher/example/generated/workflows/workflow_input_output_cfg.py
@@ -35,7 +35,7 @@ class ServerConfig(bn.ParametrizedSweep):
 def example_workflow_input_output_cfg(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """InputCfg/OutputCfg — separated input and output classes."""
     # The Bench constructor accepts the static function and the ServerConfig class.
-    # This is an alternative to the ParametrizedSweep.__call__ pattern.
+    # This is an alternative to the ParametrizedSweep.benchmark() pattern.
     bench = bn.Bench("input_output_example", ServerConfig.bench_function, ServerConfig, run_cfg)
     bench.plot_sweep(
         input_vars=[ServerConfig.param.worker_count],

--- a/bencher/example/generated/workflows/workflow_multi_sweep.py
+++ b/bencher/example/generated/workflows/workflow_multi_sweep.py
@@ -1,7 +1,5 @@
 """Auto-generated example: Multiple Sweeps — progressive report with tabs."""
 
-from typing import Any
-
 import math
 import bencher as bn
 
@@ -16,12 +14,10 @@ class DataPipeline(bn.ParametrizedSweep):
     throughput = bn.ResultVar(units="rows/s", doc="Processing throughput")
     latency = bn.ResultVar(units="ms", doc="Per-batch latency")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         storage_factor = {"ssd": 1.0, "hdd": 0.4, "network": 0.25}[self.storage]
         self.throughput = self.batch_size * math.sqrt(self.parallelism) * storage_factor * 0.5
         self.latency = 1000 * self.batch_size / max(self.throughput, 1)
-        return super().__call__()
 
 
 def example_workflow_multi_sweep(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/yaml/yaml_sweep_dict.py
+++ b/bencher/example/generated/yaml/yaml_sweep_dict.py
@@ -13,9 +13,7 @@ class YamlDictConfig(bn.ParametrizedSweep):
     total_duration = bn.ResultVar(units="min", doc="Sum of all scheduled durations")
     average_duration = bn.ResultVar(units="min", doc="Average scheduled duration")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         key, config = self.plan
         durations = config.get("durations", [])
         total = sum(durations)
@@ -29,8 +27,6 @@ class YamlDictConfig(bn.ParametrizedSweep):
             "durations": list(durations),
             "resources": dict(config.get("resources", {})),
         }
-
-        return super().__call__()
 
 
 def example_yaml_sweep_dict(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/yaml/yaml_sweep_list.py
+++ b/bencher/example/generated/yaml/yaml_sweep_list.py
@@ -11,12 +11,8 @@ class YamlConfigSweep(bn.ParametrizedSweep):
 
     total_workload = bn.ResultVar(units="tasks", doc="Total workload summed from the YAML list")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         self.total_workload = sum(self.workload.value())
-
-        return super().__call__()
 
 
 def example_yaml_sweep_list(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/benchable_objects.py
+++ b/bencher/example/meta/benchable_objects.py
@@ -24,13 +24,11 @@ class BenchableBoolResult(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.threshold) * (1.0 - 0.5 * self.difficulty)
         if self.noise_scale > 0:
             score += random.gauss(0, self.noise_scale)
         self.pass_rate = score > 0.5
-        return super().__call__()
 
 
 class BenchableVecResult(bn.ParametrizedSweep):
@@ -43,8 +41,7 @@ class BenchableVecResult(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vals = [
             math.sin(math.pi * self.x),
             math.cos(math.pi * self.y),
@@ -53,7 +50,6 @@ class BenchableVecResult(bn.ParametrizedSweep):
         if self.noise_scale > 0:
             vals = [v + random.gauss(0, self.noise_scale) for v in vals]
         self.position = vals
-        return super().__call__()
 
 
 class BenchableStringResult(bn.ParametrizedSweep):
@@ -64,13 +60,11 @@ class BenchableStringResult(bn.ParametrizedSweep):
 
     report = bn.ResultString(doc="Formatted report string")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         text = (
             f"Label: {self.label}\n\tValue: {self.value:.3f}\n\tScore: {math.sin(self.value):.3f}"
         )
         self.report = bn.tabs_in_markdown(text)
-        return super().__call__()
 
 
 class BenchablePathResult(bn.ParametrizedSweep):
@@ -80,13 +74,11 @@ class BenchablePathResult(bn.ParametrizedSweep):
 
     file_result = bn.ResultPath(doc="Generated report file")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         filename = bn.gen_path(self.content, suffix=".txt")
         with open(filename, "w", encoding="utf-8") as f:
             f.write(f"content: {self.content}\ntimestamp: deterministic")
         self.file_result = filename
-        return super().__call__()
 
 
 class BenchableDataSetResult(bn.ParametrizedSweep):
@@ -97,15 +89,13 @@ class BenchableDataSetResult(bn.ParametrizedSweep):
 
     result_ds = bn.ResultDataSet(doc="Generated dataset")
 
-    def __call__(self, **kwargs):
+    def benchmark(self):
         import xarray as xr
 
-        self.update_params_from_kwargs(**kwargs)
         vector = [self.scale * (v + self.value) for v in range(1, 5)]
         data_array = xr.DataArray(vector, dims=["index"], coords={"index": np.arange(len(vector))})
         result_df = xr.Dataset({"result_ds": data_array})
         self.result_ds = bn.ResultDataSet(result_df.to_pandas())
-        return super().__call__()
 
 
 class BenchableMultiObjective(bn.ParametrizedSweep):
@@ -119,14 +109,12 @@ class BenchableMultiObjective(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.performance = math.sin(math.pi * self.x) * math.cos(0.5 * math.pi * self.y) + 0.5
         self.cost = 0.3 + 0.7 * self.x + 0.5 * self.y**2
         if self.noise_scale > 0:
             self.performance += random.gauss(0, self.noise_scale)
             self.cost += random.gauss(0, self.noise_scale * 0.5)
-        return super().__call__()
 
 
 class BenchableIntFloat(bn.ParametrizedSweep):
@@ -137,10 +125,8 @@ class BenchableIntFloat(bn.ParametrizedSweep):
 
     output = bn.ResultVar("ul", doc="Computed output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.output = math.sin(self.int_input * 0.3) + math.cos(self.float_input * 0.2)
-        return super().__call__()
 
 
 def _polygon_points(radius, sides, start_angle=0.0):
@@ -171,8 +157,7 @@ class BenchableImageResult(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
@@ -181,7 +166,6 @@ class BenchableImageResult(bn.ParametrizedSweep):
         self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
             4 * math.tan(math.pi / self.sides)
         )
-        return super().__call__()
 
 
 class BenchableVideoResult(bn.ParametrizedSweep):
@@ -193,8 +177,7 @@ class BenchableVideoResult(bn.ParametrizedSweep):
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid_writer = bn.VideoWriter()
         num_frames = 8
         for i in range(num_frames):
@@ -204,4 +187,3 @@ class BenchableVideoResult(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
-        return super().__call__()

--- a/bencher/example/meta/example_meta.py
+++ b/bencher/example/meta/example_meta.py
@@ -1,4 +1,3 @@
-from typing import Any
 from datetime import datetime, timedelta
 
 import bencher as bn
@@ -48,9 +47,7 @@ class BenchableObject(bn.ParametrizedSweep):
     )
     _time_offset = 0.0  # offset added to output for over-time support
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         x, y, z = self.float1, self.float2, self.float3
 
         # Map categoricals to continuous parameters that shape the function.
@@ -82,8 +79,6 @@ class BenchableObject(bn.ParametrizedSweep):
             x=0, y=0, text=f"distance:{self.distance}\nnoise:{self.sample_noise}"
         )
 
-        return super().__call__()
-
 
 class BenchMeta(bn.ParametrizedSweep):
     """This class uses bencher to display the multidimensional types bencher can represent"""
@@ -102,9 +97,7 @@ class BenchMeta(bn.ParametrizedSweep):
 
     plots = bn.ResultReference(units="int")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         run_cfg = bn.BenchRunCfg()
         run_cfg.level = self.level
         run_cfg.repeats = self.sample_with_repeats
@@ -160,8 +153,6 @@ class BenchMeta(bn.ParametrizedSweep):
 
         self.plots = bn.ResultReference()
         self.plots.obj = res.to_auto()
-
-        return super().__call__()
 
 
 def example_meta(

--- a/bencher/example/meta/example_meta.py
+++ b/bencher/example/meta/example_meta.py
@@ -130,7 +130,7 @@ class BenchMeta(bn.ParametrizedSweep):
             time_offsets = [0.0, 0.3, 0.7, 1.0]
             base_time = datetime(2000, 1, 1)
             for i, offset in enumerate(time_offsets):
-                benchable._time_offset = offset
+                benchable._time_offset = offset  # pylint: disable=protected-access
                 run_cfg.clear_cache = True
                 run_cfg.clear_history = i == 0
                 res = bench.plot_sweep(

--- a/bencher/example/meta/generate_meta.py
+++ b/bencher/example/meta/generate_meta.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -334,8 +332,7 @@ def _build_class_code(info, _float_count, _cat_count, noise_val=0.0, time_offset
         cls_lines.append("    _time_offset = 0.0")
 
     cls_lines.append("")
-    cls_lines.append("    def __call__(self, **kwargs: Any) -> Any:")
-    cls_lines.append("        self.update_params_from_kwargs(**kwargs)")
+    cls_lines.append("    def benchmark(self):")
 
     if noise_val > 0 and "noise_body" in info:
         for line in info["noise_body"]:
@@ -348,7 +345,6 @@ def _build_class_code(info, _float_count, _cat_count, noise_val=0.0, time_offset
         result_name = list(info["result_vars"].keys())[0]
         cls_lines.append(f"        self.{result_name} += self._time_offset * 10")
 
-    cls_lines.append("        return super().__call__()")
     return "\n".join(cls_lines)
 
 
@@ -462,12 +458,10 @@ class BenchMetaGen(bn.ParametrizedSweep):
 
     plots = bn.ResultReference(units="int")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         key = (self.float_vars_count, self.categorical_vars_count)
         if key not in INLINE_CLASSES:
-            return super().__call__()
+            return
 
         info = INLINE_CLASSES[key]
         input_var_names = _get_input_var_names(
@@ -583,8 +577,6 @@ class BenchMetaGen(bn.ParametrizedSweep):
                 post_description=post_description,
                 run_kwargs=run_kwargs,
             )
-
-        return super().__call__()
 
 
 def example_meta(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -4,8 +4,6 @@ Covers cache/context patterns, time events, and report customization —
 features previously only shown in hand-written examples.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -27,9 +25,7 @@ class MetaAdvanced(MetaGeneratorBase):
 
     example = bn.StringSweep(ADVANCED_EXAMPLES, doc="Which advanced example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "cache_patterns":
             self._generate_cache_patterns()
         elif self.example == "time_event":
@@ -44,8 +40,6 @@ class MetaAdvanced(MetaGeneratorBase):
             self._generate_agg_over_time()
         elif self.example == "cartesian_animation":
             self._generate_cartesian_animation()
-
-        return super().__call__()
 
     def _generate_cache_patterns(self):
         """B3: Cache and context patterns."""
@@ -67,12 +61,10 @@ class NoisySensor(bn.ParametrizedSweep):
 
     noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.reading = 0.5 + 0.03 * self.temperature + math.sin(self.temperature * 0.1)
         if self.noise_scale > 0:
-            self.reading += random.gauss(0, self.noise_scale)
-        return super().__call__()'''
+            self.reading += random.gauss(0, self.noise_scale)'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=5)
 
@@ -127,12 +119,10 @@ class PullRequestBenchmark(bn.ParametrizedSweep):
 
     _event_idx = 0  # set externally per event
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"light": 1000, "medium": 500, "heavy": 200}[self.workload]
         # Simulate gradual improvement across events
-        self.throughput = base + self._event_idx * 30
-        return super().__call__()'''
+        self.throughput = base + self._event_idx * 30'''
         body = """\
 if run_cfg is None:
     run_cfg = bn.BenchRunCfg()
@@ -187,10 +177,8 @@ class ServerLatency(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
-        return super().__call__()'''
+    def benchmark(self):
+        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]'''
         body = """\
 bench = ServerLatency().to_bench(run_cfg)
 
@@ -237,11 +225,9 @@ class LatencyMonitor(bn.ParametrizedSweep):
 
     _drift = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"/api/users": 45, "/api/orders": 120}[self.endpoint]
-        self.latency = base + self._drift + random.gauss(0, 5)
-        return super().__call__()'''
+        self.latency = base + self._drift + random.gauss(0, 5)'''
         body = """\
 if run_cfg is None:
     run_cfg = bn.BenchRunCfg()
@@ -292,10 +278,8 @@ class QuadraticFit(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[-2, 2], doc="Input value")
     y = bn.ResultVar(units="ul", doc="Quadratic output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.y = self.x**2 - 1
-        return super().__call__()'''
+    def benchmark(self):
+        self.y = self.x**2 - 1'''
         body = """\
 bench = QuadraticFit().to_bench(run_cfg)
 
@@ -349,15 +333,13 @@ class ThermalPlate(bn.ParametrizedSweep):
 
     _time_offset = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         # Hot spot at centre, decaying over time
         self.temperature = (
             100 * math.sin(math.pi * self.x) * math.sin(math.pi * self.y)
             * math.exp(-0.3 * self._time_offset)
             + 20
-        )
-        return super().__call__()'''
+        )'''
         body = """\
 if run_cfg is None:
     run_cfg = bn.BenchRunCfg()
@@ -420,9 +402,7 @@ for i, offset in enumerate(time_offsets):
 
     animation = bn.ResultImage()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         all_spatial = [
             SweepVar("dim_1", [0, 1, 2]),
             SweepVar("dim_2", [0, 1, 2]),
@@ -451,8 +431,7 @@ for i, offset in enumerate(time_offsets):
             width=320,
             height=200,
         )
-        self.animation = animation_path
-        return super().__call__()'''
+        self.animation = animation_path'''
         body = """bench = CartesianAnimationSweep().to_bench(run_cfg)
 
 bench.plot_sweep(

--- a/bencher/example/meta/generate_meta_aggregation.py
+++ b/bencher/example/meta/generate_meta_aggregation.py
@@ -20,15 +20,13 @@ class GradientDirection(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "diagonal":
             self.out = self.x + self.y
         elif self.direction == "horizontal":
             self.out = self.x
         else:
-            self.out = self.y
-        return super().__call__()'''
+            self.out = self.y'''
 
 _GRADIENT_1F_1C = '''\
 class GradientScale(bn.ParametrizedSweep):
@@ -39,15 +37,13 @@ class GradientScale(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.scale == "linear":
             self.out = self.x
         elif self.scale == "quadratic":
             self.out = self.x**2
         else:
-            self.out = self.x**0.5
-        return super().__call__()'''
+            self.out = self.x**0.5'''
 
 _GRADIENT_1F_2C = '''\
 class GradientDirectionScale(bn.ParametrizedSweep):
@@ -59,8 +55,7 @@ class GradientDirectionScale(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "positive":
             base = self.x
         elif self.direction == "negative":
@@ -72,8 +67,7 @@ class GradientDirectionScale(bn.ParametrizedSweep):
         elif self.scale == "quadratic":
             self.out = base**2
         else:
-            self.out = base**0.5
-        return super().__call__()'''
+            self.out = base**0.5'''
 
 _GRADIENT_2F_2C = '''\
 class GradientSurface(bn.ParametrizedSweep):
@@ -86,8 +80,7 @@ class GradientSurface(bn.ParametrizedSweep):
 
     out = bn.ResultVar(units="v", doc="Surface value")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         if self.direction == "diagonal":
             base = self.x + self.y
         elif self.direction == "horizontal":
@@ -99,8 +92,7 @@ class GradientSurface(bn.ParametrizedSweep):
         elif self.scale == "quadratic":
             self.out = base**2
         else:
-            self.out = base**0.5
-        return super().__call__()'''
+            self.out = base**0.5'''
 
 
 def example_meta_aggregation():

--- a/bencher/example/meta/generate_meta_bool_plot_types.py
+++ b/bencher/example/meta/generate_meta_bool_plot_types.py
@@ -4,8 +4,6 @@ Shows ResultBool output with each plot type that supports it.
 Each generated example is fully self-contained with an inline class definition.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -23,11 +21,9 @@ class HealthCheckCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
-        self.healthy = random.random() < rates[self.backend]
-        return super().__call__()"""
+        self.healthy = random.random() < rates[self.backend]"""
 
 _HEALTH_CHECK_FLOAT_CODE = """\
 class HealthCheckFloat(bn.ParametrizedSweep):
@@ -37,11 +33,9 @@ class HealthCheckFloat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         score = math.sin(math.pi * self.load)
-        self.healthy = score > 0.5
-        return super().__call__()"""
+        self.healthy = score > 0.5"""
 
 _HEALTH_CHECK_FLOAT_NOISY_CODE = """\
 class HealthCheckFloatNoisy(bn.ParametrizedSweep):
@@ -51,11 +45,9 @@ class HealthCheckFloatNoisy(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         probability = math.sin(math.pi * self.load)
-        self.healthy = random.random() < probability
-        return super().__call__()"""
+        self.healthy = random.random() < probability"""
 
 _HEALTH_CHECK_2D_NOISY_CODE = """\
 class HealthCheck2DNoisy(bn.ParametrizedSweep):
@@ -66,11 +58,9 @@ class HealthCheck2DNoisy(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         probability = 0.5 + 0.4 * math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
-        self.healthy = random.random() < probability
-        return super().__call__()"""
+        self.healthy = random.random() < probability"""
 
 _RELIABILITY_CAT_CODE = """\
 class ReliabilityCat(bn.ParametrizedSweep):
@@ -80,11 +70,9 @@ class ReliabilityCat(bn.ParametrizedSweep):
 
     healthy = bn.ResultBool(doc="Whether the service is healthy")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rates = {"postgres": 0.95, "redis": 0.85, "memcached": 0.65, "sqlite": 0.40, "local": 0.15}
-        self.healthy = random.random() < rates[self.backend]
-        return super().__call__()"""
+        self.healthy = random.random() < rates[self.backend]"""
 
 _PASS_RATE_FLOAT_CODE = """\
 class PassRateFloat(bn.ParametrizedSweep):
@@ -94,11 +82,9 @@ class PassRateFloat(bn.ParametrizedSweep):
 
     passed = bn.ResultBool(doc="Whether the test passed")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         rate = 1.0 - 0.8 * self.complexity ** 1.5
-        self.passed = random.random() < rate
-        return super().__call__()"""
+        self.passed = random.random() < rate"""
 
 # ---------------------------------------------------------------------------
 # Plot configuration table
@@ -226,9 +212,7 @@ class MetaBoolPlotTypes(MetaGeneratorBase):
 
     plot_type = bn.StringSweep(BOOL_PLOT_NAMES, doc="Plot type to demonstrate with ResultBool")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         cfg = BOOL_PLOT_CONFIGS[self.plot_type]
         filename = f"bool_plot_{self.plot_type}"
         function_name = f"example_bool_plot_{self.plot_type}"
@@ -255,8 +239,6 @@ class MetaBoolPlotTypes(MetaGeneratorBase):
             run_kwargs=run_kwargs,
             class_code=cfg["class_code"],
         )
-
-        return super().__call__()
 
 
 def example_meta_bool_plot_types(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_cartesian_animation.py
+++ b/bencher/example/meta/generate_meta_cartesian_animation.py
@@ -5,8 +5,6 @@ animated dimensional extrusions — showing how each dimension builds on the
 last (point → line → grid → stack → repeats → film strip).
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -16,10 +14,8 @@ OUTPUT_DIR = "cartesian_animation"
 class MetaCartesianAnimation(MetaGeneratorBase):
     """Generate the Cartesian product animation example."""
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self._generate_cartesian_animation()
-        return super().__call__()
 
     def _generate_cartesian_animation(self):
         """Generate Cartesian product animations across dimensionality combinations."""
@@ -57,9 +53,7 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
 
     animation = bn.ResultImage()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         all_spatial = [
             SweepVar("dim_1", [0, 1, 2]),
             SweepVar("dim_2", [0, 1, 2]),
@@ -90,8 +84,7 @@ class CartesianAnimationSweep(bn.ParametrizedSweep):
             width=320,
             height=200,
         )
-        self.animation = animation_path
-        return super().__call__()'''
+        self.animation = animation_path'''
         body = """\
 bench = CartesianAnimationSweep().to_bench(run_cfg)
 

--- a/bencher/example/meta/generate_meta_composable.py
+++ b/bencher/example/meta/generate_meta_composable.py
@@ -5,8 +5,6 @@ three backends (Video, Panel, Dataset) and all four ComposeType strategies
 (right, down, sequence, overlay).
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -47,8 +45,7 @@ _BENCHABLE_IMAGE_CLASS = (
     '    polygon = bn.ResultImage(doc="Rendered polygon image")\n'
     '    area = bn.ResultVar("u^2", doc="Polygon area")\n'
     "\n"
-    "    def __call__(self, **kwargs):\n"
-    "        self.update_params_from_kwargs(**kwargs)\n"
+    "    def benchmark(self):\n"
     "        points = _polygon_points(self.radius, self.sides)\n"
     "        img = _draw_polygon_image(points, self.color, linewidth=3)\n"
     '        filepath = bn.gen_image_path("polygon")\n'
@@ -56,8 +53,7 @@ _BENCHABLE_IMAGE_CLASS = (
     "        self.polygon = str(filepath)\n"
     "        self.area = (\n"
     "            self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2\n"
-    "        ) / (4 * math.tan(math.pi / self.sides))\n"
-    "        return super().__call__()"
+    "        ) / (4 * math.tan(math.pi / self.sides))"
 )
 
 
@@ -69,9 +65,7 @@ class MetaComposableVideo(MetaGeneratorBase):
         doc="Composition strategy",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         compose = self.compose
         filename = f"composable_video_{compose}"
         function_name = f"example_composable_video_{compose}"
@@ -89,8 +83,7 @@ class MetaComposableVideo(MetaGeneratorBase):
             'doc="Number of frames")\n'
             "    composed_video = bn.ResultVideo(doc='Composed video output')\n"
             "\n"
-            "    def __call__(self, **kwargs):\n"
-            "        self.update_params_from_kwargs(**kwargs)\n"
+            "    def benchmark(self):\n"
             "        vid = bn.ComposableContainerVideo()\n"
             "        for i in range(self.num_frames):\n"
             "            angle = 360.0 * i / self.num_frames\n"
@@ -128,8 +121,6 @@ class MetaComposableVideo(MetaGeneratorBase):
             run_kwargs={"level": 2},
         )
 
-        return super().__call__()
-
 
 class MetaComposablePanel(MetaGeneratorBase):
     """Generate examples showing ComposableContainerPanel with each ComposeType."""
@@ -139,9 +130,7 @@ class MetaComposablePanel(MetaGeneratorBase):
         doc="Composition strategy",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         compose = self.compose
         filename = f"composable_panel_{compose}"
         function_name = f"example_composable_panel_{compose}"
@@ -157,8 +146,7 @@ class MetaComposablePanel(MetaGeneratorBase):
             "\n"
             "    result_image = bn.ResultImage(doc='Composed panel image')\n"
             "\n"
-            "    def __call__(self, **kwargs):\n"
-            "        self.update_params_from_kwargs(**kwargs)\n"
+            "    def benchmark(self):\n"
             "        points = _polygon_points(self.radius, self.sides)\n"
             "        img = _draw_polygon_image(points, self.color, linewidth=3)\n"
             '        filepath = bn.gen_image_path("panel_compose")\n'
@@ -187,8 +175,6 @@ class MetaComposablePanel(MetaGeneratorBase):
             run_kwargs={"level": 2},
         )
 
-        return super().__call__()
-
 
 class MetaComposableDataset(MetaGeneratorBase):
     """Generate examples showing ComposableContainerDataset with each ComposeType."""
@@ -198,9 +184,7 @@ class MetaComposableDataset(MetaGeneratorBase):
         doc="Composition strategy",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         compose = self.compose
         filename = f"composable_dataset_{compose}"
         function_name = f"example_composable_dataset_{compose}"
@@ -214,18 +198,16 @@ class MetaComposableDataset(MetaGeneratorBase):
             'default=5.0, bounds=[1.0, 10.0], doc="Collection duration")\n'
             '    result_ds = bn.ResultDataSet(doc="Collected time-series dataset")\n'
             "\n"
-            "    def __call__(self, **kwargs):\n"
+            "    def benchmark(self):\n"
             "        import xarray as xr\n"
             "        import numpy as np\n"
-            "        self.update_params_from_kwargs(**kwargs)\n"
             "        n = int(self.duration * 10)\n"
             "        t = np.linspace(0, self.duration, n)\n"
             "        values = np.sin(2 * np.pi * t / self.duration) * self.duration\n"
             '        data_array = xr.DataArray(values, dims=["time"], '
             'coords={"time": t})\n'
             "        self.result_ds = bn.ResultDataSet("
-            'xr.Dataset({"signal": data_array}).to_pandas())\n'
-            "        return super().__call__()"
+            'xr.Dataset({"signal": data_array}).to_pandas())'
         )
 
         self.generate_sweep_example(
@@ -241,15 +223,11 @@ class MetaComposableDataset(MetaGeneratorBase):
             run_kwargs={"level": 3},
         )
 
-        return super().__call__()
-
 
 class MetaComposableAllTypes(MetaGeneratorBase):
     """Generate an example that sweeps ComposeType across the Video backend."""
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         imports = f"{_POLYGON_IMPORTS}\n\n\n{_POLYGON_HELPERS}"
 
         class_code = (
@@ -265,8 +243,7 @@ class MetaComposableAllTypes(MetaGeneratorBase):
             "    )\n"
             "    composed_video = bn.ResultVideo(doc='Composed video output')\n"
             "\n"
-            "    def __call__(self, **kwargs):\n"
-            "        self.update_params_from_kwargs(**kwargs)\n"
+            "    def benchmark(self):\n"
             "        vid = bn.ComposableContainerVideo()\n"
             "        for i in range(5):\n"
             "            angle = 360.0 * i / 5\n"
@@ -309,8 +286,6 @@ class MetaComposableAllTypes(MetaGeneratorBase):
             class_code=class_code,
             run_kwargs={"level": 2},
         )
-
-        return super().__call__()
 
 
 # --- Entry point -----------------------------------------------------------

--- a/bencher/example/meta/generate_meta_const_vars.py
+++ b/bencher/example/meta/generate_meta_const_vars.py
@@ -3,8 +3,6 @@
 Shows how to use const_vars to fix parameters at specific values while sweeping others.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -27,8 +25,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
     latency = bn.ResultVar(units="ms", doc="Request latency")
     throughput = bn.ResultVar(units="req/s", doc="Request throughput")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         cache_factor = 0.6 if self.cache_enabled else 1.0
         db_base = {"postgres": 1.0, "mysql": 1.1, "sqlite": 0.7}[self.backend]
         log_penalty = {"debug": 1.3, "info": 1.0, "warn": 1.0}[self.log_level]
@@ -43,8 +40,7 @@ class ServerBenchmark(bn.ParametrizedSweep):
             import random
 
             self.latency += random.gauss(0, self.noise_scale * self.latency * 0.1)
-            self.throughput = 1000 / max(self.latency, 1)
-        return super().__call__()'''
+            self.throughput = 1000 / max(self.latency, 1)'''
 
 
 class MetaConstVars(MetaGeneratorBase):
@@ -52,9 +48,7 @@ class MetaConstVars(MetaGeneratorBase):
 
     example = bn.StringSweep(EXAMPLES, doc="Which const_vars example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "slice":
             self._gen_slice()
         elif self.example == "compare":
@@ -63,8 +57,6 @@ class MetaConstVars(MetaGeneratorBase):
             self._gen_categorical()
         elif self.example == "noise":
             self._gen_noise()
-
-        return super().__call__()
 
     def _gen_slice(self):
         """Fix disk_io=0.5 while sweeping cpu_load and memory_pct."""

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -5,8 +5,6 @@ simple sweeps and rich feature demonstrations (progressive sweeps, mixed
 results, video grids, composable containers).
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -43,15 +41,13 @@ class PolygonRenderer(bn.ParametrizedSweep):
     polygon = bn.ResultImage(doc="Rendered polygon image")
     area = bn.ResultVar("u^2", doc="Polygon area")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         points = _polygon_points(self.radius, self.sides)
         img = _draw_polygon_image(points, self.color, linewidth=3)
         filepath = bn.gen_image_path("polygon")
         img.save(filepath, "PNG")
         self.polygon = str(filepath)
-        self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (4 * math.tan(math.pi / self.sides))
-        return super().__call__()"""
+        self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (4 * math.tan(math.pi / self.sides))"""
 )
 
 _VIDEO_CLASS_CODE = (
@@ -66,8 +62,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         vid_writer = bn.VideoWriter()
         num_frames = 8
         for i in range(num_frames):
@@ -76,8 +71,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
             img = _draw_polygon_image(points, "white", linewidth=3, size=200)
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
-        self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
-        return super().__call__()"""
+        self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)"""
 )
 
 _EXTRA_IMPORTS = ["import math", "import numpy as np", "from PIL import Image, ImageDraw"]
@@ -103,12 +97,10 @@ class MetaImageVideoSweeps(MetaGeneratorBase):
     result_kind = bn.StringSweep(["result_image", "result_video"], doc="Image or video")
     input_dims = bn.IntSweep(default=0, bounds=(0, 2), doc="Number of input dimensions")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         combos = IMAGE_SWEEP_COMBOS if self.result_kind == "result_image" else VIDEO_SWEEP_COMBOS
         if self.input_dims not in combos:
-            return super().__call__()
+            return
 
         info = combos[self.input_dims]
         if self.result_kind == "result_image":
@@ -141,8 +133,6 @@ class MetaImageVideoSweeps(MetaGeneratorBase):
             run_kwargs={"level": level},
         )
 
-        return super().__call__()
-
 
 # --- Rich examples ---------------------------------------------------------
 
@@ -161,8 +151,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
         doc="Rich example to generate",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         name = self.example_name
         generator = {
             "result_image_progressive": self._gen_progressive,
@@ -172,7 +161,6 @@ class MetaImageVideoRich(MetaGeneratorBase):
             "result_image_over_time": self._gen_over_time,
         }[name]
         generator()
-        return super().__call__()
 
     # -- Progressive sweep (1 -> 2 -> 3 parameters) ---------------------------
 
@@ -308,8 +296,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
             '    num_frames = bn.IntSweep(default=5, bounds=[2, 20], doc="Frame count")\n'
             "    polygon_vid = bn.ResultVideo()\n"
             "\n"
-            "    def __call__(self, **kwargs):\n"
-            "        self.update_params_from_kwargs(**kwargs)\n"
+            "    def benchmark(self):\n"
             "        vr = bn.ComposableContainerVideo()\n"
             "        for i in range(self.num_frames):\n"
             "            angle = 360.0 * i / self.num_frames\n"

--- a/bencher/example/meta/generate_meta_levels.py
+++ b/bencher/example/meta/generate_meta_levels.py
@@ -3,8 +3,6 @@
 Demonstrates how the level parameter controls sampling density.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -14,9 +12,7 @@ OUTPUT_DIR = "levels"
 class MetaLevels(MetaGeneratorBase):
     """Generate Python example demonstrating the level sampling system."""
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         imports = "import bencher as bn\nfrom bencher.example.meta.example_meta import BenchMeta"
         levels_desc = (
             "Sample levels let you perform parameter sweeps without "
@@ -58,8 +54,6 @@ class MetaLevels(MetaGeneratorBase):
             body=body,
             class_code="",
         )
-
-        return super().__call__()
 
 
 def example_meta_levels(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_optimization.py
+++ b/bencher/example/meta/generate_meta_optimization.py
@@ -4,8 +4,6 @@ Shows optimization direction, Optuna integration, multi-objective Pareto,
 over-time importance analysis, and optimize=False aggregation.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -24,14 +22,12 @@ CLASS_CODE = "\n".join(
         "",
         '    noise_scale = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0], doc="Noise scale")',
         "",
-        "    def __call__(self, **kwargs):",
-        "        self.update_params_from_kwargs(**kwargs)",
+        "    def benchmark(self):",
         "        self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10",
         "        self.cost = 0.05 * self.cpu_cores + 0.02 * self.memory_gb",
         "        if self.noise_scale > 0:",
         "            self.performance += random.gauss(0, self.noise_scale * 5)",
         "            self.cost += random.gauss(0, self.noise_scale * 0.1)",
-        "        return super().__call__()",
     ]
 )
 
@@ -50,13 +46,11 @@ CLASS_CODE_OVERTIME = "\n".join(
         "",
         "    _drift = 0.0",
         "",
-        "    def __call__(self, **kwargs):",
-        "        self.update_params_from_kwargs(**kwargs)",
+        "    def benchmark(self):",
         "        self.performance = math.log2(self.cpu_cores + 1) * math.sqrt(self.memory_gb) * 10",
         "        self.performance *= (1.0 - self._drift * 0.15)  # degrade over time",
         "        if self.noise_scale > 0:",
         "            self.performance += random.gauss(0, self.noise_scale * 5)",
-        "        return super().__call__()",
     ]
 )
 
@@ -75,13 +69,11 @@ CLASS_CODE_AGG = "\n".join(
         "",
         '    loss = bn.ResultVar("loss", bn.OptDir.minimize, doc="Training loss (minimize)")',
         "",
-        "    def __call__(self, **kwargs):",
-        "        self.update_params_from_kwargs(**kwargs)",
+        "    def benchmark(self):",
         '        algo_sensitivity = {"gradient_descent": 1.0, "adam": 0.6, "rmsprop": 0.8}',
         "        optimal_lr = 0.01 * algo_sensitivity[self.algorithm]",
         "        self.loss = (math.log10(self.learning_rate) - math.log10(optimal_lr)) ** 2",
         "        self.loss += random.gauss(0, 0.02)",
-        "        return super().__call__()",
     ]
 )
 
@@ -92,9 +84,7 @@ class MetaOptimization(MetaGeneratorBase):
     n_objectives = bn.IntSweep(default=1, bounds=(1, 2), doc="Number of objectives")
     input_dims = bn.IntSweep(default=1, bounds=(1, 2), doc="Number of input dimensions")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         obj_word = "1_objective" if self.n_objectives == 1 else "2_objectives"
         filename = f"optim_{obj_word}_{self.input_dims}d"
         function_name = f"example_optim_{obj_word}_{self.input_dims}d"
@@ -146,8 +136,6 @@ class MetaOptimization(MetaGeneratorBase):
             run_kwargs={"level": level, "repeats": 3, "optimise": 30},
         )
 
-        return super().__call__()
-
 
 class MetaOptimizationOverTime(MetaGeneratorBase):
     """Generate optimization examples that run over time with importance analysis.
@@ -158,9 +146,7 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
 
     input_dims = bn.IntSweep(default=1, bounds=(1, 2), doc="Number of input dimensions")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         filename = f"optim_over_time_{self.input_dims}d"
         function_name = f"example_optim_over_time_{self.input_dims}d"
         title = f"Optimise Over Time: {self.input_dims}D input"
@@ -216,8 +202,6 @@ class MetaOptimizationOverTime(MetaGeneratorBase):
             run_kwargs={"level": 2, "optimise": 30, "over_time": True},
         )
 
-        return super().__call__()
-
 
 class MetaOptimizationAggregated(MetaGeneratorBase):
     """Generate examples showing optimize=False aggregation with Optuna.
@@ -228,9 +212,7 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
 
     with_over_time = bn.BoolSweep(default=False, doc="Include over_time dimension")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.with_over_time:
             filename = "optim_aggregated_over_time"
             function_name = "example_optim_aggregated_over_time"
@@ -307,8 +289,6 @@ class MetaOptimizationAggregated(MetaGeneratorBase):
                 post_description=post_description,
                 run_kwargs={"level": 3, "repeats": 3, "optimise": 30},
             )
-
-        return super().__call__()
 
 
 def example_meta_optimization(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_performance.py
+++ b/bencher/example/meta/generate_meta_performance.py
@@ -5,8 +5,6 @@ performance tracking across commits via the documentation gallery.
 """
 
 import inspect
-from typing import Any
-
 import bencher as bn
 from bencher.example.example_self_benchmark import BencherSelfBenchmark, TrivialWorkload
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
@@ -24,15 +22,11 @@ class MetaPerformance(MetaGeneratorBase):
 
     example = bn.StringSweep(PERFORMANCE_EXAMPLES, doc="Which performance example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "perf_self_benchmark":
             self._generate_self_benchmark()
         elif self.example == "perf_self_benchmark_over_time":
             self._generate_self_benchmark_over_time()
-
-        return super().__call__()
 
     def _generate_self_benchmark(self):
         """Generate the self-benchmark example."""

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -4,8 +4,6 @@ Shows ``res.to_<plot_type>()`` for each plot type with appropriate data.
 Each generated example is fully self-contained with an inline class definition.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -27,11 +25,9 @@ class CacheCompare(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Response distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
-        self.distance = lookup[self.backend]
-        return super().__call__()"""
+        self.distance = lookup[self.backend]"""
 
 _LATENCY_PROFILE_CODE = """\
 import math
@@ -44,10 +40,8 @@ class LatencyProfile(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Latency distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.distance = math.sin(math.pi * self.load) + 0.5
-        return super().__call__()"""
+    def benchmark(self):
+        self.distance = math.sin(math.pi * self.load) + 0.5"""
 
 _LATENCY_NOISY_PROFILE_CODE = """\
 import math
@@ -62,12 +56,10 @@ class LatencyNoisyProfile(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Latency distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.distance = math.sin(math.pi * self.load) + 0.5
         if self.noise_scale > 0:
-            self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()"""
+            self.distance += random.gauss(0, self.noise_scale)"""
 
 _THROUGHPUT_COMPARE_CODE = """\
 class ThroughputCompare(bn.ParametrizedSweep):
@@ -77,11 +69,9 @@ class ThroughputCompare(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Throughput distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 5.4, "memcached": 4.1, "local": 8.7}
-        self.distance = lookup[self.backend]
-        return super().__call__()"""
+        self.distance = lookup[self.backend]"""
 
 _HEATMAP_DEMO_CODE = """\
 import math
@@ -95,10 +85,8 @@ class HeatmapDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Surface height")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
-        return super().__call__()"""
+    def benchmark(self):
+        self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)"""
 
 _SURFACE_DEMO_CODE = """\
 import math
@@ -112,10 +100,8 @@ class SurfaceDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Surface height")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)
-        return super().__call__()"""
+    def benchmark(self):
+        self.distance = math.sin(math.pi * self.x) * math.cos(math.pi * self.y)"""
 
 _JITTER_DEMO_CODE = """\
 import random
@@ -129,13 +115,11 @@ class JitterDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Jittered distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
         self.distance = lookup[self.backend]
         if self.noise_scale > 0:
-            self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()"""
+            self.distance += random.gauss(0, self.noise_scale)"""
 
 _SCATTER_JITTER_DEMO_CODE = """\
 import random
@@ -149,13 +133,11 @@ class ScatterJitterDemo(bn.ParametrizedSweep):
 
     distance = bn.ResultVar("m", doc="Jittered distance metric")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {"redis": 1.2, "memcached": 0.9, "local": 0.3}
         self.distance = lookup[self.backend]
         if self.noise_scale > 0:
-            self.distance += random.gauss(0, self.noise_scale)
-        return super().__call__()"""
+            self.distance += random.gauss(0, self.noise_scale)"""
 
 # ---------------------------------------------------------------------------
 # Plot configuration table
@@ -279,9 +261,7 @@ class MetaPlotTypes(MetaGeneratorBase):
 
     plot_type = bn.StringSweep(PLOT_NAMES, doc="Plot type to demonstrate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         cfg = PLOT_CONFIGS[self.plot_type]
         filename = f"plot_{self.plot_type}"
         function_name = f"example_plot_{self.plot_type}"
@@ -314,8 +294,6 @@ class MetaPlotTypes(MetaGeneratorBase):
             run_kwargs=run_kwargs,
             class_code=cfg.get("class_code"),
         )
-
-        return super().__call__()
 
 
 def example_meta_plot_types(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_publish.py
+++ b/bencher/example/meta/generate_meta_publish.py
@@ -4,8 +4,6 @@ Demonstrates how to publish benchmark reports to GitHub Pages using both
 the BenchReport API and BenchRunner publisher integration.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -22,15 +20,11 @@ class MetaPublish(MetaGeneratorBase):
 
     example = bn.StringSweep(PUBLISH_EXAMPLES, doc="Which publishing example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "report_publish":
             self._generate_report_publish()
         elif self.example == "runner_publish":
             self._generate_runner_publish()
-
-        return super().__call__()
 
     def _generate_report_publish(self):
         """Publish a single benchmark report to GitHub Pages."""
@@ -44,10 +38,8 @@ class SimpleFloat(bn.ParametrizedSweep):
     )
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-        self.out_sin = math.sin(self.theta)
-        return super().__call__(**kwargs)'''
+    def benchmark(self):
+        self.out_sin = math.sin(self.theta)'''
         body = """\
 bench = SimpleFloat().to_bench(run_cfg)
 bench.plot_sweep(
@@ -94,10 +86,8 @@ class WaveBenchmark(bn.ParametrizedSweep):
 
     out_wave = bn.ResultVar(units="v", doc="Wave output")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-        self.out_wave = self.amplitude * math.sin(self.theta)
-        return super().__call__(**kwargs)'''
+    def benchmark(self):
+        self.out_wave = self.amplitude * math.sin(self.theta)'''
         body = """\
 bench = WaveBenchmark().to_bench(run_cfg)
 bench.plot_sweep(

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -4,8 +4,6 @@ Demonstrates how to use regression detection to catch performance
 regressions in over-time benchmarks.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -21,17 +19,13 @@ class MetaRegression(MetaGeneratorBase):
 
     example = bn.StringSweep(REGRESSION_EXAMPLES, doc="Which regression example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "regression_percentage":
             self._generate_percentage()
 
-        return super().__call__()
-
     def _generate_percentage(self):
         """Percentage-based regression detection over time."""
-        imports = "from typing import Any\nfrom datetime import datetime, timedelta\n\nimport bencher as bn"
+        imports = "from datetime import datetime, timedelta\n\nimport bencher as bn"
         class_code = '''\
 class ServerBenchmark(bn.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""
@@ -44,13 +38,11 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
     _time_offset = 0.0  # set externally per snapshot
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
         leak = 1.0 + self._time_offset * 0.12  # memory leak grows per release
         self.response_time = base_rt * leak
-        self.throughput = 1000.0 / self.response_time
-        return super().__call__()'''
+        self.throughput = 1000.0 / self.response_time'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -6,8 +6,6 @@ patterns but guard the rerun import so they run safely without the optional
 rerun-sdk dependency installed.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -24,15 +22,11 @@ class MetaRerun(MetaGeneratorBase):
 
     example = bn.StringSweep(RERUN_EXAMPLES, doc="Which rerun example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "capture_window":
             self._generate_capture_window()
         elif self.example == "rrd_publish":
             self._generate_rrd_publish()
-
-        return super().__call__()
 
     def _generate_capture_window(self):
         """Capture a rerun viewer window as a Panel widget inside a sweep."""
@@ -64,8 +58,7 @@ class RerunSweep(bn.ParametrizedSweep):
 
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
 
         # To capture rerun output as a report panel:
@@ -75,9 +68,7 @@ class RerunSweep(bn.ParametrizedSweep):
         #   self.out_pane = bn.capture_rerun_window(width=300, height=300)
         #
         # capture_rerun_window() embeds the data inline (base64) and loads
-        # the rerun viewer from CDN — no local file server needed.
-
-        return super().__call__(**kwargs)'''
+        # the rerun viewer from CDN — no local file server needed.'''
         body = """\
 bench = RerunSweep().to_bench(run_cfg)
 bench.plot_sweep(
@@ -142,8 +133,7 @@ class WaveSweep(bn.ParametrizedSweep):
 
     amplitude = bn.ResultVar(units="v", doc="Peak amplitude")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.amplitude = math.sin(self.frequency * math.pi)
 
         # To publish rerun data:
@@ -163,9 +153,7 @@ class WaveSweep(bn.ParametrizedSweep):
         #       branch_name="rerun_data",
         #       content_callback=bn.github_content,
         #   )
-        #   pane.show()
-
-        return super().__call__(**kwargs)'''
+        #   pane.show()'''
         body = """\
 bench = WaveSweep().to_bench(run_cfg)
 bench.plot_sweep(

--- a/bencher/example/meta/generate_meta_result_types.py
+++ b/bencher/example/meta/generate_meta_result_types.py
@@ -4,8 +4,6 @@ Demonstrates each result type at different input dimensionalities.
 Each generated example is self-contained with an inline class definition.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -51,11 +49,9 @@ def _build_response_timer_code():
                 "",
                 '    latency = bn.ResultVar(units="ms", doc="Response latency")',
                 "",
-                "    def __call__(self, **kwargs):",
-                "        self.update_params_from_kwargs(**kwargs)",
+                "    def benchmark(self):",
                 '        base = {"api/users": 12.0, "api/orders": 25.0}[self.endpoint]',
                 "        self.latency = base + 0.5 * math.log1p(self.concurrency)",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -82,11 +78,9 @@ def _build_health_checker_code():
                 "",
                 '    healthy = bn.ResultBool(doc="Whether the service is healthy")',
                 "",
-                "    def __call__(self, **kwargs):",
-                "        self.update_params_from_kwargs(**kwargs)",
+                "    def benchmark(self):",
                 "        score = math.sin(math.pi * self.threshold) * (1.0 - 0.5 * self.difficulty)",
                 "        self.healthy = score > 0.5",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -112,13 +106,11 @@ def _build_system_metrics_code():
                 "",
                 '    metrics = bn.ResultVec(3, "%", doc="CPU, memory, disk utilization")',
                 "",
-                "    def __call__(self, **kwargs):",
-                "        self.update_params_from_kwargs(**kwargs)",
+                "    def benchmark(self):",
                 "        cpu = 20.0 + 70.0 * math.sin(math.pi * self.load / 2.0)",
                 "        mem = 30.0 + 50.0 * self.load * math.log1p(self.instances)",
                 "        disk = 10.0 + 40.0 * math.sqrt(self.load * self.instances / 10.0)",
                 "        self.metrics = [cpu, mem, disk]",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -144,8 +136,7 @@ def _build_log_formatter_code():
                 "",
                 '    report = bn.ResultString(doc="Formatted log report")',
                 "",
-                "    def __call__(self, **kwargs):",
-                "        self.update_params_from_kwargs(**kwargs)",
+                "    def benchmark(self):",
                 "        detail = int(math.ceil(self.verbosity * 5))",
                 "        text = (",
                 '            f"Level: {self.level}\\n"',
@@ -153,7 +144,6 @@ def _build_log_formatter_code():
                 '            f"\\tDetail depth: {detail}"',
                 "        )",
                 "        self.report = bn.tabs_in_markdown(text)",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -178,15 +168,13 @@ def _build_report_exporter_code():
                 "",
                 '    file_result = bn.ResultPath(doc="Generated report file")',
                 "",
-                "    def __call__(self, **kwargs):",
-                "        self.update_params_from_kwargs(**kwargs)",
+                "    def benchmark(self):",
                 '        filename = bn.gen_path(self.format_type, suffix=".txt")',
                 '        line_count = {"summary": 5, "detailed": 20, "raw": 50}[self.format_type]',
                 '        with open(filename, "w", encoding="utf-8") as f:',
                 "            for i in range(line_count):",
                 '                f.write(f"[{self.format_type}] line {i + 1}: value={math.sin(i):.4f}\\n")',
                 "        self.file_result = filename",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -212,16 +200,14 @@ def _build_timeseries_collector_code():
                 "",
                 '    result_ds = bn.ResultDataSet(doc="Collected timeseries dataset")',
                 "",
-                "    def __call__(self, **kwargs):",
+                "    def benchmark(self):",
                 "        import xarray as xr",
                 "",
-                "        self.update_params_from_kwargs(**kwargs)",
                 "        n_samples = max(1, int(self.duration * self.sample_rate))",
                 "        values = [math.sin(2 * math.pi * i / max(n_samples, 1)) * self.duration for i in range(n_samples)]",
                 '        data_array = xr.DataArray(values, dims=["time"], coords={"time": list(range(n_samples))})',
                 '        ds = xr.Dataset({"result_ds": data_array})',
                 "        self.result_ds = bn.ResultDataSet(ds.to_pandas())",
-                "        return super().__call__()",
             ]
         ),
     )
@@ -243,11 +229,9 @@ class MetaResultTypes(MetaGeneratorBase):
     result_type = bn.StringSweep(RESULT_TYPES, doc="Result type to demonstrate")
     input_dims = bn.IntSweep(default=0, bounds=(0, 2), doc="Number of input dimensions")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.input_dims not in VALID_COMBOS.get(self.result_type, []):
-            return super().__call__()
+            return
 
         imports, class_name, result_vars, input_vars_map, class_code = BENCHABLE_MAP[
             self.result_type
@@ -287,8 +271,6 @@ class MetaResultTypes(MetaGeneratorBase):
             description=description,
             run_kwargs={"level": level},
         )
-
-        return super().__call__()
 
 
 def example_meta_result_types(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_sampling.py
+++ b/bencher/example/meta/generate_meta_sampling.py
@@ -3,8 +3,6 @@
 Shows uniform bounds, custom sample_values, and Int vs Float.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -22,10 +20,8 @@ class UniformSampler(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
-        return super().__call__()'''
+    def benchmark(self):
+        self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)'''
 
 _CUSTOM_CLASS_CODE = '''\
 class CustomSampler(bn.ParametrizedSweep):
@@ -35,10 +31,8 @@ class CustomSampler(bn.ParametrizedSweep):
 
     latency = bn.ResultVar(units="ms", doc="Response latency")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)
-        return super().__call__()'''
+    def benchmark(self):
+        self.latency = 10 + 90 * self.load + 5 * math.sin(math.pi * self.load * 3)'''
 
 _INT_FLOAT_CLASS_CODE = '''\
 class IntFloatCompare(bn.ParametrizedSweep):
@@ -49,10 +43,8 @@ class IntFloatCompare(bn.ParametrizedSweep):
 
     output = bn.ResultVar("ul", doc="Computed output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.output = math.sin(self.int_input * 0.3) + math.cos(self.float_input * 0.2)
-        return super().__call__()'''
+    def benchmark(self):
+        self.output = math.sin(self.int_input * 0.3) + math.cos(self.float_input * 0.2)'''
 
 
 class MetaSampling(MetaGeneratorBase):
@@ -60,9 +52,7 @@ class MetaSampling(MetaGeneratorBase):
 
     strategy = bn.StringSweep(STRATEGIES, doc="Sampling strategy to demonstrate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         filename = f"sampling_{self.strategy}"
         function_name = f"example_sampling_{self.strategy}"
         title = f"Sampling: {self.strategy.replace('_', ' ').title()}"
@@ -148,8 +138,6 @@ class MetaSampling(MetaGeneratorBase):
                 ),
                 run_kwargs={"level": 3},
             )
-
-        return super().__call__()
 
 
 def example_meta_sampling(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_statistics.py
+++ b/bencher/example/meta/generate_meta_statistics.py
@@ -5,8 +5,6 @@ error bands on curves, distribution plots for categorical data, and the
 effect of increasing repeat count on confidence.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -20,17 +18,13 @@ class MetaStatistics(MetaGeneratorBase):
         default=0, bounds=(0, 2), doc="Which statistics example to generate"
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example_variant == 0:
             self._generate_error_bands()
         elif self.example_variant == 1:
             self._generate_distributions()
         else:
             self._generate_repeats_comparison()
-
-        return super().__call__()
 
     def _generate_error_bands(self):
         """Error bands: mean +/- std on a 1D float sweep with repeats."""

--- a/bencher/example/meta/generate_meta_workflows.py
+++ b/bencher/example/meta/generate_meta_workflows.py
@@ -4,8 +4,6 @@ Demonstrates BenchRunner, multiple sweeps per report, and the InputCfg/OutputCfg
 separation pattern — features that only existed in manual examples until now.
 """
 
-from typing import Any
-
 import bencher as bn
 from bencher.example.meta.meta_generator_base import MetaGeneratorBase
 
@@ -24,9 +22,7 @@ class MetaWorkflows(MetaGeneratorBase):
 
     example = bn.StringSweep(WORKFLOW_EXAMPLES, doc="Which workflow example to generate")
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         if self.example == "bench_runner":
             self._generate_bench_runner()
         elif self.example == "multi_sweep_report":
@@ -35,8 +31,6 @@ class MetaWorkflows(MetaGeneratorBase):
             self._generate_input_output_cfg()
         elif self.example == "getting_started":
             self._generate_getting_started()
-
-        return super().__call__()
 
     def _generate_bench_runner(self):
         """B1: BenchRunner example showing multiple benchmarks combined."""
@@ -48,10 +42,8 @@ class SineWave(bn.ParametrizedSweep):
     theta = bn.FloatSweep(default=0, bounds=[0, math.pi], doc="Input angle", units="rad")
     out_sin = bn.ResultVar(units="V", doc="Sine output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-        self.out_sin = math.sin(self.theta)
-        return super().__call__()'''
+    def benchmark(self):
+        self.out_sin = math.sin(self.theta)'''
         body = """\
 # This example shows the building block that BenchRunner orchestrates.
 # To combine multiple independent benchmarks into one session, use:
@@ -98,12 +90,10 @@ class DataPipeline(bn.ParametrizedSweep):
     throughput = bn.ResultVar(units="rows/s", doc="Processing throughput")
     latency = bn.ResultVar(units="ms", doc="Per-batch latency")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         storage_factor = {"ssd": 1.0, "hdd": 0.4, "network": 0.25}[self.storage]
         self.throughput = self.batch_size * math.sqrt(self.parallelism) * storage_factor * 0.5
-        self.latency = 1000 * self.batch_size / max(self.throughput, 1)
-        return super().__call__()'''
+        self.latency = 1000 * self.batch_size / max(self.throughput, 1)'''
         body = """\
 bench = DataPipeline().to_bench(run_cfg)
 
@@ -186,7 +176,7 @@ class ServerConfig(bn.ParametrizedSweep):
         return output'''
         body = """\
 # The Bench constructor accepts the static function and the ServerConfig class.
-# This is an alternative to the ParametrizedSweep.__call__ pattern.
+# This is an alternative to the ParametrizedSweep.benchmark() pattern.
 bench = bn.Bench("input_output_example", ServerConfig.bench_function, ServerConfig, run_cfg)
 bench.plot_sweep(
     input_vars=[ServerConfig.param.worker_count],
@@ -233,7 +223,7 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
     """A tutorial benchmark demonstrating core bencher features step by step.
 
     This class defines both inputs (sweep variables) and outputs (result
-    variables) in a single ParametrizedSweep. The __call__ method is the
+    variables) in a single ParametrizedSweep. The benchmark() method is the
     benchmark function -- it must be pure (no side effects) so that repeated
     calls produce statistically valid results.
 
@@ -256,9 +246,7 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
         doc="Algorithm accuracy - the metric we want to optimise",
     )
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         self.accuracy = 50 + math.sin(self.intensity) * 5
 
         match self.algo_setting:
@@ -267,9 +255,7 @@ class GettingStartedBenchmark(bn.ParametrizedSweep):
             case AlgoSetting.optimum:
                 self.accuracy += 30
             case AlgoSetting.poor:
-                self.accuracy -= 20
-
-        return super().__call__(**kwargs)'''
+                self.accuracy -= 20'''
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=10)
 

--- a/bencher/example/meta/meta_generator_base.py
+++ b/bencher/example/meta/meta_generator_base.py
@@ -40,15 +40,7 @@ class MetaGeneratorBase(bn.ParametrizedSweep):
         indented_body = textwrap.indent(body, "    ")
         kwargs_str = "".join(f", {k}={v!r}" for k, v in run_kwargs.items())
 
-        # When class_code is provided, add type hints to __call__ and ensure Any import
-        if class_code:
-            if "def __call__(self, **kwargs):" in class_code:
-                class_code = class_code.replace(
-                    "def __call__(self, **kwargs):",
-                    "def __call__(self, **kwargs: Any) -> Any:",
-                )
-            if "Any" in class_code and "from typing import Any" not in imports:
-                imports = f"from typing import Any\n\n{imports}"
+        # No special handling needed for class_code — benchmark() has no type hint requirements
 
         class_block = f"\n\n{class_code}" if class_code else ""
         content = f'''"""Auto-generated example: {title}."""

--- a/bencher/example/optuna/example_optimize.py
+++ b/bencher/example/optuna/example_optimize.py
@@ -19,15 +19,13 @@ class Rastrigin(bn.ParametrizedSweep):
 
     loss = bn.ResultVar("ul", bn.OptDir.minimize)
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         A = 10
         self.loss = float(
             A * 2
             + (self.x**2 - A * np.cos(2 * np.pi * self.x))
             + (self.y**2 - A * np.cos(2 * np.pi * self.y))
         )
-        return super().__call__(**kwargs)
 
 
 def example_optimize(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/yaml_sweep_dict.py
+++ b/bencher/example/yaml_sweep_dict.py
@@ -13,9 +13,7 @@ class YamlDictConfig(bn.ParametrizedSweep):
     total_duration = bn.ResultVar(units="min", doc="Sum of all scheduled durations")
     average_duration = bn.ResultVar(units="min", doc="Average scheduled duration")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         key, config = self.plan
         durations = config.get("durations", [])
         total = sum(durations)
@@ -29,8 +27,6 @@ class YamlDictConfig(bn.ParametrizedSweep):
             "durations": list(durations),
             "resources": dict(config.get("resources", {})),
         }
-
-        return super().__call__()
 
 
 def example_yaml_sweep_dict(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/yaml_sweep_list.py
+++ b/bencher/example/yaml_sweep_list.py
@@ -11,12 +11,8 @@ class YamlConfigSweep(bn.ParametrizedSweep):
 
     total_workload = bn.ResultVar(units="tasks", doc="Total workload summed from the YAML list")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         self.total_workload = sum(self.workload.value())
-
-        return super().__call__()
 
 
 def example_yaml_sweep_list(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -199,12 +199,27 @@ class ParametrizedSweep(Parameterized):
         )
 
     def __call__(self, **kwargs) -> dict:
-        """This is the function that is called to record data samples in the benchmarking function.  It should be overridden with your custom logic and then call the parent method  "return super().__call__(**kwargs)"
+        """Dispatch to benchmark() if overridden, otherwise use legacy path.
 
         Returns:
-            dict: a dictionary with all the result variables in the ParametrisedSweep class as named key value pairs.
+            dict: a dictionary with all the result variables as named key value pairs.
         """
+        if type(self).benchmark is not ParametrizedSweep.benchmark:
+            # New-style: subclass overrides benchmark()
+            self.update_params_from_kwargs(**kwargs)
+            self.benchmark()
+            return self.get_results_values_as_dict()
+        # Legacy path: subclass overrides __call__() and handles
+        # update_params_from_kwargs + super().__call__() itself.
         return self.get_results_values_as_dict()
+
+    def benchmark(self):
+        """Override this with your benchmark logic.
+
+        When called, all sweep parameters (self.x, etc.) are already set.
+        Set result variables (self.result, etc.) directly on self.
+        No need to call update_params_from_kwargs or super().__call__().
+        """
 
     def plot_hmap(self, **kwargs):
         return self.__call__(**kwargs)["hmap"]

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -7,6 +7,7 @@ configuration and validation in benchmark runs.
 from __future__ import annotations
 
 import logging
+import warnings
 from functools import partial
 from typing import Callable
 
@@ -91,6 +92,16 @@ class WorkerManager:
         if isinstance(worker, ParametrizedSweep):
             self.worker_class_instance = worker
             self.worker = self.worker_class_instance.__call__
+            if (
+                type(worker).__call__ is not ParametrizedSweep.__call__
+                and type(worker).benchmark is ParametrizedSweep.benchmark
+            ):
+                warnings.warn(
+                    f"{type(worker).__name__} overrides __call__() which is deprecated. "
+                    "Override benchmark() instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             logger.info("setting worker from bench class.__call__")
         else:
             if isinstance(worker, type):

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -20,10 +20,8 @@ class MyBenchmark(bn.ParametrizedSweep):
     # Results — what the benchmark measures
     elapsed = bn.ResultVar(units="s")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.elapsed = run_benchmark(self.size, self.method)
-        return super().__call__()
 
 def example_benchmark(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     bench = bn.Bench("my_bench", MyBenchmark(), run_cfg=run_cfg)
@@ -153,25 +151,26 @@ if __name__ == "__main__":
     bn.run(example_foo, level=4)    # level controls sweep detail depth
 ```
 
-## The __call__ Pattern
+## The benchmark() Method
 
-Every benchmark class inherits from `bn.ParametrizedSweep` and implements `__call__`:
+Every benchmark class inherits from `bn.ParametrizedSweep` and implements `benchmark()`:
 
 ```python
 class MyBench(bn.ParametrizedSweep):
     x = bn.FloatSweep(bounds=(0, 1))
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)  # REQUIRED: sets self.x etc from sweep
-        self.result = compute(self.x)              # store result
-        return super().__call__()                   # REQUIRED: returns results dict
+    def benchmark(self):
+        self.result = compute(self.x)
 ```
 
-Three required steps:
-1. `self.update_params_from_kwargs(**kwargs)` — applies the swept values
-2. Set result variables (`self.result = ...`)
-3. `return super().__call__()` — collects and returns results
+When `benchmark()` is called, all sweep parameters (`self.x`, etc.) are already set.
+Just set result variables directly on `self`. No boilerplate required.
+
+> **Migration from `__call__`:** The old pattern of overriding `__call__()` with
+> `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` is
+> deprecated. Simply rename `__call__` to `benchmark`, remove the two boilerplate
+> lines, and remove `**kwargs` from the signature.
 
 ## File-Based Results (Images, Videos)
 
@@ -185,12 +184,10 @@ class ImageBench(bn.ParametrizedSweep):
     width = bn.IntSweep(bounds=(100, 500))
     output = bn.ResultImage()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         path = bn.gen_image_path(f"output_{self.width}")
         render_image(self.width, path)
         self.output = str(path)
-        return super().__call__()
 ```
 
 ## Entry Point Convention
@@ -208,6 +205,5 @@ class ImageBench(bn.ParametrizedSweep):
 | One StringSweep encoding multiple independent toggles | Use separate BoolSweep / IntSweep per toggle |
 | Many small plot_sweep calls for different combos | One plot_sweep with all input_vars |
 | Building panel/HTML layouts manually | Use bencher's report system |
-| Forgetting `self.update_params_from_kwargs(**kwargs)` | Always call it first in `__call__` |
-| Forgetting `return super().__call__()` | Always return it last in `__call__` |
+| Using the old `__call__` pattern with boilerplate | Override `benchmark()` instead |
 | Caching file-path results | Set `run_cfg.cache_results = False` |

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -12,10 +12,8 @@ class SimpleFloat(bn.ParametrizedSweep):
     theta = bn.FloatSweep(default=0, bounds=[0, math.pi], units="rad", samples=30)
     out_sin = bn.ResultVar(units="v", doc="sin of theta")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_sin = math.sin(self.theta)
-        return super().__call__(**kwargs)
 
 bench = SimpleFloat().to_bench()
 bench.plot_sweep()

--- a/scripts/benchmark_save.py
+++ b/scripts/benchmark_save.py
@@ -28,7 +28,6 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
 
 import bokeh
 import holoviews as hv
@@ -125,12 +124,10 @@ class SimpleBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.r1 = self.x + self.offset
         self.r2 = self.x * 2 + self.offset
         self.r3 = self.x * 3 + self.offset
-        return super().__call__()
 
 
 class ComplexBench(bn.ParametrizedSweep):
@@ -146,15 +143,13 @@ class ComplexBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = self.x + self.offset
         self.r1 = base
         self.r2 = base * 1.5
         self.r3 = base * 2
         self.r4 = base * 0.5
         self.r5 = base * 3
-        return super().__call__()
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -13,9 +13,8 @@ class TstBench(bn.ParametrizedSweep):
     cat_var = bn.StringSweep(["a", "b", "c", "d", "e"])
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs):
+    def benchmark(self):
         self.result = 1
-        return super().__call__()
 
 
 class TestAggOverDimsStd(unittest.TestCase):

--- a/test/test_benchmark_method.py
+++ b/test/test_benchmark_method.py
@@ -1,0 +1,84 @@
+"""Tests for the new benchmark() method on ParametrizedSweep."""
+
+import math
+import warnings
+
+import bencher as bn
+
+
+class NewStyleBench(bn.ParametrizedSweep):
+    """Uses the new benchmark() interface."""
+
+    x = bn.FloatSweep(default=0, bounds=[0, math.pi], samples=5)
+    result = bn.ResultVar(units="v")
+
+    def benchmark(self):
+        self.result = math.sin(self.x)
+
+
+class LegacyStyleBench(bn.ParametrizedSweep):
+    """Uses the old __call__() interface for backward compat testing."""
+
+    x = bn.FloatSweep(default=0, bounds=[0, math.pi], samples=5)
+    result = bn.ResultVar(units="v")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.result = math.sin(self.x)
+        return super().__call__()
+
+
+class NoOverrideBench(bn.ParametrizedSweep):
+    """Neither benchmark() nor __call__() overridden — returns defaults."""
+
+    x = bn.FloatSweep(default=0, bounds=[0, 1], samples=3)
+    result = bn.ResultVar(units="v")
+
+
+def test_benchmark_method_works():
+    """Test that benchmark() override works: params auto-populated, results auto-collected."""
+    bench = NewStyleBench()
+    output = bench(x=math.pi / 2)
+    assert abs(output["result"] - 1.0) < 1e-9
+
+
+def test_benchmark_method_full_sweep():
+    """Test that benchmark() works in a full sweep."""
+    bench = NewStyleBench().to_bench(bn.BenchRunCfg())
+    bench.plot_sweep()
+    assert len(bench.results) > 0
+
+
+def test_legacy_call_still_works():
+    """Test that legacy __call__ override still works (backward compat)."""
+    bench = LegacyStyleBench()
+    output = bench(x=math.pi / 2)
+    assert abs(output["result"] - 1.0) < 1e-9
+
+
+def test_legacy_call_deprecation_warning():
+    """Test that deprecation warning is emitted for legacy __call__ override."""
+    worker = LegacyStyleBench()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bn.Bench("test", worker)
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 1
+        assert "benchmark()" in str(dep_warnings[0].message)
+
+
+def test_no_override_returns_defaults():
+    """Test that a class with neither override returns default results."""
+    bench = NoOverrideBench()
+    output = bench(x=0.5)
+    assert "result" in output
+
+
+def test_new_style_no_deprecation_warning():
+    """Test that new-style benchmark() does NOT emit deprecation warning."""
+    worker = NewStyleBench()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bn.Bench("test", worker)
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) == 0

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -12,10 +12,8 @@ class CachedParamExample(bn.CachedParams):
 
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.var1 + self.var2 + random.uniform(0, 1)
-        return self.get_results_values_as_dict()
 
 
 class TestJob(unittest.TestCase):

--- a/test/test_multiprocessing_executor.py
+++ b/test/test_multiprocessing_executor.py
@@ -57,10 +57,8 @@ class MultiTypeConfig(bn.ParametrizedSweep):
     ratio = bn.FloatSweep(default=0.5, bounds=(0.0, 1.0), samples=5)
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.count * self.ratio
-        return self.get_results_values_as_dict()
 
 
 class StringOnlyConfig(bn.ParametrizedSweep):
@@ -69,10 +67,8 @@ class StringOnlyConfig(bn.ParametrizedSweep):
     algorithm = bn.StringSweep(["quick", "merge", "heap", "bubble"])
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = len(self.algorithm)
-        return self.get_results_values_as_dict()
 
 
 class EnumOnlyConfig(bn.ParametrizedSweep):
@@ -81,10 +77,8 @@ class EnumOnlyConfig(bn.ParametrizedSweep):
     algo = bn.EnumSweep(Algorithm)
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = len(self.algo)
-        return self.get_results_values_as_dict()
 
 
 class BoolOnlyConfig(bn.ParametrizedSweep):
@@ -93,10 +87,8 @@ class BoolOnlyConfig(bn.ParametrizedSweep):
     flag = bn.BoolSweep(default=True)
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = 1.0 if self.flag else 0.0
-        return self.get_results_values_as_dict()
 
 
 class MixedSelectorConfig(bn.ParametrizedSweep):
@@ -108,10 +100,8 @@ class MixedSelectorConfig(bn.ParametrizedSweep):
     weight = bn.FloatSweep(default=1.0, bounds=(0.0, 10.0), samples=3)
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.weight * (1.0 if self.active else -1.0)
-        return self.get_results_values_as_dict()
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -22,10 +22,8 @@ class Sphere(bn.ParametrizedSweep):
 
     loss = bn.ResultVar("ul", bn.OptDir.minimize)
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.loss = float(self.x**2 + self.y**2)
-        return super().__call__(**kwargs)
 
 
 class MultiObjective(bn.ParametrizedSweep):
@@ -36,11 +34,9 @@ class MultiObjective(bn.ParametrizedSweep):
     obj1 = bn.ResultVar("ul", bn.OptDir.minimize)
     obj2 = bn.ResultVar("ul", bn.OptDir.maximize)
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.obj1 = float(self.x**2)
         self.obj2 = float(-((self.x - 3) ** 2))
-        return super().__call__(**kwargs)
 
 
 class Color(bn.ClassEnum):
@@ -61,11 +57,9 @@ class CategoricalProblem(bn.ParametrizedSweep):
 
     score = bn.ResultVar("ul", bn.OptDir.minimize)
 
-    def __call__(self, **kwargs) -> dict:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         lookup = {Color.red: 1.0, Color.green: 0.5, Color.blue: 2.0}
         self.score = lookup[self.color] + (0.0 if self.flag else 0.3)
-        return super().__call__(**kwargs)
 
 
 def _run_cfg():

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -34,10 +34,8 @@ class SweepCfg(bn.ParametrizedSweep):
     string_var = StringSweep(["a", "b", "c"])
     result = bn.ResultVar()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.float_var * 2
-        return super().__call__()
 
 
 class TestOptimizeFlag(unittest.TestCase):

--- a/test/test_optuna_result.py
+++ b/test/test_optuna_result.py
@@ -98,10 +98,8 @@ class _AggCfg(bn.ParametrizedSweep):
     param1 = bn.FloatSweep(default=0.5, bounds=(0.0, 1.0))
     score = bn.ResultVar(units="score", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.score = (self.param1 - 0.3) ** 2
-        return super().__call__()
 
 
 class _MultiAggCfg(bn.ParametrizedSweep):
@@ -112,12 +110,10 @@ class _MultiAggCfg(bn.ParametrizedSweep):
     score = bn.ResultVar(units="score", direction=bn.OptDir.minimize)
     aux_score = bn.ResultVar(units="aux", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         baseline = (self.param1 - 0.3) ** 2
         self.score = baseline
         self.aux_score = baseline + 0.1
-        return super().__call__()
 
 
 class _TrialCfg(bn.ParametrizedSweep):
@@ -125,20 +121,16 @@ class _TrialCfg(bn.ParametrizedSweep):
     value = bn.FloatSweep(default=0.5, bounds=(0.0, 1.0), samples=3)
     result = bn.ResultVar(units="v", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.value * 2
-        return super().__call__()
 
 
 class _AllFalseCfg(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0.5, bounds=(0.0, 1.0), optimize=False)
     result = bn.ResultVar(units="v", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = self.x
-        return super().__call__()
 
 
 class TestOptunaOptimizeFlag(unittest.TestCase):

--- a/test/test_over_time_repeats.py
+++ b/test/test_over_time_repeats.py
@@ -4,7 +4,6 @@
 
 import random
 from datetime import datetime, timedelta
-from typing import Any
 
 import holoviews as hv
 import panel as pn
@@ -21,11 +20,9 @@ class SimpleBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.2, "local": 0.3}[self.backend]
         self.latency = base + self.offset + random.gauss(0, 0.05)
-        return super().__call__()
 
 
 class FloatBench(bn.ParametrizedSweep):
@@ -37,11 +34,9 @@ class FloatBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.0, "local": 0.5}[self.backend]
         self.time = base * self.size * 0.01 + self.offset + random.gauss(0, 0.02)
-        return super().__call__()
 
 
 def _run_over_time(benchable, input_vars, result_vars, repeats=1, snapshots=3, **cfg_kwargs):
@@ -122,10 +117,8 @@ class ZeroDimBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.value = 2.844 + self.offset
-        return super().__call__()
 
 
 # Module-scoped fixtures for shared benchmark results to reduce test execution time

--- a/test/test_over_time_save_perf.py
+++ b/test/test_over_time_save_perf.py
@@ -3,7 +3,6 @@
 import tempfile
 import time
 from datetime import datetime, timedelta
-from typing import Any
 
 import bencher as bn
 
@@ -18,12 +17,10 @@ class MultiResultBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.r1 = self.x + self.offset
         self.r2 = self.x * 2 + self.offset
         self.r3 = self.x * 3 + self.offset
-        return super().__call__()
 
 
 def _run_and_save(show_agg: bool) -> float:

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -480,10 +480,8 @@ class TestRegressionError:
 class _SimpleBench(bn.ParametrizedSweep):
     out_val = bn.ResultVar(units="s", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out_val = 1.0
-        return super().__call__(**kwargs)
 
 
 _degrade_state = {"counter": 0}
@@ -492,11 +490,9 @@ _degrade_state = {"counter": 0}
 class _DegradingBench(bn.ParametrizedSweep):
     out_val = bn.ResultVar(units="s", direction=bn.OptDir.minimize)
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         _degrade_state["counter"] += 1
         self.out_val = float(_degrade_state["counter"]) * 100.0
-        return super().__call__(**kwargs)
 
 
 class TestEndToEnd:

--- a/test/test_result_bool.py
+++ b/test/test_result_bool.py
@@ -51,10 +51,8 @@ class BoolBenchDeterministic(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[0, 1], doc="Float input")
     out = bn.ResultBool(doc="Deterministic bool output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = self.x > 0.5
-        return super().__call__(**kwargs)
 
 
 class BoolBenchAlternating(bn.ParametrizedSweep):
@@ -66,11 +64,9 @@ class BoolBenchAlternating(bn.ParametrizedSweep):
 
     _call_count = 0
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         BoolBenchAlternating._call_count += 1
         self.out = (BoolBenchAlternating._call_count % 2) == 0
-        return super().__call__(**kwargs)
 
 
 class BoolBenchAllTrue(bn.ParametrizedSweep):
@@ -79,10 +75,8 @@ class BoolBenchAllTrue(bn.ParametrizedSweep):
     cat = bn.EnumSweep(CatEnum, doc="Categorical input")
     out = bn.ResultBool(doc="Always true")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = True
-        return super().__call__(**kwargs)
 
 
 class BoolBenchAllFalse(bn.ParametrizedSweep):
@@ -91,10 +85,8 @@ class BoolBenchAllFalse(bn.ParametrizedSweep):
     cat = bn.EnumSweep(CatEnum, doc="Categorical input")
     out = bn.ResultBool(doc="Always false")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = False
-        return super().__call__(**kwargs)
 
 
 class TwoFloatBool(bn.ParametrizedSweep):
@@ -104,10 +96,8 @@ class TwoFloatBool(bn.ParametrizedSweep):
     x2 = bn.FloatSweep(default=0, bounds=[0, 1])
     out = bn.ResultBool(doc="bool output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = (self.x1 + self.x2) > 1.0
-        return super().__call__(**kwargs)
 
 
 class ThreeFloatBool(bn.ParametrizedSweep):
@@ -118,10 +108,8 @@ class ThreeFloatBool(bn.ParametrizedSweep):
     x3 = bn.FloatSweep(default=0, bounds=[0, 1])
     out = bn.ResultBool(doc="bool output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = (self.x1 + self.x2 + self.x3) > 1.5
-        return super().__call__(**kwargs)
 
 
 class BoolBenchNone(bn.ParametrizedSweep):
@@ -130,10 +118,8 @@ class BoolBenchNone(bn.ParametrizedSweep):
     cat = bn.EnumSweep(CatEnum, doc="Categorical input")
     out = bn.ResultBool(doc="None output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = None
-        return super().__call__(**kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_sample_order.py
+++ b/test/test_sample_order.py
@@ -11,15 +11,11 @@ class OrderExample(bn.ParametrizedSweep):
     # RESULTS
     call_index = bn.ResultVar()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
-
+    def benchmark(self):
         # Maintain a per-instance counter to reflect traversal order
         idx = getattr(self, "_call_counter", 0)
         self.call_index = idx
         setattr(self, "_call_counter", idx + 1)
-
-        return super().__call__()
 
 
 class TestSampleOrder(unittest.TestCase):

--- a/test/test_singleton_parametrized_sweep.py
+++ b/test/test_singleton_parametrized_sweep.py
@@ -16,10 +16,8 @@ class MySingletonSweep(ParametrizedSweepSingleton):
             self.init_count = 1
         super().__init__()
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.result = float(self.theta)
-        return super().__call__(**kwargs)
 
 
 def benchable_singleton_fn(run_cfg: bn.BenchRunCfg, report: bn.BenchReport) -> bn.BenchCfg:

--- a/test/test_sweep_timings.py
+++ b/test/test_sweep_timings.py
@@ -26,10 +26,8 @@ class TrivialSweep(bn.ParametrizedSweep):
     theta = bn.FloatSweep(default=0, bounds=[0, math.pi], samples=5)
     out = bn.ResultVar(units="v", doc="output")
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.out = math.sin(self.theta)
-        return super().__call__(**kwargs)
 
 
 def test_bench_result_has_timings():

--- a/test/test_time_event_curve.py
+++ b/test/test_time_event_curve.py
@@ -1,7 +1,5 @@
 """Tests that curve plots use the float var as x-axis when over_time uses string-based TimeEvent."""
 
-from typing import Any
-
 import panel as pn
 
 import bencher as bn
@@ -15,10 +13,8 @@ class FloatWithTimeBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         self.throughput = self.size * 0.5 + self.offset
-        return super().__call__()
 
 
 class FloatCatWithTimeBench(bn.ParametrizedSweep):
@@ -30,11 +26,9 @@ class FloatCatWithTimeBench(bn.ParametrizedSweep):
 
     offset = 0.0
 
-    def __call__(self, **kwargs: Any) -> Any:
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self):
         base = {"redis": 1.0, "local": 2.0}[self.backend]
         self.throughput = self.size * base + self.offset
-        return super().__call__()
 
 
 def _run_string_over_time(benchable, input_vars, result_vars, repeats=1, snapshots=3):


### PR DESCRIPTION
## Summary

Deprecate `__call__()` as the benchmark entry point in `ParametrizedSweep` and replace it with a streamlined `benchmark()` method that eliminates boilerplate.

### Problem

Every benchmark class currently requires 2 mandatory boilerplate lines that are easy to forget:

```python
# CURRENT — verbose, error-prone
class MyBench(bn.ParametrizedSweep):
    x = bn.FloatSweep(bounds=(0, 1))
    result = bn.ResultVar()

    def __call__(self, **kwargs):
        self.update_params_from_kwargs(**kwargs)  # boilerplate
        self.result = math.sin(self.x)
        return super().__call__()                  # boilerplate
```

### Solution

```python
# NEW — clean, no boilerplate
class MyBench(bn.ParametrizedSweep):
    x = bn.FloatSweep(bounds=(0, 1))
    result = bn.ResultVar()

    def benchmark(self):
        self.result = math.sin(self.x)
```

The framework handles `update_params_from_kwargs` and result collection automatically. Legacy `__call__` overrides continue to work with a deprecation warning.

## Implementation Plan

### Phase 1: Framework Core
- Add `benchmark()` method to `ParametrizedSweep`
- Update `__call__` dispatch: detect `benchmark()` override -> auto-handle boilerplate; otherwise fall through to legacy path
- Add deprecation warning in `WorkerManager.set_worker()` for legacy `__call__` overrides

### Phase 2: Migrate Hand-Written Examples (~14 files)
- Convert all `bencher/example/*.py` files from `__call__` to `benchmark()`

### Phase 3: Migrate Meta Generators & Regenerate
- Update `benchable_objects.py` (8 classes)
- Update `meta_generator_base.py` code generation templates
- Update `generate_meta_*.py` string templates
- Regenerate ~150 files in `bencher/example/generated/`

### Phase 4: Migrate Tests (~17 files)
- Convert test benchmark classes to `benchmark()`
- Add tests for new interface, backward compat, and deprecation warning

### Phase 5: Documentation
- Update `docs/how_to_use_bencher.md`, `docs/intro.md`, `CHANGELOG.md`

## Key Design Decision
Detection uses `type(self).benchmark is not ParametrizedSweep.benchmark` to distinguish new vs legacy code. Legacy `__call__` overrides call `super().__call__()` which hits the base — no double `update_params_from_kwargs` call occurs. See `PLAN.md` for full details.

## Scope
~193 files total (~10 hand-written examples, ~150+ auto-generated, ~30 tests)

https://claude.ai/code/session_011JrtJy1JBF3rST5WUBMHDV

## Summary by Sourcery

Deprecate ParametrizedSweep.__call__ in favor of a new benchmark() entry point while preserving backward compatibility and updating examples, generators, tests, and docs to the new interface.

New Features:
- Introduce a benchmark() method on ParametrizedSweep as the primary benchmark implementation hook.

Enhancements:
- Change ParametrizedSweep.__call__ to dispatch to benchmark() when overridden and otherwise support legacy __call__ overrides.
- Emit a DeprecationWarning when a ParametrizedSweep subclass overrides __call__ without overriding benchmark().
- Update meta generators and all auto-generated examples to emit benchmark()-based benchmark classes instead of __call__.
- Refine example and YAML-based benchmark classes to use benchmark() and simplify their implementations.

Documentation:
- Document the new benchmark() pattern, deprecating the old __call__ boilerplate-based pattern in user guides and intro docs, and note the change in the changelog.

Tests:
- Update existing tests to use benchmark() instead of __call__ on ParametrizedSweep subclasses and add dedicated tests covering benchmark() behaviour, legacy __call__ support, and deprecation warnings.