### PR TITLE
Fix .rrd filename collision and missing-recording crash in saved reports

### DIFF
--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -96,6 +96,9 @@ def rrd_file_to_pane(  # pragma: no cover
         portable — it works when served from any HTTP origin without a
         live Panel server.
     """
+    if not file_path:
+        return pn.pane.Markdown("*No recording*", width=width, height=height)
+
     rrd_path = Path(file_path).resolve()
 
     # Resolve viewer version: explicit > installed SDK > fallback.

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -196,7 +196,11 @@ def _write_rrd_sidecar(rrd_path: Path, version: str, dest_dir: Path) -> tuple[st
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    rrd_dest = dest_dir / rrd_path.name
+    # Use parent directory name as prefix to avoid collisions when multiple
+    # .rrd files share the same filename (e.g. different sweep points all
+    # produce "rerun.rrd" in unique job-key subdirectories).
+    unique_name = f"{rrd_path.parent.name}_{rrd_path.name}"
+    rrd_dest = dest_dir / unique_name
     shutil.copy2(rrd_path, rrd_dest)
 
     viewer_html = _get_cdn_viewer_html(version)
@@ -205,7 +209,7 @@ def _write_rrd_sidecar(rrd_path: Path, version: str, dest_dir: Path) -> tuple[st
     if not viewer_path.exists() or viewer_path.read_text() != viewer_html:
         viewer_path.write_text(viewer_html, encoding="utf-8")
 
-    return viewer_name, rrd_path.name
+    return viewer_name, unique_name
 
 
 def _portable_rrd_pane(

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -196,12 +196,12 @@ def _write_rrd_sidecar(rrd_path: Path, version: str, dest_dir: Path) -> tuple[st
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    # Use parent directory name as prefix to avoid collisions when multiple
-    # .rrd files share the same filename (e.g. different sweep points all
-    # produce "rerun.rrd" in unique job-key subdirectories).
-    unique_name = f"{rrd_path.parent.name}_{rrd_path.name}"
-    rrd_dest = dest_dir / unique_name
-    shutil.copy2(rrd_path, rrd_dest)
+    # Preserve the per-job-key subdirectory structure used by gen_path()
+    # to avoid collisions when multiple .rrd files share the same basename.
+    job_key = rrd_path.parent.name
+    rrd_subdir = dest_dir / job_key
+    rrd_subdir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(rrd_path, rrd_subdir / rrd_path.name)
 
     viewer_html = _get_cdn_viewer_html(version)
     viewer_name = f"viewer_{version}.html"
@@ -209,7 +209,7 @@ def _write_rrd_sidecar(rrd_path: Path, version: str, dest_dir: Path) -> tuple[st
     if not viewer_path.exists() or viewer_path.read_text() != viewer_html:
         viewer_path.write_text(viewer_html, encoding="utf-8")
 
-    return viewer_name, unique_name
+    return viewer_name, f"{job_key}/{rrd_path.name}"
 
 
 def _portable_rrd_pane(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.82.0"
+version = "1.82.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- Fix `.rrd` filename collisions when saving reports with multiple sweep points
- Guard `rrd_file_to_pane` against `None`/empty file paths that crash the report render

## Details

### 1. Filename collision in `_write_rrd_sidecar`

`gen_path()` correctly places each sweep point's `.rrd` in a unique path:
```
cachedir/rrd/rerun/{job_key_A}/rerun.rrd
cachedir/rrd/rerun/{job_key_B}/rerun.rrd
```

The live Panel server serves these fine via `/rrd_static/{job_key}/rerun.rrd`. But when `BenchReport.save()` calls `inline_rrd_iframes()`, the `_write_rrd_sidecar` function flattens everything into `_rrd/rerun.rrd` — losing uniqueness.

After this fix, files are copied as `_rrd/{job_key_A}/rerun.rrd`, `_rrd/{job_key_B}/rerun.rrd`, etc.

### 2. Crash on missing recordings in `rrd_file_to_pane`

When a sweep point skips recording (e.g. due to an IK failure or timeout), the caller may pass `None` or an empty string as `file_path`. Without a guard, `Path("").resolve()` resolves to the current working directory and the subsequent `relative_to(cache_root)` check raises a confusing `ValueError`.

Fix: return a placeholder Markdown pane (`*No recording*`) instead.

## Test plan
- [ ] Run a benchmark with multiple rerun recordings (e.g. sweeping an enum that produces per-point `.rrd` files)
- [ ] Save the report and verify the `_rrd/` directory contains distinct `.rrd` files
- [ ] Open the saved HTML and confirm each iframe loads a different recording
- [ ] Run a benchmark where some sweep points skip recording (return `None` for the `.rrd` path)
- [ ] Verify the report renders without errors, showing "*No recording*" for skipped points