### PR TITLE
Add regression_percent_floor for dual-band adaptive detection

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -375,6 +375,18 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "Useful for failing CI pipelines on benchmark regressions.",
     )
 
+    regression_percent_floor: float = param.Number(
+        default=None,
+        allow_None=True,
+        doc="Optional minimum percent change required to flag a regression, applied as a "
+        "second acceptance band on top of the adaptive method's MAD band. A regression "
+        "only fires when BOTH the MAD-based test AND the percent change exceed their "
+        "thresholds. Useful for suppressing noise-floor false positives on metrics with "
+        "few repeats: set e.g. 40.0 to require at least a 40%% change regardless of how "
+        "many MAD-sigma it is. If None (default), only the MAD band gates. "
+        "Only affects 'adaptive' method.",
+    )
+
     def __init__(self, **params: Any) -> None:
         """Initialize BenchRunCfg with current datetime if not provided."""
         if "run_date" not in params:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -352,9 +352,8 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     regression_method: str = param.Selector(
         default="adaptive",
-        objects=["percentage", "iqr", "adaptive"],
-        doc="Detection method: 'percentage' (mean comparison), "
-        "'iqr' (IQR outlier detection), "
+        objects=["percentage", "adaptive"],
+        doc="Detection method: 'percentage' (mean comparison) or "
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
@@ -363,7 +362,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
         allow_None=True,
         doc="Threshold for regression detection. Interpretation depends on method: "
         "'percentage' = percent change (default 5.0), "
-        "'iqr' = IQR multiplier (default 1.5), "
         "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
         "If None, the per-method default is used automatically.",
     )
@@ -374,16 +372,18 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "Useful for failing CI pipelines on benchmark regressions.",
     )
 
-    regression_percent_floor: float = param.Number(
+    regression_percentage: float = param.Number(
         default=None,
         allow_None=True,
-        doc="Optional minimum percent change required to flag a regression, applied as a "
-        "second acceptance band on top of the adaptive method's MAD band. A regression "
-        "only fires when BOTH the MAD-based test AND the percent change exceed their "
-        "thresholds. Useful for suppressing noise-floor false positives on metrics with "
-        "few repeats: set e.g. 40.0 to require at least a 40%% change regardless of how "
-        "many MAD-sigma it is. If None (default), only the MAD band gates. "
-        "Only affects 'adaptive' method.",
+        doc="Optional minimum percent change (directional — interpreted in the sense "
+        "of each result var's optimization direction) required to flag a regression. "
+        "Applied as a second acceptance band on top of the adaptive method's MAD "
+        "band: a regression only fires when BOTH the MAD-based test AND the percent "
+        "change exceed their thresholds. Useful for suppressing noise-floor false "
+        "positives on low-repeat or integer-valued metrics where the MAD noise floor "
+        "collapses to zero — set e.g. 40.0 to require at least a 40%% change "
+        "regardless of how many MAD-sigma it is. If None (default), only the MAD "
+        "band gates. Only affects the 'adaptive' method.",
     )
 
     def __init__(self, **params: Any) -> None:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -357,33 +357,28 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
-    regression_threshold: float = param.Number(
-        default=None,
-        allow_None=True,
-        doc="Threshold for regression detection. Interpretation depends on method: "
-        "'percentage' = percent change (default 5.0), "
-        "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
-        "If None, the per-method default is used automatically.",
+    regression_mad: float = param.Number(
+        default=3.5,
+        doc="Step-test threshold for the 'adaptive' method, in robust MAD-sigma "
+        "units. A current value more than this many MAD-sigma from the historical "
+        "median (in the regression direction) is flagged. Higher = less sensitive.",
+    )
+
+    regression_percentage: float = param.Number(
+        default=10.0,
+        doc="Minimum directional percent change required to flag a regression. "
+        "For 'percentage' method this is the primary threshold. For 'adaptive' "
+        "method it acts as a dual-band AND gate alongside regression_mad: a "
+        "regression only fires when BOTH the MAD-based test AND the percent "
+        "change exceed their thresholds. Suppresses noise-floor false positives "
+        "on low-repeat or integer-valued metrics where the MAD noise floor can "
+        "collapse to zero.",
     )
 
     regression_fail: bool = param.Boolean(
         False,
         doc="If True, raise RegressionError when a regression is detected. "
         "Useful for failing CI pipelines on benchmark regressions.",
-    )
-
-    regression_percentage: float = param.Number(
-        default=None,
-        allow_None=True,
-        doc="Optional minimum percent change (directional — interpreted in the sense "
-        "of each result var's optimization direction) required to flag a regression. "
-        "Applied as a second acceptance band on top of the adaptive method's MAD "
-        "band: a regression only fires when BOTH the MAD-based test AND the percent "
-        "change exceed their thresholds. Useful for suppressing noise-floor false "
-        "positives on low-repeat or integer-valued metrics where the MAD noise floor "
-        "collapses to zero — set e.g. 40.0 to require at least a 40%% change "
-        "regardless of how many MAD-sigma it is. If None (default), only the MAD "
-        "band gates. Only affects the 'adaptive' method.",
     )
 
     def __init__(self, **params: Any) -> None:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -352,9 +352,9 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     regression_method: str = param.Selector(
         default="adaptive",
-        objects=["percentage", "iqr", "ttest", "adaptive"],
+        objects=["percentage", "iqr", "adaptive"],
         doc="Detection method: 'percentage' (mean comparison), "
-        "'iqr' (IQR outlier detection), 'ttest' (Welch's t-test), "
+        "'iqr' (IQR outlier detection), "
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
@@ -364,7 +364,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
         doc="Threshold for regression detection. Interpretation depends on method: "
         "'percentage' = percent change (default 5.0), "
         "'iqr' = IQR multiplier (default 1.5), "
-        "'ttest' = significance level alpha (default 0.05), "
         "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
         "If None, the per-method default is used automatically.",
     )

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import bencher as bn
 
+
 class ServerBenchmark(bn.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""
 

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 
 import bencher as bn
 
-
 class ServerBenchmark(bn.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""
 

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Regression detection — percentage threshold over time."""
+"""Auto-generated example: Regression detection — default method over time."""
 
 from datetime import datetime, timedelta
 
@@ -23,10 +23,9 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
 
 def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Regression detection — percentage threshold over time."""
+    """Regression detection — default method over time."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ServerBenchmark()

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -20,10 +24,14 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     """Gradual drift — parametrised by drift rate and z-threshold."""
 
     drift_rate = bn.FloatSweep(
-        default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
+        default=1.0,
+        bounds=[0.0, 4.0],
+        doc="Drift per time step",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5,
+        bounds=[1.5, 5.5],
+        doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -34,19 +42,26 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-             for _ in range(self._N_REPEATS)]
-            for i in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [
+                    baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
+                    for _ in range(self._N_REPEATS)
+                ]
+                for i in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.drift_rate * self._N_HIST
-             + random.gauss(0, self._NOISE)
-             for _ in range(5)]
+            [
+                baseline + self.drift_rate * self._N_HIST + random.gauss(0, self._NOISE)
+                for _ in range(5)
+            ]
         )
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
             historical_samples=hist_2d.ravel(),
@@ -67,9 +82,9 @@ def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['drift_rate', 'regression_mad'],
+        input_vars=["drift_rate", "regression_mad"],
         result_vars=["detection_plot"],
-        description='A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.',
+        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -28,7 +28,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         bounds=[0.0, 4.0],
         doc="Drift per time step",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
         doc="Adaptive z-threshold",
@@ -57,7 +57,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
@@ -67,9 +67,9 @@ def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["drift_rate", "z_threshold"],
+        input_vars=["drift_rate", "regression_mad"],
         result_vars=["detection_plot"],
-        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high z_thresholds allow the trend to pass unnoticed.",
+        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -24,52 +20,56 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     """Gradual drift — parametrised by drift rate and z-threshold."""
 
     drift_rate = bn.FloatSweep(
-        default=1.0,
-        bounds=[0.0, 4.0],
-        doc="Drift per time step",
+        default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 5.0
     _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [
-                baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-                for i in range(self._N_HIST)
-            ]
-        )
+        hist_2d = np.array([
+            [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
+             for _ in range(self._N_REPEATS)]
+            for i in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [
-                baseline + self.drift_rate * self._N_HIST + random.gauss(0, self._NOISE)
-                for _ in range(5)
-            ]
+            [baseline + self.drift_rate * self._N_HIST
+             + random.gauss(0, self._NOISE)
+             for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["drift_rate", "regression_mad"],
+        input_vars=['drift_rate', 'regression_mad'],
         result_vars=["detection_plot"],
-        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
+        description='A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -24,20 +24,23 @@ _REGRESSION_STEP = 25.0
 
 
 class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
-    """Fixed 25-unit regression with varying noise — tests noise robustness."""
+    """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
         default=10.0,
-        bounds=[2.0, 40.0],
-        doc="Noise standard deviation",
+        bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
     )
-    z_threshold = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+    regression_percentage = bn.FloatSweep(
+        default=10.0,
+        bounds=[0.0, 40.0],
+        doc="Minimum percent change required to flag a regression (dual-band "
+        "AND gate). 0.0 disables the percentage gate.",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
+
+    _Z_THRESHOLD = 3.5
 
     def benchmark(self):
         baseline = 100.0
@@ -45,12 +48,14 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         current = np.array(
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
         )
+        pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            z_threshold=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
+            regression_percentage=pct,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
 
@@ -59,9 +64,9 @@ def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["noise_sigma", "z_threshold"],
+        input_vars=["noise_sigma", "regression_percentage"],
         result_vars=["detection_plot"],
-        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and every threshold catches it; at high noise the signal is buried.  The detection boundary follows noise_sigma ≈ 25 / z_threshold — above the curve the regression is masked.  This helps users understand how metric variance affects the minimum z_threshold needed to catch a real regression.",
+        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -23,12 +27,13 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
-        default=10.0, bounds=[0.0, 40.0],
-        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
-        "percentage band).",
+        default=10.0,
+        bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
     )
     regression_percentage = bn.FloatSweep(
-        default=10.0, bounds=[0.0, 40.0],
+        default=10.0,
+        bounds=[0.0, 40.0],
         doc="Minimum percent change required to flag a regression (dual-band "
         "AND gate). 0.0 disables the percentage gate.",
     )
@@ -41,18 +46,21 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
-            for _ in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+                for _ in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
-             for _ in range(5)]
+            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
@@ -74,9 +82,9 @@ def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['noise_sigma', 'regression_percentage'],
+        input_vars=["noise_sigma", "regression_percentage"],
         result_vars=["detection_plot"],
-        description='A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.',
+        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -53,7 +53,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self._Z_THRESHOLD,
+            regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
         )

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -27,13 +23,12 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
-        default=10.0,
-        bounds=[0.0, 40.0],
-        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
+        "percentage band).",
     )
     regression_percentage = bn.FloatSweep(
-        default=10.0,
-        bounds=[0.0, 40.0],
+        default=10.0, bounds=[0.0, 40.0],
         doc="Minimum percent change required to flag a regression (dual-band "
         "AND gate). 0.0 disables the percentage gate.",
     )
@@ -41,32 +36,47 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _Z_THRESHOLD = 3.5
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array([baseline + random.gauss(0, self.noise_sigma) for _ in range(20)])
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
+            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
+             for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["noise_sigma", "regression_percentage"],
+        input_vars=['noise_sigma', 'regression_percentage'],
         result_vars=["detection_plot"],
-        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
+        description='A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -20,10 +24,14 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     """Step regression — parametrised by magnitude and z-threshold."""
 
     regression_magnitude = bn.FloatSweep(
-        default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
+        default=25.0,
+        bounds=[0.0, 60.0],
+        doc="Regression step size",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5,
+        bounds=[1.5, 5.5],
+        doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -34,17 +42,20 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
-            for _ in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+                for _ in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
-             for _ in range(5)]
+            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE) for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
             historical_samples=hist_2d.ravel(),
@@ -65,9 +76,9 @@ def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['regression_magnitude', 'regression_mad'],
+        input_vars=["regression_magnitude", "regression_mad"],
         result_vars=["detection_plot"],
-        description='A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.',
+        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -24,43 +20,54 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     """Step regression — parametrised by magnitude and z-threshold."""
 
     regression_magnitude = bn.FloatSweep(
-        default=25.0,
-        bounds=[0.0, 60.0],
-        doc="Regression step size",
+        default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array([baseline + random.gauss(0, self._NOISE) for _ in range(20)])
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE) for _ in range(5)]
+            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
+             for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["regression_magnitude", "regression_mad"],
+        input_vars=['regression_magnitude', 'regression_mad'],
         result_vars=["detection_plot"],
-        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
+        description='A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -28,7 +28,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         bounds=[0.0, 60.0],
         doc="Regression step size",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
         doc="Adaptive z-threshold",
