### PR TITLE
Fix ResultRerun crash with over_time slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.80.2] - 2026-04-07
+
+### Fixed
+- Fix `ResultRerun` crash with `over_time=True` — slider now handles `.rrd` viewer panes
+
+### Added
+- Rerun over_time example: `example_rerun_over_time.py` and generated gallery entry
+
 ## [1.80.1] - 2026-04-06
 
 ### Fixed

--- a/bencher/example/example_rerun_over_time.py
+++ b/bencher/example/example_rerun_over_time.py
@@ -1,0 +1,50 @@
+"""Example: Rerun window captures with over_time tracking."""
+
+import math
+import rerun as rr
+import bencher as bn
+from datetime import datetime, timedelta
+
+
+class SweepRerunOverTime(bn.ParametrizedSweep):
+    """Sweep that logs 2D geometry to rerun, tracked over time."""
+
+    theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
+
+    out_sin = bn.ResultFloat(units="v", doc="sin of theta")
+    out_rerun = bn.ResultRerun(width=400, height=400)
+
+    _time_offset = 0.0
+
+    def benchmark(self):
+        self.out_sin = math.sin(self.theta) + self._time_offset
+        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
+        self.out_rerun = bn.capture_rerun_window()
+
+
+def example_rerun_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun window captures tracked over multiple time snapshots."""
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
+
+    benchable = SweepRerunOverTime()
+    bench = benchable.to_bench(run_cfg)
+    _base_time = datetime(2000, 1, 1)
+
+    for i, offset in enumerate([0.0, 0.5, 1.0]):
+        benchable._time_offset = offset
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        bench.plot_sweep(
+            "over_time",
+            input_vars=["theta"],
+            result_vars=["out_sin", "out_rerun"],
+            run_cfg=run_cfg,
+            time_src=_base_time + timedelta(seconds=i),
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_over_time, level=3, over_time=True)

--- a/bencher/example/example_rerun_over_time.py
+++ b/bencher/example/example_rerun_over_time.py
@@ -7,18 +7,24 @@ from datetime import datetime, timedelta
 
 
 class SweepRerunOverTime(bn.ParametrizedSweep):
-    """Sweep that logs 2D geometry to rerun, tracked over time."""
+    """Sweep that logs 2D geometry to rerun, tracked over time.
+
+    Set ``time_offset`` before each :meth:`plot_sweep` call to vary the
+    benchmark output across time snapshots.  It is a plain float (not a
+    sweep parameter) so it is not included in the Cartesian product — the
+    over_time axis is controlled externally via ``time_src``.
+    """
 
     theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
 
     out_sin = bn.ResultFloat(units="v", doc="sin of theta")
     out_rerun = bn.ResultRerun(width=400, height=400)
 
-    _time_offset = 0.0
+    time_offset = 0.0
 
     def benchmark(self):
-        self.out_sin = math.sin(self.theta) + self._time_offset
-        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
+        self.out_sin = math.sin(self.theta) + self.time_offset
+        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self.time_offset, 1]))
         self.out_rerun = bn.capture_rerun_window()
 
 
@@ -32,7 +38,7 @@ def example_rerun_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     _base_time = datetime(2000, 1, 1)
 
     for i, offset in enumerate([0.0, 0.5, 1.0]):
-        benchable._time_offset = offset
+        benchable.time_offset = offset
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
         bench.plot_sweep(

--- a/bencher/example/generated/rerun/example_rerun_over_time.py
+++ b/bencher/example/generated/rerun/example_rerun_over_time.py
@@ -1,0 +1,62 @@
+"""Auto-generated example: Rerun Over Time — track spatial visualizations across time snapshots."""
+
+import math
+from datetime import datetime, timedelta
+
+import rerun as rr
+import bencher as bn
+
+
+class RerunOverTimeSweep(bn.ParametrizedSweep):
+    """Sweep that logs 2D geometry to rerun, tracked over time.
+
+    Each call to ``benchmark()`` logs a box whose width varies with *theta*
+    plus a time-dependent offset, and captures the recording as a ``.rrd``
+    file.  Running the sweep multiple times with different ``time_src``
+    values creates an over_time history that can be scrubbed via a slider.
+    """
+
+    theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
+
+    out_sin = bn.ResultFloat(units="v", doc="sin of theta")
+    out_rerun = bn.ResultRerun(width=400, height=400)
+
+    _time_offset = 0.0
+
+    def benchmark(self):
+        self.out_sin = math.sin(self.theta) + self._time_offset
+        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
+        self.out_rerun = bn.capture_rerun_window()
+
+
+def example_rerun_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Over Time — track spatial visualizations across time snapshots."""
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
+    benchable = RerunOverTimeSweep()
+    bench = benchable.to_bench(run_cfg)
+    _base_time = datetime(2000, 1, 1)
+    for i, offset in enumerate([0.0, 0.5, 1.0]):
+        benchable._time_offset = offset
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        bench.plot_sweep(
+            "over_time",
+            input_vars=["theta"],
+            result_vars=["out_sin", "out_rerun"],
+            description="Rerun window captures tracked over multiple time snapshots. "
+            "Each call to plot_sweep with a new time_src appends a snapshot. "
+            "The rerun viewer for each sweep point is shown in a slider "
+            "that lets you scrub through the time history.",
+            post_description="The ``ResultRerun`` type stores ``.rrd`` file paths. "
+            "When combined with ``over_time=True``, a Bokeh slider swaps "
+            "between the rerun viewer iframes for each time point.",
+            run_cfg=run_cfg,
+            time_src=_base_time + timedelta(seconds=i),
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_over_time, level=3, over_time=True)

