### PR TITLE
Unify regression detection into a single MAD-sigma detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.88.0] - 2026-04-19
+
+### Changed
+- **Unified regression detection API (breaking).** The four `detect_percentage`, `detect_iqr`, `detect_ttest`, and `detect_adaptive` functions — plus the method-switching cascade that silently swapped between them based on data size — are replaced by a single `detect_regression` that always reports in MAD-sigma units. Noise is estimated with layered fallbacks inside the function (MAD → residual-MAD → discretization → relative floor), so the same call handles long noisy history, sparse history, and constant-valued integer metrics without changing method.
+- `BenchRunCfg.regression_method` removed. `regression_threshold` now always means "step-test threshold in MAD-sigma units" (default 3.5).
+- New `BenchRunCfg.regression_min_change_percent` optional AND-guard: even if the z-score exceeds `regression_threshold`, require `|percent change| ≥ min_change_percent` before flagging. Use this for stable integer metrics where the noise floor collapses and a single-unit change would otherwise produce a huge z-score.
+- `RegressionResult.method` is now always `"regression"` (the layer that produced the noise estimate is reported in `details`).
+- `example_regression_percentage` renamed to `example_regression_over_time`.
+
 ## [1.87.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BenchRunCfg.regression_method` removed. `regression_threshold` now always means "step-test threshold in MAD-sigma units" (default 3.5).
 - New `BenchRunCfg.regression_min_change_percent` optional AND-guard: even if the z-score exceeds `regression_threshold`, require `|percent change| ≥ min_change_percent` before flagging. Use this for stable integer metrics where the noise floor collapses and a single-unit change would otherwise produce a huge z-score.
 - `RegressionResult.method` is now always `"regression"` (the layer that produced the noise estimate is reported in `details`).
+- Drift detection (Theil-Sen slope + Mann-Kendall guard) now runs automatically whenever there are at least 4 historical time points. Previously it only ran when `regression_method="adaptive"`.
 - `example_regression_percentage` renamed to `example_regression_over_time`.
 
 ## [1.87.0] - 2026-04-19

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -350,23 +350,23 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "statistically compare the latest run against historical data.",
     )
 