@@ -48,7 +48,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
@@ -58,9 +58,9 @@ def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["regression_magnitude", "z_threshold"],
+        input_vars=["regression_magnitude", "regression_mad"],
         result_vars=["detection_plot"],
-        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the z_threshold is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
+        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
     )
 
     return bench

--- a/bencher/example/generated/rerun/example_rerun_regression.py
+++ b/bencher/example/generated/rerun/example_rerun_regression.py
@@ -11,7 +11,6 @@ def example_rerun_regression(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     if run_cfg is None:
         run_cfg = bn.BenchRunCfg()
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ControlSystemSweep()

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -140,30 +140,38 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
         classname="AdaptiveNoiseRobustness",
-        input_vars=("noise_sigma", "z_threshold"),
+        input_vars=("noise_sigma", "regression_percentage"),
         description=(
             "A fixed +25 step regression is present, but the noise level varies. "
-            "At low noise the regression is obvious and every threshold catches it; "
-            "at high noise the signal is buried.  The detection boundary follows "
-            "noise_sigma ≈ 25 / z_threshold — above the curve the regression is "
-            "masked.  This helps users understand how metric variance affects the "
-            "minimum z_threshold needed to catch a real regression."
+            "At low noise the regression is obvious and the MAD acceptance band "
+            "is tight; at high noise the signal is buried and the MAD band is "
+            "wide. The noise_sigma=0 row is the pathological case: MAD collapses "
+            "to zero, the MAD band is a hairline, and only the percentage band "
+            "is visible — that row shows the percentage acceptance band on its "
+            "own. Increase regression_percentage in any row to see the "
+            "percentage band expand and AND-gate the verdict."
         ),
         class_code="""\
 _REGRESSION_STEP = 25.0
 
 
 class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
-    \"\"\"Fixed 25-unit regression with varying noise — tests noise robustness.\"\"\"
+    \"\"\"Fixed 25-unit regression with varying noise and regression_percentage.\"\"\"
 
     noise_sigma = bn.FloatSweep(
-        default=10.0, bounds=[2.0, 40.0], doc="Noise standard deviation",
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
+        "percentage band).",
     )
-    z_threshold = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+    regression_percentage = bn.FloatSweep(
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Minimum percent change required to flag a regression (dual-band "
+        "AND gate). 0.0 disables the percentage gate.",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
+
+    _Z_THRESHOLD = 3.5
 
     def benchmark(self):
         baseline = 100.0
@@ -174,10 +182,12 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
              for _ in range(5)]
         )
+        pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            z_threshold=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
+            regression_percentage=pct,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
     ),

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -42,7 +42,7 @@ def _render_detection_png(hist, current, result):
     return render_regression_png(
         result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2), dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )'''
 
 
@@ -73,22 +73,36 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [baseline + random.gauss(0, self._NOISE) for _ in range(20)]
-        )
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
@@ -118,24 +132,37 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
 
     _NOISE = 5.0
     _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
+        hist_2d = np.array([
             [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-             for i in range(self._N_HIST)]
-        )
+             for _ in range(self._N_REPEATS)]
+            for i in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + self.drift_rate * self._N_HIST
              + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
@@ -172,24 +199,38 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _Z_THRESHOLD = 3.5
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [baseline + random.gauss(0, self.noise_sigma) for _ in range(20)]
-        )
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
              for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
 }
 

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -14,7 +14,7 @@ OUTPUT_DIR = "regression"
 
 
 # ---------------------------------------------------------------------------
-# Tuning examples — 2-D sweeps (effect × z_threshold) with ResultReference
+# Tuning examples — 2-D sweeps (effect × regression_mad) with ResultReference
 # ---------------------------------------------------------------------------
 
 
@@ -29,7 +29,7 @@ class TuningSpec:
 
     classname: str
     class_code: str  # full class definition (+ optional module-level constants)
-    input_vars: tuple[str, ...] = ("noise_sigma", "z_threshold")
+    input_vars: tuple[str, ...] = ("noise_sigma", "regression_mad")
     description: str = ""
 
 
@@ -50,12 +50,12 @@ _TUNING: dict[str, TuningSpec] = {
     # ---- 1. Step regression parametrised by magnitude ----------------------
     "tuning_step": TuningSpec(
         classname="AdaptiveStepDetection",
-        input_vars=("regression_magnitude", "z_threshold"),
+        input_vars=("regression_magnitude", "regression_mad"),
         description=(
             "A step regression of variable magnitude is injected (fixed noise σ=10). "
             "Each cell shows the synthesised 20-point history and the current run. "
             "When the regression magnitude is large relative to noise and the "
-            "z_threshold is low the detector fires; when the magnitude shrinks or "
+            "regression_mad is low the detector fires; when the magnitude shrinks or "
             "the threshold rises it stays quiet.  The boundary reveals the minimum "
             "detectable effect for each threshold setting."
         ),
@@ -66,7 +66,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     regression_magnitude = bn.FloatSweep(
         default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
@@ -85,7 +85,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         )
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
@@ -93,14 +93,14 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
         classname="AdaptiveDriftDetection",
-        input_vars=("drift_rate", "z_threshold"),
+        input_vars=("drift_rate", "regression_mad"),
         description=(
             "A linear drift is added to the history (fixed noise σ=5). "
             "With 20 time points, the total drift equals drift_rate × 20 "
             "and the current run continues the trend.  The adaptive drift "
             "test (Theil–Sen slope + Mann–Kendall trend guard) fires when "
             "the accumulated drift outweighs the detrended noise.  Low "
-            "drift rates or high z_thresholds allow the trend to pass "
+            "drift rates or high regression_mads allow the trend to pass "
             "unnoticed."
         ),
         class_code="""\
@@ -110,7 +110,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     drift_rate = bn.FloatSweep(
         default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
@@ -132,7 +132,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         )
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
@@ -185,7 +185,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self._Z_THRESHOLD,
+            regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
         )

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -283,7 +283,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True
-run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False
 
 benchable = ServerBenchmark()
@@ -308,7 +307,7 @@ for i, offset in enumerate(releases):
     )
 """
         self.generate_example(
-            title="Regression detection — percentage threshold over time",
+            title="Regression detection — default method over time",
             output_dir=OUTPUT_DIR,
             filename="example_regression_percentage",
             function_name="example_regression_percentage",

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -285,20 +285,12 @@ def _regression_plot_spec(
     valid_color = "#2ca02c"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
-        band_layers.append(
-            (mad_band[0], mad_band[1], valid_color, 0.15, "MAD band")
-        )
-        band_layers.append(
-            (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
-        )
+        band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "MAD band"))
+        band_layers.append((pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band"))
     elif mad_band is not None:
-        band_layers.append(
-            (mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band")
-        )
+        band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band"))
     elif pct_band is not None:
-        band_layers.append(
-            (pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band")
-        )
+        band_layers.append((pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band"))
 
     # Per-sample historical scatter: mirrors the current-run alpha scatter so
     # history and current use the same visual language. Prefer per-repeat data
@@ -458,17 +450,28 @@ def build_regression_overlay(
                 spec["ylabel"],
             ).opts(
                 hv.opts.Scatter(
-                    backend="bokeh", color="#1f77b4", alpha=0.35, size=3, show_legend=False,
+                    backend="bokeh",
+                    color="#1f77b4",
+                    alpha=0.35,
+                    size=3,
+                    show_legend=False,
                 ),
                 hv.opts.Scatter(
-                    backend="matplotlib", color="#1f77b4", alpha=0.35, s=8, show_legend=False,
+                    backend="matplotlib",
+                    color="#1f77b4",
+                    alpha=0.35,
+                    s=8,
+                    show_legend=False,
                 ),
             )
         )
     if len(hist) > 0:
         layers.append(
             hv.Curve(
-                list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"], label="history",
+                list(zip(hist_x, hist)),
+                spec["xlabel"],
+                spec["ylabel"],
+                label="history",
             ).opts(
                 hv.opts.Curve(backend="bokeh", color="#1f77b4", alpha=0.7, line_width=1.5),
                 hv.opts.Curve(backend="matplotlib", color="#1f77b4", alpha=0.7, linewidth=1.2),
@@ -508,10 +511,18 @@ def build_regression_overlay(
                 spec["ylabel"],
             ).opts(
                 hv.opts.Scatter(
-                    backend="bokeh", color=verdict_color, alpha=0.35, size=5, show_legend=False,
+                    backend="bokeh",
+                    color=verdict_color,
+                    alpha=0.35,
+                    size=5,
+                    show_legend=False,
                 ),
                 hv.opts.Scatter(
-                    backend="matplotlib", color=verdict_color, alpha=0.35, s=18, show_legend=False,
+                    backend="matplotlib",
+                    color=verdict_color,
+                    alpha=0.35,
+                    s=18,
+                    show_legend=False,
                 ),
             )
         )
@@ -562,25 +573,31 @@ def build_regression_overlay(
     for lo, hi, color, alpha, band_label in spec["band_layers"]:
         legend_entries.append(Patch(facecolor=color, alpha=alpha, label=band_label))
     legend_entries.append(
-        Line2D([], [], color="#555555", alpha=0.7, linestyle="--",
-               label=f"baseline={baseline:.3g}")
+        Line2D([], [], color="#555555", alpha=0.7, linestyle="--", label=f"baseline={baseline:.3g}")
     )
     if hist_len > 0:
-        legend_entries.append(
-            Line2D([], [], color="#1f77b4", alpha=0.7, label="history")
-        )
+        legend_entries.append(Line2D([], [], color="#1f77b4", alpha=0.7, label="history"))
     legend_entries.append(
         Line2D(
-            [], [], marker="o", linestyle="", color=verdict_color,
-            markersize=7, markeredgecolor="black", markeredgewidth=0.7,
+            [],
+            [],
+            marker="o",
+            linestyle="",
+            color=verdict_color,
+            markersize=7,
+            markeredgecolor="black",
+            markeredgewidth=0.7,
             label=f"current={spec['curr_mean']:.3g}",
         )
     )
 
     def _fill_fig_hook(
-        plot, _element,
-        _title=title, _title_color=verdict_color,
-        _title_fs=fontsize["title"], _legend_fs=fontsize["legend"],
+        plot,
+        _element,
+        _title=title,
+        _title_color=verdict_color,
+        _title_fs=fontsize["title"],
+        _legend_fs=fontsize["legend"],
         _legend=legend_entries,
     ):
         ax = plot.handles["axis"]
@@ -590,15 +607,19 @@ def build_regression_overlay(
         ax.set_position([0.15, 0.22, 0.82, 0.64])
         ax.set_title(_title, color=_title_color, fontsize=_title_fs, fontweight="bold")
         ax.legend(
-            handles=_legend, loc="upper left", fontsize=_legend_fs,
-            framealpha=0.85, ncol=2, handlelength=1.2, borderpad=0.3, labelspacing=0.3,
+            handles=_legend,
+            loc="upper left",
+            fontsize=_legend_fs,
+            framealpha=0.85,
+            ncol=2,
+            handlelength=1.2,
+            borderpad=0.3,
+            labelspacing=0.3,
         )
 
     mpl_hooks = [_fill_fig_hook]
     overlay_opts = [
-        hv.opts.Overlay(
-            title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize
-        ),
+        hv.opts.Overlay(title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize),
         hv.opts.Overlay(
             backend="bokeh",
             width=width,
@@ -621,9 +642,7 @@ def build_regression_overlay(
             ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=_fs)
 
         mpl_hooks.append(_mpl_xticks_hook)
-        overlay_opts.append(
-            hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30)
-        )
+        overlay_opts.append(hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30))
     overlay_opts.append(
         hv.opts.Overlay(backend="matplotlib", fig_inches=fig_inches, hooks=mpl_hooks)
     )
@@ -1008,9 +1027,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             .mean(dim=reduce_dims, skipna=True)
             .values.astype(float)
         )
-        current_mean_scalar = np.array(
-            [float(da.isel(over_time=-1).mean(skipna=True).values)]
-        )
+        current_mean_scalar = np.array([float(da.isel(over_time=-1).mean(skipna=True).values)])
 
         if method == "percentage":
             result = detect_percentage(

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -279,27 +279,34 @@ def _regression_plot_spec(
 
     # Shared declarative band layers — both matplotlib and holoviews iterate
     # this list so the two backends render the same thing by construction.
-    # Each entry is (lo, hi, color, alpha, label).
+    # Each entry is (lo, hi, color, alpha, label). The acceptance band always
+    # shades green: it represents the *valid* region, not the pass/fail
+    # verdict (verdict colouring lives on the current marker + connector).
+    valid_color = "#2ca02c"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
         band_layers.append(
-            (mad_band[0], mad_band[1], verdict_color, 0.15, "MAD band")
+            (mad_band[0], mad_band[1], valid_color, 0.15, "MAD band")
         )
         band_layers.append(
             (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
         )
     elif mad_band is not None:
         band_layers.append(
-            (mad_band[0], mad_band[1], verdict_color, 0.15, "acceptance band")
+            (mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band")
         )
     elif pct_band is not None:
         band_layers.append(
-            (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
+            (pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band")
         )
 
-    # Per-sample historical scatter: only plot if the x-coords align with the
-    # primary hist_x dtype (so strings/categorical fallbacks don't break the
-    # axis). Falls back to None when there is no alignment.
+    # Per-sample historical scatter: mirrors the current-run alpha scatter so
+    # history and current use the same visual language. Prefer per-repeat data
+    # when available (populated by detect_regressions); otherwise fall back to
+    # the per-time mean array itself so direct detect_* calls still get dots.
+    # Works even on categorical x-axes (string labels → integer xticks) as
+    # long as historical_all_x is numeric and aligned with the integer hist_x
+    # positions that back the tick labels.
     hist_scatter_x: np.ndarray | None = None
     hist_scatter_y: np.ndarray | None = None
     if (
@@ -307,7 +314,6 @@ def _regression_plot_spec(
         and result.historical_all_x is not None
         and len(result.historical_all) == len(result.historical_all_x)
         and len(result.historical_all) > 0
-        and xticks is None
     ):
         raw = np.asarray(result.historical_all_x)
         hist_is_dt = np.issubdtype(hist_x.dtype, np.datetime64)
@@ -317,6 +323,9 @@ def _regression_plot_spec(
         if (hist_is_dt and raw_is_dt) or (hist_is_num and raw_is_num):
             hist_scatter_x = raw
             hist_scatter_y = np.asarray(result.historical_all, dtype=float)
+    if hist_scatter_x is None and len(hist) > 0 and xticks is None:
+        hist_scatter_x = hist_x
+        hist_scatter_y = hist
 
     return {
         "hist": hist,
@@ -336,18 +345,45 @@ def _regression_plot_spec(
     }
 
 
+def _ensure_matplotlib_backend_loaded() -> None:
+    """Register the holoviews matplotlib backend without changing the default.
+
+    render_regression_png needs matplotlib to export a PNG, but the report path
+    uses bokeh — calling hv.extension('matplotlib') naively would flip the
+    global default mid-run. This loads the renderer if missing, then restores
+    the prior default. Forces the non-interactive Agg backend first so
+    holoviews doesn't pick up Tk/Qt (which leaks ``main thread is not in main
+    loop`` tracebacks at interpreter shutdown).
+    """
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+
+    import holoviews as hv
+
+    if "matplotlib" in hv.Store.renderers:
+        return
+    prev_backend = hv.Store.current_backend
+    hv.extension("matplotlib", logo=False)
+    if prev_backend and hv.Store.current_backend != prev_backend:
+        hv.Store.set_current_backend(prev_backend)
+
+
 def build_regression_overlay(
     result: RegressionResult,
     historical: np.ndarray | None = None,
     current: np.ndarray | float | None = None,
     width: int = 700,
     height: int = 350,
+    fig_inches: tuple[float, float] = (7.0, 3.5),
 ):
     """Build a :class:`holoviews.Overlay` diagnostic of a regression result.
 
