### PR TITLE
Hoist shared allocations and pre-cache numpy arrays (perf plan 2.9, 2.10)

### DIFF
--- a/PERFORMANCE_PLAN.md
+++ b/PERFORMANCE_PLAN.md
@@ -687,7 +687,7 @@ All measurements taken on Linux, Python 3.13, `auto_plot=False`.
 | Repeat (5×3 = 15 jobs) | 17ms | job_execution 5ms | |
 | Large reversed (20×20×5 = 2000) | 1085ms | job_execution ~1000ms | dataset_setup 7.3ms (vs 2.8ms sequential) |
 
-**cProfile hotspots (500 jobs, all cache hits)**:
+**cProfile hotspots (500 jobs, all cache hits, pre-2.6/2.7)**:
 
 | Function | Calls | cumtime | tottime | % of total |
 |----------|-------|---------|---------|------------|
@@ -701,6 +701,27 @@ All measurements taken on Linux, Python 3.13, `auto_plot=False`.
 **Key insight**: After all previous optimizations, the dominant bottleneck on the execution
 path is **xarray's fancy-indexing overhead** in `set_xarray_multidim` (58% of runtime).
 Bypassing xarray with `data_array.values[idx] = value` is 159× faster per write (see item 2.6).
+
+#### Updated baseline (2026-04-03, post items 2.6, 2.7, 2.9, 2.10)
+
+| Workload | Total | Top phase | Notes |
+|----------|-------|-----------|-------|
+| Medium (500 jobs, cache hits) | ~103ms | cache_check 35ms | 36% faster vs 159ms pre-2.9/2.10; 58% faster vs 244ms pre-2.6/2.7 |
+
+**cProfile hotspots (500 jobs, all cache hits, post-2.9/2.10)**:
+
+| Function | Calls | cumtime | tottime | % of total |
+|----------|-------|---------|---------|------------|
+| `prefetch` (→ diskcache `get`) | 500 | 30ms | 1ms | 29% |
+| SQLite `execute` | 666 | 19ms | 19ms | 19% |
+| `store_results` | 500 | 16ms | 9ms | 16% |
+| `setup_hashes` (→ `hash_sha1`) | 500 | 14ms | 3ms | 14% |
+| `pickle.load` (cache deser.) | 500 | 8ms | 8ms | 8% |
+
+**Key insight**: After hoisting shared allocations (2.9) and pre-caching numpy arrays (2.10),
+`store_results` dropped from 57ms to 16ms (72% reduction) and `job_submission` from 26ms
+to 19ms. The remaining dominant cost is SQLite I/O in `prefetch` (29% of runtime) and
+`pickle.load` deserialization (8%), which are inherent to the cache layer.
 
 **`to_dataset()` micro-benchmarks**:
 