--- a/bencher/example/generated/rerun/example_rerun_over_time.py
+++ b/bencher/example/generated/rerun/example_rerun_over_time.py
@@ -1,43 +1,20 @@
 """Auto-generated example: Rerun Over Time — track spatial visualizations across time snapshots."""
 
-import math
 from datetime import datetime, timedelta
 
-import rerun as rr
 import bencher as bn
-
-
-class RerunOverTimeSweep(bn.ParametrizedSweep):
-    """Sweep that logs 2D geometry to rerun, tracked over time.
-
-    Each call to ``benchmark()`` logs a box whose width varies with *theta*
-    plus a time-dependent offset, and captures the recording as a ``.rrd``
-    file.  Running the sweep multiple times with different ``time_src``
-    values creates an over_time history that can be scrubbed via a slider.
-    """
-
-    theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
-
-    out_sin = bn.ResultFloat(units="v", doc="sin of theta")
-    out_rerun = bn.ResultRerun(width=400, height=400)
-
-    _time_offset = 0.0
-
-    def benchmark(self):
-        self.out_sin = math.sin(self.theta) + self._time_offset
-        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
-        self.out_rerun = bn.capture_rerun_window()
+from bencher.example.example_rerun_over_time import SweepRerunOverTime
 
 
 def example_rerun_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Rerun Over Time — track spatial visualizations across time snapshots."""
     if run_cfg is None:
         run_cfg = bn.BenchRunCfg()
-    benchable = RerunOverTimeSweep()
+    benchable = SweepRerunOverTime()
     bench = benchable.to_bench(run_cfg)
     _base_time = datetime(2000, 1, 1)
     for i, offset in enumerate([0.0, 0.5, 1.0]):
-        benchable._time_offset = offset
+        benchable.time_offset = offset
         run_cfg.clear_cache = True
         run_cfg.clear_history = i == 0
         bench.plot_sweep(

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -77,39 +77,18 @@ bench.plot_sweep(
     def _generate_over_time(self):
         """Rerun window captures tracked over multiple time snapshots."""
         imports = (
-            "import math\n"
             "from datetime import datetime, timedelta\n\n"
-            "import rerun as rr\nimport bencher as bn"
+            "import bencher as bn\n"
+            "from bencher.example.example_rerun_over_time import SweepRerunOverTime"
         )
-        class_code = '''
-class RerunOverTimeSweep(bn.ParametrizedSweep):
-    """Sweep that logs 2D geometry to rerun, tracked over time.
-
-    Each call to ``benchmark()`` logs a box whose width varies with *theta*
-    plus a time-dependent offset, and captures the recording as a ``.rrd``
-    file.  Running the sweep multiple times with different ``time_src``
-    values creates an over_time history that can be scrubbed via a slider.
-    """
-
-    theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
-
-    out_sin = bn.ResultFloat(units="v", doc="sin of theta")
-    out_rerun = bn.ResultRerun(width=400, height=400)
-
-    _time_offset = 0.0
-
-    def benchmark(self):
-        self.out_sin = math.sin(self.theta) + self._time_offset
-        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
-        self.out_rerun = bn.capture_rerun_window()'''
         body = """\
 if run_cfg is None:
     run_cfg = bn.BenchRunCfg()
-benchable = RerunOverTimeSweep()
+benchable = SweepRerunOverTime()
 bench = benchable.to_bench(run_cfg)
 _base_time = datetime(2000, 1, 1)
 for i, offset in enumerate([0.0, 0.5, 1.0]):