-    Uses the same logic as :func:`render_regression_png` but returns a
-    backend-agnostic holoviews object, so the same plot can be embedded in an
-    HTML report (bokeh backend) or saved as a PNG (matplotlib backend).
+    Opts are applied per-backend so the same overlay renders correctly under
+    both bokeh (for embedded HTML reports) and matplotlib (for PNG export via
+    :func:`render_regression_png`). History always shows as mean line + raw
+    alpha scatter; regression-specific layers (acceptance band, baseline,
+    verdict-coloured current marker) are conditional on the data in *result*.
 
     Args:
         result: The :class:`RegressionResult` to visualise.
@@ -355,7 +391,8 @@ def build_regression_overlay(
             Falls back to ``result.historical`` if omitted.
         current: Optional current-run sample array (or scalar). Falls back to
             ``result.current_samples`` / ``result.current_value``.
-        width, height: Pixel dimensions passed to the overlay's ``opts``.
+        width, height: Pixel dimensions for the bokeh backend.
+        fig_inches: Figure size in inches for the matplotlib backend.
     """
     import holoviews as hv
 
@@ -370,21 +407,48 @@ def build_regression_overlay(
     x_start = hist_x[0] if len(hist_x) > 0 else x_current
     x_end = x_current
 
+    # Each element duplicates its style opts across both backends so they
+    # apply regardless of which renderer is active — holoviews does NOT
+    # carry no-backend opts across backend boundaries, so omitting the
+    # backend kwarg silently drops styles like alpha when rendering as PNG.
+    # Elements whose identity matters for the legend carry a ``label`` kwarg;
+    # decorative layers (hist-sample scatter, current-sample scatter, dotted
+    # connector) are label-less so the legend stays compact.
     layers = []
-    for lo, hi, color, alpha, _label in spec["band_layers"]:
+    for lo, hi, color, alpha, label in spec["band_layers"]:
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=color, alpha=alpha, line_alpha=0)
+                label=label,
+            ).opts(
+                hv.opts.Area(backend="bokeh", color=color, alpha=alpha, line_alpha=0),
+                hv.opts.Area(backend="matplotlib", color=color, alpha=alpha, linewidth=0),
+            )
         )
     layers.append(
         hv.Curve(
             [(x_start, spec["baseline"]), (x_end, spec["baseline"])],
             spec["xlabel"],
             spec["ylabel"],
-        ).opts(color="#555555", line_dash="dashed", line_width=1)
+            label=f"baseline={spec['baseline']:.3g}",
+        ).opts(
+            hv.opts.Curve(
+                backend="bokeh",
+                color="#555555",
+                alpha=0.7,
+                line_dash="dashed",
+                line_width=1,
+            ),
+            hv.opts.Curve(
+                backend="matplotlib",
+                color="#555555",
+                alpha=0.7,
+                linestyle="--",
+                linewidth=1,
+            ),
+        )
     )
     if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
         layers.append(
@@ -392,12 +456,22 @@ def build_regression_overlay(
                 list(zip(spec["hist_scatter_x"], spec["hist_scatter_y"])),
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color="#1f77b4", alpha=0.35, size=5)
+            ).opts(
+                hv.opts.Scatter(
+                    backend="bokeh", color="#1f77b4", alpha=0.35, size=3, show_legend=False,
+                ),
+                hv.opts.Scatter(
+                    backend="matplotlib", color="#1f77b4", alpha=0.35, s=8, show_legend=False,
+                ),
+            )
         )
     if len(hist) > 0:
         layers.append(
-            hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
-                color="#1f77b4", line_width=1.5
+            hv.Curve(
+                list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"], label="history",
+            ).opts(
+                hv.opts.Curve(backend="bokeh", color="#1f77b4", alpha=0.7, line_width=1.5),
+                hv.opts.Curve(backend="matplotlib", color="#1f77b4", alpha=0.7, linewidth=1.2),
             )
         )
         # Dotted connector from the last history point to the current marker
@@ -407,7 +481,24 @@ def build_regression_overlay(
                 [(hist_x[-1], hist[-1]), (x_current, spec["curr_mean"])],
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color=verdict_color, line_dash="dotted", line_width=1.5)
+            ).opts(
+                hv.opts.Curve(
+                    backend="bokeh",
+                    color=verdict_color,
+                    alpha=0.8,
+                    line_dash="dotted",
+                    line_width=1.5,
+                    show_legend=False,
+                ),
+                hv.opts.Curve(
+                    backend="matplotlib",
+                    color=verdict_color,
+                    alpha=0.8,
+                    linestyle=":",
+                    linewidth=1.2,
+                    show_legend=False,
+                ),
+            )
         )
     if len(spec["curr_samples"]) > 1:
         layers.append(
@@ -415,25 +506,128 @@ def build_regression_overlay(
                 [(x_current, v) for v in spec["curr_samples"]],
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color=verdict_color, alpha=0.35, size=5)
+            ).opts(
+                hv.opts.Scatter(
+                    backend="bokeh", color=verdict_color, alpha=0.35, size=5, show_legend=False,
+                ),
+                hv.opts.Scatter(
+                    backend="matplotlib", color=verdict_color, alpha=0.35, s=18, show_legend=False,
+                ),
+            )
         )
     layers.append(
         hv.Scatter(
             [(x_current, spec["curr_mean"])],
             spec["xlabel"],
             spec["ylabel"],
-        ).opts(color=verdict_color, size=10, line_color="black", line_width=1)
+            label=f"current={spec['curr_mean']:.3g}",
+        ).opts(
+            hv.opts.Scatter(
+                backend="bokeh",
+                color=verdict_color,
+                size=10,
+                line_color="black",
+                line_width=1,
+            ),
+            hv.opts.Scatter(
+                backend="matplotlib",
+                color=verdict_color,
+                s=70,
+                edgecolors="black",
+                linewidth=0.7,
+            ),
+        )
     )
 
     overlay = layers[0]
     for layer in layers[1:]:
         overlay = overlay * layer
 
-    opts_kwargs = dict(title=spec["title"], width=width, height=height, show_grid=True)
+    # Compact font sizing — the PNGs render at ~4–9 inches wide so the default
+    # matplotlib font sizes overflow the figure. Bokeh accepts the same dict.
+    fontsize = {"title": 9, "labels": 8, "xticks": 6, "yticks": 7, "legend": 6}
+
+    # holoviews' matplotlib backend defaults to a square data aspect, centers a
+    # small axes inside the figure, and drops Element ``label=`` on Area/Curve
+    # overlays so its own legend only shows a subset of layers. The hooks below
+    # stretch the axes, set the title manually, and build a proxy legend from
+    # the spec so every rendered layer can appear in the legend.
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
+    title = spec["title"]
+    baseline = spec["baseline"]
+    hist_len = len(hist)
+    legend_entries: list = []
+    for lo, hi, color, alpha, band_label in spec["band_layers"]:
+        legend_entries.append(Patch(facecolor=color, alpha=alpha, label=band_label))
+    legend_entries.append(
+        Line2D([], [], color="#555555", alpha=0.7, linestyle="--",
+               label=f"baseline={baseline:.3g}")
+    )
+    if hist_len > 0:
+        legend_entries.append(
+            Line2D([], [], color="#1f77b4", alpha=0.7, label="history")
+        )
+    legend_entries.append(
+        Line2D(
+            [], [], marker="o", linestyle="", color=verdict_color,
+            markersize=7, markeredgecolor="black", markeredgewidth=0.7,
+            label=f"current={spec['curr_mean']:.3g}",
+        )
+    )
+
+    def _fill_fig_hook(
+        plot, _element,
+        _title=title, _title_color=verdict_color,
+        _title_fs=fontsize["title"], _legend_fs=fontsize["legend"],
+        _legend=legend_entries,
+    ):
+        ax = plot.handles["axis"]
+        ax.set_aspect("auto")
+        # left 0.15 leaves room for y-label + ticks, top 0.86 leaves room for
+        # the title, bottom 0.22 leaves room for rotated xtick labels.
+        ax.set_position([0.15, 0.22, 0.82, 0.64])
+        ax.set_title(_title, color=_title_color, fontsize=_title_fs, fontweight="bold")
+        ax.legend(
+            handles=_legend, loc="upper left", fontsize=_legend_fs,
+            framealpha=0.85, ncol=2, handlelength=1.2, borderpad=0.3, labelspacing=0.3,
+        )
+
+    mpl_hooks = [_fill_fig_hook]
+    overlay_opts = [
+        hv.opts.Overlay(
+            title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize
+        ),
+        hv.opts.Overlay(
+            backend="bokeh",
+            width=width,
+            height=height,
+            legend_position="top_left",
+        ),
+    ]
     if spec["xticks"] is not None:
-        opts_kwargs["xticks"] = spec["xticks"]
-        opts_kwargs["xrotation"] = 30
-    return overlay.opts(**opts_kwargs)
+        # bokeh accepts [(pos, label), ...] directly; matplotlib silently
+        # ignores the label half and falls back to integer tick text, so
+        # labels have to be pushed in via a plot hook on that backend.
+        xticks_pairs = spec["xticks"]
+        xtick_fontsize = fontsize["xticks"]
+
+        def _mpl_xticks_hook(plot, _element, _pairs=xticks_pairs, _fs=xtick_fontsize):
+            ax = plot.handles["axis"]
+            positions = [p for p, _ in _pairs]
+            labels = [lbl for _, lbl in _pairs]
+            ax.set_xticks(positions)
+            ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=_fs)
+
+        mpl_hooks.append(_mpl_xticks_hook)
+        overlay_opts.append(
+            hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30)
+        )
+    overlay_opts.append(
+        hv.opts.Overlay(backend="matplotlib", fig_inches=fig_inches, hooks=mpl_hooks)
+    )
+    return overlay.opts(*overlay_opts)
 
 
 def render_regression_png(
@@ -444,38 +638,29 @@ def render_regression_png(
     figsize: tuple[float, float] = (8.0, 5.0),
     dpi: int = 100,
 ) -> str:
-    """Render a diagnostic PNG of a regression result using matplotlib.
+    """Render a diagnostic PNG by saving the shared holoviews overlay via matplotlib.
 
-    The plot contains everything needed to diagnose the *style* of regression
-    at a glance — history time-series (to reveal drift and noise), the baseline
-    line, the acceptance band (to reveal step size), and the current-run marker
-    coloured by the pass/fail verdict. The details string from
-    :class:`RegressionResult` (method-specific statistics such as z-score,
-    p-value, or percent change) is shown as a footer so the PNG is
-    self-contained — suitable for posting directly as a GitHub PR comment.
+    Produces the same plot as the in-report bokeh overlay — it calls
+    :func:`build_regression_overlay` and hands the result to holoviews'
+    matplotlib renderer, so there's a single source of truth for the
+    diagnostic visual.
 
     Args:
         result: The :class:`RegressionResult` produced by a ``detect_*`` call.
-        historical: 1-D array of the historical per-time-point means (the same
-            sequence fed into ``detect_adaptive``). Pass an
-            empty array if no history is available — only the current marker,
-            baseline, and band are drawn in that case.
-        current: Current-run sample(s). If ``None``, ``result.current_value``
-            is used. If given an array, the per-sample spread is shown as a
-            vertical strip alongside the mean marker.
+        historical: 1-D array of historical per-time-point means. Falls back
+            to ``result.historical``.
+        current: Current-run sample(s). Falls back to ``result.current_samples``
+            / ``result.current_value``.
         path: Output PNG path. If ``None``, a path is generated via
             :func:`bencher.utils.gen_image_path` so the file lives under the
             bencher cache directory.
-        figsize: Matplotlib figure size in inches.
-        dpi: Output DPI (800x500 at ``dpi=100`` works well for GitHub comments).
+        figsize: Figure size in inches (matplotlib ``fig_inches``).
+        dpi: Output DPI (500x320 at ``dpi=100`` works well for GitHub comments).
 
     Returns:
         Absolute path to the saved PNG as a string.
     """
-    import matplotlib
-
-    matplotlib.use("Agg", force=False)
-    import matplotlib.pyplot as plt
+    import holoviews as hv
 
     if path is None:
         from bencher.utils import gen_image_path
@@ -483,92 +668,16 @@ def render_regression_png(
         path = gen_image_path(f"regression_{result.variable}")
     path_str = str(path)
 
-    spec = _regression_plot_spec(result, historical, current)
-    hist = spec["hist"]
-    hist_x = spec["hist_x"]
-    curr_samples = spec["curr_samples"]
-    x_current = spec["x_current"]
-    verdict_color = spec["verdict_color"]
-
-    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-    fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
-
-    for lo, hi, color, alpha, label in spec["band_layers"]:
-        ax.axhspan(lo, hi, color=color, alpha=alpha, label=label)
-
-    ax.axhline(
-        spec["baseline"],
-        color="#555555",
-        linestyle="--",
-        linewidth=1.0,
-        label=f"baseline={spec['baseline']:.3g}",
+    _ensure_matplotlib_backend_loaded()
+    overlay = build_regression_overlay(
+        result, historical=historical, current=current, fig_inches=figsize
     )
+    # hv.renderer(...).save re-tightens the bbox and collapses the figure to
+    # roughly square regardless of fig_inches. Rendering to a Figure and
+    # using matplotlib's own savefig preserves the requested inches.
+    import matplotlib.pyplot as plt
 
-    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
-        ax.scatter(
-            spec["hist_scatter_x"],
-            spec["hist_scatter_y"],
-            color="#1f77b4",
-            alpha=0.35,
-            s=18,
-            label="history samples",
-        )
-    if len(hist) > 0:
-        ax.plot(
-            hist_x,
-            hist,
-            "-o",
-            color="#1f77b4",
-            markersize=3.5,
-            linewidth=1.2,
-            label="history",
-        )
-        # Dotted connector from the last history point to the current marker
-        # so the jump that triggered the regression is visually obvious.
-        ax.plot(
-            [hist_x[-1], x_current],
-            [hist[-1], spec["curr_mean"]],
-            linestyle=":",
-            color=verdict_color,
-            linewidth=1.2,
-            alpha=0.8,
-        )
-
-    if len(curr_samples) > 1:
-        ax.scatter(
-            [x_current] * len(curr_samples),
-            curr_samples,
-            color=verdict_color,
-            alpha=0.35,
-            s=18,
-        )
-    ax.scatter(
-        [x_current],
-        [spec["curr_mean"]],
-        color=verdict_color,
-        s=70,
-        zorder=5,
-        edgecolor="black",
-        linewidth=0.7,
-        label=f"current={spec['curr_mean']:.3g}",
-    )
-
-    # Extra margin on the right so the current marker isn't clipped by the frame.
-    ax.margins(x=0.08)
-
-    ax.set_xlabel(spec["xlabel"])
-    ax.set_ylabel(spec["ylabel"])
-    ax.grid(True, linestyle=":", alpha=0.5)
-    ax.set_title(spec["title"], color=verdict_color, fontsize=10, fontweight="bold")
-    ax.legend(loc="upper left", fontsize=7, framealpha=0.85, ncol=2)
-
-    if spec["xticks"] is not None:
-        ticks, labels = zip(*spec["xticks"])
-        ax.set_xticks(list(ticks))
-        ax.set_xticklabels(list(labels), rotation=30, ha="right")
-    elif len(hist_x) > 0 and np.issubdtype(np.asarray(hist_x).dtype, np.datetime64):
-        fig.autofmt_xdate(rotation=30)
-
+    fig = hv.render(overlay, backend="matplotlib")
     fig.savefig(path_str, dpi=dpi)
     plt.close(fig)
     return path_str

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -53,6 +53,10 @@ class RegressionResult:
     details: str
     band_lower: float | None = None
     band_upper: float | None = None
+    # Optional second acceptance band (dual-band adaptive). When both bands are
+    # populated a value must lie outside BOTH to count as a regression.
+    percent_band_lower: float | None = None
+    percent_band_upper: float | None = None
     # Arrays retained so the result can be replotted without re-running detection.
     historical: np.ndarray | None = None
     current_samples: np.ndarray | None = None
@@ -252,6 +256,11 @@ def _regression_plot_spec(
             if result.band_lower is not None and result.band_upper is not None
             else None
         ),
+        "percent_band": (
+            (result.percent_band_lower, result.percent_band_upper)
+            if result.percent_band_lower is not None and result.percent_band_upper is not None
+            else None
+        ),
         "baseline": result.baseline_value,
         "verdict_color": verdict_color,
         "title": title,
@@ -303,6 +312,15 @@ def build_regression_overlay(
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
             ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+        )
+    if spec["percent_band"] is not None:
+        plo, phi = spec["percent_band"]
+        layers.append(
+            hv.Area(
+                ([x_start, x_end], [plo, plo], [phi, phi]),
+                kdims=[spec["xlabel"]],
+                vdims=[spec["ylabel"], "pct_band_upper"],
+            ).opts(color="#9467bd", alpha=0.08, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -412,7 +430,11 @@ def render_regression_png(
 
     if spec["band"] is not None:
         lo, hi = spec["band"]
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
+        mad_label = "MAD band" if spec["percent_band"] is not None else "acceptance band"
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label=mad_label)
+    if spec["percent_band"] is not None:
+        plo, phi = spec["percent_band"]
+        ax.axhspan(plo, phi, color="#9467bd", alpha=0.08, label="percent band")
 
     ax.axhline(
         spec["baseline"],
@@ -689,6 +711,7 @@ def detect_adaptive(
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
     historical_samples: np.ndarray | None = None,
+    percent_floor: float | None = None,
 ) -> RegressionResult:
     """Robust regression detection combining step and drift tests.
 
@@ -720,6 +743,11 @@ def detect_adaptive(
             delegated ``ttest``/``percentage`` methods see the same input they
             would have received from ``detect_regressions`` directly. Falls
             back to ``historical_time_means`` when not provided.
+        percent_floor: Optional minimum percent change required to flag a
+            regression. When set, acts as a second acceptance band: a
+            regression fires only when BOTH the MAD test and the percent
+            change exceed their thresholds. Suppresses noise-floor false
+            positives on metrics with few repeats or very tight history.
     """
     if drift_threshold is None:
         drift_threshold = _DRIFT_FRAC * z_threshold
@@ -756,7 +784,7 @@ def detect_adaptive(
 
     # Step test — current mean vs robust baseline in MAD-sigma units.
     z_step = (curr_mean - baseline) / noise_floor
-    step_regressed = _is_regression(z_step, direction) and abs(z_step) > z_threshold
+    step_mad = _is_regression(z_step, direction) and abs(z_step) > z_threshold
 
     # Drift test — Theil–Sen slope on Hampel-filtered history, MK significance.
     # Use residual (detrended) noise as the denominator so a real drift can't
@@ -777,13 +805,33 @@ def detect_adaptive(
     z_drift = drift_total / drift_noise
     _, mk_p = kendalltau(indices, filtered)
     mk_p = float(mk_p) if not np.isnan(mk_p) else 1.0
-    drift_regressed = (
+    drift_mad = (
         _is_regression(z_drift, direction) and abs(z_drift) > drift_threshold and mk_p < mk_alpha
     )
 
+    change = _safe_change_percent(curr_mean, baseline)
+
+    # Dual-band gate: when percent_floor is set, each test must also be
+    # confirmed by a percent-change gate. The step gate uses the observed
+    # current-vs-baseline change; the drift gate uses the projected end-of-
+    # history drift so a trend that doesn't cumulatively move more than the
+    # floor is treated as inside the band.
+    if percent_floor is not None:
+        step_pct_ok = _exceeds_directional_threshold(change, percent_floor, direction)
+        drift_change = _safe_change_percent(baseline + drift_total, baseline)
+        drift_pct_ok = _exceeds_directional_threshold(drift_change, percent_floor, direction)
+        percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
+        percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+    else:
+        step_pct_ok = True
+        drift_pct_ok = True
+        percent_band_lower = None
+        percent_band_upper = None
+
+    step_regressed = step_mad and step_pct_ok
+    drift_regressed = drift_mad and drift_pct_ok
     regressed = step_regressed or drift_regressed
 
-    change = _safe_change_percent(curr_mean, baseline)
     fired = []
     if step_regressed:
         fired.append("step")
@@ -796,6 +844,8 @@ def detect_adaptive(
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
     )
+    if percent_floor is not None:
+        details += f", pct_floor={percent_floor}% (change={change:+.2f}%)"
 
     return RegressionResult(
         variable=variable,
@@ -809,6 +859,8 @@ def detect_adaptive(
         details=details,
         band_lower=baseline - z_threshold * noise_floor,
         band_upper=baseline + z_threshold * noise_floor,
+        percent_band_lower=percent_band_lower,
+        percent_band_upper=percent_band_upper,
     )
 
 
@@ -841,6 +893,8 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     # Use per-method default when no explicit threshold is provided.
     if threshold is None:
         threshold = _METHOD_DEFAULTS.get(method, 5.0)
+
+    percent_floor = getattr(run_cfg, "regression_percent_floor", None)
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -885,6 +939,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 z_threshold=threshold,
                 direction=direction,
                 historical_samples=historical_clean,
+                percent_floor=percent_floor,
             )
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -1,9 +1,9 @@
 """Benchmark regression detection for over-time benchmarks.
 
 Provides statistical methods to detect if benchmark values have changed
-significantly between runs. Supports percentage threshold, IQR-based outlier
-detection, and an adaptive MAD-based detector with an optional percent
-floor for dual-band suppression.
+significantly between runs. Supports a percentage threshold and an
+adaptive MAD-based detector with an optional percent floor for dual-band
+suppression.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 # Default thresholds per method — used when the user hasn't explicitly set a threshold.
 _METHOD_DEFAULTS = {
     "percentage": 5.0,  # percent change
-    "iqr": 1.5,  # IQR multiplier
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
@@ -244,6 +243,37 @@ def _regression_plot_spec(
     )
     title = f"{result.variable} — {result.method} — {verdict_label}  (Δ {change_str})"
 
+    mad_band = (
+        (result.band_lower, result.band_upper)
+        if result.band_lower is not None and result.band_upper is not None
+        else None
+    )
+    pct_band = (
+        (result.percent_band_lower, result.percent_band_upper)
+        if result.percent_band_lower is not None and result.percent_band_upper is not None
+        else None
+    )
+
+    # Shared declarative band layers — both matplotlib and holoviews iterate
+    # this list so the two backends render the same thing by construction.
+    # Each entry is (lo, hi, color, alpha, label).
+    band_layers: list[tuple[float, float, str, float, str]] = []
+    if mad_band is not None and pct_band is not None:
+        band_layers.append(
+            (mad_band[0], mad_band[1], verdict_color, 0.15, "MAD band")
+        )
+        band_layers.append(
+            (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
+        )
+    elif mad_band is not None:
+        band_layers.append(
+            (mad_band[0], mad_band[1], verdict_color, 0.15, "acceptance band")
+        )
+    elif pct_band is not None:
+        band_layers.append(
+            (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
+        )
+
     return {
         "hist": hist,
         "hist_x": hist_x,
@@ -251,16 +281,7 @@ def _regression_plot_spec(
         "curr_samples": curr_samples,
         "curr_mean": curr_mean,
         "x_current": x_current,
-        "band": (
-            (result.band_lower, result.band_upper)
-            if result.band_lower is not None and result.band_upper is not None
-            else None
-        ),
-        "percent_band": (
-            (result.percent_band_lower, result.percent_band_upper)
-            if result.percent_band_lower is not None and result.percent_band_upper is not None
-            else None
-        ),
+        "band_layers": band_layers,
         "baseline": result.baseline_value,
         "verdict_color": verdict_color,
         "title": title,
@@ -304,49 +325,13 @@ def build_regression_overlay(
     x_end = x_current
 
     layers = []
-    mad_band = spec["band"]
-    pct_band = spec["percent_band"]
-    if mad_band is not None and pct_band is not None:
-        # Combined acceptance band (AND gate -> accept if inside either band
-        # => the union is the effective acceptance region).
-        lo = min(mad_band[0], pct_band[0])
-        hi = max(mad_band[1], pct_band[1])
+    for lo, hi, color, alpha, _label in spec["band_layers"]:
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
-        )
-        for edge in (mad_band[0], mad_band[1]):
-            layers.append(
-                hv.Curve(
-                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
-                ).opts(color="#888888", line_dash="dotted", line_width=0.8)
-            )
-        for edge in (pct_band[0], pct_band[1]):
-            layers.append(
-                hv.Curve(
-                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
-                ).opts(color="#9467bd", line_dash="dashed", line_width=0.8)
-            )
-    elif mad_band is not None:
-        lo, hi = mad_band
-        layers.append(
-            hv.Area(
-                ([x_start, x_end], [lo, lo], [hi, hi]),
-                kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
-        )
-    elif pct_band is not None:
-        plo, phi = pct_band
-        layers.append(
-            hv.Area(
-                ([x_start, x_end], [plo, plo], [phi, phi]),
-                kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+            ).opts(color=color, alpha=alpha, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -418,7 +403,7 @@ def render_regression_png(
     Args:
         result: The :class:`RegressionResult` produced by a ``detect_*`` call.
         historical: 1-D array of the historical per-time-point means (the same
-            sequence fed into ``detect_adaptive`` / ``detect_iqr``). Pass an
+            sequence fed into ``detect_adaptive``). Pass an
             empty array if no history is available — only the current marker,
             baseline, and band are drawn in that case.
         current: Current-run sample(s). If ``None``, ``result.current_value``
@@ -454,28 +439,8 @@ def render_regression_png(
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
 
-    mad_band = spec["band"]
-    pct_band = spec["percent_band"]
-    if mad_band is not None and pct_band is not None:
-        # AND gate means a point is accepted if it sits inside EITHER band,
-        # so the effective acceptance region is the union of the two.
-        lo = min(mad_band[0], pct_band[0])
-        hi = max(mad_band[1], pct_band[1])
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band (MAD ∪ %)")
-        ax.axhline(
-            mad_band[0], color="#888888", linestyle=":", linewidth=0.8, label="MAD edge"
-        )
-        ax.axhline(mad_band[1], color="#888888", linestyle=":", linewidth=0.8)
-        ax.axhline(
-            pct_band[0], color="#9467bd", linestyle="--", linewidth=0.8, label="percent edge"
-        )
-        ax.axhline(pct_band[1], color="#9467bd", linestyle="--", linewidth=0.8)
-    elif mad_band is not None:
-        lo, hi = mad_band
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
-    elif pct_band is not None:
-        plo, phi = pct_band
-        ax.axhspan(plo, phi, color=verdict_color, alpha=0.10, label="acceptance band")
+    for lo, hi, color, alpha, label in spec["band_layers"]:
+        ax.axhspan(lo, hi, color=color, alpha=alpha, label=label)
 
     ax.axhline(
         spec["baseline"],
@@ -614,63 +579,6 @@ def detect_percentage(
     )
 
 
-def detect_iqr(
-    variable: str,
-    historical_time_means: np.ndarray,
-    current: np.ndarray,
-    iqr_scale: float = 1.5,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """IQR outlier detection using per-time-point means from history.
-
-    Args:
-        variable: Name of the result variable being checked.
-        historical_time_means: Array of per-time-point mean values from history.
-        current: Current run values (will be averaged).
-        iqr_scale: Multiplier for IQR to define outlier bounds (default 1.5).
-        direction: Optimization direction from the result variable.
-    """
-    clean = _clean_1d(historical_time_means)
-    curr_mean = float(np.nanmean(current))
-
-    if len(clean) < 4:
-        # Not enough time points for robust IQR; fall back to percentage using
-        # the default percentage threshold so the comparison stays meaningful.
-        return detect_percentage(
-            variable,
-            clean,
-            current,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
-            direction=direction,
-        )
-
-    q1 = float(np.percentile(clean, 25))
-    q3 = float(np.percentile(clean, 75))
-    iqr = q3 - q1
-    lower = q1 - iqr_scale * iqr
-    upper = q3 + iqr_scale * iqr
-
-    hist_mean = float(np.nanmean(clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-
-    outside_bounds = curr_mean > upper or curr_mean < lower
-    regressed = outside_bounds and _is_regression(change, direction)
-
-    return RegressionResult(
-        variable=variable,
-        method="iqr",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=iqr_scale,
-        direction=direction.value,
-        details=f"IQR bounds [{lower:.4g}, {upper:.4g}], current={curr_mean:.4g}",
-        band_lower=lower,
-        band_upper=upper,
-    )
-
-
 def _robust_scale(values: np.ndarray) -> tuple[float, float]:
     """Return (median, MAD-based sigma) for a 1-D numeric array.
 
@@ -706,7 +614,7 @@ def detect_adaptive(
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
     historical_samples: np.ndarray | None = None,
-    percent_floor: float | None = None,
+    regression_percentage: float | None = None,
 ) -> RegressionResult:
     """Robust regression detection combining step and drift tests.
 
@@ -738,8 +646,9 @@ def detect_adaptive(
             delegated ``percentage`` detector sees the same input it would
             have received from ``detect_regressions`` directly. Falls back to
             ``historical_time_means`` when not provided.
-        percent_floor: Optional minimum percent change required to flag a
-            regression. When set, acts as a second acceptance band: a
+        regression_percentage: Optional minimum percent change required to
+            flag a regression (directional, i.e. interpreted against
+            ``direction``). When set, acts as a second acceptance band: a
             regression fires only when BOTH the MAD test and the percent
             change exceed their thresholds. Suppresses noise-floor false
             positives on metrics with few repeats or very tight history.
@@ -758,10 +667,14 @@ def detect_adaptive(
         fallback_hist = (
             _clean_1d(historical_samples) if historical_samples is not None else hist_clean
         )
-        # Sparse history -> percentage check. When ``percent_floor`` is set it
-        # doubles as the percentage threshold so the sparse regime honours the
-        # same floor the user configured for dual-band suppression.
-        effective_pct = percent_floor if percent_floor is not None else _METHOD_DEFAULTS["percentage"]
+        # Sparse history -> percentage check. When ``regression_percentage`` is
+        # set it doubles as the percentage threshold so the sparse regime honours
+        # the same knob the user configured for dual-band suppression.
+        effective_pct = (
+            regression_percentage
+            if regression_percentage is not None
+            else _METHOD_DEFAULTS["percentage"]
+        )
         result = detect_percentage(
             variable,
             fallback_hist,
@@ -769,10 +682,10 @@ def detect_adaptive(
             threshold_percent=effective_pct,
             direction=direction,
         )
-        if percent_floor is not None:
+        if regression_percentage is not None:
             baseline = result.baseline_value
-            result.percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
-            result.percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+            result.percent_band_lower = baseline * (1.0 - regression_percentage / 100.0)
+            result.percent_band_upper = baseline * (1.0 + regression_percentage / 100.0)
         return result
 
     baseline, mad_sigma = _robust_scale(hist_clean)
@@ -807,17 +720,19 @@ def detect_adaptive(
 
     change = _safe_change_percent(curr_mean, baseline)
 
-    # Dual-band gate: when percent_floor is set, each test must also be
-    # confirmed by a percent-change gate. The step gate uses the observed
+    # Dual-band gate: when regression_percentage is set, each test must also
+    # be confirmed by a percent-change gate. The step gate uses the observed
     # current-vs-baseline change; the drift gate uses the projected end-of-
     # history drift so a trend that doesn't cumulatively move more than the
-    # floor is treated as inside the band.
-    if percent_floor is not None:
-        step_pct_ok = _exceeds_directional_threshold(change, percent_floor, direction)
+    # threshold is treated as inside the band.
+    if regression_percentage is not None:
+        step_pct_ok = _exceeds_directional_threshold(change, regression_percentage, direction)
         drift_change = _safe_change_percent(baseline + drift_total, baseline)
-        drift_pct_ok = _exceeds_directional_threshold(drift_change, percent_floor, direction)
-        percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
-        percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+        drift_pct_ok = _exceeds_directional_threshold(
+            drift_change, regression_percentage, direction
+        )
+        percent_band_lower = baseline * (1.0 - regression_percentage / 100.0)
+        percent_band_upper = baseline * (1.0 + regression_percentage / 100.0)
     else:
         step_pct_ok = True
         drift_pct_ok = True
@@ -840,8 +755,8 @@ def detect_adaptive(
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
     )
-    if percent_floor is not None:
-        details += f", pct_floor={percent_floor}% (change={change:+.2f}%)"
+    if regression_percentage is not None:
+        details += f", pct={regression_percentage}% (change={change:+.2f}%)"
 
     return RegressionResult(
         variable=variable,
@@ -890,7 +805,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     if threshold is None:
         threshold = _METHOD_DEFAULTS.get(method, 5.0)
 
-    percent_floor = getattr(run_cfg, "regression_percent_floor", None)
+    regression_percentage = getattr(run_cfg, "regression_percentage", None)
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -911,7 +826,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             continue
 
         time_means_arr: np.ndarray | None = None
-        if method in ("iqr", "adaptive"):
+        if method == "adaptive":
             reduce_dims = [d for d in da.dims if d != "over_time"]
             time_means_arr = (
                 da.isel(over_time=slice(None, -1))
@@ -923,8 +838,6 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             result = detect_percentage(
                 var_name, historical_clean, current_clean, threshold, direction
             )
-        elif method == "iqr":
-            result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
@@ -933,7 +846,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 z_threshold=threshold,
                 direction=direction,
                 historical_samples=historical_clean,
-                percent_floor=percent_floor,
+                regression_percentage=regression_percentage,
             )
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -2,7 +2,8 @@
 
 Provides statistical methods to detect if benchmark values have changed
 significantly between runs. Supports percentage threshold, IQR-based outlier
-detection, and Welch's t-test.
+detection, and an adaptive MAD-based detector with an optional percent
+floor for dual-band suppression.
 """
 
 from __future__ import annotations
@@ -20,7 +21,6 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 _METHOD_DEFAULTS = {
     "percentage": 5.0,  # percent change
     "iqr": 1.5,  # IQR multiplier
-    "ttest": 0.05,  # significance level alpha
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
@@ -304,8 +304,13 @@ def build_regression_overlay(
     x_end = x_current
 
     layers = []
-    if spec["band"] is not None:
-        lo, hi = spec["band"]
+    mad_band = spec["band"]
+    pct_band = spec["percent_band"]
+    if mad_band is not None and pct_band is not None:
+        # Combined acceptance band (AND gate -> accept if inside either band
+        # => the union is the effective acceptance region).
+        lo = min(mad_band[0], pct_band[0])
+        hi = max(mad_band[1], pct_band[1])
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
@@ -313,14 +318,35 @@ def build_regression_overlay(
                 vdims=[spec["ylabel"], "band_upper"],
             ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
         )
-    if spec["percent_band"] is not None:
-        plo, phi = spec["percent_band"]
+        for edge in (mad_band[0], mad_band[1]):
+            layers.append(
+                hv.Curve(
+                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
+                ).opts(color="#888888", line_dash="dotted", line_width=0.8)
+            )
+        for edge in (pct_band[0], pct_band[1]):
+            layers.append(
+                hv.Curve(
+                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
+                ).opts(color="#9467bd", line_dash="dashed", line_width=0.8)
+            )
+    elif mad_band is not None:
+        lo, hi = mad_band
+        layers.append(
+            hv.Area(
+                ([x_start, x_end], [lo, lo], [hi, hi]),
+                kdims=[spec["xlabel"]],
+                vdims=[spec["ylabel"], "band_upper"],
+            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+        )
+    elif pct_band is not None:
+        plo, phi = pct_band
         layers.append(
             hv.Area(
                 ([x_start, x_end], [plo, plo], [phi, phi]),
                 kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "pct_band_upper"],
-            ).opts(color="#9467bd", alpha=0.08, line_alpha=0)
+                vdims=[spec["ylabel"], "band_upper"],
+            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -428,13 +454,28 @@ def render_regression_png(
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
 
-    if spec["band"] is not None:
-        lo, hi = spec["band"]
-        mad_label = "MAD band" if spec["percent_band"] is not None else "acceptance band"
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label=mad_label)
-    if spec["percent_band"] is not None:
-        plo, phi = spec["percent_band"]
-        ax.axhspan(plo, phi, color="#9467bd", alpha=0.08, label="percent band")
+    mad_band = spec["band"]
+    pct_band = spec["percent_band"]
+    if mad_band is not None and pct_band is not None:
+        # AND gate means a point is accepted if it sits inside EITHER band,
+        # so the effective acceptance region is the union of the two.
+        lo = min(mad_band[0], pct_band[0])
+        hi = max(mad_band[1], pct_band[1])
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band (MAD ∪ %)")
+        ax.axhline(
+            mad_band[0], color="#888888", linestyle=":", linewidth=0.8, label="MAD edge"
+        )
+        ax.axhline(mad_band[1], color="#888888", linestyle=":", linewidth=0.8)
+        ax.axhline(
+            pct_band[0], color="#9467bd", linestyle="--", linewidth=0.8, label="percent edge"
+        )
+        ax.axhline(pct_band[1], color="#9467bd", linestyle="--", linewidth=0.8)
+    elif mad_band is not None:
+        lo, hi = mad_band
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
+    elif pct_band is not None:
+        plo, phi = pct_band
+        ax.axhspan(plo, phi, color=verdict_color, alpha=0.10, label="acceptance band")
 
     ax.axhline(
         spec["baseline"],
@@ -630,52 +671,6 @@ def detect_iqr(
     )
 
 
-def detect_ttest(
-    variable: str,
-    historical: np.ndarray,
-    current: np.ndarray,
-    alpha: float = 0.05,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """Welch's t-test between historical and current samples."""
-    hist_clean = _clean_1d(historical)
-    curr_clean = _clean_1d(current)
-
-    if len(hist_clean) < 2 or len(curr_clean) < 2:
-        # Fall back to percentage with alpha-based threshold
-        return detect_percentage(
-            variable, hist_clean, curr_clean, threshold_percent=alpha * 100, direction=direction
-        )
-
-    from scipy.stats import ttest_ind
-
-    if direction == OptDir.minimize:
-        alt = "greater"  # regression = current > historical
-    elif direction == OptDir.maximize:
-        alt = "less"  # regression = current < historical
-    else:
-        alt = "two-sided"
-
-    stat, pvalue = ttest_ind(curr_clean, hist_clean, equal_var=False, alternative=alt)
-
-    hist_mean = float(np.nanmean(hist_clean))
-    curr_mean = float(np.nanmean(curr_clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-    regressed = pvalue < alpha
-
-    return RegressionResult(
-        variable=variable,
-        method="ttest",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=alpha,
-        direction=direction.value,
-        details=f"t-stat={stat:.4g}, p-value={pvalue:.4g}, alpha={alpha}",
-    )
-
-
 def _robust_scale(values: np.ndarray) -> tuple[float, float]:
     """Return (median, MAD-based sigma) for a 1-D numeric array.
 
@@ -740,9 +735,9 @@ def detect_adaptive(
         direction: Optimization direction from the result variable.
         historical_samples: Optional flat array of all historical samples
             (not per-time means). Used for the sparse-history fallback so the
-            delegated ``ttest``/``percentage`` methods see the same input they
-            would have received from ``detect_regressions`` directly. Falls
-            back to ``historical_time_means`` when not provided.
+            delegated ``percentage`` detector sees the same input it would
+            have received from ``detect_regressions`` directly. Falls back to
+            ``historical_time_means`` when not provided.
         percent_floor: Optional minimum percent change required to flag a
             regression. When set, acts as a second acceptance band: a
             regression fires only when BOTH the MAD test and the percent
@@ -756,28 +751,29 @@ def detect_adaptive(
     curr_clean = _clean_1d(current)
     curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
 
-    # Not enough history for a robust scale — fall back to less strict checks.
-    # Use the full per-sample history when available so the fallback behaves
-    # like a direct call to detect_ttest/detect_percentage.
+    # Not enough history for a robust scale — fall back to a percentage
+    # check. Use the full per-sample history when available so the fallback
+    # behaves like a direct call to detect_percentage.
     if len(hist_clean) < 4:
         fallback_hist = (
             _clean_1d(historical_samples) if historical_samples is not None else hist_clean
         )
-        if len(fallback_hist) >= 2 and len(curr_clean) >= 2:
-            return detect_ttest(
-                variable,
-                fallback_hist,
-                curr_clean,
-                alpha=_METHOD_DEFAULTS["ttest"],
-                direction=direction,
-            )
-        return detect_percentage(
+        # Sparse history -> percentage check. When ``percent_floor`` is set it
+        # doubles as the percentage threshold so the sparse regime honours the
+        # same floor the user configured for dual-band suppression.
+        effective_pct = percent_floor if percent_floor is not None else _METHOD_DEFAULTS["percentage"]
+        result = detect_percentage(
             variable,
             fallback_hist,
             curr_clean,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
+            threshold_percent=effective_pct,
             direction=direction,
         )
+        if percent_floor is not None:
+            baseline = result.baseline_value
+            result.percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
+            result.percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+        return result
 
     baseline, mad_sigma = _robust_scale(hist_clean)
     noise_floor = max(mad_sigma, 1e-6 * abs(baseline), 1e-12)
@@ -929,8 +925,6 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             )
         elif method == "iqr":
             result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
-        elif method == "ttest":
-            result = detect_ttest(var_name, historical_clean, current_clean, threshold, direction)
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
@@ -957,10 +951,10 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             result.current_x = time_coord[-1]
         else:
             result.historical = historical_clean
-            # percentage/ttest pass the flat history (repeat * over_time); we
-            # only record over_time coords when they line up with the flat
-            # history length — otherwise pair current_x with the integer
-            # indices used by the plot and leave both unset.
+            # percentage passes the flat history (repeat * over_time); only
+            # record over_time coords when they line up with the flat history
+            # length — otherwise pair current_x with the integer indices used
+            # by the plot and leave both unset.
             if len(time_coord) - 1 == len(historical_clean):
                 result.historical_x = time_coord[:-1]
                 result.current_x = time_coord[-1]

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -19,14 +19,14 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 
 # Default thresholds per method — used when the user hasn't explicitly set a threshold.
 _METHOD_DEFAULTS = {
-    "percentage": 5.0,  # percent change
+    "percentage": 10.0,  # percent change
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
 # Consistency factor so MAD estimates the standard deviation of a Gaussian.
 _MAD_TO_SIGMA = 1.4826
 
-# Drift threshold defaults to this fraction of z_threshold when not set by caller.
+# Drift threshold defaults to this fraction of regression_mad when not set by caller.
 _DRIFT_FRAC = 0.85
 
 # Hampel filter cutoff (in MAD units) used to drop outliers from the slope fit.
@@ -59,6 +59,11 @@ class RegressionResult:
     # Arrays retained so the result can be replotted without re-running detection.
     historical: np.ndarray | None = None
     current_samples: np.ndarray | None = None
+    # Optional per-sample historical data (flat: all repeats from all historical
+    # time points) with paired x-coords — used to render a scatter overlay
+    # showing the full spread at each time point, not just the per-time mean.
+    historical_all: np.ndarray | None = None
+    historical_all_x: np.ndarray | None = None
     # x-axis coordinates for the historical and current points (typically the
     # ``over_time`` datetimes). Optional: falls back to integer indices.
     historical_x: np.ndarray | None = None
@@ -243,13 +248,31 @@ def _regression_plot_spec(
     )
     title = f"{result.variable} — {result.method} — {verdict_label}  (Δ {change_str})"
 
+    baseline = result.baseline_value
+
+    def _clip(band: tuple[float, float] | None) -> tuple[float, float] | None:
+        """Clip the band to the side(s) that actually gate regressions.
+
+        Stored bands are symmetric around the baseline, but for directional
+        metrics only one side flags a regression. Minimize only trips on
+        values above baseline; maximize only trips on values below. None
+        flags either side, so the full symmetric band stays."""
+        if band is None:
+            return None
+        lo, hi = band
+        if result.direction == OptDir.minimize.value:
+            return (baseline, hi)
+        if result.direction == OptDir.maximize.value:
+            return (lo, baseline)
+        return (lo, hi)
+
     mad_band = (
-        (result.band_lower, result.band_upper)
+        _clip((result.band_lower, result.band_upper))
         if result.band_lower is not None and result.band_upper is not None
         else None
     )
     pct_band = (
-        (result.percent_band_lower, result.percent_band_upper)
+        _clip((result.percent_band_lower, result.percent_band_upper))
         if result.percent_band_lower is not None and result.percent_band_upper is not None
         else None
     )
@@ -274,9 +297,32 @@ def _regression_plot_spec(
             (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
         )
 
+    # Per-sample historical scatter: only plot if the x-coords align with the
+    # primary hist_x dtype (so strings/categorical fallbacks don't break the
+    # axis). Falls back to None when there is no alignment.
+    hist_scatter_x: np.ndarray | None = None
+    hist_scatter_y: np.ndarray | None = None
+    if (
+        result.historical_all is not None
+        and result.historical_all_x is not None
+        and len(result.historical_all) == len(result.historical_all_x)
+        and len(result.historical_all) > 0
+        and xticks is None
+    ):
+        raw = np.asarray(result.historical_all_x)
+        hist_is_dt = np.issubdtype(hist_x.dtype, np.datetime64)
+        raw_is_dt = np.issubdtype(raw.dtype, np.datetime64)
+        hist_is_num = np.issubdtype(hist_x.dtype, np.number)
+        raw_is_num = np.issubdtype(raw.dtype, np.number)
+        if (hist_is_dt and raw_is_dt) or (hist_is_num and raw_is_num):
+            hist_scatter_x = raw
+            hist_scatter_y = np.asarray(result.historical_all, dtype=float)
+
     return {
         "hist": hist,
         "hist_x": hist_x,
+        "hist_scatter_x": hist_scatter_x,
+        "hist_scatter_y": hist_scatter_y,
         "xticks": xticks,
         "curr_samples": curr_samples,
         "curr_mean": curr_mean,
@@ -340,6 +386,14 @@ def build_regression_overlay(
             spec["ylabel"],
         ).opts(color="#555555", line_dash="dashed", line_width=1)
     )
+    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
+        layers.append(
+            hv.Scatter(
+                list(zip(spec["hist_scatter_x"], spec["hist_scatter_y"])),
+                spec["xlabel"],
+                spec["ylabel"],
+            ).opts(color="#1f77b4", alpha=0.35, size=5)
+        )
     if len(hist) > 0:
         layers.append(
             hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
@@ -450,6 +504,15 @@ def render_regression_png(
         label=f"baseline={spec['baseline']:.3g}",
     )
 
+    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
+        ax.scatter(
+            spec["hist_scatter_x"],
+            spec["hist_scatter_y"],
+            color="#1f77b4",
+            alpha=0.35,
+            s=18,
+            label="history samples",
+        )
     if len(hist) > 0:
         ax.plot(
             hist_x,
@@ -609,7 +672,7 @@ def detect_adaptive(
     variable: str,
     historical_time_means: np.ndarray,
     current: np.ndarray,
-    z_threshold: float = 3.5,
+    regression_mad: float = 3.5,
     drift_threshold: float | None = None,
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
@@ -623,7 +686,7 @@ def detect_adaptive(
     run's deviation in those noise units. Two orthogonal tests run in parallel:
 
     * **Short-term step** — flags if ``(current_mean - baseline) / noise_floor``
-      exceeds ``z_threshold`` in the regression direction.
+      exceeds ``regression_mad`` in the regression direction.
     * **Long-term drift** — fits a Theil–Sen slope on the historical time-point
       means (after a Hampel filter removes isolated outliers) and flags if the
       total projected drift, scaled by ``noise_floor``, exceeds
@@ -635,9 +698,9 @@ def detect_adaptive(
         historical_time_means: 1-D array of per-time-point mean values from
             history (one entry per prior run).
         current: Current run values (will be averaged).
-        z_threshold: Step-test threshold in MAD-sigma units.
+        regression_mad: Step-test threshold in MAD-sigma units.
         drift_threshold: Drift-test threshold in MAD-sigma units. If ``None``,
-            defaults to ``_DRIFT_FRAC * z_threshold`` so users need to tune
+            defaults to ``_DRIFT_FRAC * regression_mad`` so users need to tune
             only one knob.
         mk_alpha: Significance level for the Mann–Kendall trend guard.
         direction: Optimization direction from the result variable.
@@ -654,7 +717,7 @@ def detect_adaptive(
             positives on metrics with few repeats or very tight history.
     """
     if drift_threshold is None:
-        drift_threshold = _DRIFT_FRAC * z_threshold
+        drift_threshold = _DRIFT_FRAC * regression_mad
 
     hist_clean = _clean_1d(historical_time_means)
     curr_clean = _clean_1d(current)
@@ -693,7 +756,7 @@ def detect_adaptive(
 
     # Step test — current mean vs robust baseline in MAD-sigma units.
     z_step = (curr_mean - baseline) / noise_floor
-    step_mad = _is_regression(z_step, direction) and abs(z_step) > z_threshold
+    step_mad = _is_regression(z_step, direction) and abs(z_step) > regression_mad
 
     # Drift test — Theil–Sen slope on Hampel-filtered history, MK significance.
     # Use residual (detrended) noise as the denominator so a real drift can't
@@ -750,7 +813,7 @@ def detect_adaptive(
         fired.append("drift")
     fired_str = "+".join(fired) if fired else "none"
     details = (
-        f"fired={fired_str}, z_step={z_step:+.2f} (|z|>{z_threshold}), "
+        f"fired={fired_str}, z_step={z_step:+.2f} (|z|>{regression_mad}), "
         f"z_drift={z_drift:+.2f} (|z|>{drift_threshold:.2f}), "
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
@@ -765,11 +828,11 @@ def detect_adaptive(
         current_value=curr_mean,
         baseline_value=baseline,
         change_percent=change,
-        threshold=z_threshold,
+        threshold=regression_mad,
         direction=direction.value,
         details=details,
-        band_lower=baseline - z_threshold * noise_floor,
-        band_upper=baseline + z_threshold * noise_floor,
+        band_lower=baseline - regression_mad * noise_floor,
+        band_upper=baseline + regression_mad * noise_floor,
         percent_band_lower=percent_band_lower,
         percent_band_upper=percent_band_upper,
     )
@@ -799,13 +862,12 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         return report
 
     method = run_cfg.regression_method
-    threshold = run_cfg.regression_threshold
-
-    # Use per-method default when no explicit threshold is provided.
-    if threshold is None:
-        threshold = _METHOD_DEFAULTS.get(method, 5.0)
-
+    regression_mad = getattr(run_cfg, "regression_mad", None)
+    if regression_mad is None:
+        regression_mad = _METHOD_DEFAULTS["adaptive"]
     regression_percentage = getattr(run_cfg, "regression_percentage", None)
+    if regression_percentage is None:
+        regression_percentage = _METHOD_DEFAULTS["percentage"]
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -836,14 +898,14 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
 
         if method == "percentage":
             result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
+                var_name, historical_clean, current_clean, regression_percentage, direction
             )
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
                 time_means_arr,
                 current_clean,
-                z_threshold=threshold,
+                regression_mad=regression_mad,
                 direction=direction,
                 historical_samples=historical_clean,
                 regression_percentage=regression_percentage,
@@ -851,7 +913,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")
             result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
+                var_name, historical_clean, current_clean, regression_percentage, direction
             )
 
         # Retain the arrays used for plotting so downstream consumers (reports,
@@ -872,6 +934,22 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 result.historical_x = time_coord[:-1]
                 result.current_x = time_coord[-1]
         result.current_samples = current_clean
+
+        # Per-sample historical scatter: flatten the 2D slice (all repeats at
+        # every historical time point) and broadcast the time coords so the
+        # renderers can show every sample as a dot at its real x position.
+        hist_slice = da.isel(over_time=slice(None, -1))
+        if hist_slice.size > 0:
+            hist_2d = np.moveaxis(
+                np.asarray(hist_slice.values, dtype=float),
+                list(hist_slice.dims).index("over_time"),
+                0,
+            ).reshape(hist_slice.sizes["over_time"], -1)
+            hist_samples_flat = hist_2d.ravel()
+            hist_x_flat = np.repeat(time_coord[:-1], hist_2d.shape[1])
+            mask = ~np.isnan(hist_samples_flat)
+            result.historical_all = hist_samples_flat[mask]
+            result.historical_all_x = hist_x_flat[mask]
 
         report.results.append(result)
 

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -996,24 +996,35 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         if len(current_clean) == 0 or len(historical_clean) == 0:
             continue
 
-        time_means_arr: np.ndarray | None = None
-        if method == "adaptive":
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
+        # Aggregate every non-time dim (parameter grid, repeats) into a single
+        # scalar per time point before handing the series to any detector.
+        # Without this, a 2-D param sweep over time threads both detection and
+        # the history plot through parameter-grid structure — the line zigzags
+        # through cells instead of showing time drift, and the baseline/band
+        # end up wildly out of scale relative to individual cells.
+        reduce_dims = [d for d in da.dims if d != "over_time"]
+        time_means_arr = (
+            da.isel(over_time=slice(None, -1))
+            .mean(dim=reduce_dims, skipna=True)
+            .values.astype(float)
+        )
+        current_mean_scalar = np.array(
+            [float(da.isel(over_time=-1).mean(skipna=True).values)]
+        )
 
         if method == "percentage":
             result = detect_percentage(
-                var_name, historical_clean, current_clean, regression_percentage, direction
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
             )
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
                 time_means_arr,
-                current_clean,
+                current_mean_scalar,
                 regression_mad=regression_mad,
                 direction=direction,
                 historical_samples=historical_clean,
@@ -1022,26 +1033,20 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")
             result = detect_percentage(
-                var_name, historical_clean, current_clean, regression_percentage, direction
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
             )
 
         # Retain the arrays used for plotting so downstream consumers (reports,
         # bot comments) can rebuild the diagnostic without re-running detection.
         time_coord = dataset["over_time"].values
-        if time_means_arr is not None:
-            result.historical = time_means_arr
-            # Per-time means are aligned with over_time, one value per time point.
-            result.historical_x = time_coord[:-1]
-            result.current_x = time_coord[-1]
-        else:
-            result.historical = historical_clean
-            # percentage passes the flat history (repeat * over_time); only
-            # record over_time coords when they line up with the flat history
-            # length — otherwise pair current_x with the integer indices used
-            # by the plot and leave both unset.
-            if len(time_coord) - 1 == len(historical_clean):
-                result.historical_x = time_coord[:-1]
-                result.current_x = time_coord[-1]
+        result.historical = time_means_arr
+        # Per-time means are aligned with over_time, one value per time point.
+        result.historical_x = time_coord[:-1]
+        result.current_x = time_coord[-1]
         result.current_samples = current_clean
 
         # Per-sample historical scatter: flatten the 2D slice (all repeats at

--- a/pixi.lock
+++ b/pixi.lock
@@ -102,7 +102,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -277,7 +277,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -455,7 +455,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -631,7 +631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -806,7 +806,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -1474,8 +1474,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.86.0
-  sha256: 6d3a35e41f361d8365c56a72d93c42a7c079c6f67b2af2a70d0d5498de5ffeaf
+  version: 1.88.0
+  sha256: 6df428054a0fcd1ebd4c1239d8f79181cdf0b51676d09020f89983aa91bde7d2
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -2660,10 +2660,10 @@ packages:
   - flake8-implicit-str-concat==0.4.0 ; extra == 'lint'
   - isort>=5.12 ; extra == 'lint'
   - pre-commit>=3.3 ; extra == 'lint'
-- pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
   name: narwhals
-  version: 2.19.0
-  sha256: 1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b
+  version: 2.20.0
+  sha256: 16e750ea5507d4ba6e8d03455b5f93a535e0405976561baea235bca5dc9f475d
   requires_dist:
   - cudf-cu12>=24.10.0 ; extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.87.0"
+version = "1.88.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -359,7 +359,12 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None, regression_percentage=None):
+    def _make_cfg(
+        result_vars,
+        method="percentage",
+        regression_mad=None,
+        regression_percentage=None,
+    ):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -367,12 +372,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold, regression_percentage):
+            def __init__(self, method, regression_mad, regression_percentage):
                 self.regression_method = method
-                self.regression_threshold = threshold
+                self.regression_mad = regression_mad
                 self.regression_percentage = regression_percentage
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, regression_percentage)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, regression_mad, regression_percentage)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -412,7 +417,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert report.results[0].variable == "metric"
@@ -432,7 +437,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions
 
@@ -445,7 +450,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions, report.summary()
 
@@ -460,7 +465,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "step" in report.results[0].details
@@ -476,12 +481,12 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.maximize)
         rv.name = "metric"
 
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         without_pct = detect_regressions(ds, bench_cfg, run_cfg)
         assert without_pct.has_regressions
 
         bench_cfg, run_cfg = self._make_cfg(
-            [rv], method="adaptive", threshold=3.5, regression_percentage=40.0
+            [rv], method="adaptive", regression_mad=3.5, regression_percentage=40.0
         )
         with_pct = detect_regressions(ds, bench_cfg, run_cfg)
         assert not with_pct.has_regressions
@@ -499,7 +504,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "drift" in report.results[0].details
@@ -532,7 +537,7 @@ class TestDetectRegressions:
         rv_a.name = "metric_a"
         rv_b = ResultFloat(units="s", direction=OptDir.minimize)
         rv_b.name = "metric_b"
-        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 2
         assert report.has_regressions
@@ -548,7 +553,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="bogus", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="bogus", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert report.results[0].method == "percentage"
@@ -587,11 +592,11 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
 
-        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report_strict = detect_regressions(ds, bench_cfg_strict, run_cfg_strict)
         assert report_strict.has_regressions
 
-        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", threshold=15.0)
+        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", regression_percentage=15.0)
         report_loose = detect_regressions(ds, bench_cfg_loose, run_cfg_loose)
         assert not report_loose.has_regressions
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -13,7 +13,6 @@ from bencher.regression import (
     RegressionResult,
     build_regression_overlay,
     detect_adaptive,
-    detect_iqr,
     detect_percentage,
     detect_regressions,
     render_regression_png,
@@ -100,44 +99,6 @@ class TestDetectPercentage:
             "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
         )
         assert not result.regressed
-
-
-# ── detect_iqr ─────────────────────────────────────────────────────────────
-
-
-class TestDetectIqr:
-    def test_within_bounds(self):
-        time_means = np.array([100.0, 101.0, 99.0, 100.5, 98.5])
-        curr = np.array([101.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_outlier_above_minimize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([20.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_outlier_below_maximize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_improvement_not_regression_minimize(self):
-        """For minimize, an outlier below bounds is an improvement, not a regression."""
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])  # well below — improvement for minimize
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_fallback_with_few_points(self):
-        """With <4 historical time points, should fall back to percentage."""
-        time_means = np.array([100.0, 101.0])
-        curr = np.array([200.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back
-        assert result.regressed
 
 
 # ── detect_adaptive ────────────────────────────────────────────────────────
@@ -266,44 +227,52 @@ class TestDetectAdaptive:
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
-    # ---- dual-band (percent_floor) ----
+    # ---- dual-band (regression_percentage) ----
 
-    def test_percent_floor_suppresses_mad_only_fire(self):
-        """Tight MAD-derived noise flagged a small change; percent floor blocks it."""
+    def test_regression_percentage_suppresses_mad_only_fire(self):
+        """Tight MAD-derived noise flagged a small change; percentage gate blocks it."""
         hist = np.array([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
         # 20% change at 10 sigma — MAD would normally fire.
         curr = np.array([12.0])
-        without_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert without_floor.regressed
-        with_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=30.0)
-        assert not with_floor.regressed
-        assert with_floor.percent_band_lower is not None
-        assert with_floor.percent_band_upper is not None
+        without_pct = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert without_pct.regressed
+        with_pct = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=30.0
+        )
+        assert not with_pct.regressed
+        assert with_pct.percent_band_lower is not None
+        assert with_pct.percent_band_upper is not None
 
-    def test_percent_floor_allows_real_regression(self):
+    def test_regression_percentage_allows_real_regression(self):
         """When both MAD and percent thresholds are exceeded, still fires."""
         hist = 100.0 + np.random.default_rng(0).normal(0, 1.0, 20)
         curr = np.array([200.0])  # 100% change and huge z
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        result = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=10.0
+        )
         assert result.regressed
 
-    def test_percent_floor_none_preserves_behavior(self):
+    def test_regression_percentage_none_preserves_behavior(self):
         """Passing None is identical to leaving it unset (current behavior)."""
         rng = np.random.default_rng(0)
         hist = 100.0 + rng.normal(0, 15.0, 20)
         curr = 150.0 + rng.normal(0, 15.0, 10)
-        with_none = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=None)
+        with_none = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=None
+        )
         baseline = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert with_none.regressed == baseline.regressed
         assert with_none.percent_band_lower is None
 
-    def test_percent_floor_direction_aware_improvement(self):
+    def test_regression_percentage_direction_aware_improvement(self):
         """Percent gate respects optimization direction."""
         hist = np.array([10.0] * 20)
         # 20% decrease — for minimize this is improvement (never regression),
         # and the gate shouldn't change that.
         curr = np.array([8.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        result = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=10.0
+        )
         assert not result.regressed
 
     def test_sparse_fallback_uses_full_samples(self):
@@ -390,7 +359,7 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None, percent_floor=None):
+    def _make_cfg(result_vars, method="percentage", threshold=None, regression_percentage=None):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -398,12 +367,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold, percent_floor):
+            def __init__(self, method, threshold, regression_percentage):
                 self.regression_method = method
                 self.regression_threshold = threshold
-                self.regression_percent_floor = percent_floor
+                self.regression_percentage = regression_percentage
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, percent_floor)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, regression_percentage)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -467,26 +436,6 @@ class TestDetectRegressions:
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions
 
-    def test_iqr_method(self):
-        values = np.array(
-            [
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [50.0, 50.0],
-            ]
-        )
-        ds = self._make_dataset(n_times=6, n_repeats=2, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="iqr", threshold=1.5)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
     def test_adaptive_method_no_false_positive_on_noisy_stable(self):
         """Adaptive must not trip on a noisy-but-stable signal (user's pain point)."""
         rng = np.random.default_rng(0)
@@ -516,9 +465,9 @@ class TestDetectRegressions:
         assert report.has_regressions
         assert "step" in report.results[0].details
 
-    def test_adaptive_percent_floor_suppresses_single_repeat_fire(self):
+    def test_adaptive_regression_percentage_suppresses_single_repeat_fire(self):
         """Single-repeat variable with stable history + modest drop is suppressed
-        when a percent floor is set, but would otherwise fire on MAD alone."""
+        when a regression percentage is set, but would otherwise fire on MAD alone."""
         # Tight history at 10 with one earlier dip; current=7 (-30%).
         values = np.array([[10.0], [10.0], [6.0], [10.0], [10.0], [7.0]])
         ds = self._make_dataset(n_times=6, n_repeats=1, values=values)
@@ -528,15 +477,15 @@ class TestDetectRegressions:
         rv.name = "metric"
 
         bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
-        without_floor = detect_regressions(ds, bench_cfg, run_cfg)
-        assert without_floor.has_regressions
+        without_pct = detect_regressions(ds, bench_cfg, run_cfg)
+        assert without_pct.has_regressions
 
         bench_cfg, run_cfg = self._make_cfg(
-            [rv], method="adaptive", threshold=3.5, percent_floor=40.0
+            [rv], method="adaptive", threshold=3.5, regression_percentage=40.0
         )
-        with_floor = detect_regressions(ds, bench_cfg, run_cfg)
-        assert not with_floor.has_regressions
-        assert with_floor.results[0].percent_band_lower is not None
+        with_pct = detect_regressions(ds, bench_cfg, run_cfg)
+        assert not with_pct.has_regressions
+        assert with_pct.results[0].percent_band_lower is not None
 
     def test_adaptive_method_detects_gradual_drift(self):
         """Adaptive fires on slow drift where no single step exceeds percentage."""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -537,7 +537,9 @@ class TestDetectRegressions:
         rv_a.name = "metric_a"
         rv_b = ResultFloat(units="s", direction=OptDir.minimize)
         rv_b.name = "metric_b"
-        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", regression_percentage=5.0)
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv_a, rv_b], method="percentage", regression_percentage=5.0
+        )
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 2
         assert report.has_regressions
@@ -592,11 +594,15 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
 
-        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
+        bench_cfg_strict, run_cfg_strict = self._make_cfg(
+            [rv], method="percentage", regression_percentage=5.0
+        )
         report_strict = detect_regressions(ds, bench_cfg_strict, run_cfg_strict)
         assert report_strict.has_regressions
 
-        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", regression_percentage=15.0)
+        bench_cfg_loose, run_cfg_loose = self._make_cfg(
+            [rv], method="percentage", regression_percentage=15.0
+        )
         report_loose = detect_regressions(ds, bench_cfg_loose, run_cfg_loose)
         assert not report_loose.has_regressions
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -308,6 +308,46 @@ class TestDetectAdaptive:
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
+    # ---- dual-band (percent_floor) ----
+
+    def test_percent_floor_suppresses_mad_only_fire(self):
+        """Tight MAD-derived noise flagged a small change; percent floor blocks it."""
+        hist = np.array([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
+        # 20% change at 10 sigma — MAD would normally fire.
+        curr = np.array([12.0])
+        without_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert without_floor.regressed
+        with_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=30.0)
+        assert not with_floor.regressed
+        assert with_floor.percent_band_lower is not None
+        assert with_floor.percent_band_upper is not None
+
+    def test_percent_floor_allows_real_regression(self):
+        """When both MAD and percent thresholds are exceeded, still fires."""
+        hist = 100.0 + np.random.default_rng(0).normal(0, 1.0, 20)
+        curr = np.array([200.0])  # 100% change and huge z
+        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        assert result.regressed
+
+    def test_percent_floor_none_preserves_behavior(self):
+        """Passing None is identical to leaving it unset (current behavior)."""
+        rng = np.random.default_rng(0)
+        hist = 100.0 + rng.normal(0, 15.0, 20)
+        curr = 150.0 + rng.normal(0, 15.0, 10)
+        with_none = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=None)
+        baseline = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert with_none.regressed == baseline.regressed
+        assert with_none.percent_band_lower is None
+
+    def test_percent_floor_direction_aware_improvement(self):
+        """Percent gate respects optimization direction."""
+        hist = np.array([10.0] * 20)
+        # 20% decrease — for minimize this is improvement (never regression),
+        # and the gate shouldn't change that.
+        curr = np.array([8.0])
+        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        assert not result.regressed
+
     def test_sparse_fallback_uses_full_samples(self):
         """Fallback must honour `historical_samples` so it sees all raw values.
 
@@ -392,7 +432,7 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None):
+    def _make_cfg(result_vars, method="percentage", threshold=None, percent_floor=None):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -400,11 +440,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold):
+            def __init__(self, method, threshold, percent_floor):
                 self.regression_method = method
                 self.regression_threshold = threshold
+                self.regression_percent_floor = percent_floor
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, percent_floor)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -530,6 +571,28 @@ class TestDetectRegressions:
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "step" in report.results[0].details
+
+    def test_adaptive_percent_floor_suppresses_single_repeat_fire(self):
+        """Single-repeat variable with stable history + modest drop is suppressed
+        when a percent floor is set, but would otherwise fire on MAD alone."""
+        # Tight history at 10 with one earlier dip; current=7 (-30%).
+        values = np.array([[10.0], [10.0], [6.0], [10.0], [10.0], [7.0]])
+        ds = self._make_dataset(n_times=6, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.maximize)
+        rv.name = "metric"
+
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        without_floor = detect_regressions(ds, bench_cfg, run_cfg)
+        assert without_floor.has_regressions
+
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv], method="adaptive", threshold=3.5, percent_floor=40.0
+        )
+        with_floor = detect_regressions(ds, bench_cfg, run_cfg)
+        assert not with_floor.has_regressions
+        assert with_floor.results[0].percent_band_lower is not None
 
     def test_adaptive_method_detects_gradual_drift(self):
         """Adaptive fires on slow drift where no single step exceeds percentage."""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -16,7 +16,6 @@ from bencher.regression import (
     detect_iqr,
     detect_percentage,
     detect_regressions,
-    detect_ttest,
     render_regression_png,
 )
 from bencher.variables.results import OptDir
@@ -141,47 +140,6 @@ class TestDetectIqr:
         assert result.regressed
 
 
-# ── detect_ttest ───────────────────────────────────────────────────────────
-
-
-class TestDetectTtest:
-    def test_no_significant_difference(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(100, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_significant_increase_minimize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_significant_decrease_maximize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(90, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_fallback_single_sample(self):
-        hist = np.array([100.0])
-        curr = np.array([200.0])
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back to percentage-based check
-        assert result.regressed  # still correctly detected as regression
-        assert result.change_percent > 0.0  # percentage change indicates degradation for minimize
-
-    def test_direction_none_two_sided(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.none)
-        assert result.regressed
-
-
 # ── detect_adaptive ────────────────────────────────────────────────────────
 
 
@@ -285,7 +243,7 @@ class TestDetectAdaptive:
         hist = np.array([100.0, 101.0, 99.0])
         curr = np.array([100.0, 102.0])
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert result.method in ("ttest", "percentage")
+        assert result.method == "percentage"
 
     def test_sparse_history_single_current_falls_back(self):
         hist = np.array([100.0, 200.0])
@@ -351,9 +309,10 @@ class TestDetectAdaptive:
     def test_sparse_fallback_uses_full_samples(self):
         """Fallback must honour `historical_samples` so it sees all raw values.
 
-        With 3 time points but many samples per point, ttest has enough data
-        to be statistically meaningful — whereas passing only per-time means
-        would leave ttest with just 3 points.
+        With 3 time points but many samples per point, the sparse-history
+        fallback should still detect a clear regression via the percentage
+        check — passing only per-time means would leave it blind to the
+        per-sample variance.
         """
         rng = self._rng()
         hist_time_means = np.array([100.0, 100.0, 100.0])
@@ -366,8 +325,7 @@ class TestDetectAdaptive:
             direction=OptDir.minimize,
             historical_samples=hist_samples,
         )
-        # Must fall back to ttest since we have plenty of samples.
-        assert result.method == "ttest"
+        assert result.method == "percentage"
         assert result.regressed
 
 
@@ -526,20 +484,6 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
         bench_cfg, run_cfg = self._make_cfg([rv], method="iqr", threshold=1.5)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
-    def test_ttest_method(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, (5, 10))
-        curr = rng.normal(200, 1, (1, 10))
-        values = np.vstack([hist, curr])
-        ds = self._make_dataset(n_times=6, n_repeats=10, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="ttest", threshold=0.05)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
 


### PR DESCRIPTION
## Summary

- Adds an optional `regression_percent_floor` knob to `BenchRunCfg` that layers a percent-change acceptance band on top of the `adaptive` method's MAD band.
- With the floor set, a regression fires only when BOTH tests reject — MAD-based z-score AND percent change exceed their thresholds. `None` preserves current behavior.
- Primary use case: low-repeat variables where the MAD-derived noise floor is very tight, so a modest real move trips the step test even though the absolute percent change is small in practice.

## Design

- `detect_adaptive` takes a new `percent_floor` parameter. The step gate uses `_safe_change_percent(curr_mean, baseline)`; the drift gate uses the projected end-of-history change so a trend whose total projected drift is below the floor is allowed.
- `RegressionResult` now carries `percent_band_lower` / `percent_band_upper`; the existing `band_lower` / `band_upper` still describe the MAD band.
- The PNG and holoviews diagnostic renderers draw both bands when both are present (MAD band in the verdict colour, percent band in purple), and relabel the MAD band as "MAD band" when the percent band is also shown.

## Test plan

- [x] `pixi run pytest test/test_regression.py` — 72 passed
- [x] `pixi run lint` — 10.00/10 pylint, no new ruff/ty findings
- [x] New unit tests cover: percent floor suppresses MAD-only fire on tight history; percent floor preserves real regressions; `percent_floor=None` is identical to the pre-change behavior; percent gate is direction-aware; integration test end-to-end via `detect_regressions` with a low-repeat dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an optional dual-band percent-change floor to the adaptive regression detector and propagate it through configuration, detection, and visualization.

New Features:
- Add a regression_percent_floor option to BenchRunCfg that sets a minimum percent change required to flag regressions for the adaptive method.
- Extend adaptive regression detection to combine MAD-based tests with an optional percent-change gate, only firing when both thresholds are exceeded.
- Augment RegressionResult and regression plots to carry and render a second percent-based acceptance band alongside the MAD band.

Tests:
- Add unit and integration tests covering percent_floor behavior, configuration wiring, direction awareness, and preservation of existing behavior when unset.