### PR TITLE
Add PaneLayout option for tab-based multi-dimensional container display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ are:
 | `rerun_` | `rerun/` | example |
 | `agg_` | `aggregation/` | aggregation form, agg_fn |
 | `cartesian_` | `cartesian_animation/` | (single example) |
+| `container_tab_` | `container_tabs/` | layout mode, dimensionality |
 
 **Rules for adding new generators:**
 1. Pick a short, unique section prefix that does not collide with existing prefixes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ are:
 | `rerun_` | `rerun/` | example |
 | `agg_` | `aggregation/` | aggregation form, agg_fn |
 | `cartesian_` | `cartesian_animation/` | (single example) |
-| `container_tab_` | `container_tabs/` | layout mode, dimensionality |
+| `container_tab_` | `container_tabs/` | layout mode |
 
 **Rules for adding new generators:**
 1. Pick a short, unique section prefix that does not collide with existing prefixes.

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -39,6 +39,7 @@ from .variables.results import (
 from .results.composable_container.composable_container_base import (
     ComposeType,
     ComposableContainerBase,
+    PaneLayout,
 )
 from .results.composable_container.composable_container_video import (
     ComposableContainerVideo,

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from bencher.variables.sweep_base import hash_sha1, describe_variable
 from bencher.variables.time import TimeSnapshot, TimeEvent
 from bencher.variables.results import OptDir
+from bencher.results.composable_container.composable_container_base import PaneLayout
 from bencher.job import Executors
 from bencher.results.laxtex_result import to_latex
 
@@ -217,6 +218,15 @@ class BenchRunCfg(BenchPlotSrvCfg):
     )
 
     raise_duplicate_exception: bool = param.Boolean(False, doc=" Used to debug unique plot names.")
+
+    pane_layout = param.Selector(
+        default=PaneLayout.grid,
+        objects=list(PaneLayout),
+        doc="Controls how multi-dimensional data is laid out in panel displays. "
+        "'grid' uses rows/columns (default). "
+        "'tabs' uses tabs for all outer dimensions. "
+        "'tabs_and_grid' uses tabs for the outermost dimension and grid for inner ones.",
+    )
 
     # ==================== TIME & HISTORY PARAMETERS ====================
     # These parameters control time-based features and historical tracking

--- a/bencher/example/example_container_tabs.py
+++ b/bencher/example/example_container_tabs.py
@@ -9,49 +9,14 @@ This is especially useful for large container results (e.g. rerun windows, image
 where a single large display with tab selection is preferable to a dense grid.
 """
 
-import math
-
-import numpy as np
-from PIL import Image, ImageDraw
-
 import bencher as bn
-
-
-def _polygon_points(radius, sides, start_angle=0.0):
-    points = []
-    for ang in np.linspace(0, 360, sides + 1):
-        angle = math.radians(start_angle + ang)
-        points.append([math.sin(angle) * radius, math.cos(angle) * radius])
-    return points
-
-
-def _draw_polygon_image(points, color, linewidth=3, size=300):
-    img = Image.new("RGBA", (size, size), (255, 255, 255, 255))
-    draw = ImageDraw.Draw(img)
-    scaled = [((p[0] + 1) * size / 2, (1 - p[1]) * size / 2) for p in points]
-    draw.line(scaled, fill=color, width=int(linewidth))
-    return img
-
-
-class PolygonSweep(bn.ParametrizedSweep):
-    sides = bn.IntSweep(default=3, bounds=(3, 7), doc="Number of polygon sides")
-    color = bn.StringSweep(["red", "green", "blue"], doc="Line color")
-    radius = bn.FloatSweep(default=0.6, bounds=(0.3, 1.0), doc="Polygon radius")
-
-    polygon = bn.ResultImage(doc="Rendered polygon image")
-
-    def benchmark(self):
-        points = _polygon_points(self.radius, self.sides)
-        img = _draw_polygon_image(points, self.color)
-        filepath = bn.gen_image_path("tab_polygon")
-        img.save(filepath, "PNG")
-        self.polygon = str(filepath)
+from bencher.example.example_image import BenchPolygons
 
 
 def example_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Show container results using tabs layout for dimension navigation."""
 
-    bench = PolygonSweep().to_bench(run_cfg)
+    bench = BenchPolygons().to_bench(run_cfg)
 
     # Grid layout (default) - all dimensions as rows/columns
     bench.plot_sweep(

--- a/bencher/example/example_container_tabs.py
+++ b/bencher/example/example_container_tabs.py
@@ -4,9 +4,6 @@ Demonstrates PaneLayout options for controlling how dimensions are arranged:
 - PaneLayout.grid: rows/columns for all dimensions (default)
 - PaneLayout.tabs: tabs for all outer dimensions
 - PaneLayout.tabs_and_grid: tabs for the outermost dimension, grid for inner ones
-
-This is especially useful for large container results (e.g. rerun windows, images, videos)
-where a single large display with tab selection is preferable to a dense grid.
 """
 
 import bencher as bn
@@ -18,27 +15,11 @@ def example_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
     bench = BenchPolygons().to_bench(run_cfg)
 
-    # Grid layout (default) - all dimensions as rows/columns
-    bench.plot_sweep(
-        title="Grid Layout (default)",
-        input_vars=["sides", "color"],
-        result_vars=["polygon"],
-    )
-
-    # Tabs layout - outer dimensions as tabs
     bench.plot_sweep(
         title="Tabs Layout",
         input_vars=["sides", "color"],
         result_vars=["polygon"],
         run_cfg=bn.BenchRunCfg.with_defaults(run_cfg, pane_layout=bn.PaneLayout.tabs),
-    )
-
-    # Mixed layout - outermost dimension as tabs, inner as grid
-    bench.plot_sweep(
-        title="Tabs + Grid Layout (3 dims)",
-        input_vars=["sides", "color", "radius"],
-        result_vars=["polygon"],
-        run_cfg=bn.BenchRunCfg.with_defaults(run_cfg, pane_layout=bn.PaneLayout.tabs_and_grid),
     )
 
     return bench

--- a/bencher/example/example_container_tabs.py
+++ b/bencher/example/example_container_tabs.py
@@ -1,0 +1,83 @@
+"""Example: Display multi-dimensional container results using tabs instead of grids.
+
+Demonstrates PaneLayout options for controlling how dimensions are arranged:
+- PaneLayout.grid: rows/columns for all dimensions (default)
+- PaneLayout.tabs: tabs for all outer dimensions
+- PaneLayout.tabs_and_grid: tabs for the outermost dimension, grid for inner ones
+
+This is especially useful for large container results (e.g. rerun windows, images, videos)
+where a single large display with tab selection is preferable to a dense grid.
+"""
+
+import math
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+import bencher as bn
+
+
+def _polygon_points(radius, sides, start_angle=0.0):
+    points = []
+    for ang in np.linspace(0, 360, sides + 1):
+        angle = math.radians(start_angle + ang)
+        points.append([math.sin(angle) * radius, math.cos(angle) * radius])
+    return points
+
+
+def _draw_polygon_image(points, color, linewidth=3, size=300):
+    img = Image.new("RGBA", (size, size), (255, 255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    scaled = [((p[0] + 1) * size / 2, (1 - p[1]) * size / 2) for p in points]
+    draw.line(scaled, fill=color, width=int(linewidth))
+    return img
+
+
+class PolygonSweep(bn.ParametrizedSweep):
+    sides = bn.IntSweep(default=3, bounds=(3, 7), doc="Number of polygon sides")
+    color = bn.StringSweep(["red", "green", "blue"], doc="Line color")
+    radius = bn.FloatSweep(default=0.6, bounds=(0.3, 1.0), doc="Polygon radius")
+
+    polygon = bn.ResultImage(doc="Rendered polygon image")
+
+    def benchmark(self):
+        points = _polygon_points(self.radius, self.sides)
+        img = _draw_polygon_image(points, self.color)
+        filepath = bn.gen_image_path("tab_polygon")
+        img.save(filepath, "PNG")
+        self.polygon = str(filepath)
+
+
+def example_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Show container results using tabs layout for dimension navigation."""
+
+    bench = PolygonSweep().to_bench(run_cfg)
+
+    # Grid layout (default) - all dimensions as rows/columns
+    bench.plot_sweep(
+        title="Grid Layout (default)",
+        input_vars=["sides", "color"],
+        result_vars=["polygon"],
+    )
+
+    # Tabs layout - outer dimensions as tabs
+    bench.plot_sweep(
+        title="Tabs Layout",
+        input_vars=["sides", "color"],
+        result_vars=["polygon"],
+        run_cfg=bn.BenchRunCfg.with_defaults(run_cfg, pane_layout=bn.PaneLayout.tabs),
+    )
+
+    # Mixed layout - outermost dimension as tabs, inner as grid
+    bench.plot_sweep(
+        title="Tabs + Grid Layout (3 dims)",
+        input_vars=["sides", "color", "radius"],
+        result_vars=["polygon"],
+        run_cfg=bn.BenchRunCfg.with_defaults(run_cfg, pane_layout=bn.PaneLayout.tabs_and_grid),
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_container_tabs, level=2)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -124,6 +124,7 @@ def generate_python_files():
     from bencher.example.meta.generate_meta_cartesian_animation import (
         example_meta_cartesian_animation,
     )
+    from bencher.example.meta.generate_meta_container_tabs import example_meta_container_tabs
 
     example_meta()
     example_meta_result_types()
@@ -147,6 +148,7 @@ def generate_python_files():
     example_meta_rerun()
     example_meta_aggregation()
     example_meta_cartesian_animation()
+    example_meta_container_tabs()
 
     # Write __init__.py files so generated examples are importable
     for d in GENERATED_DIR.rglob("*"):
@@ -427,6 +429,7 @@ SECTION_GROUPS = [
             ("Level System", "levels"),
             ("Sampling Strategies", "sampling"),
             ("Composable Containers", "composable_containers"),
+            ("Container Tab Layouts", "container_tabs"),
             ("Aggregation", "aggregation"),
             ("Constant Variables", "const_vars"),
             ("Statistics", "statistics"),

--- a/bencher/example/meta/generate_meta_container_tabs.py
+++ b/bencher/example/meta/generate_meta_container_tabs.py
@@ -13,14 +13,13 @@ OUTPUT_DIR = "container_tabs"
 _BENCHABLE_MODULE = "bencher.example.example_image"
 _BENCHABLE_CLASS = "BenchPolygons"
 
+_LAYOUT_NAMES = [pl.value for pl in bn.PaneLayout.all()]
+
 
 class MetaContainerTabLayout(MetaGeneratorBase):
     """Generate examples showing each PaneLayout with 2 input dimensions."""
 
-    layout = bn.StringSweep(
-        ["grid", "tabs", "tabs_and_grid"],
-        doc="Pane layout mode",
-    )
+    layout = bn.StringSweep(_LAYOUT_NAMES, doc="Pane layout mode")
 
     def benchmark(self):
         layout = self.layout
@@ -47,10 +46,7 @@ class MetaContainerTabLayout(MetaGeneratorBase):
 class MetaContainerTabLayout3D(MetaGeneratorBase):
     """Generate examples showing each PaneLayout with 3 input dimensions."""
 
-    layout = bn.StringSweep(
-        ["grid", "tabs", "tabs_and_grid"],
-        doc="Pane layout mode",
-    )
+    layout = bn.StringSweep(_LAYOUT_NAMES, doc="Pane layout mode")
 
     def benchmark(self):
         layout = self.layout
@@ -79,18 +75,16 @@ class MetaContainerTabLayout3D(MetaGeneratorBase):
 
 def example_meta_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Generate all container tab layout meta-examples."""
-    # 2D layout examples: one per PaneLayout
     bench = MetaContainerTabLayout().to_bench(run_cfg)
     bench.plot_sweep(
         title="Container Tab Layout Examples (2D)",
-        input_vars=[bn.sweep("layout", ["grid", "tabs", "tabs_and_grid"])],
+        input_vars=[bn.sweep("layout", _LAYOUT_NAMES)],
     )
 
-    # 3D layout examples: one per PaneLayout
     bench3d = MetaContainerTabLayout3D().to_bench(run_cfg)
     bench3d.plot_sweep(
         title="Container Tab Layout Examples (3D)",
-        input_vars=[bn.sweep("layout", ["grid", "tabs", "tabs_and_grid"])],
+        input_vars=[bn.sweep("layout", _LAYOUT_NAMES)],
     )
 
     return bench

--- a/bencher/example/meta/generate_meta_container_tabs.py
+++ b/bencher/example/meta/generate_meta_container_tabs.py
@@ -1,0 +1,100 @@
+"""Meta-generator: Container Tab Layout Showcase.
+
+Generates examples demonstrating the PaneLayout options for controlling how
+multi-dimensional data is laid out in panel displays — grids, tabs, or a
+combination of both.  Uses the BenchPolygons class from example_image.py.
+"""
+
+import bencher as bn
+from bencher.example.meta.meta_generator_base import MetaGeneratorBase
+
+OUTPUT_DIR = "container_tabs"
+
+_BENCHABLE_MODULE = "bencher.example.example_image"
+_BENCHABLE_CLASS = "BenchPolygons"
+
+
+class MetaContainerTabLayout(MetaGeneratorBase):
+    """Generate examples showing each PaneLayout with 2 input dimensions."""
+
+    layout = bn.StringSweep(
+        ["grid", "tabs", "tabs_and_grid"],
+        doc="Pane layout mode",
+    )
+
+    def benchmark(self):
+        layout = self.layout
+        filename = f"container_tab_layout_{layout}"
+        function_name = f"example_container_tab_layout_{layout}"
+        title = f"Container Layout: PaneLayout.{layout} (2D)"
+
+        self.generate_sweep_example(
+            title=title,
+            output_dir=OUTPUT_DIR,
+            filename=filename,
+            function_name=function_name,
+            benchable_class=_BENCHABLE_CLASS,
+            benchable_module=_BENCHABLE_MODULE,
+            input_vars='["sides", "color"]',
+            result_vars='["polygon"]',
+            run_cfg_lines=[
+                f"run_cfg.pane_layout = bn.PaneLayout.{layout}",
+            ],
+            run_kwargs={"level": 2},
+        )
+
+
+class MetaContainerTabLayout3D(MetaGeneratorBase):
+    """Generate examples showing each PaneLayout with 3 input dimensions."""
+
+    layout = bn.StringSweep(
+        ["grid", "tabs", "tabs_and_grid"],
+        doc="Pane layout mode",
+    )
+
+    def benchmark(self):
+        layout = self.layout
+        filename = f"container_tab_3d_{layout}"
+        function_name = f"example_container_tab_3d_{layout}"
+        title = f"Container Layout: PaneLayout.{layout} (3D)"
+
+        self.generate_sweep_example(
+            title=title,
+            output_dir=OUTPUT_DIR,
+            filename=filename,
+            function_name=function_name,
+            benchable_class=_BENCHABLE_CLASS,
+            benchable_module=_BENCHABLE_MODULE,
+            input_vars='["sides", "color", "radius"]',
+            result_vars='["polygon"]',
+            run_cfg_lines=[
+                f"run_cfg.pane_layout = bn.PaneLayout.{layout}",
+            ],
+            run_kwargs={"level": 2},
+        )
+
+
+# --- Entry point -----------------------------------------------------------
+
+
+def example_meta_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Generate all container tab layout meta-examples."""
+    # 2D layout examples: one per PaneLayout
+    bench = MetaContainerTabLayout().to_bench(run_cfg)
+    bench.plot_sweep(
+        title="Container Tab Layout Examples (2D)",
+        input_vars=[bn.sweep("layout", ["grid", "tabs", "tabs_and_grid"])],
+    )
+
+    # 3D layout examples: one per PaneLayout
+    bench3d = MetaContainerTabLayout3D().to_bench(run_cfg)
+    bench3d.plot_sweep(
+        title="Container Tab Layout Examples (3D)",
+        input_vars=[bn.sweep("layout", ["grid", "tabs", "tabs_and_grid"])],
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_meta_container_tabs)

--- a/bencher/example/meta/generate_meta_container_tabs.py
+++ b/bencher/example/meta/generate_meta_container_tabs.py
@@ -1,8 +1,8 @@
 """Meta-generator: Container Tab Layout Showcase.
 
-Generates examples demonstrating the PaneLayout options for controlling how
-multi-dimensional data is laid out in panel displays — grids, tabs, or a
-combination of both.  Uses the BenchPolygons class from example_image.py.
+Generates examples demonstrating tab-based PaneLayout options using
+the BenchPolygons class from example_image.py.  Only the non-default
+layouts are shown (grid is already demonstrated by every other example).
 """
 
 import bencher as bn
@@ -13,19 +13,20 @@ OUTPUT_DIR = "container_tabs"
 _BENCHABLE_MODULE = "bencher.example.example_image"
 _BENCHABLE_CLASS = "BenchPolygons"
 
-_LAYOUT_NAMES = [pl.value for pl in bn.PaneLayout.all()]
+# Only generate examples for layouts that differ from the default grid.
+_TAB_LAYOUTS = ["tabs", "tabs_and_grid"]
 
 
 class MetaContainerTabLayout(MetaGeneratorBase):
-    """Generate examples showing each PaneLayout with 2 input dimensions."""
+    """Generate examples showing tab-based PaneLayout modes."""
 
-    layout = bn.StringSweep(_LAYOUT_NAMES, doc="Pane layout mode")
+    layout = bn.StringSweep(_TAB_LAYOUTS, doc="Pane layout mode")
 
     def benchmark(self):
         layout = self.layout
-        filename = f"container_tab_layout_{layout}"
-        function_name = f"example_container_tab_layout_{layout}"
-        title = f"Container Layout: PaneLayout.{layout} (2D)"
+        filename = f"container_tab_{layout}"
+        function_name = f"example_container_tab_{layout}"
+        title = f"Container Layout: PaneLayout.{layout}"
 
         self.generate_sweep_example(
             title=title,
@@ -43,50 +44,16 @@ class MetaContainerTabLayout(MetaGeneratorBase):
         )
 
 
-class MetaContainerTabLayout3D(MetaGeneratorBase):
-    """Generate examples showing each PaneLayout with 3 input dimensions."""
-
-    layout = bn.StringSweep(_LAYOUT_NAMES, doc="Pane layout mode")
-
-    def benchmark(self):
-        layout = self.layout
-        filename = f"container_tab_3d_{layout}"
-        function_name = f"example_container_tab_3d_{layout}"
-        title = f"Container Layout: PaneLayout.{layout} (3D)"
-
-        self.generate_sweep_example(
-            title=title,
-            output_dir=OUTPUT_DIR,
-            filename=filename,
-            function_name=function_name,
-            benchable_class=_BENCHABLE_CLASS,
-            benchable_module=_BENCHABLE_MODULE,
-            input_vars='["sides", "color", "radius"]',
-            result_vars='["polygon"]',
-            run_cfg_lines=[
-                f"run_cfg.pane_layout = bn.PaneLayout.{layout}",
-            ],
-            run_kwargs={"level": 2},
-        )
-
-
 # --- Entry point -----------------------------------------------------------
 
 
 def example_meta_container_tabs(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Generate all container tab layout meta-examples."""
+    """Generate container tab layout meta-examples."""
     bench = MetaContainerTabLayout().to_bench(run_cfg)
     bench.plot_sweep(
-        title="Container Tab Layout Examples (2D)",
-        input_vars=[bn.sweep("layout", _LAYOUT_NAMES)],
+        title="Container Tab Layout Examples",
+        input_vars=[bn.sweep("layout", _TAB_LAYOUTS)],
     )
-
-    bench3d = MetaContainerTabLayout3D().to_bench(run_cfg)
-    bench3d.plot_sweep(
-        title="Container Tab Layout Examples (3D)",
-        input_vars=[bn.sweep("layout", _LAYOUT_NAMES)],
-    )
-
     return bench
 
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -254,6 +254,7 @@ class BenchResult(
             )
             plot_cols.append(self.to(BandResult, aggregate=input_names))
 
+        kwargs.setdefault("pane_layout", self.bench_cfg.pane_layout)
         plot_cols.append(self.to_auto(**kwargs))
         plot_cols.append(self.bench_cfg.to_post_description())
         return plot_cols

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -676,6 +676,30 @@ class BenchResultBase:
             **kwargs,
         )
 
+    @staticmethod
+    def _child_pane_layout(pane_layout: PaneLayout) -> PaneLayout:
+        """Return the layout to use for child dimensions during recursion."""
+        if pane_layout == PaneLayout.tabs_and_grid:
+            return PaneLayout.grid
+        return pane_layout
+
+    def _iter_pane_slices(
+        self, dataset, selected_dim, plot_callback, target_dimension, result_var, child_layout
+    ):
+        """Yield (label_val, panes) for each slice along selected_dim."""
+        for i in range(dataset.sizes[selected_dim]):
+            sliced = dataset.isel({selected_dim: i})
+            label_val = sliced.coords[selected_dim].values.item()
+            panes = self._to_panes_da(
+                sliced,
+                plot_callback=plot_callback,
+                target_dimension=target_dimension,
+                horizontal=len(sliced.sizes) <= target_dimension + 1,
+                result_var=result_var,
+                pane_layout=child_layout,
+            )
+            yield label_val, panes
+
     def _to_panes_da(
         self,
         dataset: xr.Dataset,
@@ -698,14 +722,16 @@ class BenchResultBase:
         if num_pane_dims > target_dimension and num_pane_dims != 0:
             selected_dim = pane_dims[-1]
             dim_color = color_tuple_to_css(int_to_col(num_pane_dims - 2, 0.05, 1.0))
-
-            # Determine whether this dimension level uses tabs or grid
             use_tabs = pane_layout in (PaneLayout.tabs, PaneLayout.tabs_and_grid)
-
-            # For child dimensions: tabs stays tabs, tabs_and_grid becomes grid
-            child_layout = pane_layout
-            if pane_layout == PaneLayout.tabs_and_grid:
-                child_layout = PaneLayout.grid
+            child_layout = self._child_pane_layout(pane_layout)
+            slices = self._iter_pane_slices(
+                dataset,
+                selected_dim,
+                plot_callback,
+                target_dimension,
+                result_var,
+                child_layout,
+            )
 
             if use_tabs:
                 outer_container = ComposableContainerPanel(
@@ -713,19 +739,8 @@ class BenchResultBase:
                     background_col=dim_color,
                     compose_method=ComposeType.sequence,
                 )
-                for i in range(dataset.sizes[selected_dim]):
-                    sliced = dataset.isel({selected_dim: i})
-                    label_val = sliced.coords[selected_dim].values.item()
+                for label_val, panes in slices:
                     label = ComposableContainerBase.label_formatter(selected_dim, label_val)
-
-                    panes = self._to_panes_da(
-                        sliced,
-                        plot_callback=plot_callback,
-                        target_dimension=target_dimension,
-                        horizontal=len(sliced.sizes) <= target_dimension + 1,
-                        result_var=result_var,
-                        pane_layout=child_layout,
-                    )
                     outer_container.append((label, panes))
             else:
                 outer_container = ComposableContainerPanel(
@@ -734,24 +749,13 @@ class BenchResultBase:
                     compose_method=ComposeType.down if not horizontal else ComposeType.right,
                 )
                 max_len = 0
-                for i in range(dataset.sizes[selected_dim]):
-                    sliced = dataset.isel({selected_dim: i})
-                    label_val = sliced.coords[selected_dim].values.item()
+                for label_val, panes in slices:
                     inner_container = ComposableContainerPanel(
                         name=outer_container.name,
                         width=num_pane_dims - target_dimension,
                         var_name=selected_dim,
                         var_value=label_val,
                         compose_method=ComposeType.down if horizontal else ComposeType.right,
-                    )
-
-                    panes = self._to_panes_da(
-                        sliced,
-                        plot_callback=plot_callback,
-                        target_dimension=target_dimension,
-                        horizontal=len(sliced.sizes) <= target_dimension + 1,
-                        result_var=result_var,
-                        pane_layout=child_layout,
                     )
                     max_len = max(max_len, inner_container.label_len)
                     inner_container.append(panes)

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -27,7 +27,7 @@ from bencher.variables.results import ResultReference, ResultDataSet, ResultVide
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
 )
-from bencher.results.composable_container.composable_container_base import ComposeType
+from bencher.results.composable_container.composable_container_base import ComposeType, PaneLayout
 
 from collections import defaultdict
 
@@ -519,6 +519,7 @@ class BenchResultBase:
         pane_collection: pn.pane = None,
         zip_results=False,
         reduce: ReduceType | None = None,
+        pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ) -> pn.Row | None:
         if hv_dataset is None:
@@ -543,6 +544,7 @@ class BenchResultBase:
                         rv,
                         plot_callback=partial(plot_callback, **kwargs),
                         target_dimension=target_dimension,
+                        pane_layout=pane_layout,
                     )
                 )
 
@@ -570,6 +572,7 @@ class BenchResultBase:
         hv_dataset: hv.Dataset | None = None,
         agg_over_dims: list[str] | None = None,
         agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
+        pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ) -> pn.panel | None:
         # Initialize default filters if not provided to avoid shared mutable defaults
@@ -634,6 +637,7 @@ class BenchResultBase:
                 result_types=result_types,
                 pane_collection=pane_collection,
                 reduce=reduce,
+                pane_layout=pane_layout,
                 **kwargs,
             )
         return matches_res.to_panel()
@@ -644,6 +648,7 @@ class BenchResultBase:
         result_var: ResultVar,
         plot_callback: Callable | None = None,
         target_dimension: int = 1,
+        pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ):
         dims = len(hv_dataset.dimensions())
@@ -663,6 +668,7 @@ class BenchResultBase:
             target_dimension=target_dimension,
             horizontal=pane_dims <= target_dimension + 1,
             result_var=result_var,
+            pane_layout=pane_layout,
             **kwargs,
         )
 
@@ -673,6 +679,7 @@ class BenchResultBase:
         target_dimension=1,
         horizontal=False,
         result_var=None,
+        pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ) -> pn.panel:
         dims = list(d for d in dataset.sizes)
@@ -686,38 +693,67 @@ class BenchResultBase:
 
         if num_pane_dims > target_dimension and num_pane_dims != 0:
             selected_dim = pane_dims[-1]
-            # print(f"selected dim {dim_sel}")
             dim_color = color_tuple_to_css(int_to_col(num_pane_dims - 2, 0.05, 1.0))
 
-            outer_container = ComposableContainerPanel(
-                name=" vs ".join(pane_dims),
-                background_col=dim_color,
-                compose_method=ComposeType.down if not horizontal else ComposeType.right,
-            )
-            max_len = 0
-            for i in range(dataset.sizes[selected_dim]):
-                sliced = dataset.isel({selected_dim: i})
-                label_val = sliced.coords[selected_dim].values.item()
-                inner_container = ComposableContainerPanel(
-                    name=outer_container.name,
-                    width=num_pane_dims - target_dimension,
-                    var_name=selected_dim,
-                    var_value=label_val,
-                    compose_method=ComposeType.down if horizontal else ComposeType.right,
-                )
+            # Determine whether this dimension level uses tabs or grid
+            use_tabs = pane_layout in (PaneLayout.tabs, PaneLayout.tabs_and_grid)
 
-                panes = self._to_panes_da(
-                    sliced,
-                    plot_callback=plot_callback,
-                    target_dimension=target_dimension,
-                    horizontal=len(sliced.sizes) <= target_dimension + 1,
-                    result_var=result_var,
+            # For child dimensions: tabs stays tabs, tabs_and_grid becomes grid
+            child_layout = pane_layout
+            if pane_layout == PaneLayout.tabs_and_grid:
+                child_layout = PaneLayout.grid
+
+            if use_tabs:
+                outer_container = ComposableContainerPanel(
+                    name=" vs ".join(pane_dims),
+                    background_col=dim_color,
+                    compose_method=ComposeType.sequence,
                 )
-                max_len = max(max_len, inner_container.label_len)
-                inner_container.append(panes)
-                outer_container.append(inner_container.container)
-            for c in outer_container.container:
-                c[0].width = max_len * 7
+                for i in range(dataset.sizes[selected_dim]):
+                    sliced = dataset.isel({selected_dim: i})
+                    label_val = sliced.coords[selected_dim].values.item()
+                    label = ComposableContainerBase.label_formatter(selected_dim, label_val)
+
+                    panes = self._to_panes_da(
+                        sliced,
+                        plot_callback=plot_callback,
+                        target_dimension=target_dimension,
+                        horizontal=len(sliced.sizes) <= target_dimension + 1,
+                        result_var=result_var,
+                        pane_layout=child_layout,
+                    )
+                    outer_container.append((label, panes))
+            else:
+                outer_container = ComposableContainerPanel(
+                    name=" vs ".join(pane_dims),
+                    background_col=dim_color,
+                    compose_method=ComposeType.down if not horizontal else ComposeType.right,
+                )
+                max_len = 0
+                for i in range(dataset.sizes[selected_dim]):
+                    sliced = dataset.isel({selected_dim: i})
+                    label_val = sliced.coords[selected_dim].values.item()
+                    inner_container = ComposableContainerPanel(
+                        name=outer_container.name,
+                        width=num_pane_dims - target_dimension,
+                        var_name=selected_dim,
+                        var_value=label_val,
+                        compose_method=ComposeType.down if horizontal else ComposeType.right,
+                    )
+
+                    panes = self._to_panes_da(
+                        sliced,
+                        plot_callback=plot_callback,
+                        target_dimension=target_dimension,
+                        horizontal=len(sliced.sizes) <= target_dimension + 1,
+                        result_var=result_var,
+                        pane_layout=child_layout,
+                    )
+                    max_len = max(max_len, inner_container.label_len)
+                    inner_container.append(panes)
+                    outer_container.append(inner_container.container)
+                for c in outer_container.container:
+                    c[0].width = max_len * 7
         else:
             # When over_time is active with >1 time points, the dataset still
             # contains the over_time dimension (it was excluded from pane recursion
@@ -733,7 +769,7 @@ class BenchResultBase:
                 return self._pane_over_time_slider(dataset, result_var)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
-        return outer_container.container
+        return outer_container.render()
 
     def _pane_over_time_slider(
         self,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -27,7 +27,11 @@ from bencher.variables.results import ResultReference, ResultDataSet, ResultVide
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
 )
-from bencher.results.composable_container.composable_container_base import ComposeType, PaneLayout
+from bencher.results.composable_container.composable_container_base import (
+    ComposeType,
+    ComposableContainerBase,
+    PaneLayout,
+)
 
 from collections import defaultdict
 

--- a/bencher/results/composable_container/__init__.py
+++ b/bencher/results/composable_container/__init__.py
@@ -1,6 +1,7 @@
 from bencher.results.composable_container.composable_container_base import (
     ComposeType,
     ComposableContainerBase,
+    PaneLayout,
 )
 from bencher.results.composable_container.composable_container_video import (
     ComposableContainerVideo,

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -40,6 +40,11 @@ class PaneLayout(StrEnum):
     tabs = auto()
     tabs_and_grid = auto()
 
+    @classmethod
+    def all(cls) -> list[PaneLayout]:
+        """Return all layout values.  Use this instead of hard-coded name lists."""
+        return list(cls)
+
 
 @dataclass(kw_only=True)
 class ComposableContainerBase:

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -28,6 +28,19 @@ class ComposeType(StrEnum):
         return ComposeType.right if horizontal else ComposeType.down
 
 
+class PaneLayout(StrEnum):
+    """Controls how multi-dimensional data is laid out in panel displays.
+
+    grid: Use rows/columns for all dimensions (default, existing behavior)
+    tabs: Use tabs for all outer dimensions, only the innermost uses grid
+    tabs_and_grid: Use tabs for the outermost dimension, grid for inner dimensions
+    """
+
+    grid = auto()
+    tabs = auto()
+    tabs_and_grid = auto()
+
+
 @dataclass(kw_only=True)
 class ComposableContainerBase:
     """A base class for renderer backends.  A composable renderer"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.75.2"
+version = "1.76.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
Add PaneLayout enum (grid, tabs, tabs_and_grid) to control how
multi-dimensional data is laid out in panel displays. This enables
navigating dimensions via tabs instead of dense grids, which is
especially useful for large container results like rerun windows.

- PaneLayout.grid: rows/columns for all dimensions (default, unchanged)
- PaneLayout.tabs: tabs for all outer dimensions
- PaneLayout.tabs_and_grid: tabs for outermost dim, grid for inner ones

The setting is available on BenchRunCfg.pane_layout and flows through
the full plot chain (filter → map_plot_panes → to_panes_multi_panel →
_to_panes_da).

https://claude.ai/code/session_01ULSQdfkac7UBh1SLwyPPYb

## Summary by Sourcery

Introduce configurable pane layouts for multi-dimensional container displays and add examples showcasing tab-based layouts.

New Features:
- Add PaneLayout enum to control grid, tabs, or mixed tabs-and-grid layouts for multi-dimensional panel displays.
- Expose pane_layout option on BenchRunCfg and propagate it through the plotting pipeline for automatic use in auto-plots.
- Support tab-based composition of container panels, enabling navigation of outer dimensions via tabs instead of dense grids.
- Add concrete and meta-generated examples demonstrating container tab layouts in 2D and 3D sweeps.

Documentation:
- Document container tab layout options via new example scripts and generated example section entries for container tab layouts and naming conventions.