### PR TITLE
docs: Improve ResultBool discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Bencher is a benchmarking framework built around these core concepts:
 - **ComposableContainer**: Framework for combining multiple result types
 - **Video/Image Results**: Support for multimedia outputs
 - Results automatically cached using diskcache based on parameter hashes
+- **Result type selection**: Use `ResultBool` for binary outcomes (success/failure), `ResultVar` for continuous metrics, `ResultString` for text, `ResultImage`/`ResultVideo`/`ResultPath` for files
 
 ### Data Flow
 1. Define parameter sweep configuration class inheriting from ParametrizedSweep

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -90,7 +90,11 @@ class OptDir(StrEnum):
 
 
 class ResultVar(Number):
-    """A class to represent result variables and the desired optimisation direction"""
+    """A class to represent continuous result variables and the desired optimisation direction.
+
+    For boolean (success/failure) outcomes, use ``ResultBool`` instead — it locks
+    bounds to [0, 1] and produces correct boolean-style plots.
+    """
 
     __slots__ = ["units", "direction"]
 

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -114,7 +114,11 @@ class ResultVar(Number):
 
 
 class ResultBool(ResultVar):
-    """A ResultVar subclass for boolean (0/1) results with bounds locked to [0, 1]."""
+    """A result type for binary outcomes (success/failure, pass/fail, reachable/unreachable).
+
+    Bounds are locked to [0, 1] and plots use boolean-style rendering.
+    For continuous scalar metrics (time, distance, score), use ``ResultVar`` instead.
+    """
 
     def __init__(self, units="ratio", direction: OptDir = OptDir.minimize, default=0, **params):
         super().__init__(units=units, direction=direction, allow_None=True, **params)

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -82,9 +82,18 @@ Use `IntSweep(bounds=(0, N))` when 0 means "feature absent" and 1+ controls magn
 
 | Type | Use for | Set to |
 |---|---|---|
-| `bn.ResultVar(units="s")` | Scalar metrics | `self.elapsed = 0.42` |
+| `bn.ResultVar(units="s")` | Continuous scalar metrics (time, distance, score) | `self.elapsed = 0.42` |
+| `bn.ResultBool()` | Success/failure, pass/fail, any binary outcome | `self.success = True` |
+| `bn.ResultString()` | Text outputs, labels, error messages | `self.error_msg = "timeout"` |
 | `bn.ResultImage()` | Images, GIFs | `self.img = "/path/to/output.png"` |
 | `bn.ResultVideo()` | Videos | `self.vid = video_writer.write()` |
+| `bn.ResultPath()` | Downloadable file outputs | `self.artifact = "/path/to/file"` |
+| `bn.ResultContainer()` | Embeddable HTML/panel content | `self.widget = pane` |
+| `bn.ResultVec(size=3)` | Fixed-size vector results (x, y, z) | `self.position = [1.0, 2.0, 3.0]` |
+
+**Choosing between ResultVar and ResultBool:** If a result is binary (success/failure,
+reachable/unreachable, pass/fail), always use `ResultBool` — it locks bounds to [0, 1]
+and produces correct boolean-style plots. Only use `ResultVar` for continuous metrics.
 
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
@@ -207,3 +216,4 @@ class ImageBench(bn.ParametrizedSweep):
 | Building panel/HTML layouts manually | Use bencher's report system |
 | Using the old `__call__` pattern with boilerplate | Override `benchmark()` instead |
 | Caching file-path results | Set `run_cfg.cache_results = False` |
+| Using `ResultVar` for success/failure booleans | Use `ResultBool()` — bounds are [0, 1], plots render correctly |


### PR DESCRIPTION
## Summary

- Expand the Result Types table in `docs/how_to_use_bencher.md` to include all result types (`ResultBool`, `ResultString`, `ResultPath`, `ResultContainer`, `ResultVec`) — previously only `ResultVar`, `ResultImage`, and `ResultVideo` were listed
- Add explicit guidance on choosing `ResultBool` vs `ResultVar` for binary outcomes
- Add a Common Mistakes entry for using `ResultVar` for success/failure booleans
- Update `ResultVar` docstring to cross-reference `ResultBool`
- Add result type selection guidance to `CLAUDE.md`/`AGENTS.md`

## Motivation

When `ResultBool` is absent from the docs, both humans and LLMs default to `ResultVar` with manual `0.0`/`1.0` encoding for boolean outcomes. This loses the automatic bounds locking and correct boolean-style plot rendering that `ResultBool` provides.

## Test plan

- [ ] Verify `pixi run ci` passes (docs-only + docstring change, no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve documentation and guidance for selecting appropriate result types, especially promoting ResultBool for binary outcomes.

Enhancements:
- Update the ResultVar docstring to clarify it is for continuous metrics and to cross-reference ResultBool for boolean outcomes.

Documentation:
- Expand the result types table in how_to_use_bencher.md to list all major result types and clarify their recommended use cases, including ResultBool.
- Add guidance on choosing ResultBool instead of ResultVar for binary success/failure metrics, including a new common mistake entry and plotting/bounds implications.
- Document result type selection best practices in AGENTS.md for agents and LLMs using the framework.