### PR TITLE
Claude/review hash compatibility 0ez zg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.85.0] - 2026-04-18
+
+### Fixed
+- **Benchmark-level cache identity for reshaped sweeps**: `SweepBase.hash_persistent` previously hashed only `(units, samples)`, so reshaping a `FloatSweep`/`IntSweep`/`SweepSelector` (changing bounds, step, `sample_values`, or `objects`) silently left the benchmark-level cache and `over_time` history keyed by the old shape, returning stale coordinates. Fixed by introducing an explicit `_sweep_identity` whitelist (bounds, sample_values, step, objects) with a slot-coverage test that catches future "added a slot, forgot the hash" regressions.
+- `CACHE_VERSION` bumped to `"3"` and folded directly into `BenchCfg.hash_persistent` so version bumps atomically invalidate every benchmark-level and over_time key.
+
+### Changed
+- `ResultFloat.direction` and `ResultRerun.width`/`height` moved to `_hash_exclude`: these are interpretive/cosmetic fields that should not invalidate history when changed.
+- New `TestGoldenBenchCfgHash` regression pins byte-exact values for a canonical `BenchCfg`; any future change to what contributes to the hash fails CI loudly and forces a deliberate `CACHE_VERSION` bump.
+
 ## [1.84.0] - 2026-04-12
 
 ### Changed

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -15,6 +15,7 @@ from bencher.variables.time import TimeSnapshot, TimeEvent
 from bencher.variables.results import OptDir
 from bencher.results.composable_container.composable_container_base import PaneLayout
 from bencher.job import Executors
+from bencher.cache_management import CACHE_VERSION
 from bencher.results.laxtex_result import to_latex
 
 T = TypeVar("T")  # Generic type variable
@@ -639,8 +640,13 @@ class BenchCfg(BenchRunCfg):
         # a benchmark's display title does not invalidate cached results or
         # lose over_time history.  The benchmark is uniquely identified by
         # bench_name + input/result/const vars + tag + over_time + repeats.
