### PR TITLE
perf: speed up RTD docs build

### DIFF
--- a/bencher/example/generated/cartesian_animation/example_cartesian_animation.py
+++ b/bencher/example/generated/cartesian_animation/example_cartesian_animation.py
@@ -87,4 +87,4 @@ def example_cartesian_animation(run_cfg: bn.BenchRunCfg | None = None) -> bn.Ben
 
 
 if __name__ == "__main__":
-    bn.run(example_cartesian_animation, level=4, cache_samples=False)
+    bn.run(example_cartesian_animation, level=3, cache_samples=False)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import bencher as bn
@@ -71,9 +72,9 @@ def _take_thumbnail(
 
     def _screenshot_with(pg) -> bytes:
         pg.set_viewport_size({"width": width, "height": height})
-        pg.goto(html_path.resolve().as_uri(), wait_until="load", timeout=15000)
-        # Brief pause for Bokeh/Panel JS to render plots after DOM load
-        pg.wait_for_timeout(2000)
+        pg.goto(html_path.resolve().as_uri(), wait_until="networkidle", timeout=15000)
+        # Brief pause for Bokeh/Panel JS to render plots after network settles
+        pg.wait_for_timeout(500)
         return pg.screenshot()
 
     if page is not None:
@@ -206,6 +207,7 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path, pag
         run_cfg.over_time = True
     optimise = run_kwargs.get("optimise", 0)
     print(f"Running {py_file}...")
+    t_exec_start = time.perf_counter()
     bench = example_fn(run_cfg)
 
     if optimise and bench.results:
@@ -221,14 +223,18 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path, pag
         directory=str(report_dir),
         in_html_folder=False,
     )
-    print(f"  Saved report to {report_path}")
+    exec_elapsed = time.perf_counter() - t_exec_start
+    print(f"  Saved report to {report_path} ({exec_elapsed:.1f}s)")
 
     # Generate thumbnail screenshot
     thumb_path = THUMBS_EXTRA_DIR / rel.parent / f"{stem}.png"
+    t_thumb_start = time.perf_counter()
     try:
         _take_thumbnail(Path(report_path), thumb_path, page=page)
-        print(f"  Saved thumbnail to {thumb_path}")
+        thumb_elapsed = time.perf_counter() - t_thumb_start
+        print(f"  Saved thumbnail to {thumb_path} ({thumb_elapsed:.1f}s)")
     except Exception as e:  # pylint: disable=broad-except
+        thumb_elapsed = time.perf_counter() - t_thumb_start
         print(f"  WARNING: Failed to save thumbnail for {stem}: {e}")
 
     # Generate RST that shows source + embeds HTML report
@@ -258,6 +264,8 @@ def run_example_and_save(py_file: Path, docs_dir: Path, generated_dir: Path, pag
         "section_rel": str(rel.parent),
         "rst_rel": str(rel.with_suffix("").as_posix()),
         "bench_name": bench.bench_name,
+        "exec_s": exec_elapsed,
+        "thumb_s": thumb_elapsed,
     }
 
 
@@ -523,8 +531,28 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
     print(f"  Generated gallery page: {gallery_path}")
 
 
+def _print_timing_summary(examples_metadata: list[dict]) -> None:
+    """Print a summary of example execution and thumbnail times, sorted by total duration."""
+    timed = [(m["exec_s"] + m["thumb_s"], m) for m in examples_metadata if "exec_s" in m]
+    timed.sort(reverse=True)
+    total_exec = sum(m["exec_s"] for m in examples_metadata if "exec_s" in m)
+    total_thumb = sum(m["thumb_s"] for m in examples_metadata if "thumb_s" in m)
+    print(f"\n{'=' * 70}")
+    print(f"Timing summary: {len(timed)} examples")
+    print(f"  Total execution+save: {total_exec:.1f}s")
+    print(f"  Total thumbnails:     {total_thumb:.1f}s")
+    print(f"  Combined:             {total_exec + total_thumb:.1f}s")
+    print("\nTop 15 slowest (exec+thumb):")
+    for total_s, m in timed[:15]:
+        print(
+            f"  {total_s:6.2f}s  (exec {m['exec_s']:.1f}s + thumb {m['thumb_s']:.1f}s)  {m['stem']}"
+        )
+    print(f"{'=' * 70}\n")
+
+
 def generate_all() -> list[Path]:
     """Generate Python examples, run them, save HTML reports, generate RST for docs."""
+    t_all_start = time.perf_counter()
     # Clean output directories
     if META_DOCS_DIR.exists():
         shutil.rmtree(META_DOCS_DIR)
