### PR TITLE
ux: improve validation, error messages, and onboarding docs

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -114,6 +114,13 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     headless: bool = param.Boolean(False, doc="Run the benchmarks headlessly")
 
+    dry_run: bool = param.Boolean(
+        False,
+        doc="When True, plot_sweep() computes the sweep grid and logs a summary "
+        "(total combinations, parameter ranges, evaluation count) without "
+        "executing the benchmark function.",
+    )
+
     # ==================== CACHE PARAMETERS ====================
     # These parameters control caching behavior at both benchmark and sample level
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -83,6 +83,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
         nightly (bool): Run a more extensive set of tests for a nightly benchmark
         time_event (str): String representation of a sequence over time
         headless (bool): Run the benchmarks headlessly
+        dry_run (bool): Preview sweep grid without executing the benchmark function
         level (int): Method of defining the number of samples to sweep over
         run_tag (str): Tag for isolating cached results
         run_date (datetime): Date the benchmark run was performed

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import datetime
 from itertools import product, combinations
 
@@ -353,8 +354,6 @@ class Bench(BenchPlotServer):
         self.last_run_cfg = run_cfg
 
         if isinstance(input_vars_in, dict):
-            import warnings
-
             warnings.warn(
                 "Passing input_vars as a dict is deprecated. "
                 "Use a list of bn.sweep() specs instead.",

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -372,8 +372,6 @@ class Bench(BenchPlotServer):
             result_vars_in[i] = self.convert_vars_to_params(result_vars_in[i], "result", run_cfg)
 
         if not result_vars_in:
-            import warnings
-
             warnings.warn(
                 f"No result variables found for '{self.bench_name}'. "
                 "Define at least one result variable on your class "

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -466,8 +466,10 @@ class Bench(BenchPlotServer):
                 vals = iv.values()
                 n = len(vals)
                 total *= n
-                lo, hi = vals[0], vals[-1]
-                summary_parts.append(f"  {iv.name}: {n} values [{lo} .. {hi}]")
+                if n > 0:
+                    summary_parts.append(f"  {iv.name}: {n} values [{vals[0]} .. {vals[-1]}]")
+                else:
+                    summary_parts.append(f"  {iv.name}: 0 values")
             evals = total * run_cfg.repeats
             logging.info(
                 "Dry run for '%s':\n%s\n  Total: %d combinations x %d repeats = %d evaluations",

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -371,6 +371,17 @@ class Bench(BenchPlotServer):
         for i in range(len(result_vars_in)):
             result_vars_in[i] = self.convert_vars_to_params(result_vars_in[i], "result", run_cfg)
 
+        if not result_vars_in:
+            import warnings
+
+            warnings.warn(
+                f"No result variables found for '{self.bench_name}'. "
+                "Define at least one result variable on your class "
+                "(e.g., output = bn.ResultFloat()).",
+                UserWarning,
+                stacklevel=2,
+            )
+
         for r in result_vars_in:
             r_name = getattr(r, "name", str(r))
             logging.info("result var: %s", r_name)
@@ -451,6 +462,26 @@ class Bench(BenchPlotServer):
             agg_over_dims=agg_over_dims,
             agg_fn=agg_fn,
         )
+        if run_cfg.dry_run:
+            total = 1
+            summary_parts = []
+            for iv in input_vars_in:
+                vals = iv.values()
+                n = len(vals)
+                total *= n
+                lo, hi = vals[0], vals[-1]
+                summary_parts.append(f"  {iv.name}: {n} values [{lo} .. {hi}]")
+            evals = total * run_cfg.repeats
+            logging.info(
+                "Dry run for '%s':\n%s\n  Total: %d combinations x %d repeats = %d evaluations",
+                title,
+                "\n".join(summary_parts) if summary_parts else "  (no input vars)",
+                total,
+                run_cfg.repeats,
+                evals,
+            )
+            return BenchResult(bench_cfg)
+
         return self.run_sweep(bench_cfg, run_cfg, time_src, sample_order)
 
     @staticmethod

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -246,7 +246,16 @@ class ResultCollector:
             result_dict = result if isinstance(result, dict) else result.param.values()
 
             for rv in bench_res.bench_cfg.result_vars:
-                result_value = result_dict[rv.name]
+                try:
+                    result_value = result_dict[rv.name]
+                except KeyError:
+                    available = list(result_dict.keys())
+                    raise KeyError(
+                        f"Result variable '{rv.name}' was not set by the "
+                        f"benchmark function. Available keys: {available}. "
+                        f"Make sure your benchmark() method sets "
+                        f"self.{rv.name}."
+                    ) from None
                 if bench_run_cfg.print_bench_results:
                     logger.info(f"{rv.name}: {result_value}")
 

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -579,6 +579,12 @@ class FloatSweep(Number, SweepBase):
         """
         samps = self.samples
         if self.sample_values is None:
+            if self.sweep_bounds is None:
+                raise RuntimeError(
+                    "FloatSweep requires bounds or sample_values. "
+                    "Use FloatSweep(bounds=[lo, hi]) or "
+                    "FloatSweep(sample_values=[...])."
+                )
             if self.step is None:
                 return np.linspace(self.sweep_bounds[0], self.sweep_bounds[1], samps)
 

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from functools import partial
 from typing import Any
 from param import Parameter, Parameterized
@@ -223,6 +224,14 @@ class ParametrizedSweep(Parameterized):
             return self.get_results_values_as_dict()
         # Legacy path: subclass overrides __call__() and handles
         # update_params_from_kwargs + super().__call__() itself.
+        if type(self).__call__ is ParametrizedSweep.__call__:
+            warnings.warn(
+                f"{type(self).__name__} does not override benchmark(). "
+                "Results will contain only default values. "
+                "Define a benchmark() method on your class.",
+                UserWarning,
+                stacklevel=2,
+            )
         return self.get_results_values_as_dict()
 
     def benchmark(self):

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -78,6 +78,30 @@ backend = bn.StringSweep(["cpu", "gpu"])
 Use `IntSweep(bounds=(0, N))` when 0 means "feature absent" and 1+ controls magnitude
 (e.g., number of retries, repeat count, number of threads).
 
+## The Level System
+
+Instead of specifying `samples` on each sweep variable, you can use the `level`
+parameter to control sampling density globally with a single knob:
+
+| Level | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+|---|---|---|---|---|---|---|---|
+| Samples per dimension | 1 | 2 | 3 | 5 | 9 | 17 | 33 |
+
+Higher levels reuse all lower-level samples (binary subdivision), so cached results
+carry over automatically. Start low for quick iteration, increase for publication
+quality:
+
+```python
+# Quick check — 2 samples per dimension
+bn.run(example_benchmark, level=2)
+
+# Publication quality — 9 samples per dimension
+bn.run(example_benchmark, level=5)
+```
+
+See [Concepts: The Level System](concepts.md#the-level-system) for the full formula
+and theory.
+
 ## Result Types
 
 | Type | Use for | Set to |
@@ -149,6 +173,20 @@ bench.plot_sweep(
 
 ## Run Configuration
 
+`BenchRunCfg` has many options, but you rarely need more than a few:
+
+| Parameter | Default | What it does |
+|---|---|---|
+| `level` | 0 | Sampling density per dimension (see Level System above) |
+| `repeats` | 1 | How many times to evaluate each combination |
+| `cache_samples` | False | Cache individual results across runs (resume interrupted sweeps) |
+| `cache_results` | False | Cache the entire sweep result (skip re-runs with same inputs) |
+| `over_time` | False | Track results across multiple runs for time-series analysis |
+| `headless` | False | Skip opening a browser to display results |
+
+All other parameters have sensible defaults. See `BenchRunCfg`'s docstring for the
+full reference.
+
 ```python
 def example_foo(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     run_cfg.cache_results = False   # disable for file-based / non-deterministic results
@@ -205,6 +243,29 @@ class ImageBench(bn.ParametrizedSweep):
 - Accept `run_cfg: bn.BenchRunCfg | None = None`
 - Return the `bn.Bench` instance
 - Use `bn.run(example_func)` in `__main__`
+
+## Aggregating Dimensions
+
+When sweeping many dimensions, the visualizations can become unwieldy. Use the
+`aggregate` parameter on `plot_sweep()` to collapse dimensions into summary
+statistics (mean, std, etc.):
+
+```python
+bench.plot_sweep(
+    "Aggregated view",
+    input_vars=["x", "y", "method"],
+    result_vars=["elapsed"],
+    aggregate=True,          # collapse all dimensions except the first
+    # aggregate=2,           # collapse the last 2 dimensions
+    # aggregate=["method"],  # collapse only the "method" dimension
+    agg_fn="mean",           # aggregation function: mean, sum, max, min, median
+)
+```
+
+- `aggregate=True` — collapse all dimensions except the first into a single
+  aggregated statistic
+- `aggregate=N` (int) — collapse the last N dimensions
+- `aggregate=["var1", "var2"]` — collapse only the named dimensions
 
 ## Common Mistakes
 

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -183,6 +183,7 @@ bench.plot_sweep(
 | `cache_results` | False | Cache the entire sweep result (skip re-runs with same inputs) |
 | `over_time` | False | Track results across multiple runs for time-series analysis |
 | `headless` | False | Skip opening a browser to display results |
+| `dry_run` | False | Log the sweep grid summary without executing the benchmark |
 
 All other parameters have sensible defaults. See `BenchRunCfg`'s docstring for the
 full reference.


### PR DESCRIPTION
## Summary

- **Defensive validation**: FloatSweep raises clear error on missing bounds, result_collector shows expected vs available keys on KeyError, warns when `benchmark()` is not overridden or no result variables are found
- **Dry-run mode**: `BenchRunCfg(dry_run=True)` previews the sweep grid (parameter ranges, total evaluations) without executing
- **Documentation**: Added level system quick-reference, BenchRunCfg getting-started table, and `aggregate` parameter docs to `how_to_use_bencher.md`

## Test plan

- [ ] `pixi run ci` passes (1 pre-existing `test_timeline` hash mismatch excluded)
- [ ] `pixi run python bencher/example/example_simple_float.py` works unchanged
- [ ] `FloatSweep()` without bounds raises clear `RuntimeError` at `.values()` time
- [ ] Typo in result variable name produces helpful `KeyError` with available keys
- [ ] `ParametrizedSweep` subclass without `benchmark()` emits warning
- [ ] `BenchRunCfg(dry_run=True)` logs sweep summary without executing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen sweep validation and configurability, improve user feedback during benchmarking, and expand documentation for core concepts and configuration options.

New Features:
- Add a dry-run mode to BenchRunCfg that computes and logs sweep grid summaries without executing benchmarks.

Bug Fixes:
- Raise a clear runtime error when FloatSweep is used without bounds or explicit sample values.
- Provide a descriptive KeyError when benchmark results omit a declared result variable, including available keys.

Enhancements:
- Warn when no result variables are found for a bench, guiding users to define at least one result metric.
- Warn when a ParametrizedSweep subclass does not override benchmark(), indicating that only default result values will be produced.

Documentation:
- Document the level system with a quick-reference table and examples.
- Add a BenchRunCfg quick-start table covering the most commonly used run configuration parameters.
- Document the aggregate parameter on plot_sweep(), including usage patterns and aggregation options.