### PR TITLE
fix: coerce sweep bounds/values to declared type

### DIFF
--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -483,10 +483,10 @@ class IntSweep(Integer, SweepBase):
                 self.samples = samples
             self.sample_values = None
         else:
-            self.sample_values = sample_values
+            self.sample_values = [int(v) for v in sample_values]
             self.samples = len(self.sample_values)
             if "default" not in params:
-                self.default = sample_values[0]
+                self.default = self.sample_values[0]
 
     def _coerce_bound(self, value):
         return int(value)
@@ -704,8 +704,8 @@ def p(
 def with_level(arr: list, level: int) -> list:
     """Apply level-based sampling to a list of values.
 
-    This function uses an IntSweep with the provided values and applies level-based
-    sampling to it, returning the resulting values.
+    Uses the same level→sample-count table as SweepBase.with_level and picks
+    evenly spaced items from *arr* by index.
 
     Args:
         arr (list): list of values to sample from
@@ -714,5 +714,7 @@ def with_level(arr: list, level: int) -> list:
     Returns:
         list: The level-sampled values
     """
-    return IntSweep(sample_values=arr).with_level(level).values()
-    # return tmp.with_sample_values(arr).with_level(level).values()
+    assert level >= 1
+    level_samples = [0, 1, 2, 3, 5, 9, 17, 33, 65, 129, 257, 513, 1025, 2049]
+    n = level_samples[min(12, level)]
+    return SweepBase.indices_to_samples(None, n, list(arr))

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -468,7 +468,7 @@ class IntSweep(Integer, SweepBase):
         # Redirect bounds -> softbounds so param doesn't hard-enforce them
         user_bounds = params.pop("bounds", None)
         if user_bounds is not None:
-            params["softbounds"] = user_bounds
+            params["softbounds"] = (int(user_bounds[0]), int(user_bounds[1]))
         Integer.__init__(self, **params)
 
         self.units = units
@@ -478,7 +478,7 @@ class IntSweep(Integer, SweepBase):
             if samples is None:
                 if self.sweep_bounds is None:
                     raise RuntimeError("You must define bounds for integer types")
-                self.samples = 1 + self.sweep_bounds[1] - self.sweep_bounds[0]
+                self.samples = int(1 + self.sweep_bounds[1] - self.sweep_bounds[0])
             else:
                 self.samples = samples
             self.sample_values = None
@@ -487,6 +487,9 @@ class IntSweep(Integer, SweepBase):
             self.samples = len(self.sample_values)
             if "default" not in params:
                 self.default = sample_values[0]
+
+    def _coerce_bound(self, value):
+        return int(value)
 
     def values(self) -> list[int]:
         """Return all the values for the parameter sweep.
@@ -553,20 +556,25 @@ class FloatSweep(Number, SweepBase):
         # Redirect bounds -> softbounds so param doesn't hard-enforce them
         user_bounds = params.pop("bounds", None)
         if user_bounds is not None:
-            params["softbounds"] = user_bounds
+            params["softbounds"] = (float(user_bounds[0]), float(user_bounds[1]))
         Number.__init__(self, step=step, **params)
 
         self.units = units
         self.optimize = optimize
 
-        self.sample_values = sample_values
+        self.sample_values = (
+            [float(v) for v in sample_values] if sample_values is not None else None
+        )
 
         if sample_values is None:
             self.samples = samples
         else:
             self.samples = len(self.sample_values)
             if "default" not in params:
-                self.default = sample_values[0]
+                self.default = self.sample_values[0]
+
+    def _coerce_bound(self, value):
+        return float(value)
 
     def values(self) -> list[float]:
         """Return all the values for the parameter sweep.
@@ -588,7 +596,7 @@ class FloatSweep(Number, SweepBase):
             if self.step is None:
                 return np.linspace(self.sweep_bounds[0], self.sweep_bounds[1], samps)
 
-            return np.arange(self.sweep_bounds[0], self.sweep_bounds[1], self.step)
+            return np.arange(self.sweep_bounds[0], self.sweep_bounds[1], self.step, dtype=float)
         return self.sample_values
 
 

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -150,6 +150,10 @@ class SweepBase(param.Parameter):
             output.step = None  # pylint: disable = attribute-defined-outside-init
         return output
 
+    def _coerce_bound(self, value):
+        """Override in subclasses to coerce bound values to the correct type."""
+        return value
+
     def with_bounds(self, low: float, high: float, samples: int | None = None) -> SweepBase:
         """Create a copy with overridden sweep bounds (and optionally sample count).
 
@@ -166,6 +170,7 @@ class SweepBase(param.Parameter):
         """
         if low >= high:
             raise ValueError(f"low must be less than high, got low={low}, high={high}")
+        low, high = self._coerce_bound(low), self._coerce_bound(high)
         output = deepcopy(self)
         if hasattr(output, "softbounds"):
             output.softbounds = (low, high)  # pylint: disable=attribute-defined-outside-init

--- a/test/test_sweep_type_coercion.py
+++ b/test/test_sweep_type_coercion.py
@@ -1,0 +1,63 @@
+"""Tests that FloatSweep always returns floats and IntSweep always returns ints,
+regardless of the Python types passed for bounds or sample_values."""
+
+import numpy as np
+
+from bencher.variables.inputs import FloatSweep, IntSweep
+
+
+class TestFloatSweepTypeCoercion:
+    def test_int_bounds_linspace_returns_float(self):
+        vals = FloatSweep(bounds=[0, 5], samples=6).values()
+        assert all(isinstance(v, (float, np.floating)) for v in vals)
+
+    def test_int_bounds_arange_returns_float(self):
+        vals = FloatSweep(bounds=[0, 5], step=1).values()
+        assert all(isinstance(v, (float, np.floating)) for v in vals)
+
+    def test_mixed_bounds_coerced_to_float(self):
+        fs = FloatSweep(bounds=[0, 5.0])
+        assert all(isinstance(b, float) for b in fs.softbounds)
+
+    def test_all_int_bounds_coerced_to_float(self):
+        fs = FloatSweep(bounds=[0, 5])
+        assert all(isinstance(b, float) for b in fs.softbounds)
+
+    def test_int_sample_values_returned_as_float(self):
+        vals = FloatSweep(sample_values=[0, 1, 2]).values()
+        assert all(isinstance(v, float) for v in vals)
+
+    def test_with_bounds_int_args_stored_as_float(self):
+        fs = FloatSweep(bounds=[0.0, 5.0], samples=3).with_bounds(0, 10, 3)
+        assert all(isinstance(b, float) for b in fs.softbounds)
+        assert all(isinstance(v, (float, np.floating)) for v in fs.values())
+
+    def test_default_from_int_sample_values_is_float(self):
+        fs = FloatSweep(sample_values=[0, 1, 2])
+        assert isinstance(fs.default, float)
+
+
+class TestIntSweepTypeCoercion:
+    def test_float_bounds_do_not_crash(self):
+        vals = IntSweep(bounds=[0.0, 5.0]).values()
+        assert all(isinstance(v, (int, np.integer)) for v in vals)
+
+    def test_non_numeric_sample_values_preserved(self):
+        """IntSweep is used as a generic index-based selector (e.g. with_level),
+        so sample_values must not be coerced."""
+        vals = IntSweep(sample_values=["a", "b", "c"]).values()
+        assert vals == ["a", "b", "c"]
+
+    def test_float_sample_values_preserved(self):
+        """Float sample_values passed to IntSweep for index-based subsampling
+        must not be truncated to int."""
+        vals = IntSweep(sample_values=[0.2, 0.5, 1.0]).values()
+        assert vals == [0.2, 0.5, 1.0]
+
+    def test_with_bounds_float_args_stored_as_int(self):
+        ints = IntSweep(bounds=[0, 5]).with_bounds(0.0, 10.0)
+        assert all(isinstance(b, int) for b in ints.softbounds)
+
+    def test_samples_count_is_int_with_float_bounds(self):
+        ints = IntSweep(bounds=[0.0, 5.0])
+        assert isinstance(ints.samples, int)

--- a/test/test_sweep_type_coercion.py
+++ b/test/test_sweep_type_coercion.py
@@ -42,17 +42,10 @@ class TestIntSweepTypeCoercion:
         vals = IntSweep(bounds=[0.0, 5.0]).values()
         assert all(isinstance(v, (int, np.integer)) for v in vals)
 
-    def test_non_numeric_sample_values_preserved(self):
-        """IntSweep is used as a generic index-based selector (e.g. with_level),
-        so sample_values must not be coerced."""
-        vals = IntSweep(sample_values=["a", "b", "c"]).values()
-        assert vals == ["a", "b", "c"]
-
-    def test_float_sample_values_preserved(self):
-        """Float sample_values passed to IntSweep for index-based subsampling
-        must not be truncated to int."""
-        vals = IntSweep(sample_values=[0.2, 0.5, 1.0]).values()
-        assert vals == [0.2, 0.5, 1.0]
+    def test_float_sample_values_coerced_to_int(self):
+        vals = IntSweep(sample_values=[1.0, 2.0, 3.0]).values()
+        assert all(isinstance(v, (int, np.integer)) for v in vals)
+        assert vals == [1, 2, 3]
 
     def test_with_bounds_float_args_stored_as_int(self):
         ints = IntSweep(bounds=[0, 5]).with_bounds(0.0, 10.0)


### PR DESCRIPTION
## Summary

- **FloatSweep** now coerces bounds to `float` and sample_values to `float`, so `FloatSweep(bounds=[0, 5], step=1)` always returns float64 values instead of int64
- **IntSweep** now coerces bounds to `int`, sample_values to `int`, and the derived `self.samples` count to `int`, fixing a crash when float bounds were passed (e.g. `IntSweep(bounds=[0.0, 5.0])`)
- Added `_coerce_bound()` hook on `SweepBase` (used by `with_bounds()`) so subclasses enforce their type at every entry point
- Decoupled `with_level()` from `IntSweep` — it was misusing IntSweep as a generic index-based selector; now calls `SweepBase.indices_to_samples` directly

## Test plan

- [x] 11 new tests in `test/test_sweep_type_coercion.py` covering all bug scenarios
- [x] Full test suite passes (1176 passed, 0 failed)
- [x] Lint + format clean (pylint 10/10, ruff clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)