### PR TITLE
Start over_time film-strip labels from t=1

### DIFF
--- a/bencher/results/manim_cartesian/cartesian_product_scene.py
+++ b/bencher/results/manim_cartesian/cartesian_product_scene.py
@@ -334,7 +334,7 @@ class TimelineShape(Shape):
 
             # Frame number label below the strip (skipped when drawn as fixed-size overlay)
             if not self._skip_labels:
-                label = f"t={i}"
+                label = f"t={i + 1}"
                 bbox = img.textbbox((0, 0), label, font=font_label)
                 tw = bbox[2] - bbox[0]
                 lx = fx + (frame_w - tw) // 2
@@ -406,7 +406,7 @@ class TimelineShape(Shape):
             center = fx + scaled_fw / 2
             if center < 0 or center > canvas_w:
                 continue
-            label = f"t={i}"
+            label = f"t={i + 1}"
             bbox = img.textbbox((0, 0), label, font=font_label)
             tw = bbox[2] - bbox[0]
             img.text(

--- a/test/test_cartesian_pil_renderer.py
+++ b/test/test_cartesian_pil_renderer.py
@@ -178,7 +178,7 @@ class TestDrawRegression:
 
     def test_timeline(self):
         tl = TimelineShape(Shape(), 3)
-        assert _render_hash(tl, 500, 200) == "7d903d8b7bc4bc5e084d7bd7c4a441bb"
+        assert _render_hash(tl, 500, 200) == "c77e2b39b2cdc21008b7f7008955be3b"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Film-strip frame labels in the cartesian animation now start from `t=1` instead of `t=0`, so the last label `t=N` matches the count shown elsewhere in the output text.
- Updated render regression hash in tests to match.

## Test plan
- [x] `test_cartesian_pil_renderer.py` and `test_manim_cartesian.py` pass (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align film-strip timeline labels in the cartesian animation with 1-based time indexing and update corresponding render hash expectation in tests.

Bug Fixes:
- Ensure film-strip frame labels start at t=1 so the final label t=N matches the count shown elsewhere in the output text.

Tests:
- Update cartesian timeline render regression hash to reflect the new frame labeling.