+        #
+        # CACHE_VERSION is folded in so that bumping it atomically invalidates
+        # every benchmark-level and over_time history key without relying
+        # solely on the on-disk version-file check in ``ensure_cache_version``.
         hash_val = hash_sha1(
             (
+                CACHE_VERSION,
                 hash_sha1(str(self.bench_name)),
                 hash_sha1(self.over_time),
                 repeats_hash,

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -28,8 +28,14 @@ from diskcache import Cache
 
 logger = logging.getLogger(__name__)
 
-# Bump this when the cache layout changes in an incompatible way.
-CACHE_VERSION = "2"
+# Bump this when the cache layout changes in an incompatible way OR when
+# anything that contributes to ``BenchCfg.hash_persistent()`` changes in a
+# way that would otherwise silently collide with existing on-disk entries.
+# The version is also folded directly into the hash (see
+# ``BenchCfg.hash_persistent``) so bumping here atomically invalidates every
+# benchmark-level and over_time history key in addition to wiping the on-disk
+# tree via ``ensure_cache_version()``.
+CACHE_VERSION = "3"
 
 # Default cache size for benchmark results (100 GB).
 # Used by ResultCollector, SweepExecutor, and Bench.

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -63,9 +63,19 @@ class SweepSelector(Selector, SweepBase):
     def _sweep_identity(self) -> tuple:
         """Include ``objects`` so changing the option set busts the cache.
 
-        Elements with ``__bencher_hash__`` (e.g. :class:`YamlSelection`) are
-        fingerprinted via that hook so changing a YAML value under the same
-        key still invalidates the benchmark-level cache.
+        Each element is fingerprinted in one of two ways:
+
+        * If it exposes ``__bencher_hash__`` (e.g. :class:`YamlSelection`),
+          that hook is called — returning something cross-process stable.
+          This is the required contract for arbitrary / user-defined types.
+        * Otherwise we fall back to ``str(o)``.  This is safe for primitive
+          option types (``str``, ``bool``, ``Enum``, numeric) whose ``__str__``
+          is deterministic, but an object inheriting the default
+          ``object.__str__`` will render as ``<Foo at 0x7f...>`` — a memory
+          address that changes every process and would silently produce
+          different cache keys on every run.  If you put custom instances in
+          a :class:`SweepSelector`, either implement ``__bencher_hash__`` or
+          a deterministic ``__str__``/``__repr__``.
         """
 
         def _obj_fingerprint(o):

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -60,6 +60,29 @@ class SweepSelector(Selector, SweepBase):
         """
         return self.indices_to_samples(self.samples, self.objects)
 
+    def _sweep_identity(self) -> tuple:
+        """Include ``objects`` so changing the option set busts the cache.
+
+        Elements with ``__bencher_hash__`` (e.g. :class:`YamlSelection`) are
+        fingerprinted via that hook so changing a YAML value under the same
+        key still invalidates the benchmark-level cache.
+        """
+
+        def _obj_fingerprint(o):
+            hook = getattr(o, "__bencher_hash__", None)
+            if callable(hook):
+                return hook()
+            return str(o)
+
+        objects = self.objects
+        if isinstance(objects, dict):
+            obj_tuple = tuple((str(k), _obj_fingerprint(v)) for k, v in objects.items())
+        elif objects is not None:
+            obj_tuple = tuple(_obj_fingerprint(o) for o in objects)
+        else:
+            obj_tuple = ()
+        return super()._sweep_identity() + (obj_tuple,)
+
     # ------------------------------------------------------------------
     # Dynamic update helpers
     # ------------------------------------------------------------------
@@ -358,6 +381,10 @@ class YamlSweep(SweepSelector):
     """
 
     __slots__ = shared_slots + ["yaml_path", "_entries", "default_key"]
+    # ``objects`` already carries the fingerprint of every YAML entry (via
+    # :meth:`YamlSelection.__bencher_hash__`), so these internal fields are
+    # redundant for cache identity.
+    _sweep_hash_exclude = ("yaml_path", "_entries", "default_key")
 
     def __init__(
         self,
@@ -491,6 +518,11 @@ class IntSweep(Integer, SweepBase):
     def _coerce_bound(self, value):
         return int(value)
 
+    def _sweep_identity(self) -> tuple:
+        """Include bounds and sample_values so a reshaped sweep busts the cache."""
+        sample_values = tuple(self.sample_values) if self.sample_values else None
+        return super()._sweep_identity() + (self.sweep_bounds, sample_values)
+
     def values(self) -> list[int]:
         """Return all the values for the parameter sweep.
 
@@ -575,6 +607,11 @@ class FloatSweep(Number, SweepBase):
 
     def _coerce_bound(self, value):
         return float(value)
+
+    def _sweep_identity(self) -> tuple:
+        """Include bounds, sample_values, and step so a reshaped sweep busts the cache."""
+        sample_values = tuple(self.sample_values) if self.sample_values else None
+        return super()._sweep_identity() + (self.sweep_bounds, sample_values, self.step)
 
     def values(self) -> list[float]:
         """Return all the values for the parameter sweep.

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -86,7 +86,13 @@ class SweepSelector(Selector, SweepBase):
 
         objects = self.objects
         if isinstance(objects, dict):
-            obj_tuple = tuple((str(k), _obj_fingerprint(v)) for k, v in objects.items())
+            # Sort by key-string so semantically equal dicts with different
+            # insertion orders produce the same fingerprint.
+            items = sorted(
+                ((str(k), _obj_fingerprint(v)) for k, v in objects.items()),
+                key=lambda kv: kv[0],
+            )
+            obj_tuple = tuple(items)
         elif objects is not None:
             obj_tuple = tuple(_obj_fingerprint(o) for o in objects)
         else:
@@ -530,7 +536,7 @@ class IntSweep(Integer, SweepBase):
 
     def _sweep_identity(self) -> tuple:
         """Include bounds and sample_values so a reshaped sweep busts the cache."""
-        sample_values = tuple(self.sample_values) if self.sample_values else None
+        sample_values = tuple(self.sample_values) if self.sample_values is not None else None
         return super()._sweep_identity() + (self.sweep_bounds, sample_values)
 
     def values(self) -> list[int]:
@@ -620,7 +626,7 @@ class FloatSweep(Number, SweepBase):
 
     def _sweep_identity(self) -> tuple:
         """Include bounds, sample_values, and step so a reshaped sweep busts the cache."""
-        sample_values = tuple(self.sample_values) if self.sample_values else None
+        sample_values = tuple(self.sample_values) if self.sample_values is not None else None
         return super()._sweep_identity() + (self.sweep_bounds, sample_values, self.step)
 
     def values(self) -> list[float]:

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -98,7 +98,11 @@ class ResultFloat(Number):
     """
 
     __slots__ = ["units", "direction", "share_axis", "max_time_events"]
-    _hash_exclude = ("share_axis", "max_time_events")  # display/retention-only
+    # ``direction`` is excluded because flipping minimize<->maximize does not
+    # change the recorded numeric values, only their interpretation for
+    # Pareto/optimizer plots.  Keeping it in the hash would needlessly wipe
+    # over_time history when the user merely retargets the optimizer.
+    _hash_exclude = ("direction", "share_axis", "max_time_events")
 
     def __init__(
         self,
@@ -300,6 +304,9 @@ class ResultRerun(ResultContainer):
     """
 
     __slots__ = ["width", "height"]
+    # width/height are viewer-pane sizing hints; they do not change the content
+    # of the recorded .rrd file, so they must not invalidate the cache.
+    _hash_exclude = ("width", "height")
 
     def __init__(
         self, default=None, units="rerun", width=600, height=600, max_time_events=None, **params

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -88,9 +88,43 @@ class SweepBase(param.Parameter):
         """
         raise NotImplementedError
 
+    # Slots deliberately omitted from the identity tuple.  Subclasses may
+    # extend this via their own ``_sweep_hash_exclude`` attribute; the
+    # slot-coverage test walks the MRO and unions them all.  A slot is
+    # considered properly declared if it either appears in
+    # :meth:`_sweep_identity` (changing it changes the hash) OR is listed
+    # in ``_sweep_hash_exclude`` on some ancestor.
+    _sweep_hash_exclude: tuple[str, ...] = ("optimize",)
+
+    def _sweep_identity(self) -> tuple:
+        """Return the tuple of values that uniquely identifies this sweep for
+        the benchmark-level and over_time history caches.
+
+        Subclasses MUST override and call ``super()._sweep_identity() + (...)``
+        to append any shape-affecting fields: bounds, sample_values, step,
+        ``objects``, etc.  Any field that changes the set of sampled values
+        or the coordinate labels of the resulting xarray must contribute
+        here, otherwise the benchmark-level cache and over_time history
+        will silently serve stale data for a reshaped sweep.
+
+        The class name is included so that different Sweep subclasses with
+        the same identity tuple do not collide.
+
+        Note: the sample cache is keyed solely by concrete input values
+        (see :class:`bencher.worker_job.WorkerJob`) and is unaffected by
+        this hash, so widening a sweep range still reuses per-sample cache
+        entries for overlapping inputs.
+        """
+        return (type(self).__name__, self.units, self.samples)  # pylint: disable=no-member
+
     def hash_persistent(self) -> str:
-        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return hash_sha1((self.units, self.samples))  # pylint: disable=no-member
+        """Deterministic hash based on :meth:`_sweep_identity`.
+
+        Avoids Python's per-process hash randomisation so two Bench runs
+        (or two processes) compute identical cache keys for equivalent
+        sweeps.
+        """
+        return hash_sha1(self._sweep_identity())
 
     def sampling_str(self) -> str:
         """Generate a string representation of the of the sampling procedure"""

--- a/pixi.lock
+++ b/pixi.lock
@@ -1302,8 +1302,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.82.0
-  sha256: 6268fd97b6e1e7934f69c92ba26066579d3b9e3b91459411439386fae12721ed
+  version: 1.85.0
+  sha256: 3dda1370981eb0a33326780af6a3a146822034de42d5a768bdcde9923909f599
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.84.0"
+version = "1.85.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -535,6 +535,33 @@ class TestSweepHashShapeFields:
             == StringSweep(["a", "b"], units="ul").hash_persistent()
         )
 
+    def test_sweep_selector_uses_bencher_hash_hook(self):
+        """Custom objects exposing ``__bencher_hash__`` must route through the hook.
+
+        This is the contract users rely on to get cross-process deterministic
+        cache keys when the selector's options are not primitive types.
+        """
+        from bencher.variables.inputs import SweepSelector
+
+        class Opt:
+            def __init__(self, val):
+                self.val = val
+
+            def __bencher_hash__(self):
+                return ("Opt", self.val)
+
+        a = SweepSelector(objects=[Opt(1), Opt(2)], units="ul")
+        b = SweepSelector(objects=[Opt(1), Opt(2)], units="ul")
+        assert a.hash_persistent() == b.hash_persistent(), (
+            "SweepSelector should treat objects with equal __bencher_hash__ as equal, "
+            "even if the instances themselves differ."
+        )
+
+        c = SweepSelector(objects=[Opt(10), Opt(20)], units="ul")
+        assert a.hash_persistent() != c.hash_persistent(), (
+            "Different __bencher_hash__ payloads must produce different sweep hashes."
+        )
+
 
 def _discover_sweep_classes():
     """Auto-discover concrete SweepBase subclasses that can be instantiated for tests."""

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -436,3 +436,379 @@ class TestCrossProcessDeterminism:
             f"BenchCfg.hash_persistent() differs across processes: "
             f"{hashes_a['BenchCfg']!r} != {hashes_b['BenchCfg']!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Sweep-class hash coverage
+#
+# The benchmark-level and over_time history caches use
+# ``BenchCfg.hash_persistent`` which hashes every input/const Sweep variable
+# via ``SweepBase.hash_persistent``.  Any field that changes the set of
+# sampled values (bounds, sample_values, objects, step) MUST contribute to
+# that hash — otherwise a reshaped sweep silently serves stale results.
+#
+# The sample cache is keyed separately (see bencher.worker_job.WorkerJob)
+# by the concrete input tuple + tag, so sweep-hash changes do not affect
+# sample-cache reuse across widened/narrowed sweeps.
+# ---------------------------------------------------------------------------
+
+
+class TestSweepHashShapeFields:
+    """Changing any shape-affecting sweep field must change the hash."""
+
+    def test_float_sweep_bounds_change_hash(self):
+        from bencher.variables.inputs import FloatSweep
+
+        a = FloatSweep(bounds=(0.0, 1.0), samples=10, units="m/s")
+        b = FloatSweep(bounds=(0.0, 100.0), samples=10, units="m/s")
+        assert a.hash_persistent() != b.hash_persistent(), (
+            "FloatSweep bounds must contribute to the hash — otherwise the "
+            "benchmark-level cache returns a dataset with stale coordinates."
+        )
+
+    def test_float_sweep_sample_values_change_hash(self):
+        from bencher.variables.inputs import FloatSweep
+
+        a = FloatSweep(sample_values=[1.0, 2.0, 3.0], units="m/s")
+        b = FloatSweep(sample_values=[10.0, 20.0, 30.0], units="m/s")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_float_sweep_step_changes_hash(self):
+        from bencher.variables.inputs import FloatSweep
+
+        a = FloatSweep(bounds=(0.0, 1.0), samples=10, step=0.1, units="m/s")
+        b = FloatSweep(bounds=(0.0, 1.0), samples=10, step=0.01, units="m/s")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_int_sweep_bounds_change_hash(self):
+        from bencher.variables.inputs import IntSweep
+
+        a = IntSweep(bounds=(0, 10), samples=5, units="ul")
+        b = IntSweep(bounds=(0, 1000), samples=5, units="ul")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_int_sweep_sample_values_change_hash(self):
+        from bencher.variables.inputs import IntSweep
+
+        a = IntSweep(sample_values=[1, 2, 3], units="ul")
+        b = IntSweep(sample_values=[10, 20, 30], units="ul")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_string_sweep_objects_change_hash(self):
+        from bencher.variables.inputs import StringSweep
+
+        a = StringSweep(["a", "b"], units="ul")
+        b = StringSweep(["x", "y"], units="ul")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_enum_sweep_objects_change_hash(self):
+        from enum import Enum
+
+        from bencher.variables.inputs import EnumSweep
+
+        class E1(Enum):
+            A = 1
+            B = 2
+
+        class E2(Enum):
+            X = 10
+            Y = 20
+
+        a = EnumSweep(E1, units="ul")
+        b = EnumSweep(E2, units="ul")
+        assert a.hash_persistent() != b.hash_persistent()
+
+    def test_equivalent_sweeps_produce_same_hash(self):
+        """Determinism: two independently constructed equivalent sweeps match."""
+        from bencher.variables.inputs import FloatSweep, IntSweep, StringSweep
+
+        assert (
+            FloatSweep(bounds=(0.0, 1.0), samples=10, units="m/s").hash_persistent()
+            == FloatSweep(bounds=(0.0, 1.0), samples=10, units="m/s").hash_persistent()
+        )
+        assert (
+            IntSweep(bounds=(0, 10), samples=5, units="ul").hash_persistent()
+            == IntSweep(bounds=(0, 10), samples=5, units="ul").hash_persistent()
+        )
+        assert (
+            StringSweep(["a", "b"], units="ul").hash_persistent()
+            == StringSweep(["a", "b"], units="ul").hash_persistent()
+        )
+
+
+def _discover_sweep_classes():
+    """Auto-discover concrete SweepBase subclasses that can be instantiated for tests."""
+    import bencher.variables.inputs as inputs_module
+    from bencher.variables.sweep_base import SweepBase
+
+    classes = []
+    for _name, obj in inspect.getmembers(inputs_module, inspect.isclass):
+        if (
+            isinstance(obj, type)
+            and issubclass(obj, SweepBase)
+            and obj is not SweepBase
+            and obj.__module__ == inputs_module.__name__
+        ):
+            classes.append(obj)
+    return classes
+
+
+def _make_sweep_instance(cls):
+    """Instantiate a sweep class with sensible defaults for slot-coverage tests."""
+    from enum import Enum
+
+    from bencher.variables.inputs import (
+        BoolSweep,
+        EnumSweep,
+        FloatSweep,
+        IntSweep,
+        StringSweep,
+        YamlSweep,
+        SweepSelector,
+    )
+
+    if cls is FloatSweep:
+        return FloatSweep(bounds=(0.0, 1.0), samples=5, units="m/s")
+    if cls is IntSweep:
+        return IntSweep(bounds=(0, 10), samples=5, units="ul")
+    if cls is StringSweep:
+        return StringSweep(["a", "b", "c"], units="ul")
+    if cls is BoolSweep:
+        return BoolSweep(units="ul")
+    if cls is EnumSweep:
+
+        class _E(Enum):
+            A = 1
+            B = 2
+
+        return EnumSweep(_E, units="ul")
+    if cls is YamlSweep:
+        return None  # needs a filesystem path; covered indirectly via SweepSelector
+    if cls is SweepSelector:
+        return SweepSelector(objects=["a", "b"], units="ul")
+    return None
+
+
+def _collect_sweep_mro_slots(cls):
+    """Walk MRO and gather bencher-defined __slots__ entries (dedup, preserving order).
+
+    Stops at the ``param`` framework boundary so we only enforce the
+    whitelist discipline on slots that bencher itself introduced —
+    ``param``'s own slots (``compute_default_fn``, ``check_on_set``, etc.)
+    are framework internals outside our control.
+    """
+    all_slots = []
+    seen = set()
+    for klass in cls.__mro__:
+        if getattr(klass, "__module__", "") in _PARAM_MODULES or klass is object:
+            break
+        slots = klass.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot in slots:
+            if slot not in seen:
+                seen.add(slot)
+                all_slots.append(slot)
+    return all_slots
+
+
+def _collect_sweep_mro_excludes(cls):
+    """Union of ``_sweep_hash_exclude`` across the bencher portion of the MRO."""
+    excludes = set()
+    for klass in cls.__mro__:
+        if getattr(klass, "__module__", "") in _PARAM_MODULES or klass is object:
+            break
+        excludes.update(getattr(klass, "_sweep_hash_exclude", ()))
+    return excludes
+
+
+_SWEEP_CLASSES = [c for c in _discover_sweep_classes() if _make_sweep_instance(c) is not None]
+
+
+class TestSweepSlotCoverage:
+    """Enforce the whitelist discipline for Sweep classes.
+
+    Every ``__slots__`` entry on a concrete Sweep class must either
+    contribute to ``_sweep_identity`` (verified by mutating it and checking
+    the hash changes) or be explicitly listed in ``_sweep_hash_exclude`` on
+    some ancestor.  This catches the class of bug where someone adds a new
+    slot to ``FloatSweep``/``IntSweep``/etc. and forgets to extend the
+    identity tuple — the new field would otherwise silently not contribute,
+    and the benchmark-level cache would collide on it.
+    """
+
+    @pytest.mark.parametrize("cls", _SWEEP_CLASSES, ids=lambda c: c.__name__)
+    def test_each_slot_is_hashed_or_excluded(self, cls):
+        slots = _collect_sweep_mro_slots(cls)
+        excludes = _collect_sweep_mro_excludes(cls)
+
+        # ``_sweep_hash_exclude`` entries must actually name real slots —
+        # otherwise the annotation is a typo silently ignored by the test.
+        stale_excludes = excludes - set(slots)
+        assert not stale_excludes, (
+            f"{cls.__name__}._sweep_hash_exclude names {stale_excludes} "
+            f"which are not in __slots__={slots}"
+        )
+
+        instance = _make_sweep_instance(cls)
+        if instance is None:
+            pytest.skip(f"No fixture for {cls.__name__}")
+
+        baseline = instance.hash_persistent()
+
+        for slot in slots:
+            if slot in excludes:
+                # Excluded slot: mutating it must NOT change the hash.
+                mutated = _make_sweep_instance(cls)
+                try:
+                    original = getattr(mutated, slot)
+                    sentinel = (
+                        "__sentinel_value__" if original != "__sentinel_value__" else "__other__"
+                    )
+                    object.__setattr__(mutated, slot, sentinel)
+                except (AttributeError, TypeError, ValueError):
+                    continue  # can't mutate cleanly; excluded by virtue of being unsettable
+                assert mutated.hash_persistent() == baseline, (
+                    f"{cls.__name__}: slot {slot!r} is in _sweep_hash_exclude "
+                    f"but mutating it changed the hash. Either remove it from "
+                    f"_sweep_hash_exclude or fix _sweep_identity."
+                )
+            else:
+                # Non-excluded slot: changing it MUST change the hash.  We
+                # try a handful of sentinel values so we are resilient to
+                # param-level type checks.
+                candidates = [None, 0, 1, -1, "__sweep_hash_probe__", (0, 0), (1, 2), [1, 2, 3]]
+                mutated_hashes = set()
+                for candidate in candidates:
+                    mutated = _make_sweep_instance(cls)
+                    original = getattr(mutated, slot)
+                    if candidate == original:
+                        continue
+                    try:
+                        object.__setattr__(mutated, slot, candidate)
+                    except (AttributeError, TypeError, ValueError):
+                        continue
+                    try:
+                        mutated_hashes.add(mutated.hash_persistent())
+                    except (TypeError, AttributeError, ValueError):
+                        continue
+                assert any(h != baseline for h in mutated_hashes), (
+                    f"{cls.__name__}: slot {slot!r} is NOT in _sweep_hash_exclude "
+                    f"and mutating it never changed the hash. Either add it to "
+                    f"_sweep_hash_exclude (if it is display/runtime-only) or "
+                    f"extend _sweep_identity so it contributes to the hash."
+                )
+
+
+# ---------------------------------------------------------------------------
+# Golden hash regression
+#
+# Any change that intentionally alters what ``BenchCfg.hash_persistent``
+# composes requires:
+#   1. bumping ``CACHE_VERSION`` in bencher/cache_management.py
+#   2. updating the ``GOLDEN_BENCH_CFG_HASH_*`` values below
+#   3. documenting the break in CHANGELOG.md
+#
+# This test exists so incidental drift (e.g. someone adding a new field to
+# the hash tuple) fails CI loudly instead of silently stranding every
+# on-disk benchmark-level and over_time entry in the field.
+# ---------------------------------------------------------------------------
+
+GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS = "afbbadba143168305abeaab3e2e53ea9c429c2a5"
+GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "6093b4560b17af4dab2f14f5609b7b945499df63"
+
+
+def _build_golden_bench_cfg():
+    from bencher.variables.inputs import FloatSweep, IntSweep, StringSweep
+    from bencher.variables.results import ResultFloat
+
+    cfg = BenchCfg()
+    cfg.bench_name = "golden_bench"
+    cfg.title = "should not affect hash"
+    cfg.over_time = False
+    cfg.repeats = 3
+    cfg.tag = "golden_tag"
+    cfg.input_vars = [
+        FloatSweep(bounds=(0.0, 1.0), samples=5, units="m/s"),
+        IntSweep(bounds=(0, 10), samples=4, units="count"),
+        StringSweep(["a", "b", "c"], units="label"),
+    ]
+    cfg.result_vars = [ResultFloat(units="kg", doc="mass")]
+    cfg.const_vars = [(FloatSweep(bounds=(0.0, 1.0), samples=5, units="m/s"), 0.5)]
+    return cfg
+
+
+class TestGoldenBenchCfgHash:
+    """Byte-exact regression check on the BenchCfg hash composition.
+
+    If this test fails and you did not intend to invalidate every on-disk
+    cache, something has drifted.  If you DID intend to change the hash
+    (e.g. including a new field, excluding a cosmetic one), update the
+    constants above AND bump ``CACHE_VERSION`` so existing installations
+    clear their caches cleanly.
+    """
+
+    def test_golden_hash_with_repeats(self):
+        cfg = _build_golden_bench_cfg()
+        assert cfg.hash_persistent(include_repeats=True) == (
+            GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS
+        ), (
+            "BenchCfg hash drifted. See the module docstring for the "
+            "procedure to intentionally update this value."
+        )
+
+    def test_golden_hash_without_repeats(self):
+        cfg = _build_golden_bench_cfg()
+        assert cfg.hash_persistent(include_repeats=False) == (
+            GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS
+        )
+
+    def test_title_change_does_not_affect_golden_hash(self):
+        cfg = _build_golden_bench_cfg()
+        cfg.title = "a completely different title"
+        assert cfg.hash_persistent(include_repeats=True) == GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS
+
+    def test_cache_version_participates_in_hash(self):
+        """Bumping CACHE_VERSION must change the hash atomically."""
+        import bencher.bench_cfg as bench_cfg_mod
+
+        cfg = _build_golden_bench_cfg()
+        original = cfg.hash_persistent(include_repeats=True)
+        saved_version = bench_cfg_mod.CACHE_VERSION
+        try:
+            bench_cfg_mod.CACHE_VERSION = saved_version + "_test_probe"
+            bumped = cfg.hash_persistent(include_repeats=True)
+        finally:
+            bench_cfg_mod.CACHE_VERSION = saved_version
+        assert bumped != original, (
+            "CACHE_VERSION must participate in BenchCfg.hash_persistent so "
+            "bumping it atomically invalidates every cache key."
+        )
+
+    def test_sweep_bounds_change_bench_hash(self):
+        """End-to-end: widening a FloatSweep invalidates the benchmark-level cache."""
+        from bencher.variables.inputs import FloatSweep
+
+        cfg_a = _build_golden_bench_cfg()
+        cfg_b = _build_golden_bench_cfg()
+        cfg_b.input_vars[0] = FloatSweep(bounds=(0.0, 1000.0), samples=5, units="m/s")
+        assert cfg_a.hash_persistent(include_repeats=True) != cfg_b.hash_persistent(
+            include_repeats=True
+        ), (
+            "Changing FloatSweep bounds must change the BenchCfg hash — "
+            "otherwise the benchmark-level cache returns stale coordinates."
+        )
+
+    def test_result_direction_does_not_change_bench_hash(self):
+        """Flipping minimize<->maximize must not invalidate history."""
+        from bencher.variables.results import OptDir, ResultFloat
+
+        cfg_a = _build_golden_bench_cfg()
+        cfg_b = _build_golden_bench_cfg()
+        cfg_b.result_vars = [ResultFloat(units="kg", direction=OptDir.maximize, doc="mass")]
+        assert cfg_a.hash_persistent(include_repeats=True) == cfg_b.hash_persistent(
+            include_repeats=True
+        ), (
+            "ResultFloat.direction is interpretive metadata and must not "
+            "contribute to the cache key."
+        )

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -20,6 +20,7 @@ import sys
 import textwrap
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from enum import Enum
 
 import param
 import pytest
@@ -502,8 +503,6 @@ class TestSweepHashShapeFields:
         assert a.hash_persistent() != b.hash_persistent()
 
     def test_enum_sweep_objects_change_hash(self):
-        from enum import Enum
-
         from bencher.variables.inputs import EnumSweep
 
         class E1(Enum):
@@ -580,40 +579,36 @@ def _discover_sweep_classes():
     return classes
 
 
-def _make_sweep_instance(cls):
-    """Instantiate a sweep class with sensible defaults for slot-coverage tests."""
-    from enum import Enum
+class _SweepFixtureEnum(Enum):
+    A = 1
+    B = 2
 
+
+def _make_sweep_instance(cls):
+    """Instantiate a sweep class with sensible defaults for slot-coverage tests.
+
+    YamlSweep returns None (needs a filesystem path; covered indirectly via
+    SweepSelector).  Unknown subclasses also return None so the caller skips them.
+    """
     from bencher.variables.inputs import (
         BoolSweep,
         EnumSweep,
         FloatSweep,
         IntSweep,
         StringSweep,
-        YamlSweep,
         SweepSelector,
     )
 
-    if cls is FloatSweep:
-        return FloatSweep(bounds=(0.0, 1.0), samples=5, units="m/s")
-    if cls is IntSweep:
-        return IntSweep(bounds=(0, 10), samples=5, units="ul")
-    if cls is StringSweep:
-        return StringSweep(["a", "b", "c"], units="ul")
-    if cls is BoolSweep:
-        return BoolSweep(units="ul")
-    if cls is EnumSweep:
-
-        class _E(Enum):
-            A = 1
-            B = 2
-
-        return EnumSweep(_E, units="ul")
-    if cls is YamlSweep:
-        return None  # needs a filesystem path; covered indirectly via SweepSelector
-    if cls is SweepSelector:
-        return SweepSelector(objects=["a", "b"], units="ul")
-    return None
+    factories = {
+        FloatSweep: lambda: FloatSweep(bounds=(0.0, 1.0), samples=5, units="m/s"),
+        IntSweep: lambda: IntSweep(bounds=(0, 10), samples=5, units="ul"),
+        StringSweep: lambda: StringSweep(["a", "b", "c"], units="ul"),
+        BoolSweep: lambda: BoolSweep(units="ul"),
+        EnumSweep: lambda: EnumSweep(_SweepFixtureEnum, units="ul"),
+        SweepSelector: lambda: SweepSelector(objects=["a", "b"], units="ul"),
+    }
+    factory = factories.get(cls)
+    return factory() if factory is not None else None
 
 
 def _collect_sweep_mro_slots(cls):
@@ -747,7 +742,6 @@ GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "6093b4560b17af4dab2f14f5609b7b945499d
 
 def _build_golden_bench_cfg():
     from bencher.variables.inputs import FloatSweep, IntSweep, StringSweep
-    from bencher.variables.results import ResultFloat
 
     cfg = BenchCfg()
     cfg.bench_name = "golden_bench"
@@ -828,7 +822,7 @@ class TestGoldenBenchCfgHash:
 
     def test_result_direction_does_not_change_bench_hash(self):
         """Flipping minimize<->maximize must not invalidate history."""
-        from bencher.variables.results import OptDir, ResultFloat
+        from bencher.variables.results import OptDir
 
         cfg_a = _build_golden_bench_cfg()
         cfg_b = _build_golden_bench_cfg()


### PR DESCRIPTION
## Summary by Sourcery

Strengthen and correct persistent hashing for sweep variables and benchmark configurations so cache keys change only when sweep shape or cache-relevant configuration changes, and remain stable/deterministic across processes and releases.

New Features:
- Introduce an explicit `_sweep_identity` mechanism for sweep classes to define cache-relevant identity fields, including bounds, step, sample values, and selector objects.
- Add byte-exact golden-hash regression tests for `BenchCfg.hash_persistent` to pin the cache key composition and enforce deliberate cache-version bumps on change.

Bug Fixes:
- Ensure reshaping sweeps (changing bounds, step, sample values, or selector objects) correctly invalidates benchmark-level and `over_time` caches instead of reusing stale coordinates.
- Include `CACHE_VERSION` in `BenchCfg.hash_persistent` so cache-version bumps atomically invalidate all benchmark-level and history cache keys.
- Exclude interpretive/cosmetic result properties such as `ResultFloat.direction` and `ResultRerun` dimensions from hash identity so changing them does not unnecessarily invalidate history.

Enhancements:
- Refine `SweepSelector` hashing to support deterministic fingerprints for custom option objects via `__bencher_hash__` or stable string representations.
- Add a whitelist/coverage test over sweep-class `__slots__` to ensure every new slot either participates in the sweep hash identity or is explicitly excluded, preventing silent cache-collision regressions.

Build:
- Bump the project version to 1.85.0 to reflect the cache-identity and hashing changes.

Documentation:
- Update the changelog with details of the cache-identity fixes, hash semantics, and version bump.

Tests:
- Add comprehensive tests covering sweep hash behavior, slot coverage, selector hashing with `__bencher_hash__`, and golden benchmark-configuration hashes for both repeat-sensitive and repeat-agnostic modes.