@@ -680,6 +708,9 @@ def generate_all() -> list[Path]:
 {entries_str}
 """
     (META_DOCS_DIR / "index.rst").write_text(meta_index, encoding="utf-8")
+
+    _print_timing_summary(examples_metadata)
+    print(f"Total generate_all() time: {time.perf_counter() - t_all_start:.1f}s")
 
     return sorted(META_DOCS_DIR.rglob("*.rst"))
 

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -534,9 +534,7 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
 def _print_timing_summary(examples_metadata: list[dict]) -> None:
     """Print a summary of example execution and thumbnail times, sorted by total duration."""
     timed = [
-        (m.get("exec_s", 0) + m.get("thumb_s", 0), m)
-        for m in examples_metadata
-        if "exec_s" in m
+        (m.get("exec_s", 0) + m.get("thumb_s", 0), m) for m in examples_metadata if "exec_s" in m
     ]
     timed.sort(key=lambda x: x[0], reverse=True)
     total_exec = sum(m["exec_s"] for m in examples_metadata if "exec_s" in m)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -533,8 +533,12 @@ def generate_gallery_page(examples_metadata: list[dict], docs_dir: Path):
 
 def _print_timing_summary(examples_metadata: list[dict]) -> None:
     """Print a summary of example execution and thumbnail times, sorted by total duration."""
-    timed = [(m["exec_s"] + m["thumb_s"], m) for m in examples_metadata if "exec_s" in m]
-    timed.sort(reverse=True)
+    timed = [
+        (m.get("exec_s", 0) + m.get("thumb_s", 0), m)
+        for m in examples_metadata
+        if "exec_s" in m
+    ]
+    timed.sort(key=lambda x: x[0], reverse=True)
     total_exec = sum(m["exec_s"] for m in examples_metadata if "exec_s" in m)
     total_thumb = sum(m["thumb_s"] for m in examples_metadata if "thumb_s" in m)
     print(f"\n{'=' * 70}")

--- a/bencher/example/meta/generate_meta_cartesian_animation.py
+++ b/bencher/example/meta/generate_meta_cartesian_animation.py
@@ -113,7 +113,7 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             class_code=class_code,
-            run_kwargs={"level": 4, "cache_samples": False},
+            run_kwargs={"level": 3, "cache_samples": False},
         )
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -138,7 +138,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -295,7 +295,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5c/ad/6c4395649a212a6c603a72c5b9ab5dce3135a1546cfdffa3c427e71fd535/sqlalchemy-2.0.48-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/90/1e/410dd499c039deacff395eec01a9da057125fcd0c97e3badc252c6a2d6a7/sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -454,7 +454,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/21/dd/3b7c53f1dbbf736fd27041aee68f8ac52226b610f914085b1652c2323442/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/61/0722511d98c54de95acb327824cb759e8653789af2b1944ab1cc69d32565/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -611,7 +611,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/9a/0c28b6371e0cdcb14f8f1930778cb3123acfcbd2c95bb9cf6b4a2ba0cce3/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -767,7 +767,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
@@ -4097,10 +4097,10 @@ packages:
   name: sortedcontainers
   version: 2.4.0
   sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
-- pypi: https://files.pythonhosted.org/packages/21/dd/3b7c53f1dbbf736fd27041aee68f8ac52226b610f914085b1652c2323442/sqlalchemy-2.0.48-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
-  version: 2.0.48
-  sha256: 6f7b7243850edd0b8b97043f04748f31de50cf426e939def5c16bedb540698f7
+  version: 2.0.49
+  sha256: 3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672
   requires_dist:
   - importlib-metadata ; python_full_version < '3.8'
   - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
@@ -4135,10 +4135,10 @@ packages:
   - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/37/9a/0c28b6371e0cdcb14f8f1930778cb3123acfcbd2c95bb9cf6b4a2ba0cce3/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/90/1e/410dd499c039deacff395eec01a9da057125fcd0c97e3badc252c6a2d6a7/sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
-  version: 2.0.48
-  sha256: 34634e196f620c7a61d18d5cf7dc841ca6daa7961aed75d532b7e58b309ac894
+  version: 2.0.49
+  sha256: 6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1
   requires_dist:
   - importlib-metadata ; python_full_version < '3.8'
   - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
@@ -4173,10 +4173,10 @@ packages:
   - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/5c/ad/6c4395649a212a6c603a72c5b9ab5dce3135a1546cfdffa3c427e71fd535/sqlalchemy-2.0.48-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/b1/61/0722511d98c54de95acb327824cb759e8653789af2b1944ab1cc69d32565/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
-  version: 2.0.48
-  sha256: 10853a53a4a00417a00913d270dddda75815fcb80675874285f41051c094d7dd
+  version: 2.0.49
+  sha256: 4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536
   requires_dist:
   - importlib-metadata ; python_full_version < '3.8'
   - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
@@ -4211,10 +4211,10 @@ packages:
   - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
   - sqlcipher3-binary ; extra == 'sqlcipher'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
-  version: 2.0.48
-  sha256: b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed
+  version: 2.0.49
+  sha256: 47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3
   requires_dist:
   - importlib-metadata ; python_full_version < '3.8'
   - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'


### PR DESCRIPTION
## Summary
- Reduce Playwright screenshot wait from 2000ms to 500ms per example, using `wait_until="networkidle"` instead of `"load"` — saves ~228s on RTD builds (1.5s × 152 examples)
- Cap cartesian_animation level from 4 to 3 — was the single slowest example at 13.8s producing a 16MB HTML file
- Add per-example timing instrumentation with a sorted summary printed at the end of `generate_all()` for ongoing visibility

## Profiling data

Measured locally (no Playwright): **80.2s total** across 152 examples.

| Bucket | Count |
|--------|-------|
| < 0.5s | 118 |
| 0.5–1s | 18 |
| 1–2s | 9 |
| 2–5s | 5 |
| 5–10s | 1 |
| > 10s | 1 (cartesian_animation at 13.8s) |

The screenshot wait (2s × 152 = ~304s) was **4× the execution time** on RTD — the dominant bottleneck.

## Test plan
- [x] `pixi run ci` passes (1177 passed, 3 pre-existing file_server flakes)
- [ ] Verify RTD build completes successfully with timing summary in logs
- [ ] Spot-check thumbnails on built docs still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize example gallery docs generation performance and add timing visibility for RTD builds.

Enhancements:
- Reduce Playwright thumbnail capture wait time and rely on network idle detection to speed up screenshot generation.
- Cap the cartesian animation example complexity to lower its runtime and output size.
- Instrument example execution and thumbnail generation with per-example timing data and a consolidated timing summary for generate_all().