-    benchable._time_offset = offset
+    benchable.time_offset = offset
     run_cfg.clear_cache = True
     run_cfg.clear_history = i == 0
     bench.plot_sweep(
@@ -134,7 +113,6 @@ for i, offset in enumerate([0.0, 0.5, 1.0]):
             function_name="example_rerun_over_time",
             imports=imports,
             body=body,
-            class_code=class_code,
             run_kwargs={"level": 3, "over_time": True},
         )
 

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -13,6 +13,7 @@ OUTPUT_DIR = "rerun"
 
 RERUN_EXAMPLES = [
     "capture_window",
+    "over_time",
 ]
 
 
@@ -24,6 +25,8 @@ class MetaRerun(MetaGeneratorBase):
     def benchmark(self):
         if self.example == "capture_window":
             self._generate_capture_window()
+        elif self.example == "over_time":
+            self._generate_over_time()
 
     def _generate_capture_window(self):
         """Capture a rerun viewer window as a Panel widget inside a sweep."""
@@ -69,6 +72,70 @@ bench.plot_sweep(
             body=body,
             class_code=class_code,
             run_kwargs={"level": 3},
+        )
+
+    def _generate_over_time(self):
+        """Rerun window captures tracked over multiple time snapshots."""
+        imports = (
+            "import math\n"
+            "from datetime import datetime, timedelta\n\n"
+            "import rerun as rr\nimport bencher as bn"
+        )
+        class_code = '''
+class RerunOverTimeSweep(bn.ParametrizedSweep):
+    """Sweep that logs 2D geometry to rerun, tracked over time.
+
+    Each call to ``benchmark()`` logs a box whose width varies with *theta*
+    plus a time-dependent offset, and captures the recording as a ``.rrd``
+    file.  Running the sweep multiple times with different ``time_src``
+    values creates an over_time history that can be scrubbed via a slider.
+    """
+
+    theta = bn.FloatSweep(default=1, bounds=[1, 4], doc="Box half-size", units="rad", samples=5)
+
+    out_sin = bn.ResultFloat(units="v", doc="sin of theta")
+    out_rerun = bn.ResultRerun(width=400, height=400)
+
+    _time_offset = 0.0
+
+    def benchmark(self):
+        self.out_sin = math.sin(self.theta) + self._time_offset
+        rr.log("boxes", rr.Boxes2D(half_sizes=[self.theta + self._time_offset, 1]))
+        self.out_rerun = bn.capture_rerun_window()'''
+        body = """\
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
+benchable = RerunOverTimeSweep()
+bench = benchable.to_bench(run_cfg)
+_base_time = datetime(2000, 1, 1)
+for i, offset in enumerate([0.0, 0.5, 1.0]):
+    benchable._time_offset = offset
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    bench.plot_sweep(
+        "over_time",
+        input_vars=["theta"],
+        result_vars=["out_sin", "out_rerun"],
+        description="Rerun window captures tracked over multiple time snapshots. "
+        "Each call to plot_sweep with a new time_src appends a snapshot. "
+        "The rerun viewer for each sweep point is shown in a slider "
+        "that lets you scrub through the time history.",
+        post_description="The ``ResultRerun`` type stores ``.rrd`` file paths. "
+        "When combined with ``over_time=True``, a Bokeh slider swaps "
+        "between the rerun viewer iframes for each time point.",
+        run_cfg=run_cfg,
+        time_src=_base_time + timedelta(seconds=i),
+    )
+"""
+        self.generate_example(
+            title="Rerun Over Time — track spatial visualizations across time snapshots",
+            output_dir=OUTPUT_DIR,
+            filename="example_rerun_over_time",
+            function_name="example_rerun_over_time",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"level": 3, "over_time": True},
         )
 
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -879,13 +879,14 @@ class BenchResultBase:
         is_rerun = isinstance(result_var, ResultRerun)
         is_video = isinstance(result_var, ResultVideo)
 
+        if is_rerun:
+            from bencher.utils_rrd import rrd_file_to_pane
+
         html_list = []
         for t in time_vals:
             ds_t = dataset.sel(over_time=t)
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
             if is_rerun:
-                from bencher.utils_rrd import rrd_file_to_pane
-
                 pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
                 html_list.append(pane.object)
             else:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -22,7 +22,13 @@ from bencher.variables.results import ResultFloat, ResultBool
 from bencher.plotting.plot_filter import VarRange, PlotFilter
 from bencher.utils import listify
 
-from bencher.variables.results import ResultReference, ResultDataSet, ResultVideo, ResultImage
+from bencher.variables.results import (
+    ResultReference,
+    ResultDataSet,
+    ResultVideo,
+    ResultImage,
+    ResultRerun,
+)
 
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
@@ -841,7 +847,7 @@ class BenchResultBase:
                 self.bench_cfg.over_time
                 and "over_time" in list(dataset.sizes)
                 and dataset.sizes["over_time"] > 1