-    regression_method: str = param.Selector(
-        default="adaptive",
-        objects=["percentage", "iqr", "ttest", "adaptive"],
-        doc="Detection method: 'percentage' (mean comparison), "
-        "'iqr' (IQR outlier detection), 'ttest' (Welch's t-test), "
-        "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
-    )
-
     regression_threshold: float = param.Number(
         default=None,
         allow_None=True,
-        doc="Threshold for regression detection. Interpretation depends on method: "
-        "'percentage' = percent change (default 5.0), "
-        "'iqr' = IQR multiplier (default 1.5), "
-        "'ttest' = significance level alpha (default 0.05), "
-        "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
-        "If None, the per-method default is used automatically.",
+        doc="Step-test threshold for regression detection, expressed in "
+        "MAD-sigma units (robust z-score). A regression fires when "
+        "|current - baseline| / noise > threshold in the direction that "
+        "worsens the metric. Defaults to 3.5 when None.",
+    )
+
+    regression_min_change_percent: float = param.Number(
+        default=None,
+        allow_None=True,
+        doc="Optional AND-guard: even if the z-score exceeds "
+        "regression_threshold, require |percent change| >= this value "
+        "before flagging. Useful for highly stable metrics (e.g. integer "
+        "counters) where the noise floor collapses and a single-unit "
+        "change would otherwise yield a huge z-score. None disables.",
     )
 
     regression_fail: bool = param.Boolean(

--- a/bencher/example/generated/regression/example_regression_over_time.py
+++ b/bencher/example/generated/regression/example_regression_over_time.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Regression detection — percentage threshold over time."""
+"""Auto-generated example: Regression detection — over time."""
 
 from datetime import datetime, timedelta
 
@@ -23,11 +23,10 @@ class ServerBenchmark(bn.ParametrizedSweep):
         self.throughput = 1000.0 / self.response_time
 
 
-def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Regression detection — percentage threshold over time."""
+def example_regression_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Regression detection — over time."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ServerBenchmark()
@@ -55,4 +54,4 @@ def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.B
 
 
 if __name__ == "__main__":
-    bn.run(example_regression_percentage, over_time=True)
+    bn.run(example_regression_over_time, over_time=True)

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Adaptive detector — tuning drift."""
+"""Auto-generated example: Regression detector — tuning drift."""
 
 import random
 
@@ -65,7 +65,7 @@ class DriftDetection(bn.ParametrizedSweep):
 
 
 def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Adaptive detector — tuning drift."""
+    """Regression detector — tuning drift."""
     bench = DriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["drift_rate", "z_threshold"],

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -5,11 +5,11 @@ import random
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive, render_regression_png
+from bencher.regression import detect_regression, render_regression_png
 
 
 def _render_detection_png(hist, current, result):
-    """Render the adaptive-detector outcome as a PNG and return its path."""
+    """Render the detector outcome as a PNG and return its path."""
     return render_regression_png(
         result,
         hist,
@@ -20,7 +20,7 @@ def _render_detection_png(hist, current, result):
     )
 
 
-class AdaptiveDriftDetection(bn.ParametrizedSweep):
+class DriftDetection(bn.ParametrizedSweep):
     """Gradual drift — parametrised by drift rate and z-threshold."""
 
     drift_rate = bn.FloatSweep(
@@ -31,7 +31,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     z_threshold = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -53,23 +53,24 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
                 for _ in range(5)
             ]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric",
             hist,
             current,
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
+            historical_time_means=hist,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
 
 
 def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning drift."""
-    bench = AdaptiveDriftDetection().to_bench(run_cfg)
+    bench = DriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["drift_rate", "z_threshold"],
         result_vars=["detection_plot"],
-        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high z_thresholds allow the trend to pass unnoticed.",
+        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high z_thresholds allow the trend to pass unnoticed.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Adaptive detector — tuning noise."""
+"""Auto-generated example: Regression detector — tuning noise."""
 
 import random
 
@@ -56,7 +56,7 @@ class NoiseRobustness(bn.ParametrizedSweep):
 
 
 def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Adaptive detector — tuning noise."""
+    """Regression detector — tuning noise."""
     bench = NoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["noise_sigma", "z_threshold"],

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -5,11 +5,11 @@ import random
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive, render_regression_png
+from bencher.regression import detect_regression, render_regression_png
 
 
 def _render_detection_png(hist, current, result):
-    """Render the adaptive-detector outcome as a PNG and return its path."""
+    """Render the detector outcome as a PNG and return its path."""
     return render_regression_png(
         result,
         hist,
@@ -23,18 +23,18 @@ def _render_detection_png(hist, current, result):
 _REGRESSION_STEP = 25.0
 
 
-class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
+class NoiseRobustness(bn.ParametrizedSweep):
     """Fixed 25-unit regression with varying noise — tests noise robustness."""
 
     noise_sigma = bn.FloatSweep(
         default=10.0,
-        bounds=[2.0, 40.0],
+        bounds=[0.0, 40.0],
         doc="Noise standard deviation",
     )
     z_threshold = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -45,7 +45,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         current = np.array(
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric",
             hist,
             current,
@@ -57,7 +57,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
 
 def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning noise."""
-    bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
+    bench = NoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["noise_sigma", "z_threshold"],
         result_vars=["detection_plot"],

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -5,11 +5,11 @@ import random
 import numpy as np
 
 import bencher as bn
-from bencher.regression import detect_adaptive, render_regression_png
+from bencher.regression import detect_regression, render_regression_png
 
 
 def _render_detection_png(hist, current, result):
-    """Render the adaptive-detector outcome as a PNG and return its path."""
+    """Render the detector outcome as a PNG and return its path."""
     return render_regression_png(
         result,
         hist,
@@ -20,7 +20,7 @@ def _render_detection_png(hist, current, result):
     )
 
 
-class AdaptiveStepDetection(bn.ParametrizedSweep):
+class StepDetection(bn.ParametrizedSweep):
     """Step regression — parametrised by magnitude and z-threshold."""
 
     regression_magnitude = bn.FloatSweep(
@@ -31,7 +31,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     z_threshold = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -44,7 +44,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         current = np.array(
             [baseline + self.regression_magnitude + random.gauss(0, self._NOISE) for _ in range(5)]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric",
             hist,
             current,
@@ -56,7 +56,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
 
 def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning step."""
-    bench = AdaptiveStepDetection().to_bench(run_cfg)
+    bench = StepDetection().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["regression_magnitude", "z_threshold"],
         result_vars=["detection_plot"],

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Adaptive detector — tuning step."""
+"""Auto-generated example: Regression detector — tuning step."""
 
 import random
 
@@ -55,7 +55,7 @@ class StepDetection(bn.ParametrizedSweep):
 
 
 def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Adaptive detector — tuning step."""
+    """Regression detector — tuning step."""
     bench = StepDetection().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["regression_magnitude", "z_threshold"],

--- a/bencher/example/generated/rerun/example_rerun_regression.py
+++ b/bencher/example/generated/rerun/example_rerun_regression.py
@@ -11,7 +11,6 @@ def example_rerun_regression(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     if run_cfg is None:
         run_cfg = bn.BenchRunCfg()
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ControlSystemSweep()

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -2,7 +2,7 @@
 
 Demonstrates how to use regression detection to catch performance
 regressions in over-time benchmarks, and 2-D tuning grids that show
-where the adaptive detector fires or stays quiet.
+where the unified detector fires or stays quiet.
 """
 
 from dataclasses import dataclass
@@ -38,7 +38,7 @@ class TuningSpec:
 # suitable for a GitHub PR comment.
 _TUNING_RENDER_FN = '''\
 def _render_detection_png(hist, current, result):
-    """Render the adaptive-detector outcome as a PNG and return its path."""
+    """Render the detector outcome as a PNG and return its path."""
     return render_regression_png(
         result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
@@ -49,7 +49,7 @@ def _render_detection_png(hist, current, result):
 _TUNING: dict[str, TuningSpec] = {
     # ---- 1. Step regression parametrised by magnitude ----------------------
     "tuning_step": TuningSpec(
-        classname="AdaptiveStepDetection",
+        classname="StepDetection",
         input_vars=("regression_magnitude", "z_threshold"),
         description=(
             "A step regression of variable magnitude is injected (fixed noise σ=10). "
@@ -60,14 +60,14 @@ _TUNING: dict[str, TuningSpec] = {
             "detectable effect for each threshold setting."
         ),
         class_code="""\
-class AdaptiveStepDetection(bn.ParametrizedSweep):
+class StepDetection(bn.ParametrizedSweep):
     \"\"\"Step regression — parametrised by magnitude and z-threshold.\"\"\"
 
     regression_magnitude = bn.FloatSweep(
         default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
     )
     z_threshold = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -83,7 +83,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
             [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric", hist, current,
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
@@ -92,26 +92,26 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     ),
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
-        classname="AdaptiveDriftDetection",
+        classname="DriftDetection",
         input_vars=("drift_rate", "z_threshold"),
         description=(
             "A linear drift is added to the history (fixed noise σ=5). "
             "With 20 time points, the total drift equals drift_rate × 20 "
-            "and the current run continues the trend.  The adaptive drift "
-            "test (Theil–Sen slope + Mann–Kendall trend guard) fires when "
+            "and the current run continues the trend.  The drift test "
+            "(Theil–Sen slope + Mann–Kendall trend guard) fires when "
             "the accumulated drift outweighs the detrended noise.  Low "
             "drift rates or high z_thresholds allow the trend to pass "
             "unnoticed."
         ),
         class_code="""\
-class AdaptiveDriftDetection(bn.ParametrizedSweep):
+class DriftDetection(bn.ParametrizedSweep):
     \"\"\"Gradual drift — parametrised by drift rate and z-threshold.\"\"\"
 
     drift_rate = bn.FloatSweep(
         default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
     )
     z_threshold = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -130,16 +130,17 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
              + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric", hist, current,
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
+            historical_time_means=hist,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
     ),
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
-        classname="AdaptiveNoiseRobustness",
+        classname="NoiseRobustness",
         input_vars=("noise_sigma", "z_threshold"),
         description=(
             "A fixed +25 step regression is present, but the noise level varies. "
@@ -153,14 +154,14 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
 _REGRESSION_STEP = 25.0
 
 
-class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
+class NoiseRobustness(bn.ParametrizedSweep):
     \"\"\"Fixed 25-unit regression with varying noise — tests noise robustness.\"\"\"
 
     noise_sigma = bn.FloatSweep(
-        default=10.0, bounds=[2.0, 40.0], doc="Noise standard deviation",
+        default=10.0, bounds=[0.0, 40.0], doc="Noise standard deviation",
     )
     z_threshold = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Detector z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -174,7 +175,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
              for _ in range(5)]
         )
-        result = detect_adaptive(
+        result = detect_regression(
             "metric", hist, current,
             z_threshold=self.z_threshold,
             direction=bn.OptDir.minimize,
@@ -189,7 +190,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
 # ---------------------------------------------------------------------------
 
 REGRESSION_EXAMPLES = [
-    "regression_percentage",
+    "regression_over_time",
     *[f"regression_{tuning}" for tuning in _TUNING],
 ]
 
@@ -200,8 +201,8 @@ class MetaRegression(MetaGeneratorBase):
     example = bn.StringSweep(REGRESSION_EXAMPLES, doc="Which regression example to generate")
 
     def benchmark(self):
-        if self.example == "regression_percentage":
-            self._generate_percentage_over_time()
+        if self.example == "regression_over_time":
+            self._generate_over_time()
             return
 
         for tuning, spec in _TUNING.items():
@@ -209,8 +210,8 @@ class MetaRegression(MetaGeneratorBase):
                 self._generate_tuning(tuning, spec)
                 return
 
-    def _generate_percentage_over_time(self):
-        """End-to-end over_time example that trips the percentage detector."""
+    def _generate_over_time(self):
+        """End-to-end over_time example that trips the detector."""
         imports = "from datetime import datetime, timedelta\n\nimport bencher as bn"
         class_code = '''\
 class ServerBenchmark(bn.ParametrizedSweep):
@@ -232,7 +233,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True
-run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False
 
 benchable = ServerBenchmark()
@@ -257,10 +257,10 @@ for i, offset in enumerate(releases):
     )
 """
         self.generate_example(
-            title="Regression detection — percentage threshold over time",
+            title="Regression detection — over time",
             output_dir=OUTPUT_DIR,
-            filename="example_regression_percentage",
-            function_name="example_regression_percentage",
+            filename="example_regression_over_time",
+            function_name="example_regression_over_time",
             imports=imports,
             body=body,
             class_code=class_code,
@@ -275,7 +275,7 @@ for i, offset in enumerate(releases):
             "import random\n\n"
             "import numpy as np\n\n"
             "import bencher as bn\n"
-            "from bencher.regression import detect_adaptive, render_regression_png"
+            "from bencher.regression import detect_regression, render_regression_png"
         )
 
         class_code = _TUNING_RENDER_FN + "\n\n\n" + spec.class_code

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -269,7 +269,7 @@ for i, offset in enumerate(releases):
 
     def _generate_tuning(self, tuning: str, spec: TuningSpec) -> None:
         """Emit a 2D tuning example with holoviews ResultReference output."""
-        title = f"Adaptive detector — {tuning.replace('_', ' ')}"
+        title = f"Regression detector — {tuning.replace('_', ' ')}"
 
         imports = (
             "import random\n\n"

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -88,7 +88,6 @@ bench.plot_sweep(
 if run_cfg is None:
     run_cfg = bn.BenchRunCfg()
 run_cfg.regression_detection = True
-run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False
 
 benchable = ControlSystemSweep()

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -497,11 +497,7 @@ def _safe_change_percent(current: float, baseline: float) -> float:
 
 
 def _is_regression(delta: float, direction: OptDir) -> bool:
-    """Return True if *delta* is a regression given the optimization direction.
-
-    Accepts either a signed percent change or a signed z-score — both share the
-    same sign convention.
-    """
+    """Return True if *delta* (a signed z-score) worsens the metric."""
     if direction == OptDir.minimize:
         return delta > 0  # higher is worse
     if direction == OptDir.maximize:
@@ -625,8 +621,8 @@ def detect_regression(
     if min_change_percent is None:
         percent_ok = True
     elif not np.isfinite(change):
-        # Baseline is zero and current isn't — can't compute a percent change,
-        # so the guard can't be satisfied and the result is never flagged.
+        # change is inf (zero baseline, nonzero current) or nan — the guard
+        # can't meaningfully compare a percent change, so treat as unsatisfied.
         percent_ok = False
     else:
         percent_ok = abs(change) >= min_change_percent

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -1,13 +1,14 @@
 """Benchmark regression detection for over-time benchmarks.
 
-Provides statistical methods to detect if benchmark values have changed
-significantly between runs. Supports percentage threshold, IQR-based outlier
-detection, and Welch's t-test.
+Provides a single statistical detector that flags significant changes between
+a current run and historical runs. Noise is estimated in MAD-sigma units with
+layered fallbacks (MAD → residual-MAD → discretization → relative floor), so
+one function handles everything from noisy Gaussian history down to a single
+prior sample.
 """
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -16,22 +17,24 @@ import xarray as xr
 
 from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 
-# Default thresholds per method — used when the user hasn't explicitly set a threshold.
-_METHOD_DEFAULTS = {
-    "percentage": 5.0,  # percent change
-    "iqr": 1.5,  # IQR multiplier
-    "ttest": 0.05,  # significance level alpha
-    "adaptive": 3.5,  # robust z-score threshold in MAD units
-}
+# Default step-test threshold in MAD-sigma units.
+_DEFAULT_Z_THRESHOLD = 3.5
 
 # Consistency factor so MAD estimates the standard deviation of a Gaussian.
 _MAD_TO_SIGMA = 1.4826
 
-# Drift threshold defaults to this fraction of z_threshold when not set by caller.
+# Drift threshold defaults to this fraction of z_threshold.
 _DRIFT_FRAC = 0.85
 
 # Hampel filter cutoff (in MAD units) used to drop outliers from the slope fit.
 _HAMPEL_K = 5.0
+
+# Mann–Kendall significance gate for the drift test.
+_MK_ALPHA = 0.1
+
+# Fallback floors when noise estimates collapse to zero.
+_RELATIVE_FLOOR = 1e-6
+_ABSOLUTE_FLOOR = 1e-12
 
 
 class RegressionError(Exception):
@@ -366,15 +369,11 @@ def render_regression_png(
     The plot contains everything needed to diagnose the *style* of regression
     at a glance — history time-series (to reveal drift and noise), the baseline
     line, the acceptance band (to reveal step size), and the current-run marker
-    coloured by the pass/fail verdict. The details string from
-    :class:`RegressionResult` (method-specific statistics such as z-score,
-    p-value, or percent change) is shown as a footer so the PNG is
-    self-contained — suitable for posting directly as a GitHub PR comment.
+    coloured by the pass/fail verdict.
 
     Args:
-        result: The :class:`RegressionResult` produced by a ``detect_*`` call.
-        historical: 1-D array of the historical per-time-point means (the same
-            sequence fed into ``detect_adaptive`` / ``detect_iqr``). Pass an
+        result: The :class:`RegressionResult` produced by :func:`detect_regression`.
+        historical: 1-D array of the historical per-time-point means. Pass an
             empty array if no history is available — only the current marker,
             baseline, and band are drawn in that case.
         current: Current-run sample(s). If ``None``, ``result.current_value``
@@ -432,8 +431,6 @@ def render_regression_png(
             linewidth=1.2,
             label="history",
         )
-        # Dotted connector from the last history point to the current marker
-        # so the jump that triggered the regression is visually obvious.
         ax.plot(
             [hist_x[-1], x_current],
             [hist[-1], spec["curr_mean"]],
@@ -462,7 +459,6 @@ def render_regression_png(
         label=f"current={spec['curr_mean']:.3g}",
     )
 
-    # Extra margin on the right so the current marker isn't clipped by the frame.
     ax.margins(x=0.08)
 
     ax.set_xlabel(spec["xlabel"])
@@ -491,6 +487,8 @@ def _clean_1d(a: np.ndarray) -> np.ndarray:
 
 def _safe_change_percent(current: float, baseline: float) -> float:
     """Calculate percentage change, handling zero baseline gracefully."""
+    if not np.isfinite(current) or not np.isfinite(baseline):
+        return float("nan")
     if baseline == 0:
         if current == 0:
             return 0.0
@@ -498,168 +496,21 @@ def _safe_change_percent(current: float, baseline: float) -> float:
     return ((current - baseline) / abs(baseline)) * 100.0
 
 
-def _is_regression(change_percent: float, direction: OptDir) -> bool:
-    """Determine if a change constitutes a regression given the optimization direction."""
+def _is_regression(delta: float, direction: OptDir) -> bool:
+    """Return True if *delta* is a regression given the optimization direction.
+
+    Accepts either a signed percent change or a signed z-score — both share the
+    same sign convention.
+    """
     if direction == OptDir.minimize:
-        return change_percent > 0  # higher is worse
+        return delta > 0  # higher is worse
     if direction == OptDir.maximize:
-        return change_percent < 0  # lower is worse
+        return delta < 0  # lower is worse
     return True  # OptDir.none — any significant change is a regression
 
 
-def _exceeds_directional_threshold(
-    change_percent: float,
-    threshold_percent: float,
-    direction: OptDir,
-) -> bool:
-    """Check if change exceeds threshold in the direction-appropriate sense."""
-    if direction == OptDir.minimize:
-        return change_percent > threshold_percent
-    if direction == OptDir.maximize:
-        return change_percent < -threshold_percent
-    return abs(change_percent) > threshold_percent
-
-
-def detect_percentage(
-    variable: str,
-    historical: np.ndarray,
-    current: np.ndarray,
-    threshold_percent: float = 5.0,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """Compare current mean vs historical mean by percentage threshold."""
-    hist_mean = float(np.nanmean(historical))
-    curr_mean = float(np.nanmean(current))
-    change = _safe_change_percent(curr_mean, hist_mean)
-
-    exceeds = _exceeds_directional_threshold(change, threshold_percent, direction)
-    regressed = exceeds and _is_regression(change, direction)
-
-    frac = threshold_percent / 100.0
-    return RegressionResult(
-        variable=variable,
-        method="percentage",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=threshold_percent,
-        direction=direction.value,
-        details=f"Change {change:+.2f}% vs threshold {threshold_percent}%",
-        band_lower=hist_mean * (1.0 - frac),
-        band_upper=hist_mean * (1.0 + frac),
-    )
-
-
-def detect_iqr(
-    variable: str,
-    historical_time_means: np.ndarray,
-    current: np.ndarray,
-    iqr_scale: float = 1.5,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """IQR outlier detection using per-time-point means from history.
-
-    Args:
-        variable: Name of the result variable being checked.
-        historical_time_means: Array of per-time-point mean values from history.
-        current: Current run values (will be averaged).
-        iqr_scale: Multiplier for IQR to define outlier bounds (default 1.5).
-        direction: Optimization direction from the result variable.
-    """
-    clean = _clean_1d(historical_time_means)
-    curr_mean = float(np.nanmean(current))
-
-    if len(clean) < 4:
-        # Not enough time points for robust IQR; fall back to percentage using
-        # the default percentage threshold so the comparison stays meaningful.
-        return detect_percentage(
-            variable,
-            clean,
-            current,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
-            direction=direction,
-        )
-
-    q1 = float(np.percentile(clean, 25))
-    q3 = float(np.percentile(clean, 75))
-    iqr = q3 - q1
-    lower = q1 - iqr_scale * iqr
-    upper = q3 + iqr_scale * iqr
-
-    hist_mean = float(np.nanmean(clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-
-    outside_bounds = curr_mean > upper or curr_mean < lower
-    regressed = outside_bounds and _is_regression(change, direction)
-
-    return RegressionResult(
-        variable=variable,
-        method="iqr",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=iqr_scale,
-        direction=direction.value,
-        details=f"IQR bounds [{lower:.4g}, {upper:.4g}], current={curr_mean:.4g}",
-        band_lower=lower,
-        band_upper=upper,
-    )
-
-
-def detect_ttest(
-    variable: str,
-    historical: np.ndarray,
-    current: np.ndarray,
-    alpha: float = 0.05,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """Welch's t-test between historical and current samples."""
-    hist_clean = _clean_1d(historical)
-    curr_clean = _clean_1d(current)
-
-    if len(hist_clean) < 2 or len(curr_clean) < 2:
-        # Fall back to percentage with alpha-based threshold
-        return detect_percentage(
-            variable, hist_clean, curr_clean, threshold_percent=alpha * 100, direction=direction
-        )
-
-    from scipy.stats import ttest_ind
-
-    if direction == OptDir.minimize:
-        alt = "greater"  # regression = current > historical
-    elif direction == OptDir.maximize:
-        alt = "less"  # regression = current < historical
-    else:
-        alt = "two-sided"
-
-    stat, pvalue = ttest_ind(curr_clean, hist_clean, equal_var=False, alternative=alt)
-
-    hist_mean = float(np.nanmean(hist_clean))
-    curr_mean = float(np.nanmean(curr_clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-    regressed = pvalue < alpha
-
-    return RegressionResult(
-        variable=variable,
-        method="ttest",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=alpha,
-        direction=direction.value,
-        details=f"t-stat={stat:.4g}, p-value={pvalue:.4g}, alpha={alpha}",
-    )
-
-
 def _robust_scale(values: np.ndarray) -> tuple[float, float]:
-    """Return (median, MAD-based sigma) for a 1-D numeric array.
-
-    The MAD is scaled by 1.4826 so it matches the standard deviation for
-    Gaussian data.
-    """
+    """Return (median, MAD-based sigma) for a 1-D numeric array."""
     median = float(np.median(values))
     mad = float(np.median(np.abs(values - median)))
     return median, _MAD_TO_SIGMA * mad
@@ -670,8 +521,7 @@ def _residual_sigma(values: np.ndarray) -> float:
 
     For data ``y[i] = trend[i] + eps[i]`` the diff ``y[i+1] - y[i]`` has variance
     ``2 * sigma^2``, so ``MAD(diff) * 1.4826 / sqrt(2)`` recovers sigma even
-    when ``trend`` is non-stationary. This prevents a gradual drift from
-    inflating its own noise estimate and masking itself.
+    when ``trend`` is non-stationary.
     """
     if len(values) < 2:
         return 0.0
@@ -680,126 +530,175 @@ def _residual_sigma(values: np.ndarray) -> float:
     return _MAD_TO_SIGMA * mad / np.sqrt(2.0)
 
 
-def detect_adaptive(
+def _discretization_floor(values: np.ndarray) -> float:
+    """Smallest non-zero absolute step between successive history values.
+
+    For integer-valued metrics this is at least 1, providing a meaningful
+    noise floor when both MAD and residual-MAD collapse to zero (constant
+    history). Returns 0 when no non-zero steps exist.
+    """
+    if len(values) < 2:
+        return 0.0
+    diffs = np.abs(np.diff(values))
+    non_zero = diffs[diffs > 0]
+    return float(np.min(non_zero)) if len(non_zero) else 0.0
+
+
+def _estimate_noise(values: np.ndarray, baseline: float) -> tuple[float, str]:
+    """Estimate noise in a 1-D history with layered fallbacks.
+
+    Returns ``(noise, source)`` where *source* names the layer that produced
+    the estimate: ``"mad"`` → ``"residual"`` → ``"discretization"`` → ``"floor"``.
+    The final result is always clamped to at least ``_RELATIVE_FLOOR * |baseline|``
+    (and an absolute floor of ``_ABSOLUTE_FLOOR``) so divisions never explode.
+    """
+    rel_floor = max(_RELATIVE_FLOOR * abs(baseline), _ABSOLUTE_FLOOR)
+
+    if len(values) >= 2:
+        _, mad_sigma = _robust_scale(values)
+        if mad_sigma > 0:
+            return max(mad_sigma, rel_floor), "mad"
+        resid = _residual_sigma(values)
+        if resid > 0:
+            return max(resid, rel_floor), "residual"
+        disc = _discretization_floor(values)
+        if disc > 0:
+            return max(disc, rel_floor), "discretization"
+    return rel_floor, "floor"
+
+
+def detect_regression(
     variable: str,
-    historical_time_means: np.ndarray,
+    historical: np.ndarray,
     current: np.ndarray,
-    z_threshold: float = 3.5,
-    drift_threshold: float | None = None,
-    mk_alpha: float = 0.1,
+    *,
+    z_threshold: float = _DEFAULT_Z_THRESHOLD,
+    min_change_percent: float | None = None,
     direction: OptDir = OptDir.minimize,
-    historical_samples: np.ndarray | None = None,
+    historical_time_means: np.ndarray | None = None,
+    drift_threshold: float | None = None,
 ) -> RegressionResult:
-    """Robust regression detection combining step and drift tests.
+    """Detect a regression in a metric using robust step and drift tests.
 
-    The method estimates the metric's inherent noise from history using a
-    median + MAD (median absolute deviation) scale and expresses the current
-    run's deviation in those noise units. Two orthogonal tests run in parallel:
-
-    * **Short-term step** — flags if ``(current_mean - baseline) / noise_floor``
-      exceeds ``z_threshold`` in the regression direction.
-    * **Long-term drift** — fits a Theil–Sen slope on the historical time-point
-      means (after a Hampel filter removes isolated outliers) and flags if the
-      total projected drift, scaled by ``noise_floor``, exceeds
-      ``drift_threshold`` and a Mann–Kendall test confirms monotonic trend
-      with ``p < mk_alpha``.
+    Noise is estimated in MAD-sigma units with layered fallbacks so the same
+    function handles everything from long noisy history down to a single prior
+    sample. The step test always runs. The drift test runs whenever
+    *historical_time_means* is provided and has at least 4 entries.
 
     Args:
-        variable: Name of the result variable being checked.
-        historical_time_means: 1-D array of per-time-point mean values from
-            history (one entry per prior run).
-        current: Current run values (will be averaged).
+        variable: Name of the result variable.
+        historical: Flat 1-D array of all historical samples.
+        current: Current-run samples (will be averaged).
         z_threshold: Step-test threshold in MAD-sigma units.
-        drift_threshold: Drift-test threshold in MAD-sigma units. If ``None``,
-            defaults to ``_DRIFT_FRAC * z_threshold`` so users need to tune
-            only one knob.
-        mk_alpha: Significance level for the Mann–Kendall trend guard.
+        min_change_percent: Optional AND-guard — even if ``|z| > z_threshold``,
+            require ``|percent change| >= min_change_percent`` before flagging.
+            Useful for stable metrics where the noise floor collapses to the
+            relative floor and a single-unit change yields a huge z-score.
+            Set to ``None`` (default) to disable.
         direction: Optimization direction from the result variable.
-        historical_samples: Optional flat array of all historical samples
-            (not per-time means). Used for the sparse-history fallback so the
-            delegated ``ttest``/``percentage`` methods see the same input they
-            would have received from ``detect_regressions`` directly. Falls
-            back to ``historical_time_means`` when not provided.
+        historical_time_means: Optional 1-D array of per-time-point means
+            (one entry per prior time step). When provided with ≥4 entries a
+            drift test runs alongside the step test.
+        drift_threshold: Drift-test threshold in MAD-sigma units. If ``None``,
+            defaults to ``0.85 * z_threshold`` so users tune only one knob.
     """
-    if drift_threshold is None:
-        drift_threshold = _DRIFT_FRAC * z_threshold
-
-    hist_clean = _clean_1d(historical_time_means)
+    hist_clean = _clean_1d(historical)
     curr_clean = _clean_1d(current)
-    curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
 
-    # Not enough history for a robust scale — fall back to less strict checks.
-    # Use the full per-sample history when available so the fallback behaves
-    # like a direct call to detect_ttest/detect_percentage.
-    if len(hist_clean) < 4:
-        fallback_hist = (
-            _clean_1d(historical_samples) if historical_samples is not None else hist_clean
-        )
-        if len(fallback_hist) >= 2 and len(curr_clean) >= 2:
-            return detect_ttest(
-                variable,
-                fallback_hist,
-                curr_clean,
-                alpha=_METHOD_DEFAULTS["ttest"],
-                direction=direction,
-            )
-        return detect_percentage(
-            variable,
-            fallback_hist,
-            curr_clean,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
-            direction=direction,
-        )
+    if len(curr_clean) == 0:
+        curr_mean = float("nan")
+    elif len(curr_clean) == 1:
+        curr_mean = float(curr_clean[0])
+    else:
+        curr_mean = float(np.mean(curr_clean))
 
-    baseline, mad_sigma = _robust_scale(hist_clean)
-    noise_floor = max(mad_sigma, 1e-6 * abs(baseline), 1e-12)
+    if len(hist_clean) >= 2:
+        baseline, _ = _robust_scale(hist_clean)
+    elif len(hist_clean) == 1:
+        baseline = float(hist_clean[0])
+    else:
+        baseline = float("nan")
 
-    # Step test — current mean vs robust baseline in MAD-sigma units.
-    z_step = (curr_mean - baseline) / noise_floor
-    step_regressed = _is_regression(z_step, direction) and abs(z_step) > z_threshold
-
-    # Drift test — Theil–Sen slope on Hampel-filtered history, MK significance.
-    # Use residual (detrended) noise as the denominator so a real drift can't
-    # inflate its own noise estimate and mask itself.
-    deviations = np.abs(hist_clean - baseline)
-    keep = deviations <= _HAMPEL_K * max(mad_sigma, 1e-12)
-    filtered = hist_clean[keep] if keep.sum() >= 4 else hist_clean
-    indices = np.arange(len(filtered), dtype=float)
-
-    resid_sigma = _residual_sigma(filtered)
-    drift_noise = max(resid_sigma, 1e-6 * abs(baseline), 1e-12)
-
-    from scipy.stats import kendalltau, theilslopes
-
-    slope = float(theilslopes(filtered, indices)[0])
-    # Slope is per index-step; total drift across n points spans (n-1) steps.
-    drift_total = slope * (len(filtered) - 1)
-    z_drift = drift_total / drift_noise
-    _, mk_p = kendalltau(indices, filtered)
-    mk_p = float(mk_p) if not np.isnan(mk_p) else 1.0
-    drift_regressed = (
-        _is_regression(z_drift, direction) and abs(z_drift) > drift_threshold and mk_p < mk_alpha
-    )
-
-    regressed = step_regressed or drift_regressed
+    noise_floor, noise_source = _estimate_noise(hist_clean, baseline)
 
     change = _safe_change_percent(curr_mean, baseline)
+    percent_ok = (
+        True
+        if min_change_percent is None or not np.isfinite(change)
+        else abs(change) >= min_change_percent
+    )
+    if min_change_percent is not None and not np.isfinite(change):
+        # Baseline is zero and current isn't — can't compute a percent change,
+        # so the guard can't be satisfied and the result is never flagged.
+        percent_ok = False
+
+    # Step test
+    if np.isfinite(curr_mean) and np.isfinite(baseline):
+        z_step = (curr_mean - baseline) / noise_floor
+    else:
+        z_step = 0.0
+    step_regressed = _is_regression(z_step, direction) and abs(z_step) > z_threshold and percent_ok
+
+    # Drift test (optional)
+    drift_thresh = _DRIFT_FRAC * z_threshold if drift_threshold is None else drift_threshold
+    z_drift = 0.0
+    mk_p = 1.0
+    drift_regressed = False
+
+    if historical_time_means is not None:
+        tm = _clean_1d(historical_time_means)
+        if len(tm) >= 4:
+            tm_baseline, tm_mad = _robust_scale(tm)
+            deviations = np.abs(tm - tm_baseline)
+            keep = deviations <= _HAMPEL_K * max(tm_mad, 1e-12)
+            filtered = tm[keep] if keep.sum() >= 4 else tm
+            indices = np.arange(len(filtered), dtype=float)
+            resid = _residual_sigma(filtered)
+            drift_noise = max(resid, _RELATIVE_FLOOR * abs(tm_baseline), _ABSOLUTE_FLOOR)
+
+            from scipy.stats import kendalltau, theilslopes
+
+            slope = float(theilslopes(filtered, indices)[0])
+            drift_total = slope * (len(filtered) - 1)
+            z_drift = drift_total / drift_noise
+            _, mk_p = kendalltau(indices, filtered)
+            mk_p = float(mk_p) if not np.isnan(mk_p) else 1.0
+            drift_regressed = (
+                _is_regression(z_drift, direction)
+                and abs(z_drift) > drift_thresh
+                and mk_p < _MK_ALPHA
+                and percent_ok
+            )
+
+    # Cast to plain Python bool — xarray comparisons return np.bool_ which
+    # fails strict `is True`/`is False` identity checks.
+    regressed = bool(step_regressed or drift_regressed)
+
     fired = []
     if step_regressed:
         fired.append("step")
     if drift_regressed:
         fired.append("drift")
     fired_str = "+".join(fired) if fired else "none"
+    guard_str = f", min%={min_change_percent}" if min_change_percent is not None else ""
     details = (
         f"fired={fired_str}, z_step={z_step:+.2f} (|z|>{z_threshold}), "
-        f"z_drift={z_drift:+.2f} (|z|>{drift_threshold:.2f}), "
-        f"mk_p={mk_p:.3g} (<{mk_alpha}), "
-        f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
+        f"z_drift={z_drift:+.2f} (|z|>{drift_thresh:.2f}), "
+        f"mk_p={mk_p:.3g} (<{_MK_ALPHA}), "
+        f"baseline={baseline:.4g}, noise={noise_floor:.4g} ({noise_source})"
+        f"{guard_str}"
     )
+
+    if np.isfinite(baseline):
+        band_lower = baseline - z_threshold * noise_floor
+        band_upper = baseline + z_threshold * noise_floor
+    else:
+        band_lower = None
+        band_upper = None
 
     return RegressionResult(
         variable=variable,
-        method="adaptive",
+        method="regression",
         regressed=regressed,
         current_value=curr_mean,
         baseline_value=baseline,
@@ -807,21 +706,22 @@ def detect_adaptive(
         threshold=z_threshold,
         direction=direction.value,
         details=details,
-        band_lower=baseline - z_threshold * noise_floor,
-        band_upper=baseline + z_threshold * noise_floor,
+        band_lower=band_lower,
+        band_upper=band_upper,
     )
 
 
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
-    """Run regression detection on a dataset with over_time dimension.
+    """Run regression detection on a dataset with ``over_time`` dimension.
 
-    For each numeric result variable, splits the dataset at the last over_time index,
-    runs the configured detection method, and collects results into a report.
+    For each numeric result variable, splits the dataset at the last over_time
+    index, runs :func:`detect_regression`, and collects results into a report.
 
     Args:
         dataset: xarray Dataset with over_time dimension.
         bench_cfg: BenchCfg with result_vars list.
-        run_cfg: BenchRunCfg with regression_method, regression_threshold.
+        run_cfg: BenchRunCfg with ``regression_threshold`` (z-score) and
+            ``regression_min_change_percent``.
 
     Returns:
         RegressionReport with results for each variable.
@@ -835,12 +735,10 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     if n_times < 2:
         return report
 
-    method = run_cfg.regression_method
     threshold = run_cfg.regression_threshold
-
-    # Use per-method default when no explicit threshold is provided.
     if threshold is None:
-        threshold = _METHOD_DEFAULTS.get(method, 5.0)
+        threshold = _DEFAULT_Z_THRESHOLD
+    min_change_percent = getattr(run_cfg, "regression_min_change_percent", None)
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -853,62 +751,33 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         da = dataset[var_name]
         direction = rv.direction if hasattr(rv, "direction") else OptDir.none
 
-        # Split: historical = all but last, current = last
         current_clean = _clean_1d(da.isel(over_time=-1).values)
         historical_clean = _clean_1d(da.isel(over_time=slice(None, -1)).values)
 
         if len(current_clean) == 0 or len(historical_clean) == 0:
             continue
 
-        time_means_arr: np.ndarray | None = None
-        if method in ("iqr", "adaptive"):
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
+        reduce_dims = [d for d in da.dims if d != "over_time"]
+        time_means_arr = (
+            da.isel(over_time=slice(None, -1))
+            .mean(dim=reduce_dims, skipna=True)
+            .values.astype(float)
+        )
 
-        if method == "percentage":
-            result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
-            )
-        elif method == "iqr":
-            result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
-        elif method == "ttest":
-            result = detect_ttest(var_name, historical_clean, current_clean, threshold, direction)
-        elif method == "adaptive":
-            result = detect_adaptive(
-                var_name,
-                time_means_arr,
-                current_clean,
-                z_threshold=threshold,
-                direction=direction,
-                historical_samples=historical_clean,
-            )
-        else:
-            logging.warning(f"Unknown regression method '{method}', falling back to percentage")
-            result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
-            )
+        result = detect_regression(
+            var_name,
+            historical_clean,
+            current_clean,
+            z_threshold=threshold,
+            min_change_percent=min_change_percent,
+            direction=direction,
+            historical_time_means=time_means_arr,
+        )
 
-        # Retain the arrays used for plotting so downstream consumers (reports,
-        # bot comments) can rebuild the diagnostic without re-running detection.
         time_coord = dataset["over_time"].values
-        if time_means_arr is not None:
-            result.historical = time_means_arr
-            # Per-time means are aligned with over_time, one value per time point.
-            result.historical_x = time_coord[:-1]
-            result.current_x = time_coord[-1]
-        else:
-            result.historical = historical_clean
-            # percentage/ttest pass the flat history (repeat * over_time); we
-            # only record over_time coords when they line up with the flat
-            # history length — otherwise pair current_x with the integer
-            # indices used by the plot and leave both unset.
-            if len(time_coord) - 1 == len(historical_clean):
-                result.historical_x = time_coord[:-1]
-                result.current_x = time_coord[-1]
+        result.historical = time_means_arr
+        result.historical_x = time_coord[:-1]
+        result.current_x = time_coord[-1]
         result.current_samples = current_clean
 
         report.results.append(result)

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -622,15 +622,14 @@ def detect_regression(
     noise_floor, noise_source = _estimate_noise(hist_clean, baseline)
 
     change = _safe_change_percent(curr_mean, baseline)
-    percent_ok = (
-        True
-        if min_change_percent is None or not np.isfinite(change)
-        else abs(change) >= min_change_percent
-    )
-    if min_change_percent is not None and not np.isfinite(change):
+    if min_change_percent is None:
+        percent_ok = True
+    elif not np.isfinite(change):
         # Baseline is zero and current isn't — can't compute a percent change,
         # so the guard can't be satisfied and the result is never flagged.
         percent_ok = False
+    else:
+        percent_ok = abs(change) >= min_change_percent
 
     # Step test
     if np.isfinite(curr_mean) and np.isfinite(baseline):

--- a/pixi.lock
+++ b/pixi.lock
@@ -1474,8 +1474,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.86.0
-  sha256: 6d3a35e41f361d8365c56a72d93c42a7c079c6f67b2af2a70d0d5498de5ffeaf
+  version: 1.88.0
+  sha256: 6df428054a0fcd1ebd4c1239d8f79181cdf0b51676d09020f89983aa91bde7d2
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.87.0"
+version = "1.88.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -12,185 +12,19 @@ from bencher.regression import (
     RegressionReport,
     RegressionResult,
     build_regression_overlay,
-    detect_adaptive,
-    detect_iqr,
-    detect_percentage,
+    detect_regression,
     detect_regressions,
-    detect_ttest,
     render_regression_png,
 )
 from bencher.variables.results import OptDir
 
 
-# ── detect_percentage ──────────────────────────────────────────────────────
+# ── detect_regression ──────────────────────────────────────────────────────
 
 
-class TestDetectPercentage:
-    def test_no_regression_within_threshold(self):
-        hist = np.array([100.0, 102.0, 98.0, 101.0])
-        curr = np.array([101.0, 103.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert not result.regressed
-
-    def test_regression_above_threshold_minimize(self):
-        hist = np.array([100.0, 100.0, 100.0])
-        curr = np.array([110.0, 112.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert result.regressed
-        assert result.change_percent > 5.0
-
-    def test_regression_below_threshold_maximize(self):
-        hist = np.array([100.0, 100.0, 100.0])
-        curr = np.array([90.0, 88.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.maximize
-        )
-        assert result.regressed
-        assert result.change_percent < -5.0
-
-    def test_improvement_not_regression_minimize(self):
-        """For minimize, a decrease is an improvement, not a regression."""
-        hist = np.array([100.0, 100.0])
-        curr = np.array([80.0, 82.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert not result.regressed
-
-    def test_improvement_not_regression_maximize(self):
-        """For maximize, an increase is an improvement, not a regression."""
-        hist = np.array([100.0, 100.0])
-        curr = np.array([120.0, 118.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.maximize
-        )
-        assert not result.regressed
-
-    def test_direction_none_any_change(self):
-        hist = np.array([100.0, 100.0])
-        curr = np.array([110.0])
-        result = detect_percentage("x", hist, curr, threshold_percent=5.0, direction=OptDir.none)
-        assert result.regressed
-
-    def test_zero_baseline(self):
-        hist = np.array([0.0, 0.0])
-        curr = np.array([1.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert result.regressed
-        assert result.change_percent == float("inf")
-
-    def test_zero_baseline_zero_current(self):
-        hist = np.array([0.0, 0.0])
-        curr = np.array([0.0])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert not result.regressed
-        assert result.change_percent == 0.0
-
-    def test_nan_handling(self):
-        hist = np.array([100.0, np.nan, 100.0])
-        curr = np.array([100.0, np.nan])
-        result = detect_percentage(
-            "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
-        )
-        assert not result.regressed
-
-
-# ── detect_iqr ─────────────────────────────────────────────────────────────
-
-
-class TestDetectIqr:
-    def test_within_bounds(self):
-        time_means = np.array([100.0, 101.0, 99.0, 100.5, 98.5])
-        curr = np.array([101.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_outlier_above_minimize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([20.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_outlier_below_maximize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_improvement_not_regression_minimize(self):
-        """For minimize, an outlier below bounds is an improvement, not a regression."""
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])  # well below — improvement for minimize
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_fallback_with_few_points(self):
-        """With <4 historical time points, should fall back to percentage."""
-        time_means = np.array([100.0, 101.0])
-        curr = np.array([200.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back
-        assert result.regressed
-
-
-# ── detect_ttest ───────────────────────────────────────────────────────────
-
-
-class TestDetectTtest:
-    def test_no_significant_difference(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(100, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_significant_increase_minimize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_significant_decrease_maximize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(90, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_fallback_single_sample(self):
-        hist = np.array([100.0])
-        curr = np.array([200.0])
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back to percentage-based check
-        assert result.regressed  # still correctly detected as regression
-        assert result.change_percent > 0.0  # percentage change indicates degradation for minimize
-
-    def test_direction_none_two_sided(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.none)
-        assert result.regressed
-
-
-# ── detect_adaptive ────────────────────────────────────────────────────────
-
-
-class TestDetectAdaptive:
-    """Noise-aware tests covering false-positive suppression and true-positive detection.
-
-    The adaptive method estimates inherent noise via MAD and tests both sudden
-    steps and long-term drift. These scenarios verify the detector stays quiet
-    on stable-but-noisy signals while firing on real regressions.
+class TestDetectRegression:
+    """Unified detector. One step test (always), one drift test (optional),
+    expressed in MAD-sigma units. Noise is estimated with layered fallbacks.
     """
 
     def _rng(self):
@@ -202,32 +36,31 @@ class TestDetectAdaptive:
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 0.5, 20)
         curr = np.array([100.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
     def test_stable_high_noise_no_regression(self):
-        """User's case: noisy but stable signal must not trip a regression."""
+        """Noisy but stable signal must not trip a regression."""
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 15.0, 20)
         curr = 100.0 + rng.normal(0, 15.0, 10)
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed, f"false positive on noisy-stable signal: {result.details}"
 
     def test_isolated_historical_outlier_no_regression(self):
         """A single glitch in history must not move the baseline."""
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 1.0, 20)
-        hist[5] = 500.0  # one-off spike
+        hist[5] = 500.0
         curr = np.array([101.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
     def test_heavy_tailed_noise_no_regression(self):
-        """Student-t (df=2) has occasional huge draws but no drift."""
         rng = self._rng()
         hist = 100.0 + rng.standard_t(2, size=30)
         curr = np.array([100.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
     def test_oscillating_stable_no_regression(self):
@@ -235,7 +68,9 @@ class TestDetectAdaptive:
         i = np.arange(20, dtype=float)
         hist = 100.0 + 10.0 * np.sin(i)
         curr = np.array([101.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression(
+            "x", hist, curr, direction=OptDir.minimize, historical_time_means=hist
+        )
         assert not result.regressed
 
     # ---- true-positive detection ----
@@ -244,7 +79,7 @@ class TestDetectAdaptive:
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 15.0, 20)
         curr = 150.0 + rng.normal(0, 15.0, 10)
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert result.regressed
         assert "step" in result.details
 
@@ -253,82 +88,112 @@ class TestDetectAdaptive:
         i = np.arange(20, dtype=float)
         hist = 100.0 + 1.5 * i + rng.normal(0, 5.0, 20)
         curr = np.array([float(100.0 + 1.5 * 20)])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression(
+            "x", hist, curr, direction=OptDir.minimize, historical_time_means=hist
+        )
         assert result.regressed
         assert "drift" in result.details
 
     def test_improvement_not_regression_minimize(self):
-        """For minimize, a step *down* is an improvement, not a regression."""
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 1.0, 20)
         curr = np.array([50.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
     def test_improvement_not_regression_maximize(self):
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 1.0, 20)
         curr = np.array([150.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.maximize)
+        result = detect_regression("x", hist, curr, direction=OptDir.maximize)
         assert not result.regressed
 
     def test_direction_none_fires_either_way(self):
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 1.0, 20)
         curr = np.array([150.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.none)
+        result = detect_regression("x", hist, curr, direction=OptDir.none)
         assert result.regressed
 
-    # ---- fallback for sparse data ----
+    # ---- sparse / edge-case history (layered noise fallback) ----
 
-    def test_sparse_history_falls_back(self):
+    def test_sparse_history_still_runs(self):
+        """Short history must still produce a verdict via the relative floor."""
         hist = np.array([100.0, 101.0, 99.0])
         curr = np.array([100.0, 102.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert result.method in ("ttest", "percentage")
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
+        assert result.method == "regression"
+        assert np.isfinite(result.baseline_value)
 
-    def test_sparse_history_single_current_falls_back(self):
-        hist = np.array([100.0, 200.0])
-        curr = np.array([200.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert result.method == "percentage"
+    def test_single_historical_sample_runs(self):
+        """Even a single prior sample produces a result."""
+        hist = np.array([100.0])
+        curr = np.array([100.0])
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
+        assert not result.regressed
 
     def test_constant_history_with_identical_current(self):
         """Zero-variance history with matching current must not fire."""
         hist = np.full(20, 100.0)
         curr = np.array([100.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
     def test_nan_current_is_guarded(self):
-        """All-NaN current must not trigger warnings or false regression."""
         rng = self._rng()
         hist = 100.0 + rng.normal(0, 1.0, 20)
         curr = np.array([np.nan, np.nan])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
-    def test_sparse_fallback_uses_full_samples(self):
-        """Fallback must honour `historical_samples` so it sees all raw values.
+    # ---- integer / stable metric (min_change_percent guard) ----
 
-        With 3 time points but many samples per point, ttest has enough data
-        to be statistically meaningful — whereas passing only per-time means
-        would leave ttest with just 3 points.
+    def test_integer_metric_one_step_fires_without_guard(self):
+        """Default behaviour: stable integer + one-unit change fires on z-score.
+
+        This is the documented pathology — the user opts out of it by setting
+        min_change_percent. Locked in as a regression test so the behaviour is
+        explicit.
         """
-        rng = self._rng()
-        hist_time_means = np.array([100.0, 100.0, 100.0])
-        hist_samples = 100.0 + rng.normal(0, 1.0, 60)  # 3 points x 20 repeats
-        curr = 110.0 + rng.normal(0, 1.0, 20)
-        result = detect_adaptive(
-            "x",
-            hist_time_means,
-            curr,
-            direction=OptDir.minimize,
-            historical_samples=hist_samples,
-        )
-        # Must fall back to ttest since we have plenty of samples.
-        assert result.method == "ttest"
+        hist = np.full(20, 100.0, dtype=float)
+        curr = np.array([101.0])
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
         assert result.regressed
+
+    def test_integer_metric_one_step_suppressed_by_guard(self):
+        """With min_change_percent=5, a 1% change on a stable baseline is ignored."""
+        hist = np.full(20, 100.0, dtype=float)
+        curr = np.array([101.0])
+        result = detect_regression(
+            "x", hist, curr, direction=OptDir.minimize, min_change_percent=5.0
+        )
+        assert not result.regressed
+
+    def test_min_change_percent_still_fires_on_big_change(self):
+        """Guard doesn't suppress legitimate regressions."""
+        hist = np.full(20, 100.0, dtype=float)
+        curr = np.array([200.0])
+        result = detect_regression(
+            "x", hist, curr, direction=OptDir.minimize, min_change_percent=5.0
+        )
+        assert result.regressed
+
+    def test_noise_floor_reports_source(self):
+        """The `details` string identifies which noise-estimation layer fired."""
+        rng = self._rng()
+        hist = 100.0 + rng.normal(0, 2.0, 20)
+        curr = np.array([100.0])
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
+        assert "(mad)" in result.details
+
+    def test_noise_floor_residual_on_strict_monotone(self):
+        """Pure linear history has MAD that correlates with trend, so MAD > 0
+        still triggers the 'mad' branch. This test just verifies noise is finite."""
+        hist = np.arange(20, dtype=float) + 100.0
+        curr = np.array([120.0])
+        result = detect_regression("x", hist, curr, direction=OptDir.minimize)
+        assert np.isfinite(result.band_lower)
+        assert np.isfinite(result.band_upper)
 
 
 # ── RegressionReport ───────────────────────────────────────────────────────
@@ -346,23 +211,23 @@ class TestRegressionReport:
             results=[
                 RegressionResult(
                     variable="metric_a",
-                    method="percentage",
+                    method="regression",
                     regressed=True,
                     current_value=110.0,
                     baseline_value=100.0,
                     change_percent=10.0,
-                    threshold=5.0,
+                    threshold=3.5,
                     direction="minimize",
                     details="test",
                 ),
                 RegressionResult(
                     variable="metric_b",
-                    method="percentage",
+                    method="regression",
                     regressed=False,
                     current_value=101.0,
                     baseline_value=100.0,
                     change_percent=1.0,
-                    threshold=5.0,
+                    threshold=3.5,
                     direction="minimize",
                     details="test",
                 ),
@@ -379,7 +244,6 @@ class TestRegressionReport:
 class TestDetectRegressions:
     @staticmethod
     def _make_dataset(n_times=3, n_repeats=2, values=None):
-        """Create a synthetic dataset with over_time dimension."""
         if values is None:
             values = np.arange(n_times * n_repeats, dtype=float).reshape(n_times, n_repeats)
         ds = xr.Dataset(
@@ -392,19 +256,17 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None):
-        """Create minimal bench_cfg and run_cfg mocks."""
-
+    def _make_cfg(result_vars, threshold=None, min_change_percent=None):
         class FakeBenchCfg:
             def __init__(self, result_vars):
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold):
-                self.regression_method = method
+            def __init__(self, threshold, min_change_percent):
                 self.regression_threshold = threshold
+                self.regression_min_change_percent = min_change_percent
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold)
+        return FakeBenchCfg(result_vars), FakeRunCfg(threshold, min_change_percent)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -413,8 +275,8 @@ class TestDetectRegressions:
             result_vars = []
 
         class FakeRun:
-            regression_method = "percentage"
             regression_threshold = None
+            regression_min_change_percent = None
 
         report = detect_regressions(ds, FakeCfg(), FakeRun())
         assert not report.has_regressions
@@ -429,8 +291,7 @@ class TestDetectRegressions:
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions
 
-    def test_detects_regression_percentage(self):
-        # Historical: times 0-2 have mean ~100, time 3 has mean ~200
+    def test_detects_big_step(self):
         values = np.array(
             [
                 [100.0, 100.0],
@@ -444,66 +305,13 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert report.results[0].variable == "metric"
         assert report.results[0].change_percent > 50
 
-    def test_detects_no_regression(self):
-        values = np.array(
-            [
-                [100.0, 100.0],
-                [100.0, 100.0],
-                [100.0, 100.0],
-                [101.0, 101.0],
-            ]
-        )
-        ds = self._make_dataset(n_times=4, n_repeats=2, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert not report.has_regressions
-
-    def test_iqr_method(self):
-        values = np.array(
-            [
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [50.0, 50.0],
-            ]
-        )
-        ds = self._make_dataset(n_times=6, n_repeats=2, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="iqr", threshold=1.5)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
-    def test_ttest_method(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, (5, 10))
-        curr = rng.normal(200, 1, (1, 10))
-        values = np.vstack([hist, curr])
-        ds = self._make_dataset(n_times=6, n_repeats=10, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="ttest", threshold=0.05)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
-    def test_adaptive_method_no_false_positive_on_noisy_stable(self):
-        """Adaptive must not trip on a noisy-but-stable signal (user's pain point)."""
+    def test_no_false_positive_on_noisy_stable(self):
         rng = np.random.default_rng(0)
         values = 100.0 + rng.normal(0, 15.0, size=(20, 4))
         ds = self._make_dataset(n_times=20, n_repeats=4, values=values)
@@ -511,12 +319,11 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions, report.summary()
 
-    def test_adaptive_method_detects_sudden_step(self):
-        """Adaptive fires on a sudden jump that is large relative to noise."""
+    def test_detects_sudden_step_via_adaptive(self):
         rng = np.random.default_rng(0)
         stable = 100.0 + rng.normal(0, 2.0, size=(20, 4))
         jump = 150.0 + rng.normal(0, 2.0, size=(1, 4))
@@ -526,13 +333,12 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "step" in report.results[0].details
 
-    def test_adaptive_method_detects_gradual_drift(self):
-        """Adaptive fires on slow drift where no single step exceeds percentage."""
+    def test_detects_gradual_drift(self):
         rng = np.random.default_rng(0)
         n_times = 20
         n_repeats = 4
@@ -543,7 +349,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "drift" in report.results[0].details
@@ -560,15 +366,23 @@ class TestDetectRegressions:
         assert not report.has_regressions
 
     def test_multiple_result_vars_mixed(self):
-        """Multiple result vars: one regressed, one not."""
-        values_a = np.array([[100.0], [100.0], [200.0]])  # regresses
-        values_b = np.array([[50.0], [50.0], [51.0]])  # stable
+        """Two result vars, one stable, one step — only the step fires."""
+        rng = np.random.default_rng(0)
+        # metric_a: clearly degraded at the last point
+        a_stable = 100.0 + rng.normal(0, 2.0, size=(10, 4))
+        a_jump = 200.0 + rng.normal(0, 2.0, size=(1, 4))
+        values_a = np.vstack([a_stable, a_jump])
+        # metric_b: oscillating around a fixed baseline so no drift trend
+        ncoord = values_a.shape[0]
+        nrep = values_a.shape[1]
+        i = np.arange(ncoord, dtype=float)[:, None]
+        values_b = 50.0 + 0.5 * np.sin(i) + np.zeros((1, nrep))
         ds = xr.Dataset(
             {
                 "metric_a": (["over_time", "repeat"], values_a),
                 "metric_b": (["over_time", "repeat"], values_b),
             },
-            coords={"over_time": np.arange(3), "repeat": [0]},
+            coords={"over_time": np.arange(ncoord), "repeat": np.arange(nrep)},
         )
         from bencher.variables.results import ResultFloat
 
@@ -576,7 +390,7 @@ class TestDetectRegressions:
         rv_a.name = "metric_a"
         rv_b = ResultFloat(units="s", direction=OptDir.minimize)
         rv_b.name = "metric_b"
-        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], threshold=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 2
         assert report.has_regressions
@@ -584,21 +398,7 @@ class TestDetectRegressions:
         assert names["metric_a"] is True
         assert names["metric_b"] is False
 
-    def test_unknown_method_falls_back_to_percentage(self):
-        """Unknown regression method should fall back to percentage detection."""
-        values = np.array([[100.0, 100.0], [100.0, 100.0], [200.0, 200.0]])
-        ds = self._make_dataset(n_times=3, n_repeats=2, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="bogus", threshold=5.0)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-        assert report.results[0].method == "percentage"
-
     def test_var_not_in_dataset_skipped(self):
-        """Result var not present in dataset should be silently skipped."""
         values = np.array([[100.0, 100.0], [200.0, 200.0]])
         ds = self._make_dataset(n_times=2, n_repeats=2, values=values)
         from bencher.variables.results import ResultFloat
@@ -610,7 +410,6 @@ class TestDetectRegressions:
         assert len(report.results) == 0
 
     def test_non_numeric_result_var_skipped(self):
-        """Non-numeric result types (e.g. ResultImage) should be skipped."""
         values = np.array([[100.0, 100.0], [200.0, 200.0]])
         ds = self._make_dataset(n_times=2, n_repeats=2, values=values)
         from bencher.variables.results import ResultImage
@@ -622,29 +421,50 @@ class TestDetectRegressions:
         assert len(report.results) == 0
 
     def test_custom_threshold_overrides_default(self):
-        """Explicit threshold should override the per-method default."""
-        # 10% change — regresses with threshold=5, not with threshold=15
-        values = np.array([[100.0, 100.0], [100.0, 100.0], [110.0, 110.0]])
-        ds = self._make_dataset(n_times=3, n_repeats=2, values=values)
+        """Explicit threshold changes sensitivity."""
+        rng = np.random.default_rng(0)
+        stable = 100.0 + rng.normal(0, 2.0, size=(5, 2))
+        jump = 110.0 + rng.normal(0, 2.0, size=(1, 2))
+        values = np.vstack([stable, jump])
+        ds = self._make_dataset(n_times=6, n_repeats=2, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
 
-        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], threshold=2.0)
         report_strict = detect_regressions(ds, bench_cfg_strict, run_cfg_strict)
         assert report_strict.has_regressions
 
-        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", threshold=15.0)
+        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], threshold=10.0)
         report_loose = detect_regressions(ds, bench_cfg_loose, run_cfg_loose)
         assert not report_loose.has_regressions
+
+    def test_min_change_percent_applied_via_cfg(self):
+        """run_cfg.regression_min_change_percent reaches the detector."""
+        # Stable integer series, single-unit jump
+        values = np.full((10, 1), 100.0)
+        values[-1, 0] = 101.0
+        ds = self._make_dataset(n_times=10, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+
+        # Without guard — fires on integer pathology
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5)
+        assert detect_regressions(ds, bench_cfg, run_cfg).has_regressions
+
+        # With guard — suppressed
+        bench_cfg, run_cfg = self._make_cfg([rv], threshold=3.5, min_change_percent=5.0)
+        assert not detect_regressions(ds, bench_cfg, run_cfg).has_regressions
 
     def test_result_bool_supported(self):
         values = np.array(
             [
-                [0.0, 0.0],  # baseline
-                [0.0, 0.0],  # still good
-                [1.0, 1.0],  # regression for direction=OptDir.minimize
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [1.0, 1.0],
             ]
         )
         ds = self._make_dataset(n_times=3, n_repeats=2, values=values)
@@ -697,58 +517,61 @@ class _DegradingBench(bn.ParametrizedSweep):
 
 class TestEndToEnd:
     def test_plot_sweep_with_regression_detection(self):
-        """Full end-to-end test: run plot_sweep with over_time and regression_detection."""
         run_cfg = bn.BenchRunCfg()
         run_cfg.over_time = True
         run_cfg.repeats = 2
         run_cfg.regression_detection = True
-        run_cfg.regression_method = "percentage"
         run_cfg.regression_fail = False
         run_cfg.auto_plot = False
         run_cfg.headless = True
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = True
 
         bench = bn.Bench("test_regression_e2e", _SimpleBench(), run_cfg=run_cfg)
-        # Run twice to get 2 time points with same values — no regression
         bench.plot_sweep(plot_callbacks=False)
-        bench.sample_cache = None  # reset cache for new run
+        bench.sample_cache = None
+        run_cfg.clear_history = False
         res2 = bench.plot_sweep(plot_callbacks=False)
 
         assert res2.regression_report is not None
         assert not res2.regression_report.has_regressions
 
     def test_detection_disabled_leaves_report_none(self):
-        """When regression_detection=False, regression_report should stay None."""
         run_cfg = bn.BenchRunCfg()
         run_cfg.over_time = True
         run_cfg.repeats = 1
         run_cfg.regression_detection = False
         run_cfg.auto_plot = False
         run_cfg.headless = True
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = True
 
         bench = bn.Bench("test_regression_disabled", _SimpleBench(), run_cfg=run_cfg)
         bench.plot_sweep(plot_callbacks=False)
         bench.sample_cache = None
+        run_cfg.clear_history = False
         res2 = bench.plot_sweep(plot_callbacks=False)
 
         assert res2.regression_report is None
 
     def test_regression_fail_raises(self):
-        """Verify that regression_fail=True raises RegressionError."""
         _degrade_state["counter"] = 0
 
         run_cfg = bn.BenchRunCfg()
         run_cfg.over_time = True
         run_cfg.repeats = 1
         run_cfg.regression_detection = True
-        run_cfg.regression_method = "percentage"
         run_cfg.regression_fail = True
         run_cfg.auto_plot = False
         run_cfg.headless = True
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = True
 
         bench = bn.Bench("test_regression_fail", _DegradingBench(), run_cfg=run_cfg)
         bench.plot_sweep(plot_callbacks=False)
         bench.sample_cache = None
 
+        run_cfg.clear_history = False
         with pytest.raises(bn.RegressionError):
             bench.plot_sweep(plot_callbacks=False)
 
@@ -759,7 +582,7 @@ class TestEndToEnd:
 def _make_result(historical_x=None, current_x=None):
     hist = np.array([100.0, 102.0, 99.0, 101.0, 100.5, 98.5, 101.2])
     curr = np.array([130.0])
-    r = detect_percentage("metric", hist, curr, threshold_percent=5.0)
+    r = detect_regression("metric", hist, curr, direction=OptDir.minimize)
     r.historical = hist
     r.current_samples = curr
     if historical_x is not None:
@@ -795,7 +618,6 @@ class TestRenderRegressionPng:
         assert os.path.getsize(path) > 1000
 
     def test_png_method_alias(self, tmp_path):
-        """RegressionResult.render_png delegates to the module function."""
         r = _make_result()
         out = tmp_path / "alias.png"
         r.render_png(path=str(out))
@@ -803,13 +625,7 @@ class TestRenderRegressionPng:
 
 
 class TestBuildRegressionOverlay:
-    """build_regression_overlay should render through bokeh on every x dtype.
-
-    The regression was: HSpan/HLine combined with a categorical x-axis threw
-    UFuncNoLoopError inside holoviews' get_extents. The fix uses explicit-coord
-    Area/Curve primitives, so driving it through Panel's get_root is the
-    end-to-end proof that the crash is gone.
-    """
+    """build_regression_overlay should render through bokeh on every x dtype."""
 
     @staticmethod
     def _render_through_panel(overlay, tmp_path, name):
@@ -830,20 +646,16 @@ class TestBuildRegressionOverlay:
         self._render_through_panel(build_regression_overlay(r), tmp_path, "dt")
 
     def test_overlay_string_axis_git_time_event(self, tmp_path):
-        """Regression test: git_time_event strings previously crashed bokeh render."""
         labels = [f"2024-06-{15 + i:02d} abc{i}234d" for i in range(7)]
         r = _make_result(historical_x=labels, current_x="2024-06-22 xyz7890")
         self._render_through_panel(build_regression_overlay(r), tmp_path, "git")
 
     def test_overlay_band_present(self):
-        """The acceptance band should be in the overlay (regression: bokeh
-        silently dropped HSpan when combined with categorical x)."""
         import holoviews as hv
 
         labels = [f"2024-06-{15 + i:02d} abc{i}234d" for i in range(7)]
         r = _make_result(historical_x=labels, current_x="2024-06-22 xyz7890")
         overlay = build_regression_overlay(r)
-        # The band is rendered as an Area element; assert one is present.
         has_area = any(isinstance(el, hv.Area) for el in overlay)
         assert has_area, f"expected an Area layer for the band, got: {list(overlay)}"
 
@@ -867,25 +679,17 @@ class _StringTimeBench(bn.ParametrizedSweep):
 
 
 def _unique_fake_time_src() -> str:
-    """git_time_event()-style string, guaranteed distinct each call."""
     _ctr[0] += 1
     return f"2026-{_ctr[0]:02d}-01 fake{_ctr[0]:04x}"
 
 
 def _duplicate_fake_time_src() -> str:
-    """git_time_event()-style string that repeats — simulates a user running
-    multiple times within the same git commit (pre-fix crash condition)."""
     return "2026-01-01 samecommit"
 
 
 class TestOverTimeStringCoords:
     """End-to-end tests against bencher's plot pipeline with git_time_event-
-    style string over_time coords. Previously crashed in two places:
-
-    - regression overlay: nanmax on Unicode dtype (fixed by categorical fallback)
-    - bar plot: duplicate over_time coords → sel returns mixed element types
-      → `HoloMap must only contain one type of object`.
-    """
+    style string over_time coords."""
 
     def _build_bench(self, time_srcs):
         run_cfg = bn.BenchRunCfg()
@@ -906,7 +710,6 @@ class TestOverTimeStringCoords:
         return bench
 
     def test_to_auto_plots_unique_string_times(self):
-        """With unique string time coords, to_auto_plots should not crash."""
         _ctr[0] = 0
         bench = self._build_bench([_unique_fake_time_src() for _ in range(3)])
         res = bench.results[-1]
@@ -914,19 +717,12 @@ class TestOverTimeStringCoords:
         assert panel is not None
 
     def test_to_auto_plots_duplicate_string_times(self):
-        """Duplicate over_time coord values previously crashed the bar holomap
-        with `HoloMap must only contain one type of object`. After the fix,
-        duplicates are deduped inside _build_time_holomap via isel + seen set.
-        """
         bench = self._build_bench([_duplicate_fake_time_src() for _ in range(3)])
         res = bench.results[-1]
-        # Must not raise even though the dataset has duplicate over_time coords.
         panel = res.to_auto_plots()
         assert panel is not None
 
     def test_regression_report_populated_with_string_times(self):
-        """regression_report should capture string historical_x for use by the
-        PNG/overlay renderers (without crashing on dtype)."""
         _ctr[0] = 0
         bench = self._build_bench([_unique_fake_time_src() for _ in range(4)])
         res = bench.results[-1]
@@ -934,9 +730,8 @@ class TestOverTimeStringCoords:
         assert res.regression_report.results, "expected at least one result"
         r = res.regression_report.results[0]
         assert r.historical_x is not None
-        assert r.historical_x.dtype.kind == "U"  # unicode
-        # Renderers must both succeed on this result.
+        assert r.historical_x.dtype.kind == "U"
         import panel as pn
 
         overlay = r.render_overlay()
-        pn.Column(pn.pane.HoloViews(overlay))  # triggers panel init render path
+        pn.Column(pn.pane.HoloViews(overlay))


### PR DESCRIPTION
## Summary
- Replace the four separate regression detectors (percentage/IQR/t-test/adaptive) with a single MAD-sigma detector. The per-method `regression_method` selector on `BenchRunCfg` is gone; configure the new detector via `regression_threshold` (MAD-sigma units, default 3.5) and the optional `regression_min_change_percent` AND-guard for stable metrics.
- Rewrite `bencher/regression.py` around `detect_regression()` / `detect_regressions()` plus `RegressionResult` / `RegressionReport`, with layered fallbacks (robust MAD → residual sigma → relative/absolute floors) so sparse history and edge-case inputs degrade cleanly instead of throwing.
- Rebuild the tuning/over-time examples and the meta generator to use the unified API, and regenerate the gallery notebooks to match.

## Test plan
- [x] `pixi run ci` (format + lint + full pytest with coverage) — passes
- [x] `pixi run pytest -k regression` — 60 regression tests pass
- [x] `pixi run generate-docs` — all 157 examples rebuild cleanly
- [ ] Sanity-check the regenerated regression gallery pages render in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify regression detection around a single MAD-sigma based detector and update configuration, tests, and examples accordingly.

New Features:
- Introduce a unified detect_regression API that performs robust step and optional drift tests using layered noise estimation fallbacks.
- Add BenchRunCfg.regression_min_change_percent as an optional percent-change guard to suppress tiny changes on very stable metrics.

Enhancements:
- Simplify BenchRunCfg by removing regression_method and standardizing regression_threshold semantics to a MAD-sigma step-test threshold.
- Improve regression detection robustness for sparse, noisy, or integer-valued histories through internal noise floors and discretization-aware fallbacks.
- Standardize RegressionResult metadata so method is always reported as "regression" and plotting helpers operate on the unified detector output.
- Refresh regression examples, meta generator, and gallery notebooks to use the new unified detector and updated example names.

Build:
- Bump project version to 1.88.0 to capture the breaking regression API change.

Documentation:
- Update changelog and example docs to describe the unified regression detector, configuration changes, and renamed regression_over_time example.

Tests:
- Rewrite and expand regression tests to target the unified detect_regression behavior, covering noise robustness, drift detection, sparse history, integer metrics, configuration propagation, and end-to-end flows.