### PR TITLE
fix: use random port instead of port=0 to avoid EADDRINUSE on Linux 6.x

### DIFF
--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
+import random
+import socket
 from pathlib import Path
 from threading import Thread
 
@@ -106,6 +108,26 @@ class BenchPlotServer:
             "This benchmark name does not exist in the results cache. Was not able to load the results to plot!  Make sure to run the bencher to generate and save results to the cache"
         )
 
+    @staticmethod
+    def _find_free_port() -> int:
+        """Find a free port by testing random ports in the dynamic/private range.
+
+        Using ``port=0`` with Tornado/Bokeh can fail on some Linux kernels
+        (notably 6.x) because the kernel deterministically assigns the same
+        ephemeral port, causing ``EADDRINUSE`` when a previous server is
+        still running.  Picking a random port from the IANA dynamic range
+        (49152-65535) avoids this.
+        """
+        for _ in range(100):
+            port = random.randint(49152, 65535)
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.bind(("0.0.0.0", port))
+                    return port
+            except OSError:
+                continue
+        raise RuntimeError("Could not find a free port after 100 attempts")
+
     def serve(
         self,
         bench_name: str,
@@ -128,6 +150,9 @@ class BenchPlotServer:
 
         extra = self._rrd_extra_patterns()
 
+        if port is None:
+            port = self._find_free_port()
+
         serve_kwargs = dict(
             title=bench_name,
             threaded=True,
@@ -135,7 +160,7 @@ class BenchPlotServer:
             address="0.0.0.0",
             websocket_origin=["*"],
             extra_patterns=extra,
-            port=port if port is not None else 0,
+            port=port,
         )
 
         return pn.serve(plots_instance, **serve_kwargs)

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import random
@@ -16,6 +17,11 @@ from tornado.web import StaticFileHandler
 from bencher.bench_cfg import BenchCfg, BenchPlotSrvCfg
 
 logging.basicConfig(level=logging.INFO)
+
+# IANA dynamic/private port range used by _find_free_port()
+_PORT_RANGE_MIN = 49152
+_PORT_RANGE_MAX = 65535
+_PORT_PROBE_ATTEMPTS = 100
 
 
 class _CorsStaticHandler(StaticFileHandler):
@@ -116,17 +122,24 @@ class BenchPlotServer:
         (notably 6.x) because the kernel deterministically assigns the same
         ephemeral port, causing ``EADDRINUSE`` when a previous server is
         still running.  Picking a random port from the IANA dynamic range
-        (49152-65535) avoids this.
+        avoids this.
+
+        Note: there is an inherent TOCTOU race between probing the port here
+        and the actual ``bind()`` inside Panel/Bokeh.  In practice the window
+        is very small and the random selection makes collisions unlikely, but
+        callers should be prepared for a rare ``OSError`` on server start.
         """
-        for _ in range(100):
-            port = random.randint(49152, 65535)
+        for _ in range(_PORT_PROBE_ATTEMPTS):
+            port = random.randint(_PORT_RANGE_MIN, _PORT_RANGE_MAX)
             try:
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                     s.bind(("0.0.0.0", port))
                     return port
-            except OSError:
-                continue
-        raise RuntimeError("Could not find a free port after 100 attempts")
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    continue
+                raise
+        raise RuntimeError(f"Could not find a free port after {_PORT_PROBE_ATTEMPTS} attempts")
 
     def serve(
         self,

--- a/bencher/example/example_rerun.py
+++ b/bencher/example/example_rerun.py
@@ -22,4 +22,3 @@ def example_rerun(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
 if __name__ == "__main__":
     bn.run(example_rerun, show=True, save=True)
-    # example_rerun(bn.BenchRunCfg(level=3)).report.show()


### PR DESCRIPTION
## Summary
- On Linux 6.x kernels, `port=0` (ask the OS for an ephemeral port) deterministically returns the **same port** every time, causing `OSError: [Errno 98] Address already in use` when a previous bencher server is still running or when progressive runs start multiple servers in one process
- Replaces `port=0` with `_find_free_port()` that picks a random port from the IANA dynamic range (49152–65535) and probes it for availability before passing it to Panel/Bokeh
- The existing `test_serve_parallel_no_port_conflict` test now passes cleanly without the background thread exception warning

## Test plan
- [x] `test_serve_auto_port` passes in isolation
- [x] `test_serve_parallel_no_port_conflict` passes without `PytestUnhandledThreadExceptionWarning`
- [x] `test_plot_server_port` (explicit port) still works
- [ ] Manual: run any `bn.run(fn)` example twice simultaneously — second instance should get a different port

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Use a randomly selected free port instead of relying on port=0 to avoid address-in-use errors when starting the bench plot server on affected Linux kernels.

Bug Fixes:
- Prevent EADDRINUSE errors on Linux 6.x by probing and selecting an available random port when no explicit port is provided.

Enhancements:
- Introduce a helper to find a free port within the IANA dynamic/private range and integrate it into the bench plot server startup logic.