@@ -754,8 +775,8 @@ Every change in this plan must pass:
 | **P0** | 1.1 Default `show_aggregated_time_tab` to `False` | Trivial | None | **High** — eliminates 2× regression vs v1.70.4 for all `over_time` users | **DONE** (v1.72.1) |
 | **P0** | 1.2 Add `report_save_ms` to SweepTimings | Low | None | **High** — enables visibility into the dominant bottleneck | **DONE** (PR #787, v1.72.1) |
 | **P0** | 1.3 Default `max_slider_points` to 20 | Trivial | Low | **High** — prevents superlinear embed cost for long histories | **DONE** (v1.72.1, default=10) |
-| **P1** | 2.6 Direct numpy indexing in `set_xarray_multidim()` | Trivial | Low | **High** — measured 159× speedup per write; saves ~346ms/500 jobs (58% of runtime on cache-hit sweeps) | |
-| **P1** | 2.7 Cache `get_input_and_results()` per class | Low | Low | **Moderate** — measured 130× speedup for namedtuple reuse; saves ~62ms/500 jobs | |
+| **P1** | 2.6 Direct numpy indexing in `set_xarray_multidim()` | Trivial | Low | **High** — measured 159× speedup per write; saves ~346ms/500 jobs (58% of runtime on cache-hit sweeps) | **DONE** (PR #885) |
+| **P1** | 2.7 Cache `get_input_and_results()` per class | Low | Low | **Moderate** — measured 130× speedup for namedtuple reuse; saves ~62ms/500 jobs | **DONE** (PR #885) |
 | **P1** | 1.7 Disable HoloViews pipeline tracking during save | Trivial | Low | Predicted **High** — profiling showed 3.3s cumtime for 4998 `pipelined_fn` calls | **REJECTED** — benchmarked; `pipelined_fn` tottime is only 28ms (overhead is in child calls, not the wrapper). `disable_pipeline()` measured same-or-slower than baseline. |
 | **P1** | 1.8 Pre-compute and freeze plot ranges | Low | Medium | Predicted **Moderate** — profiling showed 3.4s cumtime for 162 `compute_ranges` calls | **REJECTED** — `compute_ranges` tottime is only 2.5ms; the 3.4s cumtime is dominated by child data operations, not range computation itself. |
 | **P1** | 1.5 Profile Panel embed hotspots | Medium | None | **Critical** — informs all other report.save() optimizations | **DONE** — profiled in SAVE_PERFORMANCE_REPORT.md. Key finding: the bottleneck is Panel's per-state re-rendering (`plot.update`: 60 calls, 6.6s cumtime), not any single wrapping layer. `pipelined_fn` and `compute_ranges` have low tottime (~30ms combined); their high cumtimes reflect the underlying render cost, not addressable overhead. |
@@ -770,6 +791,8 @@ Every change in this plan must pass:
 | **P2** | 3.4 Lazy hash computation | Low | Low | Low-Moderate | **DONE** (PR #816 — removed dead `function_input_signature_benchmark_context` hash; remaining `@cached_property` refactor has no impact since hash is always accessed) |
 | **P2** | 4.4 Single-pass reduction | Medium | Medium | Moderate | **DONE** |
 | **P2** | 4.5 Memoize `to_dataset()` | Medium | Low-Med | High for many plots | **DONE** |
+| **P2** | 2.9 Hoist shared allocations out of per-job loop | Trivial | None | **Moderate** — saves ~7ms/500 jobs (hoists `partial()`, pre-computes title/tag) | **DONE** |
+| **P2** | 2.10 Pre-cache numpy arrays for `store_results()` | Trivial | None | **High** — saves ~41ms/500 jobs (bypasses 500× xarray `Dataset.__getitem__`) | **DONE** |
 | **P3** | 2.4 Deduplicate reversed product | Low | Low | Low — measured only 4.5ms overhead at 2000 jobs | |
 | **P3** | 2.8 Streaming parallel results | Medium | Medium | High for parallel | Deprioritized — parallel execution rarely used |
 | **P3** | 3.2 FanoutCache for parallel | Low | Low | Moderate for parallel | Deprioritized — parallel execution rarely used |

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -775,12 +775,17 @@ class Bench(BenchPlotServer):
             constant_inputs = self.define_const_inputs(bench_res.bench_cfg.const_vars)
         timings.dataset_setup_ms = elapsed()
 
-        callcount = 1
         results_list = []
         jobs = []
         cache_jobs = []
 
+        # Hoist shared allocations out of the per-job loop
+        bench_title = bench_res.bench_cfg.title
+        bench_tag = bench_res.bench_cfg.tag
+        worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
+
         with phase_timer() as elapsed:
+            callcount = 1
             for idx_tuple, function_input_vars in func_inputs:
                 job = WorkerJob(
                     function_input_vars,
@@ -788,16 +793,14 @@ class Bench(BenchPlotServer):
                     dims_name,
                     constant_inputs,
                     bench_cfg_sample_hash,
-                    bench_res.bench_cfg.tag,
+                    bench_tag,
                 )
                 job.setup_hashes()
                 jobs.append(job)
 
-                jid = f"{bench_res.bench_cfg.title}:call {callcount}/{total_jobs}"
-                worker = partial(worker_kwargs_wrapper, self.worker, bench_res.bench_cfg)
                 cache_jobs.append(
                     Job(
-                        job_id=jid,
+                        job_id=f"{bench_title}:call {callcount}/{total_jobs}",
                         function=worker,
                         job_args=job.function_input,
                         job_key=job.function_input_signature_pure,
@@ -811,6 +814,11 @@ class Bench(BenchPlotServer):
             prefetched = self.sample_cache.prefetch([cj.job_key for cj in cache_jobs])
         timings.cache_check_ms += elapsed()
 
+        # Pre-cache numpy array references to avoid per-job xarray Dataset
+        # lookups (~28ms/500 jobs). The arrays are views into the dataset so
+        # writes go directly into bench_res.ds.
+        rv_arrays = self._collector.precompute_result_arrays(bench_res)
+
         with phase_timer() as elapsed:
             for job, cache_job in zip(jobs, cache_jobs):
                 result = self.sample_cache.submit(cache_job, prefetched=prefetched)
@@ -819,10 +827,10 @@ class Bench(BenchPlotServer):
                 # completed results are cached to disk before later jobs
                 # may crash.
                 if bench_run_cfg.executor == Executors.SERIAL:
-                    self.store_results(result, bench_res, job, bench_run_cfg)
+                    self.store_results(result, bench_res, job, bench_run_cfg, rv_arrays)
             if bench_run_cfg.executor != Executors.SERIAL:
                 for job, res in zip(jobs, results_list):
-                    self.store_results(res, bench_res, job, bench_run_cfg)
+                    self.store_results(res, bench_res, job, bench_run_cfg, rv_arrays)
         timings.job_execution_ms = elapsed()
 
         for inp in bench_res.bench_cfg.all_vars:
@@ -836,9 +844,10 @@ class Bench(BenchPlotServer):
         bench_res: BenchResult,
         worker_job: WorkerJob,
         bench_run_cfg: BenchRunCfg,
+        rv_arrays: dict | None = None,
     ) -> None:
         """Store worker job results into the n-dimensional result dataset."""
-        self._collector.store_results(job_result, bench_res, worker_job, bench_run_cfg)
+        self._collector.store_results(job_result, bench_res, worker_job, bench_run_cfg, rv_arrays)
 
     def init_sample_cache(self, run_cfg: BenchRunCfg) -> FutureCache:
         """Initialize the FutureCache for storing benchmark function results."""

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -8,6 +8,7 @@ from param import Parameter
 from typing import Callable, Any
 from copy import deepcopy
 import param
+import numpy as np
 import xarray as xr
 from contextlib import suppress
 from functools import partial
@@ -844,7 +845,7 @@ class Bench(BenchPlotServer):
         bench_res: BenchResult,
         worker_job: WorkerJob,
         bench_run_cfg: BenchRunCfg,
-        rv_arrays: dict | None = None,
+        rv_arrays: dict[str, np.ndarray] | None = None,
     ) -> None:
         """Store worker job results into the n-dimensional result dataset."""
         self._collector.store_results(job_result, bench_res, worker_job, bench_run_cfg, rv_arrays)

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -62,6 +62,20 @@ def set_xarray_multidim(
     return data_array
 
 
+def _set_result_value(
+    bench_res: "BenchResult",
+    rv_arrays: dict[str, np.ndarray] | None,
+    name: str,
+    idx: tuple,
+    value: Any,
+) -> None:
+    """Write a single result value, using pre-cached numpy arrays when available."""
+    if rv_arrays is not None:
+        rv_arrays[name][idx] = value
+    else:
+        set_xarray_multidim(bench_res.ds[name], idx, value)
+
+
 class ResultCollector:
     """Manages benchmark result collection, storage, and caching.
 
@@ -224,7 +238,7 @@ class ResultCollector:
         """
         rv_arrays: dict[str, np.ndarray] = {}
         for rv in bench_res.bench_cfg.result_vars:
-            if type(rv) is ResultVec:
+            if isinstance(rv, ResultVec):
                 for i in range(rv.size):
                     rv_arrays[rv.index_name(i)] = bench_res.ds[rv.index_name(i)].values
             else:
@@ -272,34 +286,25 @@ class ResultCollector:
                     logger.info(f"{rv.name}: {result_value}")
 
                 if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):
-                    if rv_arrays is not None:
-                        rv_arrays[rv.name][idx] = result_value
-                    else:
-                        set_xarray_multidim(bench_res.ds[rv.name], idx, result_value)
+                    _set_result_value(bench_res, rv_arrays, rv.name, idx, result_value)
                 elif isinstance(rv, ResultDataSet):
                     bench_res.dataset_list.append(result_value)
-                    store_idx = len(bench_res.dataset_list) - 1
-                    if rv_arrays is not None:
-                        rv_arrays[rv.name][idx] = store_idx
-                    else:
-                        set_xarray_multidim(bench_res.ds[rv.name], idx, store_idx)
+                    _set_result_value(
+                        bench_res, rv_arrays, rv.name, idx, len(bench_res.dataset_list) - 1
+                    )
                 elif isinstance(rv, ResultReference):
                     bench_res.object_index.append(result_value)
-                    store_idx = len(bench_res.object_index) - 1
-                    if rv_arrays is not None:
-                        rv_arrays[rv.name][idx] = store_idx
-                    else:
-                        set_xarray_multidim(bench_res.ds[rv.name], idx, store_idx)
+                    _set_result_value(
+                        bench_res, rv_arrays, rv.name, idx, len(bench_res.object_index) - 1
+                    )
 
                 elif isinstance(rv, ResultVec):
                     if isinstance(result_value, (list, np.ndarray)):
                         if len(result_value) == rv.size:
                             for i in range(rv.size):
-                                name = rv.index_name(i)
-                                if rv_arrays is not None:
-                                    rv_arrays[name][idx] = result_value[i]
-                                else:
-                                    set_xarray_multidim(bench_res.ds[name], idx, result_value[i])
+                                _set_result_value(
+                                    bench_res, rv_arrays, rv.index_name(i), idx, result_value[i]
+                                )
 
                 else:
                     raise RuntimeError("Unsupported result type")

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -214,12 +214,30 @@ class ResultCollector:
             bench_cfg.iv_time = [iv_over_time]
         return extra_vars
 
+    @staticmethod
+    def precompute_result_arrays(bench_res: BenchResult) -> dict[str, np.ndarray]:
+        """Pre-fetch the underlying numpy arrays for all result variables.
+
+        This avoids repeated xarray Dataset.__getitem__ lookups (which trigger
+        _construct_dataarray) during the per-job store loop.  The returned arrays
+        are views into the dataset, so writes go directly into bench_res.ds.
+        """
+        rv_arrays: dict[str, np.ndarray] = {}
+        for rv in bench_res.bench_cfg.result_vars:
+            if type(rv) is ResultVec:
+                for i in range(rv.size):
+                    rv_arrays[rv.index_name(i)] = bench_res.ds[rv.index_name(i)].values
+            else:
+                rv_arrays[rv.name] = bench_res.ds[rv.name].values
+        return rv_arrays
+
     def store_results(
         self,
         job_result: JobFuture,
         bench_res: BenchResult,
         worker_job: WorkerJob,
         bench_run_cfg: BenchRunCfg,
+        rv_arrays: dict[str, np.ndarray] | None = None,
     ) -> None:
         """Store the results from a benchmark worker job into the benchmark result dataset.
 
@@ -232,6 +250,8 @@ class ResultCollector:
             bench_res (BenchResult): The benchmark result object to store results in
             worker_job (WorkerJob): The job metadata needed to index the result
             bench_run_cfg (BenchRunCfg): Configuration for how results should be handled
+            rv_arrays (dict, optional): Pre-computed numpy arrays from
+                precompute_result_arrays(). Falls back to dataset lookup if None.
 
         Raises:
             RuntimeError: If an unsupported result variable type is encountered
@@ -244,6 +264,7 @@ class ResultCollector:
                     logger.info(f"\t {k}:{v}")
 
             result_dict = result if isinstance(result, dict) else result.param.values()
+            idx = worker_job.index_tuple
 
             for rv in bench_res.bench_cfg.result_vars:
                 result_value = result_dict[rv.name]
@@ -251,31 +272,34 @@ class ResultCollector:
                     logger.info(f"{rv.name}: {result_value}")
 
                 if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):
-                    set_xarray_multidim(bench_res.ds[rv.name], worker_job.index_tuple, result_value)
+                    if rv_arrays is not None:
+                        rv_arrays[rv.name][idx] = result_value
+                    else:
+                        set_xarray_multidim(bench_res.ds[rv.name], idx, result_value)
                 elif isinstance(rv, ResultDataSet):
                     bench_res.dataset_list.append(result_value)
-                    set_xarray_multidim(
-                        bench_res.ds[rv.name],
-                        worker_job.index_tuple,
-                        len(bench_res.dataset_list) - 1,
-                    )
+                    store_idx = len(bench_res.dataset_list) - 1
+                    if rv_arrays is not None:
+                        rv_arrays[rv.name][idx] = store_idx
+                    else:
+                        set_xarray_multidim(bench_res.ds[rv.name], idx, store_idx)
                 elif isinstance(rv, ResultReference):
                     bench_res.object_index.append(result_value)
-                    set_xarray_multidim(
-                        bench_res.ds[rv.name],
-                        worker_job.index_tuple,
-                        len(bench_res.object_index) - 1,
-                    )
+                    store_idx = len(bench_res.object_index) - 1
+                    if rv_arrays is not None:
+                        rv_arrays[rv.name][idx] = store_idx
+                    else:
+                        set_xarray_multidim(bench_res.ds[rv.name], idx, store_idx)
 
                 elif isinstance(rv, ResultVec):
                     if isinstance(result_value, (list, np.ndarray)):
                         if len(result_value) == rv.size:
                             for i in range(rv.size):
-                                set_xarray_multidim(
-                                    bench_res.ds[rv.index_name(i)],
-                                    worker_job.index_tuple,
-                                    result_value[i],
-                                )
+                                name = rv.index_name(i)
+                                if rv_arrays is not None:
+                                    rv_arrays[name][idx] = result_value[i]
+                                else:
+                                    set_xarray_multidim(bench_res.ds[name], idx, result_value[i])
 
                 else:
                     raise RuntimeError("Unsupported result type")


### PR DESCRIPTION
## Summary
- Hoist `partial()`, `title`, and `tag` out of the per-job loop in `calculate_benchmark_results()` — avoids recreating 500 identical objects per sweep
- Pre-fetch numpy array references for all result variables before the store loop, bypassing 500× xarray `Dataset.__getitem__` lookups (each triggering `_construct_dataarray`)
- Mark items 2.6 and 2.7 as DONE and update profiling baseline in PERFORMANCE_PLAN.md

## Measured improvement (500-job cache-hit sweep)

| Metric | Before | After | Change |
|---|---|---|---|
| `store_results` | 57ms | 16ms | **-72%** |
| `job_submission` | 26ms | 19ms | **-29%** |
| `job_execution` | 67ms | 24ms | **-65%** |
| **Total sweep time** | **159ms** | **103ms** | **-36%** |

## Test plan
- [x] `pixi run ci` — 1165 tests pass, pylint 10/10
- [x] Hash determinism preserved (`test_hash_persistent.py`)
- [x] Cache hit/miss counts unchanged (`test_sample_cache.py`)
- [x] cProfile confirms xarray `_construct_dataarray` eliminated from top-25 hotspots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize benchmark job execution and result storage by hoisting shared allocations and pre-caching result array references to reduce xarray overhead.

Enhancements:
- Add precomputation of numpy array views for result variables to avoid repeated xarray dataset lookups during result storage.
- Hoist benchmark title, tag, and worker partial construction out of the per-job loop in benchmark calculation.
- Wire precomputed result arrays through benchmark execution paths so both serial and non-serial executors write directly into cached numpy buffers.
- Update performance plan documentation with new post-optimization baselines and mark items 2.6, 2.7, 2.9, and 2.10 as completed.