### PR TITLE
fix: resolve hardcoded port conflicts in rrd iframe URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Deprecated `__call__()` in favor of `benchmark()`**: `ParametrizedSweep` subclasses should now override `benchmark()` instead of `__call__()`. The new method removes the need for `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` boilerplate. The old `__call__()` pattern still works but emits a `DeprecationWarning`.
 
+## [1.75.2] - 2026-03-31
+
+### Fixed
+- `.rrd` iframe URLs no longer hardcode `localhost:8051` — CDN viewer uses relative URLs, local/hosted viewer resolves `window.location.origin` at render time via JavaScript, so reports work behind container port mappings and on any Panel server port (#866)
+- Panel server uses `port=0` (OS-assigned) when no explicit port is given, preventing `OSError: Address already in use` when other services occupy the default port (#866)
+- `_cdn_viewer_versions` cache collision between `_cdn_viewer_url` (filenames) and `_get_cdn_viewer_html` (HTML strings) — split into separate caches (#866)
+
+### Changed
+- `show=True` in `BenchRunner.run()` now auto-saves a static HTML report to `reports/` alongside the live server, with the path logged for offline viewing (#866)
+
+### Removed
+- `PANEL_PORT` constant from `utils_rrd` — no longer needed since iframe URLs are resolved dynamically (#866)
+
 ## [1.74.0] - 2026-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **Deprecated `__call__()` in favor of `benchmark()`**: `ParametrizedSweep` subclasses should now override `benchmark()` instead of `__call__()`. The new method removes the need for `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` boilerplate. The old `__call__()` pattern still works but emits a `DeprecationWarning`.
-
 ## [1.75.2] - 2026-03-31
 
 ### Fixed
 - `.rrd` iframe URLs no longer hardcode `localhost:8051` — CDN viewer uses relative URLs, local/hosted viewer resolves `window.location.origin` at render time via JavaScript, so reports work behind container port mappings and on any Panel server port (#866)
 - Panel server uses `port=0` (OS-assigned) when no explicit port is given, preventing `OSError: Address already in use` when other services occupy the default port (#866)
 - `_cdn_viewer_versions` cache collision between `_cdn_viewer_url` (filenames) and `_get_cdn_viewer_html` (HTML strings) — split into separate caches (#866)
+- Film strip labels now render at constant pixel size regardless of strip dimensions, with horizontal clipping and right-alignment for wide strips (#865)
 
 ### Changed
-- `show=True` in `BenchRunner.run()` now auto-saves a static HTML report to `reports/` alongside the live server, with the path logged for offline viewing (#866)
+- `show=True` in `BenchRunner.run()` now auto-saves a static HTML report to `reports/` in a background thread (non-blocking), with the path logged for offline viewing. Explicit `save=True` still saves synchronously. (#866)
+- **Deprecated `__call__()` in favor of `benchmark()`**: `ParametrizedSweep` subclasses should now override `benchmark()` instead of `__call__()`. The new method removes the need for `self.update_params_from_kwargs(**kwargs)` and `return super().__call__()` boilerplate. The old `__call__()` pattern still works but emits a `DeprecationWarning`. (#864)
 
 ### Removed
 - `PANEL_PORT` constant from `utils_rrd` — no longer needed since iframe URLs are resolved dynamically (#866)

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -19,10 +19,10 @@ logging.basicConfig(level=logging.INFO)
 class _CorsStaticHandler(StaticFileHandler):
     """A Tornado static file handler that adds CORS headers.
 
-    Required for rerun integration: the rerun web viewer (localhost:9090)
-    fetches .rrd files from the Panel server (localhost:8051).  Without
-    Access-Control-Allow-Origin and OPTIONS preflight handling the browser
-    silently blocks the cross-origin fetch and the viewer shows 0 B.
+    Required for rerun integration: the rerun web viewer fetches .rrd files
+    from the Panel server.  Without Access-Control-Allow-Origin and OPTIONS
+    preflight handling the browser silently blocks the cross-origin fetch
+    and the viewer shows 0 B.
 
     Note: ``Allow-Origin: *`` is appropriate here because this server is
     intended for local development only, not public-facing deployments.
@@ -128,12 +128,6 @@ class BenchPlotServer:
 
         extra = self._rrd_extra_patterns()
 
-        # When serving .rrd files, use a known port so rerun iframe URLs work.
-        if port is None and extra:
-            from bencher.utils_rrd import PANEL_PORT
-
-            port = PANEL_PORT
-
         serve_kwargs = dict(
             title=bench_name,
             threaded=True,
@@ -141,9 +135,8 @@ class BenchPlotServer:
             address="0.0.0.0",
             websocket_origin=["*"],
             extra_patterns=extra,
+            port=port if port is not None else 0,
         )
-        if port is not None:
-            serve_kwargs["port"] = port
 
         return pn.serve(plots_instance, **serve_kwargs)
 

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -394,10 +394,11 @@ class BenchRunner:
             save (bool): Whether to save the report to disk
             debug (bool): Whether to enable debug mode for publishing
         """
-        if save:
-            report.save(
+        if save or show:
+            report_path = report.save(
                 directory="reports", filename=f"{report.bench_name}.html", in_html_folder=False
             )
+            logging.info("Static report: file://%s", report_path.absolute())
         if publish and self.publisher is not None:
             if isinstance(self.publisher, GithubPagesCfg):
                 p = self.publisher

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Protocol, runtime_checkable
 import logging
+import threading
 import warnings
 import inspect
 from datetime import datetime
@@ -394,11 +395,10 @@ class BenchRunner:
             save (bool): Whether to save the report to disk
             debug (bool): Whether to enable debug mode for publishing
         """
-        if save or show:
-            report_path = report.save(
+        if save:
+            report.save(
                 directory="reports", filename=f"{report.bench_name}.html", in_html_folder=False
             )
-            logging.info("Static report: file://%s", report_path.absolute())
         if publish and self.publisher is not None:
             if isinstance(self.publisher, GithubPagesCfg):
                 p = self.publisher
@@ -407,6 +407,25 @@ class BenchRunner:
                 report.publish(remote_callback=self.publisher, debug=debug)
         if show:
             self.servers.append(report.show(self.run_cfg))
+            if not save:
+                self._save_in_background(report)
+
+    @staticmethod
+    def _save_in_background(report: BenchReport) -> None:
+        """Save a static HTML copy in a daemon thread so it doesn't block the live server."""
+
+        def _save():
+            try:
+                report_path = report.save(
+                    directory="reports",
+                    filename=f"{report.bench_name}.html",
+                    in_html_folder=False,
+                )
+                logging.info("Static report: file://%s", report_path.absolute())
+            except Exception:  # pylint: disable=broad-except
+                logging.exception("Background report save failed")
+
+        threading.Thread(target=_save, daemon=True).start()
 
     def show(
         self,

--- a/bencher/utils_rerun.py
+++ b/bencher/utils_rerun.py
@@ -22,10 +22,12 @@ or "data source left unexpectedly" messages.
    standalone use but is NOT needed for the normal report flow.
 
    CORS is critical: the rerun web viewer runs on a different origin
-   (localhost:9090) and fetches ``.rrd`` files from the Panel origin
-   (localhost:8051).  Without ``Access-Control-Allow-Origin: *`` **and**
-   ``OPTIONS`` preflight handling, browsers silently block the fetch and the
-   viewer shows 0 B of data.
+   (localhost:9090) and fetches ``.rrd`` files from the Panel server.
+   Without ``Access-Control-Allow-Origin: *`` **and** ``OPTIONS`` preflight
+   handling, browsers silently block the fetch and the viewer shows 0 B of
+   data.  The Panel port is auto-assigned (port 0) so that multiple
+   benchmarks can run in parallel; iframe URLs are built with JavaScript
+   to resolve the actual port at render time.
 
 3. **Viewer** — ``rr.start_web_viewer_server()`` launches a *local* rerun
    web viewer on port 9090.  This is the viewer that actually renders the

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -10,6 +10,7 @@ See ``utils_rerun.py`` for functions that require the rerun Python SDK
 (live capture, recording management, etc.).
 """
 
+import hashlib
 import logging
 import re
 import shutil
@@ -20,9 +21,6 @@ from urllib.parse import quote
 import panel as pn
 
 from .utils import publish_file
-
-# Port for the Panel server (must be known at render time so iframe URLs can be built).
-PANEL_PORT = 8051
 
 # Port for the local rerun web viewer server (when rerun-sdk is available).
 _RERUN_VIEWER_PORT = 9090
@@ -151,12 +149,14 @@ def rrd_file_to_pane(  # pragma: no cover
         version = _get_rerun_version()
         viewer_tpl = f"https://app.rerun.io/version/{version}/?url="
 
+    # Use a hash of the path for a stable, unique element ID.
+    uid = hashlib.sha256(str(rrd_path).encode()).hexdigest()[:12]
     return pn.pane.HTML(
-        f'<div id="rrd-wrap-{id(rrd_path)}"></div>'
+        f'<div id="rrd-wrap-{uid}"></div>'
         f"<script>"
         f"(function(){{"
         f'var rrdUrl=window.location.origin+"{rrd_static_path}";'
-        f'var el=document.getElementById("rrd-wrap-{id(rrd_path)}");'
+        f'var el=document.getElementById("rrd-wrap-{uid}");'
         f"el.innerHTML="
         f"""'<iframe src="{viewer_tpl}'+encodeURIComponent(rrdUrl)+'"'"""
         f""" +' width="{width}" height="{height}" frameborder="0"'"""
@@ -195,8 +195,11 @@ try {{
 </script></body></html>
 """
 
-# Cache of generated viewer HTML pages keyed by version.
-_cdn_viewer_versions: dict[str, str] = {}
+# Cache of written viewer page filenames, keyed by version (for /rrd_static/ URLs).
+_cdn_viewer_files: dict[str, str] = {}
+
+# Cache of rendered viewer HTML strings, keyed by version (for portable reports).
+_cdn_viewer_html: dict[str, str] = {}
 
 
 def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
@@ -207,25 +210,25 @@ def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
     from the jsDelivr CDN.  Both the viewer page and the .rrd are on the
     same HTTP origin, avoiding mixed-content blocks.
     """
-    if version not in _cdn_viewer_versions:
+    if version not in _cdn_viewer_files:
         html = _CDN_VIEWER_TEMPLATE.format(version=version)
         filename = f"viewer_{version}.html"
         viewer_path = _RRD_CACHE_DIR.resolve() / filename
         viewer_path.parent.mkdir(parents=True, exist_ok=True)
         if not viewer_path.exists() or viewer_path.read_text() != html:
             viewer_path.write_text(html)
-        _cdn_viewer_versions[version] = filename
+        _cdn_viewer_files[version] = filename
 
-    filename = _cdn_viewer_versions[version]
+    filename = _cdn_viewer_files[version]
     rrd_url = quote(f"/rrd_static/{rrd_relative.as_posix()}", safe="/:")
     return f"/rrd_static/{filename}?url={rrd_url}"
 
 
 def _get_cdn_viewer_html(version: str) -> str:
     """Return the viewer HTML string for a given rerun version (cached)."""
-    if version not in _cdn_viewer_versions:
-        _cdn_viewer_versions[version] = _CDN_VIEWER_TEMPLATE.format(version=version)
-    return _cdn_viewer_versions[version]
+    if version not in _cdn_viewer_html:
+        _cdn_viewer_html[version] = _CDN_VIEWER_TEMPLATE.format(version=version)
+    return _cdn_viewer_html[version]
 
 
 def _portable_rrd_pane(

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -124,27 +124,45 @@ def rrd_file_to_pane(  # pragma: no cover
         raise ValueError(
             f"rrd_file_to_pane expects files under {cache_root}, got {rrd_path}"
         ) from None
-    rrd_url = f"http://localhost:{PANEL_PORT}/rrd_static/{relative.as_posix()}"
+    rrd_static_path = f"/rrd_static/{relative.as_posix()}"
 
     if viewer_version is not None and not _VERSION_RE.match(viewer_version):
         raise ValueError(f"Invalid viewer_version {viewer_version!r}: must match [0-9A-Za-z._-]+")
 
     if viewer_version is not None:
+        # CDN viewer page is served from the same Panel origin — relative URL works.
         viewer_url = _cdn_viewer_url(relative, viewer_version)
-    else:
-        # Prefer the local rerun viewer when the SDK is available.
-        try:
-            from .utils_rerun import _ensure_rerun_viewer
+        return pn.pane.HTML(
+            f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
+            f' frameborder="0" allowfullscreen></iframe>',
+            width=width,
+            height=height,
+        )
 
-            _ensure_rerun_viewer()
-            viewer_url = f"http://localhost:{_RERUN_VIEWER_PORT}/?url={rrd_url}"
-        except (ImportError, ModuleNotFoundError):
-            version = _get_rerun_version()
-            viewer_url = f"https://app.rerun.io/version/{version}/?url={rrd_url}"
+    # For the local rerun viewer or hosted viewer, the .rrd URL must be
+    # absolute (cross-origin fetch).  Use JavaScript so the correct Panel
+    # server port is resolved at render time instead of being hardcoded.
+    try:
+        from .utils_rerun import _ensure_rerun_viewer
+
+        _ensure_rerun_viewer()
+        viewer_tpl = f"http://localhost:{_RERUN_VIEWER_PORT}/?url="
+    except (ImportError, ModuleNotFoundError):
+        version = _get_rerun_version()
+        viewer_tpl = f"https://app.rerun.io/version/{version}/?url="
 
     return pn.pane.HTML(
-        f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
-        f' frameborder="0" allowfullscreen></iframe>',
+        f'<div id="rrd-wrap-{id(rrd_path)}"></div>'
+        f"<script>"
+        f"(function(){{"
+        f'var rrdUrl=window.location.origin+"{rrd_static_path}";'
+        f'var el=document.getElementById("rrd-wrap-{id(rrd_path)}");'
+        f"el.innerHTML="
+        f"""'<iframe src="{viewer_tpl}'+encodeURIComponent(rrdUrl)+'"'"""
+        f""" +' width="{width}" height="{height}" frameborder="0"'"""
+        f""" +' allowfullscreen></iframe>';"""
+        f"}})();"
+        f"</script>",
         width=width,
         height=height,
     )
@@ -200,7 +218,7 @@ def _cdn_viewer_url(rrd_relative: Path, version: str) -> str:
 
     filename = _cdn_viewer_versions[version]
     rrd_url = quote(f"/rrd_static/{rrd_relative.as_posix()}", safe="/:")
-    return f"http://localhost:{PANEL_PORT}/rrd_static/{filename}?url={rrd_url}"
+    return f"/rrd_static/{filename}?url={rrd_url}"
 
 
 def _get_cdn_viewer_html(version: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.75.1"
+version = "1.75.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_plot_server.py
+++ b/test/test_plot_server.py
@@ -53,3 +53,22 @@ class TestBenchPlotServer(unittest.TestCase):
         server_cfg.show = False
         srv = bps.plot_server("test_bench_server", server_cfg)
         srv.stop()
+
+    def test_serve_auto_port(self):
+        """When no port is specified, the server should bind to an OS-assigned port."""
+        import panel as pn
+
+        bps = bn.BenchPlotServer()
+        plots = pn.Column("# test")
+        srv = bps.serve("auto_port_test", plots, port=None, show=False)
+        srv.stop()
+
+    def test_serve_parallel_no_port_conflict(self):
+        """Two servers with port=None must not raise OSError: Address already in use."""
+        import panel as pn
+
+        bps = bn.BenchPlotServer()
+        srv1 = bps.serve("parallel_1", pn.Column("# a"), port=None, show=False)
+        srv2 = bps.serve("parallel_2", pn.Column("# b"), port=None, show=False)
+        srv2.stop()
+        srv1.stop()


### PR DESCRIPTION
## Summary

When no explicit port was specified, iframe URLs for `.rrd` files were hardcoded to `localhost:8051`, so they broke whenever the Panel server ran on a different port (e.g. behind a container port mapping, or when port 8051 was unavailable).

### Changes

1. **`bench_plot_server.py`** — Always pass `port=0` when no explicit port is given, letting the OS assign a free port. Removed the hardcoded `PANEL_PORT` fallback for `.rrd` files.

2. **`utils_rrd.py`** — Changed `.rrd` iframe URLs from hardcoded `localhost:8051` to:
   - **CDN viewer**: relative URL (`/rrd_static/...`) — works on any port since it's same-origin
   - **Local/hosted rerun viewer**: JavaScript that resolves `window.location.origin` at render time to build the correct cross-origin URL dynamically
   - **Portable reports** (`report_dir`): relative URLs with `.rrd` and viewer HTML copied into the report directory — works when served from any HTTP origin (GCS, S3, etc.)
   - Removed dead `PANEL_PORT` constant
   - Fixed `_cdn_viewer_versions` cache collision between `_cdn_viewer_url` (stores filenames) and `_get_cdn_viewer_html` (stores HTML strings) — split into separate caches
   - Use stable SHA-256 hash for iframe wrapper div IDs instead of `id()` (memory address)

3. **`bench_runner.py`** — When `show=True`, a static HTML report is now auto-saved to `reports/` alongside showing the live server. The path is logged so you can open it after the process exits.

### Tests

- `test_serve_auto_port` — verifies `port=None` binds to an OS-assigned port
- `test_serve_parallel_no_port_conflict` — verifies two servers with `port=None` start without `OSError: Address already in use`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Resolve hardcoded port assumptions in rerun/Panel integrations to support auto-assigned ports, parallel servers, and portable reports.

Bug Fixes:
- Avoid hardcoding Panel server URLs in .rrd iframes by deriving origins at render time or using relative paths, preventing failures when the server is not on localhost:8051.
- Fix cache collisions between CDN viewer filename cache and HTML cache for rerun viewer pages.

Enhancements:
- Serve Panel when no port is specified using port=0 so the OS selects a free port, enabling multiple benchmark servers to run in parallel without conflicts.
- Generate rerun iframe wrapper IDs using stable SHA-256 hashes instead of memory addresses to ensure deterministic DOM element IDs.
- Log and always save a static HTML report to the reports directory whenever show=True so users can open the report after the process exits.

Tests:
- Add tests to verify that serving with port=None binds to an OS-assigned port and that two such servers can start in parallel without address-in-use errors.