### PR TITLE
Add generic Publisher protocol for custom report publishing

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -128,7 +128,7 @@ from .results.bench_result import BenchResult
 from .results.optimize_result import OptimizeResult
 from .results.video_result import VideoResult
 from .results.holoview_results.holoview_result import ReduceType, HoloviewResult
-from .bench_report import BenchReport, GithubPagesCfg
+from .bench_report import BenchReport, GithubPagesCfg, Publisher
 from .job import Executors
 from .sweep_timings import SweepTimings
 from .video_writer import VideoWriter, add_image

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import html
 import logging
 import time
-from typing import Callable
+from typing import Callable, Protocol, runtime_checkable
 import os
 from pathlib import Path
 import tempfile
@@ -26,6 +26,20 @@ def _inline_rrd(html_path: Path) -> None:
         inline_rrd_iframes(html_path)
     except Exception:  # pylint: disable=broad-except
         logging.warning("inline_rrd_iframes failed for %s", html_path, exc_info=True)
+
+
+@runtime_checkable
+class Publisher(Protocol):
+    """Generic publisher protocol for benchmark reports.
+
+    Any object with a ``publish(report)`` method satisfies this protocol.
+    Downstream projects implement their own publishers (GCS, S3, etc.)
+    without modifying bencher.
+    """
+
+    def publish(self, report: "BenchReport") -> str | None:
+        """Publish a report. Returns the published URL, or None."""
+        ...
 
 
 @dataclass

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -39,7 +39,7 @@ class Publisher(Protocol):
 
     def publish(self, report: "BenchReport") -> str | None:
         """Publish a report. Returns the published URL, or None."""
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
 
 @dataclass

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -453,7 +453,9 @@ class BenchRunner:
                 report.publish_gh_pages(p.github_user, p.repo_name, p.folder_name, p.branch_name)
             elif isinstance(self.publisher, Publisher):
                 try:
-                    self.publisher.publish(report)
+                    url = self.publisher.publish(report)
+                    if url:
+                        logging.info("Benchmark report published at %s", url)
                 except Exception:  # pylint: disable=broad-except
                     logging.exception("Publisher.publish() failed — continuing benchmark")
             else:

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from bencher.bench_cfg import BenchRunCfg, BenchCfg
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.bencher import Bench
-from bencher.bench_report import BenchReport, GithubPagesCfg
+from bencher.bench_report import BenchReport, GithubPagesCfg, Publisher
 from copy import deepcopy
 
 
@@ -451,6 +451,11 @@ class BenchRunner:
             if isinstance(self.publisher, GithubPagesCfg):
                 p = self.publisher
                 report.publish_gh_pages(p.github_user, p.repo_name, p.folder_name, p.branch_name)
+            elif isinstance(self.publisher, Publisher):
+                try:
+                    self.publisher.publish(report)
+                except Exception:  # pylint: disable=broad-except
+                    logging.exception("Publisher.publish() failed — continuing benchmark")
             else:
                 report.publish(remote_callback=self.publisher, debug=debug)
         if show:

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -69,6 +69,7 @@ def run(
     show: bool = True,
     save: bool = False,
     publish: bool = False,
+    publisher: object | None = None,
     grouped: bool = False,
     cache_samples: bool | None = None,
     over_time: bool | None = None,
@@ -95,6 +96,9 @@ def run(
         show: Show results in browser. Defaults to True.
         save: Save results to disk. Defaults to False.
         publish: Publish results. Defaults to False.
+        publisher: An object conforming to the :class:`Publisher` protocol (i.e. has a
+            ``publish(report)`` method).  Passed to :class:`BenchRunner` and called
+            after each progressive iteration when *publish* is ``True``.
         grouped: Produce a single HTML page with all benchmarks. Defaults to False.
         cache_samples: Use sample cache for previous results. None (default) auto-enables
             for progressive runs. Pass False to disable even for progressive runs.
@@ -162,7 +166,7 @@ def run(
         target = _with_optimise
 
     # Case 1: Callable — wrap in BenchRunner
-    br = BenchRunner(target)
+    br = BenchRunner(target, publisher=publisher)
     try:
         results = br.run(
             level=level,

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -14,6 +14,7 @@ from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 if TYPE_CHECKING:
     from bencher.bencher import Bench
+    from bencher.bench_report import GithubPagesCfg, Publisher
 
 # Keep references to BenchRunners with active servers so that __del__ doesn't
 # kill the panel servers while the process is still running.
@@ -69,7 +70,7 @@ def run(
     show: bool = True,
     save: bool = False,
     publish: bool = False,
-    publisher: object | None = None,
+    publisher: Publisher | GithubPagesCfg | Callable | None = None,
     grouped: bool = False,
     cache_samples: bool | None = None,
     over_time: bool | None = None,

--- a/pixi.lock
+++ b/pixi.lock
@@ -1302,8 +1302,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.79.0
-  sha256: a5cb4503740edc607d380f70fd8d8cd176f725ee0cb522389c56661ce3f1dbe1
+  version: 1.80.0
+  sha256: 60712d78401a4b4c4ce6913bd6dc0c11b3202a13ff53087b5ea534a01fdc4928
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.79.0"
+version = "1.80.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Adds a `Publisher` runtime-checkable protocol to `bench_report.py` so downstream projects can implement custom report publishers (GCS, S3, etc.) without modifying bencher
- Extends `BenchRunner.show_publish()` to dispatch on the new protocol with graceful error handling (exceptions logged, benchmark continues)
- Adds `publisher` parameter to `bn.run()` and forwards it to `BenchRunner`

## Motivation
Currently `show_publish()` only supports git-based publishing (`GithubPagesCfg` or `remote_callback`). This makes it impossible for downstream projects to plug in alternative publishing backends (e.g. uploading to cloud storage) without modifying bencher itself.

The `Publisher` protocol is a single-method interface:
```python
class Publisher(Protocol):
    def publish(self, report: BenchReport) -> str | None: ...
```

## Usage
```python
class MyPublisher:
    def publish(self, report):
        # upload report somewhere
        return "https://example.com/report"

bn.run(my_benchmark, publisher=MyPublisher(), publish=True)
```

## Test plan
- [ ] Existing tests pass (no changes to existing behavior)
- [ ] `GithubPagesCfg` dispatch still works (checked before `Publisher` in isinstance chain)
- [ ] Legacy `remote_callback` fallback still works (else branch unchanged)
- [ ] Publisher exceptions are caught and logged without interrupting benchmarks

## Summary by Sourcery

Introduce a generic publisher protocol and wiring to allow custom benchmark report publishing backends.

New Features:
- Add a runtime-checkable Publisher protocol for benchmark reports to support pluggable publishing backends.
- Extend the public run() API with an optional publisher parameter that is forwarded to BenchRunner for use during publishing.

Enhancements:
- Update BenchRunner.show_publish() to dispatch to Publisher implementations with error logging while preserving existing GithubPagesCfg and remote_callback behavior.