### PR TITLE
Skip rerun over-time entries with no data, bump to 1.82.0

### DIFF
--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -956,7 +956,6 @@ class BenchResultBase:
             ds_t = dataset.sel(over_time=t)
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
             if filepath == "NAN" or not os.path.isfile(filepath):
-                items.append(pn.Column(pn.pane.Markdown(f"**{label}**\n\n*No data (trimmed)*")))
                 continue
             pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
             items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.81.0"
+version = "1.82.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Rerun over-time view no longer shows "No data (trimmed)" placeholder columns — entries without valid `.rrd` files are silently skipped so only columns with actual data are displayed.
- Bumps holobench version from 1.81.0 to 1.82.0.

## Test plan
- [x] `pixi run ci` passes (format, lint, tests with 90% coverage)
- [ ] Run `example_rerun_regression.py` with `over_time=True` and verify only data columns appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Skip rendering placeholder columns for over-time entries without valid data files and bump the holobench package version.

Bug Fixes:
- Avoid displaying 'No data (trimmed)' columns in the over-time view when underlying data files are missing or invalid.

Chores:
- Update package version from 1.81.0 to 1.82.0.