### PR TITLE
Add PNG/bokeh diagnostic plot for regression results

### DIFF
--- a/bencher/example/generated/advanced/example_advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/example_advanced_git_time_event.py
@@ -1,5 +1,7 @@
 """Auto-generated example: Git Time Event — date + commit hash slider labels."""
 
+import random
+
 import bencher as bn
 
 
@@ -14,16 +16,23 @@ class ServerLatency(bn.ParametrizedSweep):
 
     endpoint = bn.StringSweep(["/api/users", "/api/orders", "/api/health"], doc="API endpoint")
 
-    latency = bn.ResultFloat(units="ms", doc="Response latency")
+    latency = bn.ResultFloat(units="ms", doc="Response latency", direction=bn.OptDir.minimize)
+
+    _BASE = {"/api/users": 48.0, "/api/orders": 125.0, "/api/health": 8.0}
 
     def benchmark(self):
-        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]
+        base = self._BASE[self.endpoint]
+        # Gaussian per-run noise so the regression band has a visible width.
+        self.latency = base + random.gauss(0, 0.08 * base)
 
 
 def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Git Time Event — date + commit hash slider labels."""
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
+    run_cfg.regression_detection = True
+
     bench = ServerLatency().to_bench(run_cfg)
-    bench.run_cfg.regression_detection = True
 
     # git_time_event() returns a string like "2024-06-15 abc1234d".
     # Pass it as time_src so each commit gets its own slider tick.

--- a/bencher/example/generated/advanced/example_advanced_git_time_event.py
+++ b/bencher/example/generated/advanced/example_advanced_git_time_event.py
@@ -23,6 +23,7 @@ class ServerLatency(bn.ParametrizedSweep):
 def example_advanced_git_time_event(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Git Time Event — date + commit hash slider labels."""
     bench = ServerLatency().to_bench(run_cfg)
+    bench.run_cfg.regression_detection = True
 
     # git_time_event() returns a string like "2024-06-15 abc1234d".
     # Pass it as time_src so each commit gets its own slider tick.

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -2,45 +2,21 @@
 
 import random
 
-import holoviews as hv
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive
-
-_MAD_TO_SIGMA = 1.4826
+from bencher.regression import detect_adaptive, render_regression_png
 
 
-def _render_detection_plot(hist, current_mean, regressed, z_threshold):
-    """Build a holoviews overlay showing the time-series and detection outcome."""
-    median = float(np.median(hist))
-    mad_sigma = _MAD_TO_SIGMA * float(np.median(np.abs(hist - median)))
-    noise = max(mad_sigma, 1e-6 * abs(median), 1e-12)
-
-    n = len(hist)
-    hist_curve = hv.Curve(list(enumerate(hist)), "Step", "Value").opts(
-        color="#1f77b4",
-        line_width=1.5,
-    )
-    baseline_line = hv.HLine(median).opts(color="gray", line_dash="dashed", line_width=1)
-    band = hv.HSpan(
-        median - z_threshold * noise,
-        median + z_threshold * noise,
-    ).opts(color="green", alpha=0.1)
-
-    marker_color = "#d62728" if regressed else "#2ca02c"
-    current_pt = hv.Scatter([(n, current_mean)], "Step", "Value").opts(
-        color=marker_color,
-        size=10,
-    )
-
-    z = abs(current_mean - median) / noise
-    tag = "REGRESSED" if regressed else "OK"
-
-    return (band * baseline_line * hist_curve * current_pt).opts(
-        title=f"{tag}  z={z:.1f}",
-        width=300,
-        height=200,
+def _render_detection_png(hist, current, result):
+    """Render the adaptive-detector outcome as a PNG and return its path."""
+    return render_regression_png(
+        result,
+        hist,
+        current,
+        path=bn.gen_image_path(f"regression_{result.method}"),
+        figsize=(5.0, 3.2),
+        dpi=100,
     )
 
 
@@ -58,7 +34,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 5.0
     _N_HIST = 20
@@ -84,13 +60,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist,
-            float(np.mean(current)),
-            result.regressed,
-            self.z_threshold,
-        )
+        self.detection_plot = _render_detection_png(hist, current, result)
 
 
 def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -2,45 +2,21 @@
 
 import random
 
-import holoviews as hv
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive
-
-_MAD_TO_SIGMA = 1.4826
+from bencher.regression import detect_adaptive, render_regression_png
 
 
-def _render_detection_plot(hist, current_mean, regressed, z_threshold):
-    """Build a holoviews overlay showing the time-series and detection outcome."""
-    median = float(np.median(hist))
-    mad_sigma = _MAD_TO_SIGMA * float(np.median(np.abs(hist - median)))
-    noise = max(mad_sigma, 1e-6 * abs(median), 1e-12)
-
-    n = len(hist)
-    hist_curve = hv.Curve(list(enumerate(hist)), "Step", "Value").opts(
-        color="#1f77b4",
-        line_width=1.5,
-    )
-    baseline_line = hv.HLine(median).opts(color="gray", line_dash="dashed", line_width=1)
-    band = hv.HSpan(
-        median - z_threshold * noise,
-        median + z_threshold * noise,
-    ).opts(color="green", alpha=0.1)
-
-    marker_color = "#d62728" if regressed else "#2ca02c"
-    current_pt = hv.Scatter([(n, current_mean)], "Step", "Value").opts(
-        color=marker_color,
-        size=10,
-    )
-
-    z = abs(current_mean - median) / noise
-    tag = "REGRESSED" if regressed else "OK"
-
-    return (band * baseline_line * hist_curve * current_pt).opts(
-        title=f"{tag}  z={z:.1f}",
-        width=300,
-        height=200,
+def _render_detection_png(hist, current, result):
+    """Render the adaptive-detector outcome as a PNG and return its path."""
+    return render_regression_png(
+        result,
+        hist,
+        current,
+        path=bn.gen_image_path(f"regression_{result.method}"),
+        figsize=(5.0, 3.2),
+        dpi=100,
     )
 
 
@@ -61,7 +37,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     def benchmark(self):
         baseline = 100.0
@@ -76,13 +52,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist,
-            float(np.mean(current)),
-            result.regressed,
-            self.z_threshold,
-        )
+        self.detection_plot = _render_detection_png(hist, current, result)
 
 
 def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -2,45 +2,21 @@
 
 import random
 
-import holoviews as hv
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive
-
-_MAD_TO_SIGMA = 1.4826
+from bencher.regression import detect_adaptive, render_regression_png
 
 
-def _render_detection_plot(hist, current_mean, regressed, z_threshold):
-    """Build a holoviews overlay showing the time-series and detection outcome."""
-    median = float(np.median(hist))
-    mad_sigma = _MAD_TO_SIGMA * float(np.median(np.abs(hist - median)))
-    noise = max(mad_sigma, 1e-6 * abs(median), 1e-12)
-
-    n = len(hist)
-    hist_curve = hv.Curve(list(enumerate(hist)), "Step", "Value").opts(
-        color="#1f77b4",
-        line_width=1.5,
-    )
-    baseline_line = hv.HLine(median).opts(color="gray", line_dash="dashed", line_width=1)
-    band = hv.HSpan(
-        median - z_threshold * noise,
-        median + z_threshold * noise,
-    ).opts(color="green", alpha=0.1)
-
-    marker_color = "#d62728" if regressed else "#2ca02c"
-    current_pt = hv.Scatter([(n, current_mean)], "Step", "Value").opts(
-        color=marker_color,
-        size=10,
-    )
-
-    z = abs(current_mean - median) / noise
-    tag = "REGRESSED" if regressed else "OK"
-
-    return (band * baseline_line * hist_curve * current_pt).opts(
-        title=f"{tag}  z={z:.1f}",
-        width=300,
-        height=200,
+def _render_detection_png(hist, current, result):
+    """Render the adaptive-detector outcome as a PNG and return its path."""
+    return render_regression_png(
+        result,
+        hist,
+        current,
+        path=bn.gen_image_path(f"regression_{result.method}"),
+        figsize=(5.0, 3.2),
+        dpi=100,
     )
 
 
@@ -58,7 +34,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
 
@@ -75,13 +51,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist,
-            float(np.mean(current)),
-            result.regressed,
-            self.z_threshold,
-        )
+        self.detection_plot = _render_detection_png(hist, current, result)
 
 
 def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -162,7 +162,7 @@ for i, event_name in enumerate(events):
 
     def _generate_git_time_event(self):
         """Git commit time event example."""