-                and isinstance(result_var, (ResultVideo, ResultImage))
+                and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
             ):
                 return self._pane_over_time_slider(dataset, result_var)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
@@ -856,10 +862,10 @@ class BenchResultBase:
         """Create a Panel slider widget for over_time with pane-type results.
 
         Numeric plot callbacks (line, heatmap) handle over_time internally via
-        hv.HoloMap.  Pane-type callbacks (images, videos) cannot use HoloMap
-        because they produce Panel objects, not HoloViews elements.  This method
-        builds per-time-point content and swaps it via a Bokeh JS callback to
-        avoid Panel's ImportedStyleSheet document-ownership errors.
+        hv.HoloMap.  Pane-type callbacks (images, videos, rerun) cannot use
+        HoloMap because they produce Panel objects, not HoloViews elements.
+        This method builds per-time-point content and swaps it via a Bokeh JS
+        callback to avoid Panel's ImportedStyleSheet document-ownership errors.
         """
         import base64
         from bokeh.models import CustomJS, Div
@@ -870,23 +876,30 @@ class BenchResultBase:
         is_datetime = np.issubdtype(over_time_dtype, np.datetime64)
         labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
 
-        # Pre-read file contents as base64 data-URIs for each time point.
-        # Bokeh HTML-escapes the JSON blob in the HTML page, but un-escapes
-        # it at runtime via .textContent, so full HTML tags work correctly.
+        is_rerun = isinstance(result_var, ResultRerun)
         is_video = isinstance(result_var, ResultVideo)
-        mime = "video/mp4" if is_video else "image/png"
+
         html_list = []
         for t in time_vals:
             ds_t = dataset.sel(over_time=t)
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
-            with open(filepath, "rb") as f:
-                b64 = base64.b64encode(f.read()).decode()
-            if is_video:
-                html_list.append(
-                    f'<video controls src="data:{mime};base64,{b64}" style="background:white"/>'
-                )
+            if is_rerun:
+                from bencher.utils_rrd import rrd_file_to_pane
+
+                pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
+                html_list.append(pane.object)
             else:
-                html_list.append(f'<img src="data:{mime};base64,{b64}" style="background:white"/>')
+                mime = "video/mp4" if is_video else "image/png"
+                with open(filepath, "rb") as f:
+                    b64 = base64.b64encode(f.read()).decode()
+                if is_video:
+                    html_list.append(
+                        f'<video controls src="data:{mime};base64,{b64}" style="background:white"/>'
+                    )
+                else:
+                    html_list.append(
+                        f'<img src="data:{mime};base64,{b64}" style="background:white"/>'
+                    )
 
         # Pure Bokeh Div + Slider with a JS callback — no Panel pane updates,
         # so no ImportedStyleSheet sharing across documents.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1302,8 +1302,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.80.1
-  sha256: 1283ecbb80701d38173c653ee6597ca5ba32996c3c3e5ca493c9684be2c263db
+  version: 1.80.2
+  sha256: 2272ded57f408ed2a58ad113f1a574aaacf5e9f092f26d8ebda679617434f427
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.80.1"
+version = "1.80.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Fix `TypeError: argument should be a str or an os.PathLike object, not 'ndarray'` when `ResultRerun` is used with `over_time=True`
- The over_time slider in `_pane_over_time_slider` only handled `ResultVideo` and `ResultImage` — `ResultRerun` fell through to `ds_to_container` which received an ndarray of `.rrd` paths instead of a single string
- Extend the slider to generate rerun viewer iframe HTML per time point via `rrd_file_to_pane()`
- Add `example_rerun_over_time.py` (standalone + generated gallery entry)
- Bump version to 1.80.2

## Test plan
- [x] `pixi run ci` passes (1218 tests, 0 failures)
- [x] `example_rerun_over_time.py` runs without errors
- [ ] Visual check: open saved HTML report and verify rerun viewer slider scrubs through time points

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix over_time slider handling for rerun results and add a corresponding example, while bumping the project version.

New Features:
- Add a standalone and gallery-generated rerun over_time example demonstrating ResultRerun with time-scrubbable output.

Bug Fixes:
- Prevent crashes when using ResultRerun with over_time by having the slider build rerun viewer panes instead of passing arrays of paths to the container logic.

Enhancements:
- Extend the over_time pane slider to support ResultRerun outputs alongside images and videos.

Build:
- Bump project version to 1.80.2 and update the lockfile accordingly.

Documentation:
- Document the ResultRerun over_time fix and example in the changelog.