### PR TITLE
fix: add type hints and error handling to extra_panels

### DIFF
--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Any, Literal
+from collections.abc import Callable
 import logging
 import panel as pn
 from param import Parameter
@@ -208,7 +209,7 @@ class BenchResult(
             row.append(pn.pane.Markdown("No Plotters are able to represent these results"))
         return row.pane
 
-    def to_auto_plots(self, extra_panels=None, **kwargs) -> pn.panel:
+    def to_auto_plots(self, extra_panels: list[Callable | Any] | None = None, **kwargs) -> pn.panel:
         """Given the dataset result of a benchmark run, automatically deduce how to plot the data based on the types of variables that were sampled.
 
         Args:
@@ -225,8 +226,12 @@ class BenchResult(
 
         # --- Extra panels (user-injected) ---
         if extra_panels:
-            for panel in extra_panels:
-                plot_cols.append(panel(self) if callable(panel) else panel)
+            for ep in extra_panels:
+                try:
+                    plot_cols.append(ep(self) if callable(ep) else ep)
+                except Exception:  # pylint: disable=broad-except
+                    name = getattr(ep, "__name__", repr(ep))
+                    logging.error("Extra panel %s failed", name, exc_info=True)
 
         # --- Dimension aggregation (orthogonal to over_time) ---
         if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -233,7 +233,10 @@ class BenchResult(
         if extra_panels:
             for ep in extra_panels:
                 try:
-                    plot_cols.append(ep(self) if callable(ep) else ep)
+                    if callable(ep):
+                        plot_cols.append(ep(self))
+                    else:
+                        plot_cols.append(ep)
                 except Exception:  # pylint: disable=broad-except
                     name = getattr(ep, "__name__", repr(ep))
                     logging.error("Extra panel %s failed", name, exc_info=True)

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Literal
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 import logging
 import panel as pn
 from param import Parameter
@@ -209,7 +209,12 @@ class BenchResult(
             row.append(pn.pane.Markdown("No Plotters are able to represent these results"))
         return row.pane
 
-    def to_auto_plots(self, extra_panels: list[Callable | Any] | None = None, **kwargs) -> pn.panel:
+    def to_auto_plots(
+        self,
+        extra_panels: Sequence[Callable[[BenchResult], pn.viewable.Viewable] | pn.viewable.Viewable]
+        | None = None,
+        **kwargs,
+    ) -> pn.panel:
         """Given the dataset result of a benchmark run, automatically deduce how to plot the data based on the types of variables that were sampled.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,6 +233,8 @@ not-iterable = "ignore"
 no-matching-overload = "ignore"
 # Ignore call-non-callable errors
 call-non-callable = "ignore"
+# Ignore call-top-callable errors (callable() guard + call on union types)
+call-top-callable = "ignore"
 # Ignore method override errors
 invalid-method-override = "ignore"
 # Ignore import/reference resolution errors

--- a/test/test_extra_panels.py
+++ b/test/test_extra_panels.py
@@ -63,9 +63,13 @@ class TestExtraPanels(unittest.TestCase):
             raise RuntimeError("boom")
 
         # Should not raise; the error is logged and skipped.
-        plots = res.to_auto_plots(extra_panels=[bad_panel])
+        with self.assertLogs(level="ERROR") as cm:
+            plots = res.to_auto_plots(extra_panels=[bad_panel])
+
         # The broken panel is omitted, but the rest of the output is still produced.
         self.assertGreater(len(plots), 0)
+        # Verify the error was actually logged.
+        self.assertTrue(any("bad_panel" in msg for msg in cm.output))
 
     def test_extra_panels_in_plot_callback(self):
         """extra_panels works when used inside a named plot_callbacks function."""

--- a/test/test_extra_panels.py
+++ b/test/test_extra_panels.py
@@ -55,6 +55,18 @@ class TestExtraPanels(unittest.TestCase):
         # Should be before the last element (post_description)
         self.assertLess(idx, len(plots) - 1)
 
+    def test_extra_panels_callable_error_is_caught(self):
+        """A failing callable logs the error and does not crash to_auto_plots."""
+        res = self._make_result()
+
+        def bad_panel(_bench_res):
+            raise RuntimeError("boom")
+
+        # Should not raise; the error is logged and skipped.
+        plots = res.to_auto_plots(extra_panels=[bad_panel])
+        # The broken panel is omitted, but the rest of the output is still produced.
+        self.assertGreater(len(plots), 0)
+
     def test_extra_panels_in_plot_callback(self):
         """extra_panels works when used inside a named plot_callbacks function."""
         res = self._make_result()


### PR DESCRIPTION
## Summary
- Type-annotate the `extra_panels` parameter on `to_auto_plots()` (`list[Callable | Any] | None`)
- Wrap each extra panel callback in try/except so a single failing callable logs the error instead of crashing the entire plot output
- Add test for the new error-handling behavior

Follow-up to #846.

## Test plan
- [x] New test `test_extra_panels_callable_error_is_caught` verifies failing callbacks are caught
- [x] Existing extra_panels tests still pass
- [x] CI passes (1206 passed, 1 pre-existing unrelated failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve robustness and type safety of extra panels in automatic plot generation.

Bug Fixes:
- Prevent failures in individual extra panel callbacks from crashing to_auto_plots by catching and logging exceptions instead.

Enhancements:
- Add type annotations to the extra_panels parameter of to_auto_plots to clarify expected usage.

Tests:
- Add a regression test ensuring that errors in extra panel callables are caught, logged, and do not prevent other plots from being generated.