-        imports = "import bencher as bn"
+        imports = "import random\n\nimport bencher as bn"
         class_code = '''\
 class ServerLatency(bn.ParametrizedSweep):
     """Simulates server latency measurements across endpoints.
@@ -177,13 +177,20 @@ class ServerLatency(bn.ParametrizedSweep):
         ["/api/users", "/api/orders", "/api/health"], doc="API endpoint"
     )
 
-    latency = bn.ResultFloat(units="ms", doc="Response latency")
+    latency = bn.ResultFloat(units="ms", doc="Response latency", direction=bn.OptDir.minimize)
+
+    _BASE = {"/api/users": 48.0, "/api/orders": 125.0, "/api/health": 8.0}
 
     def benchmark(self):
-        self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]'''
+        base = self._BASE[self.endpoint]
+        # Gaussian per-run noise so the regression band has a visible width.
+        self.latency = base + random.gauss(0, 0.08 * base)'''
         body = """\
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
+run_cfg.regression_detection = True
+
 bench = ServerLatency().to_bench(run_cfg)
-bench.run_cfg.regression_detection = True
 
 # git_time_event() returns a string like "2024-06-15 abc1234d".
 # Pass it as time_src so each commit gets its own slider tick.

--- a/bencher/example/meta/generate_meta_advanced.py
+++ b/bencher/example/meta/generate_meta_advanced.py
@@ -183,6 +183,7 @@ class ServerLatency(bn.ParametrizedSweep):
         self.latency = {"/api/users": 48, "/api/orders": 125, "/api/health": 8}[self.endpoint]'''
         body = """\
 bench = ServerLatency().to_bench(run_cfg)
+bench.run_cfg.regression_detection = True
 
 # git_time_event() returns a string like "2024-06-15 abc1234d".
 # Pass it as time_src so each commit gets its own slider tick.

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -33,36 +33,16 @@ class TuningSpec:
     description: str = ""
 
 
-# Shared holoviews helper emitted at the top of every tuning example file.
+# Shared helper emitted at the top of every tuning example file — renders the
+# regression as a PNG via matplotlib so the diagnostic is self-contained and
+# suitable for a GitHub PR comment.
 _TUNING_RENDER_FN = '''\
-_MAD_TO_SIGMA = 1.4826
-
-
-def _render_detection_plot(hist, current_mean, regressed, z_threshold):
-    """Build a holoviews overlay showing the time-series and detection outcome."""
-    median = float(np.median(hist))
-    mad_sigma = _MAD_TO_SIGMA * float(np.median(np.abs(hist - median)))
-    noise = max(mad_sigma, 1e-6 * abs(median), 1e-12)
-
-    n = len(hist)
-    hist_curve = hv.Curve(list(enumerate(hist)), "Step", "Value").opts(
-        color="#1f77b4", line_width=1.5,
-    )
-    baseline_line = hv.HLine(median).opts(color="gray", line_dash="dashed", line_width=1)
-    band = hv.HSpan(
-        median - z_threshold * noise, median + z_threshold * noise,
-    ).opts(color="green", alpha=0.1)
-
-    marker_color = "#d62728" if regressed else "#2ca02c"
-    current_pt = hv.Scatter([(n, current_mean)], "Step", "Value").opts(
-        color=marker_color, size=10,
-    )
-
-    z = abs(current_mean - median) / noise
-    tag = "REGRESSED" if regressed else "OK"
-
-    return (band * baseline_line * hist_curve * current_pt).opts(
-        title=f"{tag}  z={z:.1f}", width=300, height=200,
+def _render_detection_png(hist, current, result):
+    """Render the adaptive-detector outcome as a PNG and return its path."""
+    return render_regression_png(
+        result, hist, current,
+        path=bn.gen_image_path(f"regression_{result.method}"),
+        figsize=(5.0, 3.2), dpi=100,
     )'''
 
 
@@ -90,7 +70,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
 
@@ -108,10 +88,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist, float(np.mean(current)), result.regressed, self.z_threshold,
-        )""",
+        self.detection_plot = _render_detection_png(hist, current, result)""",
     ),
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
@@ -137,7 +114,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 5.0
     _N_HIST = 20
@@ -158,10 +135,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist, float(np.mean(current)), result.regressed, self.z_threshold,
-        )""",
+        self.detection_plot = _render_detection_png(hist, current, result)""",
     ),
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
@@ -189,7 +163,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
-    detection_plot = bn.ResultReference(units="plot")
+    detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     def benchmark(self):
         baseline = 100.0
@@ -205,10 +179,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
         )
-        self.detection_plot = bn.ResultReference()
-        self.detection_plot.obj = _render_detection_plot(
-            hist, float(np.mean(current)), result.regressed, self.z_threshold,
-        )""",
+        self.detection_plot = _render_detection_png(hist, current, result)""",
     ),
 }
 
@@ -302,10 +273,9 @@ for i, offset in enumerate(releases):
 
         imports = (
             "import random\n\n"
-            "import holoviews as hv\n"
             "import numpy as np\n\n"
             "import bencher as bn\n"
-            "from bencher.regression import detect_adaptive"
+            "from bencher.regression import detect_adaptive, render_regression_png"
         )
 
         class_code = _TUNING_RENDER_FN + "\n\n\n" + spec.class_code

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -59,7 +59,7 @@ class RegressionResult:
     # x-axis coordinates for the historical and current points (typically the
     # ``over_time`` datetimes). Optional: falls back to integer indices.
     historical_x: np.ndarray | None = None
-    current_x: object | None = None
+    current_x: np.ndarray | None = None
 
     def render_png(
         self,
@@ -198,22 +198,35 @@ def _regression_plot_spec(
         hist_x = np.arange(len(hist))
         xlabel = "run index"
 
-    if result.current_x is not None and (
-        np.issubdtype(np.asarray(result.current_x).dtype, np.number)
-        or np.issubdtype(np.asarray(result.current_x).dtype, np.datetime64)
-    ):
-        x_current = np.asarray(result.current_x)
-    elif result.current_x is not None and xticks is not None:
+    # Pick x_current so its dtype matches hist_x. Mixing e.g. datetime64 and
+    # int64 on the same axis raises in holoviews' range computation.
+    current_x_arr = np.asarray(result.current_x) if result.current_x is not None else None
+    if current_x_arr is not None:
+        hist_is_dt = np.issubdtype(hist_x.dtype, np.datetime64)
+        cur_is_dt = np.issubdtype(current_x_arr.dtype, np.datetime64)
+        hist_is_num = np.issubdtype(hist_x.dtype, np.number)
+        cur_is_num = np.issubdtype(current_x_arr.dtype, np.number)
+        current_x_matches_hist = (hist_is_dt and cur_is_dt) or (hist_is_num and cur_is_num)
+    else:
+        current_x_matches_hist = False
+    if current_x_matches_hist:
+        x_current = current_x_arr
+    elif current_x_arr is not None and xticks is not None:
         # String current_x — place it one step past the last history tick and
         # append it to the tick overrides.
         x_current = len(hist_x)
         xticks.append((x_current, str(result.current_x)))
     elif len(hist_x) > 0:
         # Extrapolate one step beyond the last history point.
-        if np.issubdtype(hist_x.dtype, np.datetime64) and len(hist_x) >= 2:
-            x_current = hist_x[-1] + (hist_x[-1] - hist_x[-2])
+        if np.issubdtype(hist_x.dtype, np.datetime64):
+            if len(hist_x) >= 2:
+                x_current = hist_x[-1] + (hist_x[-1] - hist_x[-2])
+            else:
+                # Single datetime point — nudge forward by a small timedelta so
+                # the current marker doesn't overlap the history point exactly.
+                x_current = hist_x[-1] + np.timedelta64(1, "s")
         else:
-            x_current = hist_x[-1] + (1 if not np.issubdtype(hist_x.dtype, np.datetime64) else 0)
+            x_current = hist_x[-1] + 1
     else:
         x_current = 0
 
@@ -303,6 +316,15 @@ def build_regression_overlay(
             hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
                 color="#1f77b4", line_width=1.5
             )
+        )
+        # Dotted connector from the last history point to the current marker
+        # so the jump that triggered the regression is visually obvious.
+        layers.append(
+            hv.Curve(
+                [(hist_x[-1], hist[-1]), (x_current, spec["curr_mean"])],
+                spec["xlabel"],
+                spec["ylabel"],
+            ).opts(color=verdict_color, line_dash="dotted", line_width=1.5)
         )
     if len(spec["curr_samples"]) > 1:
         layers.append(
@@ -410,6 +432,16 @@ def render_regression_png(
             linewidth=1.2,
             label="history",
         )
+        # Dotted connector from the last history point to the current marker
+        # so the jump that triggered the regression is visually obvious.
+        ax.plot(
+            [hist_x[-1], x_current],
+            [hist[-1], spec["curr_mean"]],
+            linestyle=":",
+            color=verdict_color,
+            linewidth=1.2,
+            alpha=0.8,
+        )
 
     if len(curr_samples) > 1:
         ax.scatter(
@@ -429,6 +461,9 @@ def render_regression_png(
         linewidth=0.7,
         label=f"current={spec['curr_mean']:.3g}",
     )
+
+    # Extra margin on the right so the current marker isn't clipped by the frame.
+    ax.margins(x=0.08)
 
     ax.set_xlabel(spec["xlabel"])
     ax.set_ylabel(spec["ylabel"])
@@ -859,19 +894,22 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
 
         # Retain the arrays used for plotting so downstream consumers (reports,
         # bot comments) can rebuild the diagnostic without re-running detection.
+        time_coord = dataset["over_time"].values
         if time_means_arr is not None:
             result.historical = time_means_arr
             # Per-time means are aligned with over_time, one value per time point.
-            result.historical_x = dataset["over_time"].isel(over_time=slice(None, -1)).values
+            result.historical_x = time_coord[:-1]
+            result.current_x = time_coord[-1]
         else:
             result.historical = historical_clean
             # percentage/ttest pass the flat history (repeat * over_time); we
-            # still record the over_time coord (minus the last) so the plotter
-            # can show dates if history is per-time only.
-            if dataset["over_time"].size - 1 == len(historical_clean):
-                result.historical_x = dataset["over_time"].isel(over_time=slice(None, -1)).values
+            # only record over_time coords when they line up with the flat
+            # history length — otherwise pair current_x with the integer
+            # indices used by the plot and leave both unset.
+            if len(time_coord) - 1 == len(historical_clean):
+                result.historical_x = time_coord[:-1]
+                result.current_x = time_coord[-1]
         result.current_samples = current_clean
-        result.current_x = dataset["over_time"].isel(over_time=-1).values
 
         report.results.append(result)
 

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import numpy as np
 import xarray as xr
@@ -52,6 +53,34 @@ class RegressionResult:
     details: str
     band_lower: float | None = None
     band_upper: float | None = None
+    # Arrays retained so the result can be replotted without re-running detection.
+    historical: np.ndarray | None = None
+    current_samples: np.ndarray | None = None
+    # x-axis coordinates for the historical and current points (typically the
+    # ``over_time`` datetimes). Optional: falls back to integer indices.
+    historical_x: np.ndarray | None = None
+    current_x: object | None = None
+
+    def render_png(
+        self,
+        historical: np.ndarray | None = None,
+        current: np.ndarray | float | None = None,
+        path: str | Path | None = None,
+        figsize: tuple[float, float] = (8.0, 5.0),
+        dpi: int = 100,
+    ) -> str:
+        """Render this result as a diagnostic PNG (see :func:`render_regression_png`)."""
+        return render_regression_png(
+            self, historical=historical, current=current, path=path, figsize=figsize, dpi=dpi
+        )
+
+    def render_overlay(
+        self,
+        historical: np.ndarray | None = None,
+        current: np.ndarray | float | None = None,
+    ):
+        """Build a :class:`holoviews.Overlay` of this result (see :func:`build_regression_overlay`)."""
+        return build_regression_overlay(self, historical=historical, current=current)
 
 
 @dataclass
@@ -121,6 +150,260 @@ class RegressionReport:
 
         md = pn.pane.Markdown(self.to_markdown(), name="Regression Report", width=800)
         report.prepend_to_result(bench_res, md)
+
+
+def _regression_plot_spec(
+    result: RegressionResult,
+    historical: np.ndarray | None,
+    current: np.ndarray | float | None,
+) -> dict:
+    """Prepare the data + styling used by both the matplotlib and holoviews renderers.
+
+    Resolves the history and current arrays from the arguments first, falling
+    back to anything stored on *result*. Returns a dict of primitives the
+    backend-specific renderers consume. Keeping this shared guarantees the PNG
+    and in-report plots stay in sync as the diagnostic evolves.
+    """
+    if historical is None:
+        historical = result.historical if result.historical is not None else np.array([])
+    hist = _clean_1d(np.asarray(historical, dtype=float))
+
+    if current is None:
+        current = result.current_samples
+    if current is None:
+        curr_samples = np.array([result.current_value], dtype=float)
+    else:
+        curr_samples = _clean_1d(np.asarray(current, dtype=float).ravel())
+        if len(curr_samples) == 0:
+            curr_samples = np.array([result.current_value], dtype=float)
+    curr_mean = float(np.mean(curr_samples))
+
+    # Use the recorded over_time coordinates when they line up with history,
+    # so the x-axis shows real timestamps rather than integer indices.
+    hist_x: np.ndarray
+    if result.historical_x is not None and len(result.historical_x) == len(hist):
+        hist_x = np.asarray(result.historical_x)
+        xlabel = "time"
+    else:
+        hist_x = np.arange(len(hist))
+        xlabel = "run index"
+
+    if result.current_x is not None:
+        x_current = np.asarray(result.current_x)
+    elif len(hist_x) > 0:
+        # Extrapolate one step beyond the last history point.
+        if np.issubdtype(hist_x.dtype, np.datetime64) and len(hist_x) >= 2:
+            x_current = hist_x[-1] + (hist_x[-1] - hist_x[-2])
+        else:
+            x_current = hist_x[-1] + (1 if not np.issubdtype(hist_x.dtype, np.datetime64) else 0)
+    else:
+        x_current = 0
+
+    verdict_color = "#d62728" if result.regressed else "#2ca02c"
+    verdict_label = "REGRESSED" if result.regressed else "OK"
+
+    change_str = (
+        f"{result.change_percent:+.1f}%"
+        if np.isfinite(result.change_percent)
+        else f"{result.change_percent}"
+    )
+    title = f"{result.variable} — {result.method} — {verdict_label}  (Δ {change_str})"
+
+    return {
+        "hist": hist,
+        "hist_x": hist_x,
+        "curr_samples": curr_samples,
+        "curr_mean": curr_mean,
+        "x_current": x_current,
+        "band": (
+            (result.band_lower, result.band_upper)
+            if result.band_lower is not None and result.band_upper is not None
+            else None
+        ),
+        "baseline": result.baseline_value,
+        "verdict_color": verdict_color,
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": result.variable,
+    }
+
+
+def build_regression_overlay(
+    result: RegressionResult,
+    historical: np.ndarray | None = None,
+    current: np.ndarray | float | None = None,
+    width: int = 700,
+    height: int = 350,
+):
+    """Build a :class:`holoviews.Overlay` diagnostic of a regression result.
+
+    Uses the same logic as :func:`render_regression_png` but returns a
+    backend-agnostic holoviews object, so the same plot can be embedded in an
+    HTML report (bokeh backend) or saved as a PNG (matplotlib backend).
+
+    Args:
+        result: The :class:`RegressionResult` to visualise.
+        historical: Optional 1-D array of historical per-time-point means.
+            Falls back to ``result.historical`` if omitted.
+        current: Optional current-run sample array (or scalar). Falls back to
+            ``result.current_samples`` / ``result.current_value``.
+        width, height: Pixel dimensions passed to the overlay's ``opts``.
+    """
+    import holoviews as hv
+
+    spec = _regression_plot_spec(result, historical, current)
+    hist = spec["hist"]
+    hist_x = spec["hist_x"]
+    verdict_color = spec["verdict_color"]
+    x_current = spec["x_current"]
+
+    layers = []
+    if spec["band"] is not None:
+        lo, hi = spec["band"]
+        layers.append(hv.HSpan(lo, hi).opts(color=verdict_color, alpha=0.10))
+    layers.append(
+        hv.HLine(spec["baseline"]).opts(color="#555555", line_dash="dashed", line_width=1)
+    )
+    if len(hist) > 0:
+        layers.append(
+            hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
+                color="#1f77b4", line_width=1.5
+            )
+        )
+    if len(spec["curr_samples"]) > 1:
+        layers.append(
+            hv.Scatter(
+                [(x_current, v) for v in spec["curr_samples"]],
+                spec["xlabel"],
+                spec["ylabel"],
+            ).opts(color=verdict_color, alpha=0.35, size=5)
+        )
+    layers.append(
+        hv.Scatter(
+            [(x_current, spec["curr_mean"])],
+            spec["xlabel"],
+            spec["ylabel"],
+        ).opts(color=verdict_color, size=10, line_color="black", line_width=1)
+    )
+
+    overlay = layers[0]
+    for layer in layers[1:]:
+        overlay = overlay * layer
+
+    return overlay.opts(title=spec["title"], width=width, height=height, show_grid=True)
+
+
+def render_regression_png(
+    result: RegressionResult,
+    historical: np.ndarray | None = None,
+    current: np.ndarray | float | None = None,
+    path: str | Path | None = None,
+    figsize: tuple[float, float] = (8.0, 5.0),
+    dpi: int = 100,
+) -> str:
+    """Render a diagnostic PNG of a regression result using matplotlib.
+
+    The plot contains everything needed to diagnose the *style* of regression
+    at a glance — history time-series (to reveal drift and noise), the baseline
+    line, the acceptance band (to reveal step size), and the current-run marker
+    coloured by the pass/fail verdict. The details string from
+    :class:`RegressionResult` (method-specific statistics such as z-score,
+    p-value, or percent change) is shown as a footer so the PNG is
+    self-contained — suitable for posting directly as a GitHub PR comment.
+
+    Args:
+        result: The :class:`RegressionResult` produced by a ``detect_*`` call.
+        historical: 1-D array of the historical per-time-point means (the same
+            sequence fed into ``detect_adaptive`` / ``detect_iqr``). Pass an
+            empty array if no history is available — only the current marker,
+            baseline, and band are drawn in that case.
+        current: Current-run sample(s). If ``None``, ``result.current_value``
+            is used. If given an array, the per-sample spread is shown as a
+            vertical strip alongside the mean marker.
+        path: Output PNG path. If ``None``, a path is generated via
+            :func:`bencher.utils.gen_image_path` so the file lives under the
+            bencher cache directory.
+        figsize: Matplotlib figure size in inches.
+        dpi: Output DPI (800x500 at ``dpi=100`` works well for GitHub comments).
+
+    Returns:
+        Absolute path to the saved PNG as a string.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+    import matplotlib.pyplot as plt
+
+    if path is None:
+        from bencher.utils import gen_image_path
+
+        path = gen_image_path(f"regression_{result.variable}")
+    path_str = str(path)
+
+    spec = _regression_plot_spec(result, historical, current)
+    hist = spec["hist"]
+    hist_x = spec["hist_x"]
+    curr_samples = spec["curr_samples"]
+    x_current = spec["x_current"]
+    verdict_color = spec["verdict_color"]
+
+    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
+    fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
+
+    if spec["band"] is not None:
+        lo, hi = spec["band"]
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
+
+    ax.axhline(
+        spec["baseline"],
+        color="#555555",
+        linestyle="--",
+        linewidth=1.0,
+        label=f"baseline={spec['baseline']:.3g}",
+    )
+
+    if len(hist) > 0:
+        ax.plot(
+            hist_x,
+            hist,
+            "-o",
+            color="#1f77b4",
+            markersize=3.5,
+            linewidth=1.2,
+            label="history",
+        )
+
+    if len(curr_samples) > 1:
+        ax.scatter(
+            [x_current] * len(curr_samples),
+            curr_samples,
+            color=verdict_color,
+            alpha=0.35,
+            s=18,
+        )
+    ax.scatter(
+        [x_current],
+        [spec["curr_mean"]],
+        color=verdict_color,
+        s=70,
+        zorder=5,
+        edgecolor="black",
+        linewidth=0.7,
+        label=f"current={spec['curr_mean']:.3g}",
+    )
+
+    ax.set_xlabel(spec["xlabel"])
+    ax.set_ylabel(spec["ylabel"])
+    ax.grid(True, linestyle=":", alpha=0.5)
+    ax.set_title(spec["title"], color=verdict_color, fontsize=10, fontweight="bold")
+    ax.legend(loc="upper left", fontsize=7, framealpha=0.85, ncol=2)
+
+    if len(hist_x) > 0 and np.issubdtype(np.asarray(hist_x).dtype, np.datetime64):
+        fig.autofmt_xdate(rotation=30)
+
+    fig.savefig(path_str, dpi=dpi)
+    plt.close(fig)
+    return path_str
 
 
 def _clean_1d(a: np.ndarray) -> np.ndarray:
