### PR TITLE
Recover gracefully from stale history cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.80.1] - 2026-04-06
+
+### Fixed
+- Recover gracefully from stale history cache entries after dependency upgrades (#898)
+
 ## [1.79.0] - 2026-04-05
 
 ### Added

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -378,41 +378,40 @@ class ResultCollector:
             logger.info("clearing history")
         else:
             logger.info(f"checking historical key: {bench_cfg_hash}")
-            if bench_cfg_hash in c:
-                logger.info("loading historical data from cache")
-                try:
-                    ds_old = c[bench_cfg_hash]
-                except (
-                    AttributeError,
-                    TypeError,
-                    ModuleNotFoundError,
-                    ImportError,
-                ) as exc:
-                    logger.warning(
-                        "Failed to deserialize cached history (%s: %s). "
-                        "Discarding stale cache entry and continuing with fresh data.",
-                        type(exc).__name__,
-                        exc,
-                    )
-                    try:
-                        del c[bench_cfg_hash]
-                    except Exception:
-                        pass
-                else:
-                    if (
-                        "over_time" in ds_old.dims
-                        and "over_time" in dataset.dims
-                        and ds_old["over_time"].dtype != dataset["over_time"].dtype
-                    ):
-                        logger.warning(
-                            "Discarding incompatible historical data "
-                            "(over_time dtype changed: "
-                            f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
-                        )
-                    else:
-                        dataset = xr.concat([ds_old, dataset], "over_time")
-            else:
+            try:
+                ds_old = c[bench_cfg_hash]
+            except KeyError:
                 logger.info("did not detect any historical data")
+            except (
+                AttributeError,
+                TypeError,
+                ModuleNotFoundError,
+                ImportError,
+            ) as exc:
+                logger.warning(
+                    "Failed to deserialize cached history (%s: %s). "
+                    "Discarding stale cache entry and continuing with fresh data.",
+                    type(exc).__name__,
+                    exc,
+                )
+                try:
+                    del c[bench_cfg_hash]
+                except (OSError, KeyError) as del_exc:
+                    logger.debug("Could not remove stale cache entry: %s", del_exc)
+            else:
+                logger.info("loading historical data from cache")
+                if (
+                    "over_time" in ds_old.dims
+                    and "over_time" in dataset.dims
+                    and ds_old["over_time"].dtype != dataset["over_time"].dtype
+                ):
+                    logger.warning(
+                        "Discarding incompatible historical data "
+                        "(over_time dtype changed: "
+                        f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
+                    )
+                else:
+                    dataset = xr.concat([ds_old, dataset], "over_time")
 
         if max_time_events is not None and "over_time" in dataset.dims:
             if dataset.sizes["over_time"] > max_time_events:

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -380,19 +380,37 @@ class ResultCollector:
             logger.info(f"checking historical key: {bench_cfg_hash}")
             if bench_cfg_hash in c:
                 logger.info("loading historical data from cache")
-                ds_old = c[bench_cfg_hash]
-                if (
-                    "over_time" in ds_old.dims
-                    and "over_time" in dataset.dims
-                    and ds_old["over_time"].dtype != dataset["over_time"].dtype
-                ):
+                try:
+                    ds_old = c[bench_cfg_hash]
+                except (
+                    AttributeError,
+                    TypeError,
+                    ModuleNotFoundError,
+                    ImportError,
+                ) as exc:
                     logger.warning(
-                        "Discarding incompatible historical data "
-                        "(over_time dtype changed: "
-                        f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
+                        "Failed to deserialize cached history (%s: %s). "
+                        "Discarding stale cache entry and continuing with fresh data.",
+                        type(exc).__name__,
+                        exc,
                     )
+                    try:
+                        del c[bench_cfg_hash]
+                    except Exception:
+                        pass
                 else:
-                    dataset = xr.concat([ds_old, dataset], "over_time")
+                    if (
+                        "over_time" in ds_old.dims
+                        and "over_time" in dataset.dims
+                        and ds_old["over_time"].dtype != dataset["over_time"].dtype
+                    ):
+                        logger.warning(
+                            "Discarding incompatible historical data "
+                            "(over_time dtype changed: "
+                            f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
+                        )
+                    else:
+                        dataset = xr.concat([ds_old, dataset], "over_time")
             else:
                 logger.info("did not detect any historical data")
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -31,7 +31,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.2-hf636f53_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://prefix.dev/blooop/linux-64/ralph-orchestrator-2.6.0-hb0f4dca_0.conda
@@ -98,7 +98,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -202,7 +202,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.16-he725a3c_1_cpython.conda
       - conda: https://prefix.dev/blooop/linux-64/ralph-orchestrator-2.6.0-hb0f4dca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -268,7 +268,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -375,7 +375,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
       - conda: https://prefix.dev/blooop/linux-64/ralph-orchestrator-2.6.0-hb0f4dca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -441,7 +441,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -546,7 +546,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.9-h9e4cc4f_0_cpython.conda
       - conda: https://prefix.dev/blooop/linux-64/ralph-orchestrator-2.6.0-hb0f4dca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -612,7 +612,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -715,7 +715,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.2-hf636f53_101_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://prefix.dev/blooop/linux-64/ralph-orchestrator-2.6.0-hb0f4dca_0.conda
@@ -782,7 +782,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -1302,8 +1302,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.80.0
-  sha256: 60712d78401a4b4c4ce6913bd6dc0c11b3202a13ff53087b5ea534a01fdc4928
+  version: 1.80.1
+  sha256: 1283ecbb80701d38173c653ee6597ca5ba32996c3c3e5ca493c9684be2c263db
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -2391,10 +2391,10 @@ packages:
   - flake8-implicit-str-concat==0.4.0 ; extra == 'lint'
   - isort>=5.12 ; extra == 'lint'
   - pre-commit>=3.3 ; extra == 'lint'
-- pypi: https://files.pythonhosted.org/packages/3f/c3/06490e98393dcb4d6ce2bf331a39335375c300afaef526897881fbeae6ab/narwhals-2.18.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
   name: narwhals
-  version: 2.18.1
-  sha256: a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad
+  version: 2.19.0
+  sha256: 1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b
   requires_dist:
   - cudf-cu12>=24.10.0 ; extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'
@@ -3217,17 +3217,16 @@ packages:
   version: 4.9.4
   sha256: 68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868
   requires_python: '>=3.10'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.58.2-h0bd9c3d_0.conda
-  sha256: 8addc9d2348d06f9f47ead060e3c156c78ac2fedb9409a57cd49a7b288f57a60
-  md5: 9d161e4e16adbf1155a12470ced3c4cc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.59.1-h0bd9c3d_0.conda
+  sha256: 1f0f4731c461c6b54ab5f54ffbdf92ed0eb1504a5a57d141f290c7d3d1bb4618
+  md5: 0a57b3d85d7a5f2f5e27a0ba97ebc758
   depends:
   - nodejs
-  - nodejs >=22.21.1,<23.0a0
+  - nodejs >=22.22.2,<23.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 2338998
-  timestamp: 1770404309433
+  size: 2450462
+  timestamp: 1775458000688
 - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
   name: plotly
   version: 6.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.80.0"
+version = "1.80.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -550,10 +550,14 @@ class TestStaleCacheRecovery(unittest.TestCase):
         c[unique_hash] = dataset
 
         with mock.patch.object(
-            type(c), "__getitem__", side_effect=AttributeError("'List' object has no attribute 'class_'")
+            type(c),
+            "__getitem__",
+            side_effect=AttributeError("'List' object has no attribute 'class_'"),
         ):
             with self.assertLogs("bencher.result_collector", level="WARNING") as captured_logs:
-                result = self.collector.load_history_cache(dataset, unique_hash, clear_history=False)
+                result = self.collector.load_history_cache(
+                    dataset, unique_hash, clear_history=False
+                )
 
         self.assertTrue(
             any("Failed to deserialize cached history" in msg for msg in captured_logs.output)
@@ -570,10 +574,14 @@ class TestStaleCacheRecovery(unittest.TestCase):
         c[unique_hash] = dataset
 
         with mock.patch.object(
-            type(c), "__getitem__", side_effect=ModuleNotFoundError("No module named 'old_dep'")
+            type(c),
+            "__getitem__",
+            side_effect=ModuleNotFoundError("No module named 'old_dep'"),
         ):
             with self.assertLogs("bencher.result_collector", level="WARNING") as captured_logs:
-                result = self.collector.load_history_cache(dataset, unique_hash, clear_history=False)
+                result = self.collector.load_history_cache(
+                    dataset, unique_hash, clear_history=False
+                )
 
         self.assertTrue(
             any("Failed to deserialize cached history" in msg for msg in captured_logs.output)

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -530,6 +530,57 @@ class TestDTypeIncompatibleHistory(unittest.TestCase):
         self.assertTrue(result.equals(ds_datetime))
 
 
+class TestStaleCacheRecovery(unittest.TestCase):
+    """Test that load_history_cache recovers from stale/corrupt cache entries."""
+
+    def setUp(self):
+        self.collector = ResultCollector()
+
+    def test_attribute_error_on_deserialize_discards_entry(self):
+        """A stale cache entry that raises AttributeError should be discarded gracefully."""
+        unique_hash = f"stale-cache-{uuid.uuid4()}"
+        dataset = xr.Dataset(
+            {"var": (["x", "over_time"], [[1.0]])},
+            coords={"over_time": ["v1"]},
+        )
+
+        # Seed the cache with a value, then make __getitem__ raise AttributeError
+        # to simulate a pickle deserialization failure from an upgraded dependency.
+        c = self.collector.get_history_cache()
+        c[unique_hash] = dataset
+
+        with mock.patch.object(
+            type(c), "__getitem__", side_effect=AttributeError("'List' object has no attribute 'class_'")
+        ):
+            with self.assertLogs("bencher.result_collector", level="WARNING") as captured_logs:
+                result = self.collector.load_history_cache(dataset, unique_hash, clear_history=False)
+
+        self.assertTrue(
+            any("Failed to deserialize cached history" in msg for msg in captured_logs.output)
+        )
+        # Should return the fresh dataset without crashing
+        self.assertTrue(result.equals(dataset))
+
+    def test_module_not_found_error_on_deserialize_discards_entry(self):
+        """A cache entry referencing a removed module should be discarded gracefully."""
+        unique_hash = f"stale-module-{uuid.uuid4()}"
+        dataset = xr.Dataset({"var": (["x"], [1, 2, 3])})
+
+        c = self.collector.get_history_cache()
+        c[unique_hash] = dataset
+
+        with mock.patch.object(
+            type(c), "__getitem__", side_effect=ModuleNotFoundError("No module named 'old_dep'")
+        ):
+            with self.assertLogs("bencher.result_collector", level="WARNING") as captured_logs:
+                result = self.collector.load_history_cache(dataset, unique_hash, clear_history=False)
+
+        self.assertTrue(
+            any("Failed to deserialize cached history" in msg for msg in captured_logs.output)
+        )
+        self.assertTrue(result.equals(dataset))
+
+
 class TestLazyCartesianProduct(unittest.TestCase):
     """Tests for lazy Cartesian product in setup_dataset (plan item 1.3)."""
 


### PR DESCRIPTION
## Summary
- When dependencies like `param` are upgraded, pickled history cache entries in `diskcache` can become undeserializable (e.g. `AttributeError: 'List' object has no attribute 'class_'` after a `param` upgrade)
- `load_history_cache` now catches deserialization errors (`AttributeError`, `TypeError`, `ModuleNotFoundError`, `ImportError`), logs a warning, discards the stale entry, and continues with fresh data instead of crashing
- Adds two unit tests covering `AttributeError` and `ModuleNotFoundError` recovery

## Context
The holobench 1.80.0 upgrade pulled in `param` 2.3.3, which dropped the `class_` attribute from `List` descriptors. This made CI benchmark caches created with older `param` versions unloadable, causing `AttributeError` crashes in `result_collector.py:383` during `c[bench_cfg_hash]` lookup.

## Test plan
- [x] `TestStaleCacheRecovery::test_attribute_error_on_deserialize_discards_entry` — passes
- [x] `TestStaleCacheRecovery::test_module_not_found_error_on_deserialize_discards_entry` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle stale or incompatible benchmark history cache entries more robustly during result collection

Bug Fixes:
- Gracefully recover when deserializing cached history raises AttributeError, TypeError, ModuleNotFoundError, or ImportError by discarding the bad entry and proceeding with fresh data

Tests:
- Add tests verifying that AttributeError and ModuleNotFoundError during cache access log a warning, drop the stale entry, and return the fresh dataset