### PR TITLE
Fix rerun regression over-time plot crash on panel-wrapped hvplot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.85.1] - 2026-04-19
+
+### Fixed
+- Rerun regression over-time line plots crashing when an acceptance band was overlaid on a `widget_location`-wrapped hvplot (panel pane), by composing the band onto `plot.object` when the plot is a pane wrapper.
+
 ## [1.85.0] - 2026-04-18
 
 ### Fixed

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -122,19 +122,24 @@ class LineResult(HoloviewResult):
             )
             plot = self._apply_opts(plot, xrotation=30)
 
-            # Overlay regression acceptance band if available.
+            # Overlay regression acceptance band if available.  ``plot`` is a
+            # ``panel.pane.HoloViews`` wrapper here (hvplot.line with
+            # widget_location), so we must compose onto the underlying
+            # ``.object`` rather than the pane itself.
             if self.regression_report is not None:
                 import holoviews as hv
 
                 for r in self.regression_report.results:
                     if r.variable == result_var.name and r.band_lower is not None:
-                        plot = (
-                            hv.HSpan(r.band_lower, r.band_upper).opts(color="green", alpha=0.08)
-                            * hv.HLine(r.baseline_value).opts(
-                                color="green", line_dash="dashed", line_width=1
-                            )
-                            * plot
+                        band = hv.HSpan(r.band_lower, r.band_upper).opts(
+                            color="green", alpha=0.08
+                        ) * hv.HLine(r.baseline_value).opts(
+                            color="green", line_dash="dashed", line_width=1
                         )
+                        if hasattr(plot, "object"):
+                            plot.object = band * plot.object
+                        else:
+                            plot = band * plot
 
             return plot
 

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -125,7 +125,9 @@ class LineResult(HoloviewResult):
             # Overlay regression acceptance band if available.  ``plot`` is a
             # ``panel.pane.HoloViews`` wrapper here (hvplot.line with
             # widget_location), so we must compose onto the underlying
-            # ``.object`` rather than the pane itself.
+            # ``.object`` rather than the pane itself.  ``detect_regressions``
+            # appends at most one result per variable, so we stop after the
+            # first match.
             if self.regression_report is not None:
                 import holoviews as hv
 
@@ -136,10 +138,11 @@ class LineResult(HoloviewResult):
                         ) * hv.HLine(r.baseline_value).opts(
                             color="green", line_dash="dashed", line_width=1
                         )
-                        if hasattr(plot, "object"):
+                        if isinstance(plot, pn.pane.HoloViews):
                             plot.object = band * plot.object
                         else:
                             plot = band * plot
+                        break
 
             return plot
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1302,8 +1302,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.85.0
-  sha256: 3dda1370981eb0a33326780af6a3a146822034de42d5a768bdcde9923909f599
+  version: 1.85.1
+  sha256: 34c1f5676c54414f042214d6ae740e4190e2269a11b898db61bd12a0ce4e5822
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.85.0"
+version = "1.85.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary
- `LineResult.to_line_ds` overlaid the regression acceptance band (`hv.HSpan * hv.HLine`) directly onto the hvplot return value, but because the line is built with `widget_location='bottom'` hvplot returns a `panel.pane.HoloViews` wrapper. Multiplying an `Overlay` by a pane raised `TypeError: unsupported operand type(s) for *: 'Overlay' and 'HoloViews'` and broke the entire auto-plot pipeline — regressions were detected correctly but the rendered report errored out.
- Fixed by mirroring the pattern used in `_apply_opts`: if the plot exposes an `.object` (pane wrapper) compose the band onto `plot.object`; otherwise fall back to overlaying the raw plot.
- Bumped version to `1.85.1` and recorded the fix in `CHANGELOG.md`.

## Test plan
- [x] `pixi run ci` — 1292 passed, 5 skipped
- [x] `pixi run python bencher/example/generated/rerun/example_rerun_regression.py` — runs to completion and renders the over-time line plot with the acceptance band overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix regression over-time line plots crashing when overlaying acceptance bands on hvplot outputs wrapped in Panel panes and bump project version.

Bug Fixes:
- Prevent crashes when adding regression acceptance bands to hvplot-generated over-time line plots that are wrapped in Panel HoloViews panes.

Build:
- Bump project version from 1.85.0 to 1.85.1.

Documentation:
- Document the regression plot crash fix in the changelog.