@@ -500,28 +783,24 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         if len(current_clean) == 0 or len(historical_clean) == 0:
             continue
 
+        time_means_arr: np.ndarray | None = None
+        if method in ("iqr", "adaptive"):
+            reduce_dims = [d for d in da.dims if d != "over_time"]
+            time_means_arr = (
+                da.isel(over_time=slice(None, -1))
+                .mean(dim=reduce_dims, skipna=True)
+                .values.astype(float)
+            )
+
         if method == "percentage":
             result = detect_percentage(
                 var_name, historical_clean, current_clean, threshold, direction
             )
         elif method == "iqr":
-            # Reduce all dims except over_time to get per-time-point means
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
             result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
         elif method == "ttest":
             result = detect_ttest(var_name, historical_clean, current_clean, threshold, direction)
         elif method == "adaptive":
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
             result = detect_adaptive(
                 var_name,
                 time_means_arr,
@@ -535,6 +814,22 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             result = detect_percentage(
                 var_name, historical_clean, current_clean, threshold, direction
             )
+
+        # Retain the arrays used for plotting so downstream consumers (reports,
+        # bot comments) can rebuild the diagnostic without re-running detection.
+        if time_means_arr is not None:
+            result.historical = time_means_arr
+            # Per-time means are aligned with over_time, one value per time point.
+            result.historical_x = dataset["over_time"].isel(over_time=slice(None, -1)).values
+        else:
+            result.historical = historical_clean
+            # percentage/ttest pass the flat history (repeat * over_time); we
+            # still record the over_time coord (minus the last) so the plotter
+            # can show dates if history is per-time only.
+            if dataset["over_time"].size - 1 == len(historical_clean):
+                result.historical_x = dataset["over_time"].isel(over_time=slice(None, -1)).values
+        result.current_samples = current_clean
+        result.current_x = dataset["over_time"].isel(over_time=-1).values
 
         report.results.append(result)
 

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -178,18 +178,36 @@ def _regression_plot_spec(
             curr_samples = np.array([result.current_value], dtype=float)
     curr_mean = float(np.mean(curr_samples))
 
-    # Use the recorded over_time coordinates when they line up with history,
-    # so the x-axis shows real timestamps rather than integer indices.
+    # Use the recorded over_time coordinates when they line up with history
+    # so the x-axis shows real timestamps. Non-numeric / non-datetime labels
+    # (e.g. git_time_event strings) can't be combined with HSpan/HLine in
+    # holoviews, so they fall back to integer indices with the labels
+    # surfaced as tick overrides instead.
     hist_x: np.ndarray
+    xticks: list[tuple[int, str]] | None = None
     if result.historical_x is not None and len(result.historical_x) == len(hist):
-        hist_x = np.asarray(result.historical_x)
-        xlabel = "time"
+        raw_x = np.asarray(result.historical_x)
+        if np.issubdtype(raw_x.dtype, np.number) or np.issubdtype(raw_x.dtype, np.datetime64):
+            hist_x = raw_x
+            xlabel = "time"
+        else:
+            hist_x = np.arange(len(hist))
+            xticks = [(i, str(v)) for i, v in enumerate(raw_x)]
+            xlabel = "time"
     else:
         hist_x = np.arange(len(hist))
         xlabel = "run index"
 
-    if result.current_x is not None:
+    if result.current_x is not None and (
+        np.issubdtype(np.asarray(result.current_x).dtype, np.number)
+        or np.issubdtype(np.asarray(result.current_x).dtype, np.datetime64)
+    ):
         x_current = np.asarray(result.current_x)
+    elif result.current_x is not None and xticks is not None:
+        # String current_x — place it one step past the last history tick and
+        # append it to the tick overrides.
+        x_current = len(hist_x)
+        xticks.append((x_current, str(result.current_x)))
     elif len(hist_x) > 0:
         # Extrapolate one step beyond the last history point.
         if np.issubdtype(hist_x.dtype, np.datetime64) and len(hist_x) >= 2:
@@ -212,6 +230,7 @@ def _regression_plot_spec(
     return {
         "hist": hist,
         "hist_x": hist_x,
+        "xticks": xticks,
         "curr_samples": curr_samples,
         "curr_mean": curr_mean,
         "x_current": x_current,
@@ -257,12 +276,27 @@ def build_regression_overlay(
     verdict_color = spec["verdict_color"]
     x_current = spec["x_current"]
 
+    # Build an explicit x range so band/baseline render correctly regardless
+    # of whether the x-axis is numeric, datetime, or categorical (xticks).
+    x_start = hist_x[0] if len(hist_x) > 0 else x_current
+    x_end = x_current
+
     layers = []
     if spec["band"] is not None:
         lo, hi = spec["band"]
-        layers.append(hv.HSpan(lo, hi).opts(color=verdict_color, alpha=0.10))
+        layers.append(
+            hv.Area(
+                ([x_start, x_end], [lo, lo], [hi, hi]),
+                kdims=[spec["xlabel"]],
+                vdims=[spec["ylabel"], "band_upper"],
+            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+        )
     layers.append(
-        hv.HLine(spec["baseline"]).opts(color="#555555", line_dash="dashed", line_width=1)
+        hv.Curve(
+            [(x_start, spec["baseline"]), (x_end, spec["baseline"])],
+            spec["xlabel"],
+            spec["ylabel"],
+        ).opts(color="#555555", line_dash="dashed", line_width=1)
     )
     if len(hist) > 0:
         layers.append(
@@ -290,7 +324,11 @@ def build_regression_overlay(
     for layer in layers[1:]:
         overlay = overlay * layer
 
-    return overlay.opts(title=spec["title"], width=width, height=height, show_grid=True)
+    opts_kwargs = dict(title=spec["title"], width=width, height=height, show_grid=True)
+    if spec["xticks"] is not None:
+        opts_kwargs["xticks"] = spec["xticks"]
+        opts_kwargs["xrotation"] = 30
+    return overlay.opts(**opts_kwargs)
 
 
 def render_regression_png(
@@ -398,7 +436,11 @@ def render_regression_png(
     ax.set_title(spec["title"], color=verdict_color, fontsize=10, fontweight="bold")
     ax.legend(loc="upper left", fontsize=7, framealpha=0.85, ncol=2)
 
-    if len(hist_x) > 0 and np.issubdtype(np.asarray(hist_x).dtype, np.datetime64):
+    if spec["xticks"] is not None:
+        ticks, labels = zip(*spec["xticks"])
+        ax.set_xticks(list(ticks))
+        ax.set_xticklabels(list(labels), rotation=30, ha="right")
+    elif len(hist_x) > 0 and np.issubdtype(np.asarray(hist_x).dtype, np.datetime64):
         fig.autofmt_xdate(rotation=30)
 
     fig.savefig(path_str, dpi=dpi)

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -234,7 +234,15 @@ class BenchResult(
         # --- Regression report (auto-inserted when regression detection is enabled) ---
         has_multiple_times = "over_time" in self.ds.dims and self.ds.sizes["over_time"] > 1
         if self.regression_report is not None and has_multiple_times:
-            plot_cols.append(pn.pane.Markdown(self.regression_report.to_markdown(), width=800))
+            for r in self.regression_report.results:
+                if r.historical is None or len(r.historical) == 0:
+                    continue
+                try:
+                    plot_cols.append(pn.pane.HoloViews(r.render_overlay()))
+                except Exception:  # pylint: disable=broad-except
+                    logging.error(
+                        "Failed to render regression overlay for %s", r.variable, exc_info=True
+                    )
 
         # --- Extra panels (user-injected) ---
         if extra_panels:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -890,8 +890,8 @@ class BenchResultBase:
             "No data for this time point</div>"
         )
         html_list = []
-        for t in time_vals:
-            ds_t = dataset.sel(over_time=t)
+        for idx, _t in enumerate(time_vals):
+            ds_t = dataset.isel(over_time=idx)
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
             if filepath == "NAN" or not os.path.isfile(filepath):
                 html_list.append(_NO_DATA_HTML)
@@ -952,8 +952,8 @@ class BenchResultBase:
         labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
 
         items = []
-        for t, label in zip(time_vals, labels):
-            ds_t = dataset.sel(over_time=t)
+        for idx, label in enumerate(labels):
+            ds_t = dataset.isel(over_time=idx)
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
             if filepath == "NAN" or not os.path.isfile(filepath):
                 continue

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -60,6 +60,14 @@ class BandResult(HoloviewResult):
         """
         var = result_var.name
 
+        # Suppress the over_time band when the regression overlay for this
+        # variable is already being rendered — both show the same history.
+        if self.regression_report is not None and any(
+            r.variable == var and r.historical is not None
+            for r in self.regression_report.results
+        ):
+            return None
+
         # band_agg_dims is passed through from to_band to avoid filter pre-aggregation
         agg_over_dims = kwargs.pop("band_agg_dims", None)
 
@@ -131,18 +139,6 @@ class BandResult(HoloviewResult):
             units=units,
             **kwargs,
         )
-
-        # Overlay regression acceptance band if available.
-        if overlay is not None and self.regression_report is not None:
-            for r in self.regression_report.results:
-                if r.variable == var and r.band_lower is not None:
-                    overlay = (
-                        hv.HSpan(r.band_lower, r.band_upper).opts(color="green", alpha=0.08)
-                        * hv.HLine(r.baseline_value).opts(
-                            color="green", line_dash="dashed", line_width=1
-                        )
-                        * overlay
-                    )
 
         return overlay
 

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -63,8 +63,7 @@ class BandResult(HoloviewResult):
         # Suppress the over_time band when the regression overlay for this
         # variable is already being rendered — both show the same history.
         if self.regression_report is not None and any(
-            r.variable == var and r.historical is not None
-            for r in self.regression_report.results
+            r.variable == var and r.historical is not None for r in self.regression_report.results
         ):
             return None
 

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -62,8 +62,11 @@ class BandResult(HoloviewResult):
 
         # Suppress the over_time band when the regression overlay for this
         # variable is already being rendered — both show the same history.
+        # Match the overlay creation guard in BenchResult.to_auto_plots so we
+        # don't hide the base plot when no overlay will actually be drawn.
         if self.regression_report is not None and any(
-            r.variable == var and r.historical is not None for r in self.regression_report.results
+            r.variable == var and r.historical is not None and len(r.historical) > 0
+            for r in self.regression_report.results
         ):
             return None
 

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -306,9 +306,22 @@ class HoloviewResult(VideoResult):
         kdims = self._over_time_kdims()
         holomap = hv.HoloMap(kdims=kdims)
 
+        # Use isel (positional) rather than sel (label-based) so a single time
+        # slice is always returned, even when over_time has duplicate coord
+        # values. With sel, duplicates yield a multi-row slice and hvplot
+        # returns a DynamicMap, while unique values drop the dim and return
+        # plain elements — mixed types break the HoloMap assertion.
+        seen: set = set()
         for idx in slider_indices:
             t = times[idx]
-            ds_t = dataset.sel(over_time=t)
+            try:
+                key = t.item() if hasattr(t, "item") else t
+            except ValueError:
+                key = idx
+            if key in seen:
+                continue
+            seen.add(key)
+            ds_t = dataset.isel(over_time=idx)
             holomap[t] = make_plot_fn(ds_t)
 
         slider_pane = self._holomap_with_slider_bottom(holomap)

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -114,9 +114,11 @@ class LineResult(HoloviewResult):
         ):
             # Suppress the bare over_time line when the regression overlay for
             # this variable is already being rendered — the overlay shows the
-            # same history with extra diagnostic context.
+            # same history with extra diagnostic context. Match the overlay
+            # creation guard in BenchResult.to_auto_plots so we don't hide the
+            # base plot when no overlay will actually be drawn.
             if self.regression_report is not None and any(
-                r.variable == result_var.name and r.historical is not None
+                r.variable == result_var.name and r.historical is not None and len(r.historical) > 0
                 for r in self.regression_report.results
             ):
                 return None

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -112,6 +112,14 @@ class LineResult(HoloviewResult):
             and "over_time" in da_plot.dims
             and da_plot.sizes["over_time"] > 1
         ):
+            # Suppress the bare over_time line when the regression overlay for
+            # this variable is already being rendered — the overlay shows the
+            # same history with extra diagnostic context.
+            if self.regression_report is not None and any(
+                r.variable == result_var.name and r.historical is not None
+                for r in self.regression_report.results
+            ):
+                return None
             title = self.title_from_ds(da_plot, result_var, **kwargs)
             plot = da_plot.hvplot.line(
                 x="over_time",
@@ -121,29 +129,6 @@ class LineResult(HoloviewResult):
                 **kwargs,
             )
             plot = self._apply_opts(plot, xrotation=30)
-
-            # Overlay regression acceptance band if available.  ``plot`` is a
-            # ``panel.pane.HoloViews`` wrapper here (hvplot.line with
-            # widget_location), so we must compose onto the underlying
-            # ``.object`` rather than the pane itself.  ``detect_regressions``
-            # appends at most one result per variable, so we stop after the
-            # first match.
-            if self.regression_report is not None:
-                import holoviews as hv
-
-                for r in self.regression_report.results:
-                    if r.variable == result_var.name and r.band_lower is not None:
-                        band = hv.HSpan(r.band_lower, r.band_upper).opts(
-                            color="green", alpha=0.08
-                        ) * hv.HLine(r.baseline_value).opts(
-                            color="green", line_dash="dashed", line_width=1
-                        )
-                        if isinstance(plot, pn.pane.HoloViews):
-                            plot.object = band * plot.object
-                        else:
-                            plot = band * plot
-                        break
-
             return plot
 
         # No float vars and over_time was squeezed (single time point) — no x-axis

--- a/pixi.lock
+++ b/pixi.lock
@@ -57,6 +57,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -64,6 +65,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
@@ -88,11 +90,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -125,6 +129,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -227,6 +232,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7d/d8/3217636d86c7e7b12e126e4f30ef1581047da73140614523af7495ed5f2d/coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -235,6 +241,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/42/09/7dbe3d7023f57d9b580cfa832109d521988112fd59dddfda3fddda8218f9/fonttools-4.62.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
@@ -258,11 +265,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/aa/7ab67f2b729ae6a91bcf9dcac0affb95fb8c56f7fd2b2af894ae0b0cf6fa/matplotlib-3.10.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -295,6 +304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/82/c40b68001dbec8a3faa4c08cd8c200798ac732d2854537c5449dc859f55a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -400,6 +410,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5f/4b/6157f24ca425b89fe2eb7e7be642375711ab671135be21e6faa100f7448c/contourpy-1.3.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -407,6 +418,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
@@ -431,11 +443,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/46/bddc13df6c2a40741e0cc7865bb1c9ed4796b6760bd04ce5fae3928ef917/kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -468,6 +482,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -571,6 +586,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -578,6 +594,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
@@ -602,11 +619,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -639,6 +658,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -741,6 +761,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -748,6 +769,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
@@ -772,11 +794,13 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -809,6 +833,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
@@ -1173,6 +1198,19 @@ packages:
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+  name: cycler
+  version: 0.12.1
+  sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+  requires_dist:
+  - ipython ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl
   name: debugpy
   version: 1.8.20
@@ -1246,6 +1284,142 @@ packages:
   - pytest-benchmark ; extra == 'devel'
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
+- pypi: https://files.pythonhosted.org/packages/42/09/7dbe3d7023f57d9b580cfa832109d521988112fd59dddfda3fddda8218f9/fonttools-4.62.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: fonttools
+  version: 4.62.1
+  sha256: 7bca7a1c1faf235ffe25d4f2e555246b4750220b38de8261d94ebc5ce8a23c23
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: fonttools
+  version: 4.62.1
+  sha256: 149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: fonttools
+  version: 4.62.1
+  sha256: 1c5c25671ce8805e0d080e2ffdeca7f1e86778c5cbfbeae86d7f866d8830517b
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: fonttools
+  version: 4.62.1
+  sha256: 6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1
+  requires_dist:
+  - lxml>=4.0 ; extra == 'lxml'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - pycairo ; extra == 'interpolatable'
+  - matplotlib ; extra == 'plot'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - uharfbuzz>=0.45.0 ; extra == 'repacker'
+  - lxml>=4.0 ; extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.45.0 ; extra == 'all'
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.90.0-hfc2019e_0.conda
   sha256: a75e901da5e13cbaa5546d69116a48ddb2507464fdc2f34712456c8444431567
   md5: dd272d60843d8acee216735dca2ee149
@@ -1301,7 +1475,7 @@ packages:
 - pypi: ./
   name: holobench
   version: 1.86.0
-  sha256: 35555076ff2fe79d8aed59bcd0d451d447e6ced0fdcaac104f463ecffb141aa1
+  sha256: 6d3a35e41f361d8365c56a72d93c42a7c079c6f67b2af2a70d0d5498de5ffeaf
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -1316,6 +1490,7 @@ packages:
   - strenum>=0.4.0,<=0.4.15
   - scikit-learn>=1.2,<=1.7.2
   - moviepy>=2.1.2,<=2.2.1
+  - matplotlib>=3.7,<=3.10.8
   - nbformat ; extra == 'test'
   - nbclient>=0.7,<=0.10.4 ; extra == 'test'
   - ipykernel ; extra == 'test'
@@ -2056,6 +2231,26 @@ packages:
   version: 3.0.16
   sha256: 45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: kiwisolver
+  version: 1.5.0
+  sha256: 332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/80/46/bddc13df6c2a40741e0cc7865bb1c9ed4796b6760bd04ce5fae3928ef917/kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: kiwisolver
+  version: 1.5.0
+  sha256: 2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: kiwisolver
+  version: 1.5.0
+  sha256: bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  name: kiwisolver
+  version: 1.5.0
+  sha256: 62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22
+  requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -2326,6 +2521,82 @@ packages:
   version: 3.0.3
   sha256: f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: matplotlib
+  version: 3.10.8
+  sha256: 3ab4aabc72de4ff77b3ec33a6d78a68227bf1123465887f9905ba79184a1cc04
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.23
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
+  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
+  - setuptools-scm>=7 ; extra == 'dev'
+  - setuptools>=64 ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: matplotlib
+  version: 3.10.8
+  sha256: a0a7f52498f72f13d4a25ea70f35f4cb60642b466cbb0a9be951b5bc3f45a486
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.23
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
+  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
+  - setuptools-scm>=7 ; extra == 'dev'
+  - setuptools>=64 ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8f/a0/7024215e95d456de5883e6732e708d8187d9753a21d32f8ddb3befc0c445/matplotlib-3.10.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: matplotlib
+  version: 3.10.8
+  sha256: efb30e3baaea72ce5928e32bab719ab4770099079d66726a62b11b1ef7273be4
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.23
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
+  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
+  - setuptools-scm>=7 ; extra == 'dev'
+  - setuptools>=64 ; extra == 'dev'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cb/aa/7ab67f2b729ae6a91bcf9dcac0affb95fb8c56f7fd2b2af894ae0b0cf6fa/matplotlib-3.10.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: matplotlib
+  version: 3.10.8
+  sha256: ee40c27c795bda6a5292e9cff9890189d32f7e3a0bf04e0e3c9430c4a00c37df
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.23
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=3
+  - python-dateutil>=2.7
+  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
+  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
+  - setuptools-scm>=7 ; extra == 'dev'
+  - setuptools>=64 ; extra == 'dev'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl
   name: matplotlib-inline
   version: 0.2.1
@@ -3427,6 +3698,14 @@ packages:
   - pyenchant~=3.2 ; extra == 'spelling'
   - gitpython>3 ; extra == 'testutils'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+  name: pyparsing
+  version: 3.3.2
+  sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
+  requires_dist:
+  - railroad-diagrams ; extra == 'diagrams'
+  - jinja2 ; extra == 'diagrams'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
   name: pytest
   version: 9.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "strenum>=0.4.0,<=0.4.15",
     "scikit-learn>=1.2,<=1.7.2",
     "moviepy>=2.1.2,<=2.2.1",
+    "matplotlib>=3.7,<=3.10.8",
 ]
 
 [project.urls]

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,5 +1,7 @@
 """Tests for bencher.regression module."""
 
+import os
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -9,11 +11,13 @@ from bencher.regression import (
     RegressionError,
     RegressionReport,
     RegressionResult,
+    build_regression_overlay,
     detect_adaptive,
     detect_iqr,
     detect_percentage,
     detect_regressions,
     detect_ttest,
+    render_regression_png,
 )
 from bencher.variables.results import OptDir
 
@@ -747,3 +751,98 @@ class TestEndToEnd:
 
         with pytest.raises(bn.RegressionError):
             bench.plot_sweep(plot_callbacks=False)
+
+
+# ── Renderers ───────────────────────────────────────────────────────────────
+
+
+def _make_result(historical_x=None, current_x=None):
+    hist = np.array([100.0, 102.0, 99.0, 101.0, 100.5, 98.5, 101.2])
+    curr = np.array([130.0])
+    r = detect_percentage("metric", hist, curr, threshold_percent=5.0)
+    r.historical = hist
+    r.current_samples = curr
+    if historical_x is not None:
+        r.historical_x = np.asarray(historical_x)
+    if current_x is not None:
+        r.current_x = current_x
+    return r
+
+
+class TestRenderRegressionPng:
+    """render_regression_png should handle every x-axis dtype we emit."""
+
+    def test_png_index_axis(self, tmp_path):
+        r = _make_result()
+        out = tmp_path / "idx.png"
+        path = render_regression_png(r, path=str(out))
+        assert path == str(out)
+        assert os.path.getsize(path) > 1000
+
+    def test_png_datetime_axis(self, tmp_path):
+        dates = np.array([np.datetime64("2024-01-01") + np.timedelta64(i, "D") for i in range(7)])
+        r = _make_result(historical_x=dates, current_x=np.datetime64("2024-01-08"))
+        out = tmp_path / "dt.png"
+        path = render_regression_png(r, path=str(out))
+        assert os.path.getsize(path) > 1000
+
+    def test_png_string_axis_git_time_event(self, tmp_path):
+        """git_time_event() returns strings like '2024-06-15 abc1234d'."""
+        labels = [f"2024-06-{15 + i:02d} abc{i}234d" for i in range(7)]
+        r = _make_result(historical_x=labels, current_x="2024-06-22 xyz7890")
+        out = tmp_path / "git.png"
+        path = render_regression_png(r, path=str(out))
+        assert os.path.getsize(path) > 1000
+
+    def test_png_method_alias(self, tmp_path):
+        """RegressionResult.render_png delegates to the module function."""
+        r = _make_result()
+        out = tmp_path / "alias.png"
+        r.render_png(path=str(out))
+        assert out.exists()
+
+
+class TestBuildRegressionOverlay:
+    """build_regression_overlay should render through bokeh on every x dtype.
+
+    The regression was: HSpan/HLine combined with a categorical x-axis threw
+    UFuncNoLoopError inside holoviews' get_extents. The fix uses explicit-coord
+    Area/Curve primitives, so driving it through Panel's get_root is the
+    end-to-end proof that the crash is gone.
+    """
+
+    @staticmethod
+    def _render_through_panel(overlay, tmp_path, name):
+        import panel as pn
+
+        col = pn.Column(pn.pane.HoloViews(overlay))
+        out = tmp_path / f"{name}.html"
+        col.save(str(out))
+        assert out.stat().st_size > 0
+
+    def test_overlay_index_axis(self, tmp_path):
+        r = _make_result()
+        self._render_through_panel(build_regression_overlay(r), tmp_path, "idx")
+
+    def test_overlay_datetime_axis(self, tmp_path):
+        dates = np.array([np.datetime64("2024-01-01") + np.timedelta64(i, "D") for i in range(7)])
+        r = _make_result(historical_x=dates, current_x=np.datetime64("2024-01-08"))
+        self._render_through_panel(build_regression_overlay(r), tmp_path, "dt")
+
+    def test_overlay_string_axis_git_time_event(self, tmp_path):
+        """Regression test: git_time_event strings previously crashed bokeh render."""
+        labels = [f"2024-06-{15 + i:02d} abc{i}234d" for i in range(7)]
+        r = _make_result(historical_x=labels, current_x="2024-06-22 xyz7890")
+        self._render_through_panel(build_regression_overlay(r), tmp_path, "git")
+
+    def test_overlay_band_present(self):
+        """The acceptance band should be in the overlay (regression: bokeh
+        silently dropped HSpan when combined with categorical x)."""
+        import holoviews as hv
+
+        labels = [f"2024-06-{15 + i:02d} abc{i}234d" for i in range(7)]
+        r = _make_result(historical_x=labels, current_x="2024-06-22 xyz7890")
+        overlay = build_regression_overlay(r)
+        # The band is rendered as an Area element; assert one is present.
+        has_area = any(isinstance(el, hv.Area) for el in overlay)
+        assert has_area, f"expected an Area layer for the band, got: {list(overlay)}"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -846,3 +846,97 @@ class TestBuildRegressionOverlay:
         # The band is rendered as an Area element; assert one is present.
         has_area = any(isinstance(el, hv.Area) for el in overlay)
         assert has_area, f"expected an Area layer for the band, got: {list(overlay)}"
+
+
+# ── End-to-end over_time plotting with string TimeEvent coords ─────────────
+
+_ctr = [0]
+
+
+class _StringTimeBench(bn.ParametrizedSweep):
+    """Benchmark with a categorical input var — forces the bar plot path."""
+
+    endpoint = bn.StringSweep(["a", "b", "c"], doc="endpoint")
+    latency = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+    _base = {"a": 10.0, "b": 20.0, "c": 30.0}
+
+    def benchmark(self):
+        import random
+
+        self.latency = self._base[self.endpoint] + random.gauss(0, 1.0)
+
+
+def _unique_fake_time_src() -> str:
+    """git_time_event()-style string, guaranteed distinct each call."""
+    _ctr[0] += 1
+    return f"2026-{_ctr[0]:02d}-01 fake{_ctr[0]:04x}"
+
+
+def _duplicate_fake_time_src() -> str:
+    """git_time_event()-style string that repeats — simulates a user running
+    multiple times within the same git commit (pre-fix crash condition)."""
+    return "2026-01-01 samecommit"
+
+
+class TestOverTimeStringCoords:
+    """End-to-end tests against bencher's plot pipeline with git_time_event-
+    style string over_time coords. Previously crashed in two places:
+
+    - regression overlay: nanmax on Unicode dtype (fixed by categorical fallback)
+    - bar plot: duplicate over_time coords → sel returns mixed element types
+      → `HoloMap must only contain one type of object`.
+    """
+
+    def _build_bench(self, time_srcs):
+        run_cfg = bn.BenchRunCfg()
+        run_cfg.over_time = True
+        run_cfg.regression_detection = True
+        run_cfg.auto_plot = False
+        run_cfg.headless = True
+        bench = bn.Bench("string_time", _StringTimeBench(), run_cfg=run_cfg)
+        for i, ts in enumerate(time_srcs):
+            run_cfg.clear_history = i == 0
+            run_cfg.clear_cache = True
+            bench.plot_sweep(
+                input_vars=["endpoint"],
+                result_vars=["latency"],
+                run_cfg=run_cfg,
+                time_src=ts,
+            )
+        return bench
+
+    def test_to_auto_plots_unique_string_times(self):
+        """With unique string time coords, to_auto_plots should not crash."""
+        _ctr[0] = 0
+        bench = self._build_bench([_unique_fake_time_src() for _ in range(3)])
+        res = bench.results[-1]
+        panel = res.to_auto_plots()
+        assert panel is not None
+
+    def test_to_auto_plots_duplicate_string_times(self):
+        """Duplicate over_time coord values previously crashed the bar holomap
+        with `HoloMap must only contain one type of object`. After the fix,
+        duplicates are deduped inside _build_time_holomap via isel + seen set.
+        """
+        bench = self._build_bench([_duplicate_fake_time_src() for _ in range(3)])
+        res = bench.results[-1]
+        # Must not raise even though the dataset has duplicate over_time coords.
+        panel = res.to_auto_plots()
+        assert panel is not None
+
+    def test_regression_report_populated_with_string_times(self):
+        """regression_report should capture string historical_x for use by the
+        PNG/overlay renderers (without crashing on dtype)."""
+        _ctr[0] = 0
+        bench = self._build_bench([_unique_fake_time_src() for _ in range(4)])
+        res = bench.results[-1]
+        assert res.regression_report is not None
+        assert res.regression_report.results, "expected at least one result"
+        r = res.regression_report.results[0]
+        assert r.historical_x is not None
+        assert r.historical_x.dtype.kind == "U"  # unicode
+        # Renderers must both succeed on this result.
+        import panel as pn
+
+        overlay = r.render_overlay()
+        pn.Column(pn.pane.HoloViews(overlay))  # triggers panel init render path


### PR DESCRIPTION
## Summary
- Adds a shared regression-diagnostic plot rendered as either a matplotlib PNG (for GitHub bot PR comments) or a holoviews/bokeh overlay (embedded in the HTML report). Both paths build from a single `_regression_plot_spec` so they stay in sync.
- `RegressionResult` now carries `historical`, `current_samples`, `historical_x`, `current_x`; `detect_regressions` populates them (including `over_time` datetimes), so the plot uses real dates when available and falls back to run indices for standalone use (grid examples).
- HTML reports auto-insert the overlay per variable. The bare `over_time` line/band plots are suppressed for any variable with a regression overlay to avoid two graphs for the same metric.
- The regression tuning grid examples now emit `ResultImage` PNGs via the new renderer.
- Added `matplotlib` to `pyproject.toml`.

## Test plan
- [x] `pixi run test` — 1292 passed
- [x] `pixi run lint` (pylint 10/10, ruff clean, ty warnings pre-existing)
- [x] Tuning grid examples render correctly (verified manually)
- [x] Rerun regression example now shows one unified plot per variable with a proper date axis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a unified regression diagnostic plotting system that supports both PNG output and HTML-embedded overlays, and wire it into regression detection, reporting, and examples.

New Features:
- Add rendering methods on regression results to produce matplotlib PNGs and holoviews overlays from a shared plot specification.
- Embed regression diagnostic overlays automatically into HTML benchmark reports per variable, using recorded historical and current sample data.
- Update regression tuning examples to emit self-contained diagnostic PNG images instead of holoviews references.

Enhancements:
- Extend regression results to retain historical/current values and x-axis coordinates so diagnostics can be plotted without re-running detection.
- Refine regression detection to compute and store time-aggregated histories used by multiple detection methods.
- Adjust existing over_time line and band plots to avoid duplicating history when a regression overlay is present.

Build:
- Add matplotlib as a project dependency for PNG-based regression diagnostics.