### PR TITLE
Regression plot renderer: unified matplotlib/bokeh path, per-time aggregation, band color fix

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -375,6 +375,18 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "Useful for failing CI pipelines on benchmark regressions.",
     )
 
+    regression_percent_floor: float = param.Number(
+        default=None,
+        allow_None=True,
+        doc="Optional minimum percent change required to flag a regression, applied as a "
+        "second acceptance band on top of the adaptive method's MAD band. A regression "
+        "only fires when BOTH the MAD-based test AND the percent change exceed their "
+        "thresholds. Useful for suppressing noise-floor false positives on metrics with "
+        "few repeats: set e.g. 40.0 to require at least a 40%% change regardless of how "
+        "many MAD-sigma it is. If None (default), only the MAD band gates. "
+        "Only affects 'adaptive' method.",
+    )
+
     def __init__(self, **params: Any) -> None:
         """Initialize BenchRunCfg with current datetime if not provided."""
         if "run_date" not in params:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -352,9 +352,8 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     regression_method: str = param.Selector(
         default="adaptive",
-        objects=["percentage", "iqr", "adaptive"],
-        doc="Detection method: 'percentage' (mean comparison), "
-        "'iqr' (IQR outlier detection), "
+        objects=["percentage", "adaptive"],
+        doc="Detection method: 'percentage' (mean comparison) or "
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
@@ -363,7 +362,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
         allow_None=True,
         doc="Threshold for regression detection. Interpretation depends on method: "
         "'percentage' = percent change (default 5.0), "
-        "'iqr' = IQR multiplier (default 1.5), "
         "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
         "If None, the per-method default is used automatically.",
     )
@@ -374,16 +372,18 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "Useful for failing CI pipelines on benchmark regressions.",
     )
 
-    regression_percent_floor: float = param.Number(
+    regression_percentage: float = param.Number(
         default=None,
         allow_None=True,
-        doc="Optional minimum percent change required to flag a regression, applied as a "
-        "second acceptance band on top of the adaptive method's MAD band. A regression "
-        "only fires when BOTH the MAD-based test AND the percent change exceed their "
-        "thresholds. Useful for suppressing noise-floor false positives on metrics with "
-        "few repeats: set e.g. 40.0 to require at least a 40%% change regardless of how "
-        "many MAD-sigma it is. If None (default), only the MAD band gates. "
-        "Only affects 'adaptive' method.",
+        doc="Optional minimum percent change (directional — interpreted in the sense "
+        "of each result var's optimization direction) required to flag a regression. "
+        "Applied as a second acceptance band on top of the adaptive method's MAD "
+        "band: a regression only fires when BOTH the MAD-based test AND the percent "
+        "change exceed their thresholds. Useful for suppressing noise-floor false "
+        "positives on low-repeat or integer-valued metrics where the MAD noise floor "
+        "collapses to zero — set e.g. 40.0 to require at least a 40%% change "
+        "regardless of how many MAD-sigma it is. If None (default), only the MAD "
+        "band gates. Only affects the 'adaptive' method.",
     )
 
     def __init__(self, **params: Any) -> None:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -357,33 +357,28 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
-    regression_threshold: float = param.Number(
-        default=None,
-        allow_None=True,
-        doc="Threshold for regression detection. Interpretation depends on method: "
-        "'percentage' = percent change (default 5.0), "
-        "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
-        "If None, the per-method default is used automatically.",
+    regression_mad: float = param.Number(
+        default=3.5,
+        doc="Step-test threshold for the 'adaptive' method, in robust MAD-sigma "
+        "units. A current value more than this many MAD-sigma from the historical "
+        "median (in the regression direction) is flagged. Higher = less sensitive.",
+    )
+
+    regression_percentage: float = param.Number(
+        default=10.0,
+        doc="Minimum directional percent change required to flag a regression. "
+        "For 'percentage' method this is the primary threshold. For 'adaptive' "
+        "method it acts as a dual-band AND gate alongside regression_mad: a "
+        "regression only fires when BOTH the MAD-based test AND the percent "
+        "change exceed their thresholds. Suppresses noise-floor false positives "
+        "on low-repeat or integer-valued metrics where the MAD noise floor can "
+        "collapse to zero.",
     )
 
     regression_fail: bool = param.Boolean(
         False,
         doc="If True, raise RegressionError when a regression is detected. "
         "Useful for failing CI pipelines on benchmark regressions.",
-    )
-
-    regression_percentage: float = param.Number(
-        default=None,
-        allow_None=True,
-        doc="Optional minimum percent change (directional — interpreted in the sense "
-        "of each result var's optimization direction) required to flag a regression. "
-        "Applied as a second acceptance band on top of the adaptive method's MAD "
-        "band: a regression only fires when BOTH the MAD-based test AND the percent "
-        "change exceed their thresholds. Useful for suppressing noise-floor false "
-        "positives on low-repeat or integer-valued metrics where the MAD noise floor "
-        "collapses to zero — set e.g. 40.0 to require at least a 40%% change "
-        "regardless of how many MAD-sigma it is. If None (default), only the MAD "
-        "band gates. Only affects the 'adaptive' method.",
     )
 
     def __init__(self, **params: Any) -> None:

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -352,9 +352,9 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     regression_method: str = param.Selector(
         default="adaptive",
-        objects=["percentage", "iqr", "ttest", "adaptive"],
+        objects=["percentage", "iqr", "adaptive"],
         doc="Detection method: 'percentage' (mean comparison), "
-        "'iqr' (IQR outlier detection), 'ttest' (Welch's t-test), "
+        "'iqr' (IQR outlier detection), "
         "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
     )
 
@@ -364,7 +364,6 @@ class BenchRunCfg(BenchPlotSrvCfg):
         doc="Threshold for regression detection. Interpretation depends on method: "
         "'percentage' = percent change (default 5.0), "
         "'iqr' = IQR multiplier (default 1.5), "
-        "'ttest' = significance level alpha (default 0.05), "
         "'adaptive' = robust z-score threshold in MAD units (default 3.5). "
         "If None, the per-method default is used automatically.",
     )

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import bencher as bn
 
+
 class ServerBenchmark(bn.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""
 

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 
 import bencher as bn
 
-
 class ServerBenchmark(bn.ParametrizedSweep):
     """A server benchmark whose response time degrades over successive releases."""
 

--- a/bencher/example/generated/regression/example_regression_percentage.py
+++ b/bencher/example/generated/regression/example_regression_percentage.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Regression detection — percentage threshold over time."""
+"""Auto-generated example: Regression detection — default method over time."""
 
 from datetime import datetime, timedelta
 
@@ -23,10 +23,9 @@ class ServerBenchmark(bn.ParametrizedSweep):
 
 
 def example_regression_percentage(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Regression detection — percentage threshold over time."""
+    """Regression detection — default method over time."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ServerBenchmark()

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -20,10 +24,14 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     """Gradual drift — parametrised by drift rate and z-threshold."""
 
     drift_rate = bn.FloatSweep(
-        default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
+        default=1.0,
+        bounds=[0.0, 4.0],
+        doc="Drift per time step",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5,
+        bounds=[1.5, 5.5],
+        doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -34,19 +42,26 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-             for _ in range(self._N_REPEATS)]
-            for i in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [
+                    baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
+                    for _ in range(self._N_REPEATS)
+                ]
+                for i in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.drift_rate * self._N_HIST
-             + random.gauss(0, self._NOISE)
-             for _ in range(5)]
+            [
+                baseline + self.drift_rate * self._N_HIST + random.gauss(0, self._NOISE)
+                for _ in range(5)
+            ]
         )
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
             historical_samples=hist_2d.ravel(),
@@ -67,9 +82,9 @@ def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['drift_rate', 'regression_mad'],
+        input_vars=["drift_rate", "regression_mad"],
         result_vars=["detection_plot"],
-        description='A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.',
+        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -28,7 +28,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         bounds=[0.0, 4.0],
         doc="Drift per time step",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
         doc="Adaptive z-threshold",
@@ -57,7 +57,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
@@ -67,9 +67,9 @@ def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["drift_rate", "z_threshold"],
+        input_vars=["drift_rate", "regression_mad"],
         result_vars=["detection_plot"],
-        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high z_thresholds allow the trend to pass unnoticed.",
+        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_drift.py
+++ b/bencher/example/generated/regression/example_regression_tuning_drift.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -24,52 +20,56 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     """Gradual drift — parametrised by drift rate and z-threshold."""
 
     drift_rate = bn.FloatSweep(
-        default=1.0,
-        bounds=[0.0, 4.0],
-        doc="Drift per time step",
+        default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 5.0
     _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [
-                baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-                for i in range(self._N_HIST)
-            ]
-        )
+        hist_2d = np.array([
+            [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
+             for _ in range(self._N_REPEATS)]
+            for i in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [
-                baseline + self.drift_rate * self._N_HIST + random.gauss(0, self._NOISE)
-                for _ in range(5)
-            ]
+            [baseline + self.drift_rate * self._N_HIST
+             + random.gauss(0, self._NOISE)
+             for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_drift(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning drift."""
     bench = AdaptiveDriftDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["drift_rate", "regression_mad"],
+        input_vars=['drift_rate', 'regression_mad'],
         result_vars=["detection_plot"],
-        description="A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.",
+        description='A linear drift is added to the history (fixed noise σ=5). With 20 time points, the total drift equals drift_rate × 20 and the current run continues the trend.  The adaptive drift test (Theil–Sen slope + Mann–Kendall trend guard) fires when the accumulated drift outweighs the detrended noise.  Low drift rates or high regression_mads allow the trend to pass unnoticed.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -24,20 +24,23 @@ _REGRESSION_STEP = 25.0
 
 
 class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
-    """Fixed 25-unit regression with varying noise — tests noise robustness."""
+    """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
         default=10.0,
-        bounds=[2.0, 40.0],
-        doc="Noise standard deviation",
+        bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
     )
-    z_threshold = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+    regression_percentage = bn.FloatSweep(
+        default=10.0,
+        bounds=[0.0, 40.0],
+        doc="Minimum percent change required to flag a regression (dual-band "
+        "AND gate). 0.0 disables the percentage gate.",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
+
+    _Z_THRESHOLD = 3.5
 
     def benchmark(self):
         baseline = 100.0
@@ -45,12 +48,14 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         current = np.array(
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
         )
+        pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            z_threshold=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
+            regression_percentage=pct,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
 
@@ -59,9 +64,9 @@ def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["noise_sigma", "z_threshold"],
+        input_vars=["noise_sigma", "regression_percentage"],
         result_vars=["detection_plot"],
-        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and every threshold catches it; at high noise the signal is buried.  The detection boundary follows noise_sigma ≈ 25 / z_threshold — above the curve the regression is masked.  This helps users understand how metric variance affects the minimum z_threshold needed to catch a real regression.",
+        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -23,12 +27,13 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
-        default=10.0, bounds=[0.0, 40.0],
-        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
-        "percentage band).",
+        default=10.0,
+        bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
     )
     regression_percentage = bn.FloatSweep(
-        default=10.0, bounds=[0.0, 40.0],
+        default=10.0,
+        bounds=[0.0, 40.0],
         doc="Minimum percent change required to flag a regression (dual-band "
         "AND gate). 0.0 disables the percentage gate.",
     )
@@ -41,18 +46,21 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
-            for _ in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+                for _ in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
-             for _ in range(5)]
+            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
@@ -74,9 +82,9 @@ def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['noise_sigma', 'regression_percentage'],
+        input_vars=["noise_sigma", "regression_percentage"],
         result_vars=["detection_plot"],
-        description='A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.',
+        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -53,7 +53,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self._Z_THRESHOLD,
+            regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
         )

--- a/bencher/example/generated/regression/example_regression_tuning_noise.py
+++ b/bencher/example/generated/regression/example_regression_tuning_noise.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -27,13 +23,12 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     """Fixed 25-unit regression with varying noise and regression_percentage."""
 
     noise_sigma = bn.FloatSweep(
-        default=10.0,
-        bounds=[0.0, 40.0],
-        doc="Noise standard deviation (0.0 collapses MAD and leaves only the percentage band).",
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
+        "percentage band).",
     )
     regression_percentage = bn.FloatSweep(
-        default=10.0,
-        bounds=[0.0, 40.0],
+        default=10.0, bounds=[0.0, 40.0],
         doc="Minimum percent change required to flag a regression (dual-band "
         "AND gate). 0.0 disables the percentage gate.",
     )
@@ -41,32 +36,47 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _Z_THRESHOLD = 3.5
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array([baseline + random.gauss(0, self.noise_sigma) for _ in range(20)])
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma) for _ in range(5)]
+            [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
+             for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_noise(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning noise."""
     bench = AdaptiveNoiseRobustness().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["noise_sigma", "regression_percentage"],
+        input_vars=['noise_sigma', 'regression_percentage'],
         result_vars=["detection_plot"],
-        description="A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.",
+        description='A fixed +25 step regression is present, but the noise level varies. At low noise the regression is obvious and the MAD acceptance band is tight; at high noise the signal is buried and the MAD band is wide. The noise_sigma=0 row is the pathological case: MAD collapses to zero, the MAD band is a hairline, and only the percentage band is visible — that row shows the percentage acceptance band on its own. Increase regression_percentage in any row to see the percentage band expand and AND-gate the verdict.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -7,12 +7,16 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
+
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result, hist, current,
+        result,
+        hist,
+        current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(4.5, 3.2), dpi=100,
+        figsize=(4.5, 3.2),
+        dpi=100,
     )
 
 
@@ -20,10 +24,14 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     """Step regression — parametrised by magnitude and z-threshold."""
 
     regression_magnitude = bn.FloatSweep(
-        default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
+        default=25.0,
+        bounds=[0.0, 60.0],
+        doc="Regression step size",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+        default=3.5,
+        bounds=[1.5, 5.5],
+        doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
@@ -34,17 +42,20 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
 
     def benchmark(self):
         baseline = 100.0
-        hist_2d = np.array([
-            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
-            for _ in range(self._N_HIST)
-        ])
+        hist_2d = np.array(
+            [
+                [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+                for _ in range(self._N_HIST)
+            ]
+        )
         hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
-             for _ in range(5)]
+            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE) for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist_means, current,
+            "metric",
+            hist_means,
+            current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
             historical_samples=hist_2d.ravel(),
@@ -65,9 +76,9 @@ def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=['regression_magnitude', 'regression_mad'],
+        input_vars=["regression_magnitude", "regression_mad"],
         result_vars=["detection_plot"],
-        description='A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.',
+        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -7,16 +7,12 @@ import numpy as np
 import bencher as bn
 from bencher.regression import detect_adaptive, render_regression_png
 
-
 def _render_detection_png(hist, current, result):
     """Render the adaptive-detector outcome as a PNG and return its path."""
     return render_regression_png(
-        result,
-        hist,
-        current,
+        result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2),
-        dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )
 
 
@@ -24,43 +20,54 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     """Step regression — parametrised by magnitude and z-threshold."""
 
     regression_magnitude = bn.FloatSweep(
-        default=25.0,
-        bounds=[0.0, 60.0],
-        doc="Regression step size",
+        default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
     )
     regression_mad = bn.FloatSweep(
-        default=3.5,
-        bounds=[1.5, 5.5],
-        doc="Adaptive z-threshold",
+        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array([baseline + random.gauss(0, self._NOISE) for _ in range(20)])
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
-            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE) for _ in range(5)]
+            [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
+             for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric",
-            hist,
-            current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)
 
 
 def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["regression_magnitude", "regression_mad"],
+        input_vars=['regression_magnitude', 'regression_mad'],
         result_vars=["detection_plot"],
-        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
+        description='A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.',
     )
 
     return bench

--- a/bencher/example/generated/regression/example_regression_tuning_step.py
+++ b/bencher/example/generated/regression/example_regression_tuning_step.py
@@ -28,7 +28,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         bounds=[0.0, 60.0],
         doc="Regression step size",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5,
         bounds=[1.5, 5.5],
         doc="Adaptive z-threshold",
@@ -48,7 +48,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
             "metric",
             hist,
             current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)
@@ -58,9 +58,9 @@ def example_regression_tuning_step(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     """Adaptive detector — tuning step."""
     bench = AdaptiveStepDetection().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["regression_magnitude", "z_threshold"],
+        input_vars=["regression_magnitude", "regression_mad"],
         result_vars=["detection_plot"],
-        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the z_threshold is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
+        description="A step regression of variable magnitude is injected (fixed noise σ=10). Each cell shows the synthesised 20-point history and the current run. When the regression magnitude is large relative to noise and the regression_mad is low the detector fires; when the magnitude shrinks or the threshold rises it stays quiet.  The boundary reveals the minimum detectable effect for each threshold setting.",
     )
 
     return bench

--- a/bencher/example/generated/rerun/example_rerun_regression.py
+++ b/bencher/example/generated/rerun/example_rerun_regression.py
@@ -11,6 +11,7 @@ def example_rerun_regression(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     if run_cfg is None:
         run_cfg = bn.BenchRunCfg()
     run_cfg.regression_detection = True
+    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ControlSystemSweep()

--- a/bencher/example/generated/rerun/example_rerun_regression.py
+++ b/bencher/example/generated/rerun/example_rerun_regression.py
@@ -11,7 +11,6 @@ def example_rerun_regression(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     if run_cfg is None:
         run_cfg = bn.BenchRunCfg()
     run_cfg.regression_detection = True
-    run_cfg.regression_method = "percentage"
     run_cfg.regression_fail = False
 
     benchable = ControlSystemSweep()

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -140,30 +140,38 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
         classname="AdaptiveNoiseRobustness",
-        input_vars=("noise_sigma", "z_threshold"),
+        input_vars=("noise_sigma", "regression_percentage"),
         description=(
             "A fixed +25 step regression is present, but the noise level varies. "
-            "At low noise the regression is obvious and every threshold catches it; "
-            "at high noise the signal is buried.  The detection boundary follows "
-            "noise_sigma ≈ 25 / z_threshold — above the curve the regression is "
-            "masked.  This helps users understand how metric variance affects the "
-            "minimum z_threshold needed to catch a real regression."
+            "At low noise the regression is obvious and the MAD acceptance band "
+            "is tight; at high noise the signal is buried and the MAD band is "
+            "wide. The noise_sigma=0 row is the pathological case: MAD collapses "
+            "to zero, the MAD band is a hairline, and only the percentage band "
+            "is visible — that row shows the percentage acceptance band on its "
+            "own. Increase regression_percentage in any row to see the "
+            "percentage band expand and AND-gate the verdict."
         ),
         class_code="""\
 _REGRESSION_STEP = 25.0
 
 
 class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
-    \"\"\"Fixed 25-unit regression with varying noise — tests noise robustness.\"\"\"
+    \"\"\"Fixed 25-unit regression with varying noise and regression_percentage.\"\"\"
 
     noise_sigma = bn.FloatSweep(
-        default=10.0, bounds=[2.0, 40.0], doc="Noise standard deviation",
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Noise standard deviation (0.0 collapses MAD and leaves only the "
+        "percentage band).",
     )
-    z_threshold = bn.FloatSweep(
-        default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
+    regression_percentage = bn.FloatSweep(
+        default=10.0, bounds=[0.0, 40.0],
+        doc="Minimum percent change required to flag a regression (dual-band "
+        "AND gate). 0.0 disables the percentage gate.",
     )
 
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
+
+    _Z_THRESHOLD = 3.5
 
     def benchmark(self):
         baseline = 100.0
@@ -174,10 +182,12 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
              for _ in range(5)]
         )
+        pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            z_threshold=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
+            regression_percentage=pct,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
     ),

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -42,7 +42,7 @@ def _render_detection_png(hist, current, result):
     return render_regression_png(
         result, hist, current,
         path=bn.gen_image_path(f"regression_{result.method}"),
-        figsize=(5.0, 3.2), dpi=100,
+        figsize=(4.5, 3.2), dpi=100,
     )'''
 
 
@@ -73,22 +73,36 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _NOISE = 10.0
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [baseline + random.gauss(0, self._NOISE) for _ in range(20)]
-        )
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self._NOISE) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + self.regression_magnitude + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
@@ -118,24 +132,37 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
 
     _NOISE = 5.0
     _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
+        hist_2d = np.array([
             [baseline + self.drift_rate * i + random.gauss(0, self._NOISE)
-             for i in range(self._N_HIST)]
-        )
+             for _ in range(self._N_REPEATS)]
+            for i in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + self.drift_rate * self._N_HIST
              + random.gauss(0, self._NOISE)
              for _ in range(5)]
         )
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
     # ---- 3. Noise robustness (fixed regression, varying noise) -------------
     "tuning_noise": TuningSpec(
@@ -172,24 +199,38 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
     detection_plot = bn.ResultImage(doc="Regression diagnostic PNG")
 
     _Z_THRESHOLD = 3.5
+    _N_HIST = 20
+    _N_REPEATS = 5
 
     def benchmark(self):
         baseline = 100.0
-        hist = np.array(
-            [baseline + random.gauss(0, self.noise_sigma) for _ in range(20)]
-        )
+        hist_2d = np.array([
+            [baseline + random.gauss(0, self.noise_sigma) for _ in range(self._N_REPEATS)]
+            for _ in range(self._N_HIST)
+        ])
+        hist_means = hist_2d.mean(axis=1)
         current = np.array(
             [baseline + _REGRESSION_STEP + random.gauss(0, self.noise_sigma)
              for _ in range(5)]
         )
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
-            "metric", hist, current,
+            "metric", hist_means, current,
             regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
+            historical_samples=hist_2d.ravel(),
         )
-        self.detection_plot = _render_detection_png(hist, current, result)""",
+        # git_time_event-style string labels for the x-axis; historical_all_x
+        # stays numeric (integer positions aligned with the tick labels) so
+        # the per-sample scatter still renders on the categorical axis.
+        result.historical_x = np.array(
+            [f"2024-01-{i + 1:02d} v{i:02d}" for i in range(self._N_HIST)]
+        )
+        result.current_x = f"2024-01-{self._N_HIST + 1:02d} v{self._N_HIST:02d}"
+        result.historical_all = hist_2d.ravel()
+        result.historical_all_x = np.repeat(np.arange(self._N_HIST), self._N_REPEATS)
+        self.detection_plot = _render_detection_png(hist_means, current, result)""",
     ),
 }
 

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -14,7 +14,7 @@ OUTPUT_DIR = "regression"
 
 
 # ---------------------------------------------------------------------------
-# Tuning examples — 2-D sweeps (effect × z_threshold) with ResultReference
+# Tuning examples — 2-D sweeps (effect × regression_mad) with ResultReference
 # ---------------------------------------------------------------------------
 
 
@@ -29,7 +29,7 @@ class TuningSpec:
 
     classname: str
     class_code: str  # full class definition (+ optional module-level constants)
-    input_vars: tuple[str, ...] = ("noise_sigma", "z_threshold")
+    input_vars: tuple[str, ...] = ("noise_sigma", "regression_mad")
     description: str = ""
 
 
@@ -50,12 +50,12 @@ _TUNING: dict[str, TuningSpec] = {
     # ---- 1. Step regression parametrised by magnitude ----------------------
     "tuning_step": TuningSpec(
         classname="AdaptiveStepDetection",
-        input_vars=("regression_magnitude", "z_threshold"),
+        input_vars=("regression_magnitude", "regression_mad"),
         description=(
             "A step regression of variable magnitude is injected (fixed noise σ=10). "
             "Each cell shows the synthesised 20-point history and the current run. "
             "When the regression magnitude is large relative to noise and the "
-            "z_threshold is low the detector fires; when the magnitude shrinks or "
+            "regression_mad is low the detector fires; when the magnitude shrinks or "
             "the threshold rises it stays quiet.  The boundary reveals the minimum "
             "detectable effect for each threshold setting."
         ),
@@ -66,7 +66,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     regression_magnitude = bn.FloatSweep(
         default=25.0, bounds=[0.0, 60.0], doc="Regression step size",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
@@ -85,7 +85,7 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
         )
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
@@ -93,14 +93,14 @@ class AdaptiveStepDetection(bn.ParametrizedSweep):
     # ---- 2. Gradual drift parametrised by drift rate -----------------------
     "tuning_drift": TuningSpec(
         classname="AdaptiveDriftDetection",
-        input_vars=("drift_rate", "z_threshold"),
+        input_vars=("drift_rate", "regression_mad"),
         description=(
             "A linear drift is added to the history (fixed noise σ=5). "
             "With 20 time points, the total drift equals drift_rate × 20 "
             "and the current run continues the trend.  The adaptive drift "
             "test (Theil–Sen slope + Mann–Kendall trend guard) fires when "
             "the accumulated drift outweighs the detrended noise.  Low "
-            "drift rates or high z_thresholds allow the trend to pass "
+            "drift rates or high regression_mads allow the trend to pass "
             "unnoticed."
         ),
         class_code="""\
@@ -110,7 +110,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
     drift_rate = bn.FloatSweep(
         default=1.0, bounds=[0.0, 4.0], doc="Drift per time step",
     )
-    z_threshold = bn.FloatSweep(
+    regression_mad = bn.FloatSweep(
         default=3.5, bounds=[1.5, 5.5], doc="Adaptive z-threshold",
     )
 
@@ -132,7 +132,7 @@ class AdaptiveDriftDetection(bn.ParametrizedSweep):
         )
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self.z_threshold,
+            regression_mad=self.regression_mad,
             direction=bn.OptDir.minimize,
         )
         self.detection_plot = _render_detection_png(hist, current, result)""",
@@ -185,7 +185,7 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
         pct = self.regression_percentage if self.regression_percentage > 0.0 else None
         result = detect_adaptive(
             "metric", hist, current,
-            z_threshold=self._Z_THRESHOLD,
+            regression_mad=self._Z_THRESHOLD,
             direction=bn.OptDir.minimize,
             regression_percentage=pct,
         )

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -283,7 +283,6 @@ class ServerBenchmark(bn.ParametrizedSweep):
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True
-run_cfg.regression_method = "percentage"
 run_cfg.regression_fail = False
 
 benchable = ServerBenchmark()
@@ -308,7 +307,7 @@ for i, offset in enumerate(releases):
     )
 """
         self.generate_example(
-            title="Regression detection — percentage threshold over time",
+            title="Regression detection — default method over time",
             output_dir=OUTPUT_DIR,
             filename="example_regression_percentage",
             function_name="example_regression_percentage",

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -348,9 +348,12 @@ def _ensure_matplotlib_backend_loaded() -> None:
     render_regression_png needs matplotlib to export a PNG, but the report path
     uses bokeh — calling hv.extension('matplotlib') naively would flip the
     global default mid-run. This loads the renderer if missing, then restores
-    the prior default. Forces the non-interactive Agg backend first so
-    holoviews doesn't pick up Tk/Qt (which leaks ``main thread is not in main
-    loop`` tracebacks at interpreter shutdown).
+    the prior default. Selects the non-interactive Agg backend when no
+    matplotlib backend has been configured yet (``force=False``), so holoviews
+    doesn't pick up Tk/Qt on a fresh process (which leaks ``main thread is not
+    in main loop`` tracebacks at interpreter shutdown). If the caller has
+    already configured a backend (e.g., Jupyter's inline backend), that choice
+    is left alone.
     """
     import matplotlib
 
@@ -608,6 +611,8 @@ def build_regression_overlay(
         )
     )
 
+    legend_handles = tuple(legend_entries)
+
     def _fill_fig_hook(
         plot,
         _element,
@@ -615,7 +620,7 @@ def build_regression_overlay(
         _title_color=verdict_color,
         _title_fs=fontsize["title"],
         _legend_fs=fontsize["legend"],
-        _legend=legend_entries,
+        _legend=legend_handles,
     ):
         ax = plot.handles["axis"]
         ax.set_aspect("auto")

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -285,20 +285,12 @@ def _regression_plot_spec(
     valid_color = "#2ca02c"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
-        band_layers.append(
-            (mad_band[0], mad_band[1], valid_color, 0.15, "MAD band")
-        )
-        band_layers.append(
-            (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
-        )
+        band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "MAD band"))
+        band_layers.append((pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band"))
     elif mad_band is not None:
-        band_layers.append(
-            (mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band")
-        )
+        band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band"))
     elif pct_band is not None:
-        band_layers.append(
-            (pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band")
-        )
+        band_layers.append((pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band"))
 
     # Per-sample historical scatter: mirrors the current-run alpha scatter so
     # history and current use the same visual language. Prefer per-repeat data
@@ -458,17 +450,28 @@ def build_regression_overlay(
                 spec["ylabel"],
             ).opts(
                 hv.opts.Scatter(
-                    backend="bokeh", color="#1f77b4", alpha=0.35, size=3, show_legend=False,
+                    backend="bokeh",
+                    color="#1f77b4",
+                    alpha=0.35,
+                    size=3,
+                    show_legend=False,
                 ),
                 hv.opts.Scatter(
-                    backend="matplotlib", color="#1f77b4", alpha=0.35, s=8, show_legend=False,
+                    backend="matplotlib",
+                    color="#1f77b4",
+                    alpha=0.35,
+                    s=8,
+                    show_legend=False,
                 ),
             )
         )
     if len(hist) > 0:
         layers.append(
             hv.Curve(
-                list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"], label="history",
+                list(zip(hist_x, hist)),
+                spec["xlabel"],
+                spec["ylabel"],
+                label="history",
             ).opts(
                 hv.opts.Curve(backend="bokeh", color="#1f77b4", alpha=0.7, line_width=1.5),
                 hv.opts.Curve(backend="matplotlib", color="#1f77b4", alpha=0.7, linewidth=1.2),
@@ -508,10 +511,18 @@ def build_regression_overlay(
                 spec["ylabel"],
             ).opts(
                 hv.opts.Scatter(
-                    backend="bokeh", color=verdict_color, alpha=0.35, size=5, show_legend=False,
+                    backend="bokeh",
+                    color=verdict_color,
+                    alpha=0.35,
+                    size=5,
+                    show_legend=False,
                 ),
                 hv.opts.Scatter(
-                    backend="matplotlib", color=verdict_color, alpha=0.35, s=18, show_legend=False,
+                    backend="matplotlib",
+                    color=verdict_color,
+                    alpha=0.35,
+                    s=18,
+                    show_legend=False,
                 ),
             )
         )
@@ -562,25 +573,31 @@ def build_regression_overlay(
     for lo, hi, color, alpha, band_label in spec["band_layers"]:
         legend_entries.append(Patch(facecolor=color, alpha=alpha, label=band_label))
     legend_entries.append(
-        Line2D([], [], color="#555555", alpha=0.7, linestyle="--",
-               label=f"baseline={baseline:.3g}")
+        Line2D([], [], color="#555555", alpha=0.7, linestyle="--", label=f"baseline={baseline:.3g}")
     )
     if hist_len > 0:
-        legend_entries.append(
-            Line2D([], [], color="#1f77b4", alpha=0.7, label="history")
-        )
+        legend_entries.append(Line2D([], [], color="#1f77b4", alpha=0.7, label="history"))
     legend_entries.append(
         Line2D(
-            [], [], marker="o", linestyle="", color=verdict_color,
-            markersize=7, markeredgecolor="black", markeredgewidth=0.7,
+            [],
+            [],
+            marker="o",
+            linestyle="",
+            color=verdict_color,
+            markersize=7,
+            markeredgecolor="black",
+            markeredgewidth=0.7,
             label=f"current={spec['curr_mean']:.3g}",
         )
     )
 
     def _fill_fig_hook(
-        plot, _element,
-        _title=title, _title_color=verdict_color,
-        _title_fs=fontsize["title"], _legend_fs=fontsize["legend"],
+        plot,
+        _element,
+        _title=title,
+        _title_color=verdict_color,
+        _title_fs=fontsize["title"],
+        _legend_fs=fontsize["legend"],
         _legend=legend_entries,
     ):
         ax = plot.handles["axis"]
@@ -590,15 +607,19 @@ def build_regression_overlay(
         ax.set_position([0.15, 0.22, 0.82, 0.64])
         ax.set_title(_title, color=_title_color, fontsize=_title_fs, fontweight="bold")
         ax.legend(
-            handles=_legend, loc="upper left", fontsize=_legend_fs,
-            framealpha=0.85, ncol=2, handlelength=1.2, borderpad=0.3, labelspacing=0.3,
+            handles=_legend,
+            loc="upper left",
+            fontsize=_legend_fs,
+            framealpha=0.85,
+            ncol=2,
+            handlelength=1.2,
+            borderpad=0.3,
+            labelspacing=0.3,
         )
 
     mpl_hooks = [_fill_fig_hook]
     overlay_opts = [
-        hv.opts.Overlay(
-            title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize
-        ),
+        hv.opts.Overlay(title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize),
         hv.opts.Overlay(
             backend="bokeh",
             width=width,
@@ -621,9 +642,7 @@ def build_regression_overlay(
             ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=_fs)
 
         mpl_hooks.append(_mpl_xticks_hook)
-        overlay_opts.append(
-            hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30)
-        )
+        overlay_opts.append(hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30))
     overlay_opts.append(
         hv.opts.Overlay(backend="matplotlib", fig_inches=fig_inches, hooks=mpl_hooks)
     )
@@ -1008,9 +1027,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             .mean(dim=reduce_dims, skipna=True)
             .values.astype(float)
         )
-        current_mean_scalar = np.array(
-            [float(da.isel(over_time=-1).mean(skipna=True).values)]
-        )
+        current_mean_scalar = np.array([float(da.isel(over_time=-1).mean(skipna=True).values)])
 
         if method == "percentage":
             result = detect_percentage(

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -279,27 +279,34 @@ def _regression_plot_spec(
 
     # Shared declarative band layers — both matplotlib and holoviews iterate
     # this list so the two backends render the same thing by construction.
-    # Each entry is (lo, hi, color, alpha, label).
+    # Each entry is (lo, hi, color, alpha, label). The acceptance band always
+    # shades green: it represents the *valid* region, not the pass/fail
+    # verdict (verdict colouring lives on the current marker + connector).
+    valid_color = "#2ca02c"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
         band_layers.append(
-            (mad_band[0], mad_band[1], verdict_color, 0.15, "MAD band")
+            (mad_band[0], mad_band[1], valid_color, 0.15, "MAD band")
         )
         band_layers.append(
             (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
         )
     elif mad_band is not None:
         band_layers.append(
-            (mad_band[0], mad_band[1], verdict_color, 0.15, "acceptance band")
+            (mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band")
         )
     elif pct_band is not None:
         band_layers.append(
-            (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
+            (pct_band[0], pct_band[1], valid_color, 0.15, "acceptance band")
         )
 
-    # Per-sample historical scatter: only plot if the x-coords align with the
-    # primary hist_x dtype (so strings/categorical fallbacks don't break the
-    # axis). Falls back to None when there is no alignment.
+    # Per-sample historical scatter: mirrors the current-run alpha scatter so
+    # history and current use the same visual language. Prefer per-repeat data
+    # when available (populated by detect_regressions); otherwise fall back to
+    # the per-time mean array itself so direct detect_* calls still get dots.
+    # Works even on categorical x-axes (string labels → integer xticks) as
+    # long as historical_all_x is numeric and aligned with the integer hist_x
+    # positions that back the tick labels.
     hist_scatter_x: np.ndarray | None = None
     hist_scatter_y: np.ndarray | None = None
     if (
@@ -307,7 +314,6 @@ def _regression_plot_spec(
         and result.historical_all_x is not None
         and len(result.historical_all) == len(result.historical_all_x)
         and len(result.historical_all) > 0
-        and xticks is None
     ):
         raw = np.asarray(result.historical_all_x)
         hist_is_dt = np.issubdtype(hist_x.dtype, np.datetime64)
@@ -317,6 +323,9 @@ def _regression_plot_spec(
         if (hist_is_dt and raw_is_dt) or (hist_is_num and raw_is_num):
             hist_scatter_x = raw
             hist_scatter_y = np.asarray(result.historical_all, dtype=float)
+    if hist_scatter_x is None and len(hist) > 0 and xticks is None:
+        hist_scatter_x = hist_x
+        hist_scatter_y = hist
 
     return {
         "hist": hist,
@@ -336,18 +345,45 @@ def _regression_plot_spec(
     }
 
 
+def _ensure_matplotlib_backend_loaded() -> None:
+    """Register the holoviews matplotlib backend without changing the default.
+
+    render_regression_png needs matplotlib to export a PNG, but the report path
+    uses bokeh — calling hv.extension('matplotlib') naively would flip the
+    global default mid-run. This loads the renderer if missing, then restores
+    the prior default. Forces the non-interactive Agg backend first so
+    holoviews doesn't pick up Tk/Qt (which leaks ``main thread is not in main
+    loop`` tracebacks at interpreter shutdown).
+    """
+    import matplotlib
+
+    matplotlib.use("Agg", force=False)
+
+    import holoviews as hv
+
+    if "matplotlib" in hv.Store.renderers:
+        return
+    prev_backend = hv.Store.current_backend
+    hv.extension("matplotlib", logo=False)
+    if prev_backend and hv.Store.current_backend != prev_backend:
+        hv.Store.set_current_backend(prev_backend)
+
+
 def build_regression_overlay(
     result: RegressionResult,
     historical: np.ndarray | None = None,
     current: np.ndarray | float | None = None,
     width: int = 700,
     height: int = 350,
+    fig_inches: tuple[float, float] = (7.0, 3.5),
 ):
     """Build a :class:`holoviews.Overlay` diagnostic of a regression result.
 
-    Uses the same logic as :func:`render_regression_png` but returns a
-    backend-agnostic holoviews object, so the same plot can be embedded in an
-    HTML report (bokeh backend) or saved as a PNG (matplotlib backend).
+    Opts are applied per-backend so the same overlay renders correctly under
+    both bokeh (for embedded HTML reports) and matplotlib (for PNG export via
+    :func:`render_regression_png`). History always shows as mean line + raw
+    alpha scatter; regression-specific layers (acceptance band, baseline,
+    verdict-coloured current marker) are conditional on the data in *result*.
 
     Args:
         result: The :class:`RegressionResult` to visualise.
@@ -355,7 +391,8 @@ def build_regression_overlay(
             Falls back to ``result.historical`` if omitted.
         current: Optional current-run sample array (or scalar). Falls back to
             ``result.current_samples`` / ``result.current_value``.
-        width, height: Pixel dimensions passed to the overlay's ``opts``.
+        width, height: Pixel dimensions for the bokeh backend.
+        fig_inches: Figure size in inches for the matplotlib backend.
     """
     import holoviews as hv
 
@@ -370,21 +407,48 @@ def build_regression_overlay(
     x_start = hist_x[0] if len(hist_x) > 0 else x_current
     x_end = x_current
 
+    # Each element duplicates its style opts across both backends so they
+    # apply regardless of which renderer is active — holoviews does NOT
+    # carry no-backend opts across backend boundaries, so omitting the
+    # backend kwarg silently drops styles like alpha when rendering as PNG.
+    # Elements whose identity matters for the legend carry a ``label`` kwarg;
+    # decorative layers (hist-sample scatter, current-sample scatter, dotted
+    # connector) are label-less so the legend stays compact.
     layers = []
-    for lo, hi, color, alpha, _label in spec["band_layers"]:
+    for lo, hi, color, alpha, label in spec["band_layers"]:
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=color, alpha=alpha, line_alpha=0)
+                label=label,
+            ).opts(
+                hv.opts.Area(backend="bokeh", color=color, alpha=alpha, line_alpha=0),
+                hv.opts.Area(backend="matplotlib", color=color, alpha=alpha, linewidth=0),
+            )
         )
     layers.append(
         hv.Curve(
             [(x_start, spec["baseline"]), (x_end, spec["baseline"])],
             spec["xlabel"],
             spec["ylabel"],
-        ).opts(color="#555555", line_dash="dashed", line_width=1)
+            label=f"baseline={spec['baseline']:.3g}",
+        ).opts(
+            hv.opts.Curve(
+                backend="bokeh",
+                color="#555555",
+                alpha=0.7,
+                line_dash="dashed",
+                line_width=1,
+            ),
+            hv.opts.Curve(
+                backend="matplotlib",
+                color="#555555",
+                alpha=0.7,
+                linestyle="--",
+                linewidth=1,
+            ),
+        )
     )
     if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
         layers.append(
@@ -392,12 +456,22 @@ def build_regression_overlay(
                 list(zip(spec["hist_scatter_x"], spec["hist_scatter_y"])),
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color="#1f77b4", alpha=0.35, size=5)
+            ).opts(
+                hv.opts.Scatter(
+                    backend="bokeh", color="#1f77b4", alpha=0.35, size=3, show_legend=False,
+                ),
+                hv.opts.Scatter(
+                    backend="matplotlib", color="#1f77b4", alpha=0.35, s=8, show_legend=False,
+                ),
+            )
         )
     if len(hist) > 0:
         layers.append(
-            hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
-                color="#1f77b4", line_width=1.5
+            hv.Curve(
+                list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"], label="history",
+            ).opts(
+                hv.opts.Curve(backend="bokeh", color="#1f77b4", alpha=0.7, line_width=1.5),
+                hv.opts.Curve(backend="matplotlib", color="#1f77b4", alpha=0.7, linewidth=1.2),
             )
         )
         # Dotted connector from the last history point to the current marker
@@ -407,7 +481,24 @@ def build_regression_overlay(
                 [(hist_x[-1], hist[-1]), (x_current, spec["curr_mean"])],
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color=verdict_color, line_dash="dotted", line_width=1.5)
+            ).opts(
+                hv.opts.Curve(
+                    backend="bokeh",
+                    color=verdict_color,
+                    alpha=0.8,
+                    line_dash="dotted",
+                    line_width=1.5,
+                    show_legend=False,
+                ),
+                hv.opts.Curve(
+                    backend="matplotlib",
+                    color=verdict_color,
+                    alpha=0.8,
+                    linestyle=":",
+                    linewidth=1.2,
+                    show_legend=False,
+                ),
+            )
         )
     if len(spec["curr_samples"]) > 1:
         layers.append(
@@ -415,25 +506,128 @@ def build_regression_overlay(
                 [(x_current, v) for v in spec["curr_samples"]],
                 spec["xlabel"],
                 spec["ylabel"],
-            ).opts(color=verdict_color, alpha=0.35, size=5)
+            ).opts(
+                hv.opts.Scatter(
+                    backend="bokeh", color=verdict_color, alpha=0.35, size=5, show_legend=False,
+                ),
+                hv.opts.Scatter(
+                    backend="matplotlib", color=verdict_color, alpha=0.35, s=18, show_legend=False,
+                ),
+            )
         )
     layers.append(
         hv.Scatter(
             [(x_current, spec["curr_mean"])],
             spec["xlabel"],
             spec["ylabel"],
-        ).opts(color=verdict_color, size=10, line_color="black", line_width=1)
+            label=f"current={spec['curr_mean']:.3g}",
+        ).opts(
+            hv.opts.Scatter(
+                backend="bokeh",
+                color=verdict_color,
+                size=10,
+                line_color="black",
+                line_width=1,
+            ),
+            hv.opts.Scatter(
+                backend="matplotlib",
+                color=verdict_color,
+                s=70,
+                edgecolors="black",
+                linewidth=0.7,
+            ),
+        )
     )
 
     overlay = layers[0]
     for layer in layers[1:]:
         overlay = overlay * layer
 
-    opts_kwargs = dict(title=spec["title"], width=width, height=height, show_grid=True)
+    # Compact font sizing — the PNGs render at ~4–9 inches wide so the default
+    # matplotlib font sizes overflow the figure. Bokeh accepts the same dict.
+    fontsize = {"title": 9, "labels": 8, "xticks": 6, "yticks": 7, "legend": 6}
+
+    # holoviews' matplotlib backend defaults to a square data aspect, centers a
+    # small axes inside the figure, and drops Element ``label=`` on Area/Curve
+    # overlays so its own legend only shows a subset of layers. The hooks below
+    # stretch the axes, set the title manually, and build a proxy legend from
+    # the spec so every rendered layer can appear in the legend.
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
+    title = spec["title"]
+    baseline = spec["baseline"]
+    hist_len = len(hist)
+    legend_entries: list = []
+    for lo, hi, color, alpha, band_label in spec["band_layers"]:
+        legend_entries.append(Patch(facecolor=color, alpha=alpha, label=band_label))
+    legend_entries.append(
+        Line2D([], [], color="#555555", alpha=0.7, linestyle="--",
+               label=f"baseline={baseline:.3g}")
+    )
+    if hist_len > 0:
+        legend_entries.append(
+            Line2D([], [], color="#1f77b4", alpha=0.7, label="history")
+        )
+    legend_entries.append(
+        Line2D(
+            [], [], marker="o", linestyle="", color=verdict_color,
+            markersize=7, markeredgecolor="black", markeredgewidth=0.7,
+            label=f"current={spec['curr_mean']:.3g}",
+        )
+    )
+
+    def _fill_fig_hook(
+        plot, _element,
+        _title=title, _title_color=verdict_color,
+        _title_fs=fontsize["title"], _legend_fs=fontsize["legend"],
+        _legend=legend_entries,
+    ):
+        ax = plot.handles["axis"]
+        ax.set_aspect("auto")
+        # left 0.15 leaves room for y-label + ticks, top 0.86 leaves room for
+        # the title, bottom 0.22 leaves room for rotated xtick labels.
+        ax.set_position([0.15, 0.22, 0.82, 0.64])
+        ax.set_title(_title, color=_title_color, fontsize=_title_fs, fontweight="bold")
+        ax.legend(
+            handles=_legend, loc="upper left", fontsize=_legend_fs,
+            framealpha=0.85, ncol=2, handlelength=1.2, borderpad=0.3, labelspacing=0.3,
+        )
+
+    mpl_hooks = [_fill_fig_hook]
+    overlay_opts = [
+        hv.opts.Overlay(
+            title=spec["title"], show_grid=True, show_legend=True, fontsize=fontsize
+        ),
+        hv.opts.Overlay(
+            backend="bokeh",
+            width=width,
+            height=height,
+            legend_position="top_left",
+        ),
+    ]
     if spec["xticks"] is not None:
-        opts_kwargs["xticks"] = spec["xticks"]
-        opts_kwargs["xrotation"] = 30
-    return overlay.opts(**opts_kwargs)
+        # bokeh accepts [(pos, label), ...] directly; matplotlib silently
+        # ignores the label half and falls back to integer tick text, so
+        # labels have to be pushed in via a plot hook on that backend.
+        xticks_pairs = spec["xticks"]
+        xtick_fontsize = fontsize["xticks"]
+
+        def _mpl_xticks_hook(plot, _element, _pairs=xticks_pairs, _fs=xtick_fontsize):
+            ax = plot.handles["axis"]
+            positions = [p for p, _ in _pairs]
+            labels = [lbl for _, lbl in _pairs]
+            ax.set_xticks(positions)
+            ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=_fs)
+
+        mpl_hooks.append(_mpl_xticks_hook)
+        overlay_opts.append(
+            hv.opts.Overlay(backend="bokeh", xticks=xticks_pairs, xrotation=30)
+        )
+    overlay_opts.append(
+        hv.opts.Overlay(backend="matplotlib", fig_inches=fig_inches, hooks=mpl_hooks)
+    )
+    return overlay.opts(*overlay_opts)
 
 
 def render_regression_png(
@@ -444,38 +638,29 @@ def render_regression_png(
     figsize: tuple[float, float] = (8.0, 5.0),
     dpi: int = 100,
 ) -> str:
-    """Render a diagnostic PNG of a regression result using matplotlib.
+    """Render a diagnostic PNG by saving the shared holoviews overlay via matplotlib.
 
-    The plot contains everything needed to diagnose the *style* of regression
-    at a glance — history time-series (to reveal drift and noise), the baseline
-    line, the acceptance band (to reveal step size), and the current-run marker
-    coloured by the pass/fail verdict. The details string from
-    :class:`RegressionResult` (method-specific statistics such as z-score,
-    p-value, or percent change) is shown as a footer so the PNG is
-    self-contained — suitable for posting directly as a GitHub PR comment.
+    Produces the same plot as the in-report bokeh overlay — it calls
+    :func:`build_regression_overlay` and hands the result to holoviews'
+    matplotlib renderer, so there's a single source of truth for the
+    diagnostic visual.
 
     Args:
         result: The :class:`RegressionResult` produced by a ``detect_*`` call.
-        historical: 1-D array of the historical per-time-point means (the same
-            sequence fed into ``detect_adaptive``). Pass an
-            empty array if no history is available — only the current marker,
-            baseline, and band are drawn in that case.
-        current: Current-run sample(s). If ``None``, ``result.current_value``
-            is used. If given an array, the per-sample spread is shown as a
-            vertical strip alongside the mean marker.
+        historical: 1-D array of historical per-time-point means. Falls back
+            to ``result.historical``.
+        current: Current-run sample(s). Falls back to ``result.current_samples``
+            / ``result.current_value``.
         path: Output PNG path. If ``None``, a path is generated via
             :func:`bencher.utils.gen_image_path` so the file lives under the
             bencher cache directory.
-        figsize: Matplotlib figure size in inches.
-        dpi: Output DPI (800x500 at ``dpi=100`` works well for GitHub comments).
+        figsize: Figure size in inches (matplotlib ``fig_inches``).
+        dpi: Output DPI (500x320 at ``dpi=100`` works well for GitHub comments).
 
     Returns:
         Absolute path to the saved PNG as a string.
     """
-    import matplotlib
-
-    matplotlib.use("Agg", force=False)
-    import matplotlib.pyplot as plt
+    import holoviews as hv
 
     if path is None:
         from bencher.utils import gen_image_path
@@ -483,92 +668,16 @@ def render_regression_png(
         path = gen_image_path(f"regression_{result.variable}")
     path_str = str(path)
 
-    spec = _regression_plot_spec(result, historical, current)
-    hist = spec["hist"]
-    hist_x = spec["hist_x"]
-    curr_samples = spec["curr_samples"]
-    x_current = spec["x_current"]
-    verdict_color = spec["verdict_color"]
-
-    fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-    fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
-
-    for lo, hi, color, alpha, label in spec["band_layers"]:
-        ax.axhspan(lo, hi, color=color, alpha=alpha, label=label)
-
-    ax.axhline(
-        spec["baseline"],
-        color="#555555",
-        linestyle="--",
-        linewidth=1.0,
-        label=f"baseline={spec['baseline']:.3g}",
+    _ensure_matplotlib_backend_loaded()
+    overlay = build_regression_overlay(
+        result, historical=historical, current=current, fig_inches=figsize
     )
+    # hv.renderer(...).save re-tightens the bbox and collapses the figure to
+    # roughly square regardless of fig_inches. Rendering to a Figure and
+    # using matplotlib's own savefig preserves the requested inches.
+    import matplotlib.pyplot as plt
 
-    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
-        ax.scatter(
-            spec["hist_scatter_x"],
-            spec["hist_scatter_y"],
-            color="#1f77b4",
-            alpha=0.35,
-            s=18,
-            label="history samples",
-        )
-    if len(hist) > 0:
-        ax.plot(
-            hist_x,
-            hist,
-            "-o",
-            color="#1f77b4",
-            markersize=3.5,
-            linewidth=1.2,
-            label="history",
-        )
-        # Dotted connector from the last history point to the current marker
-        # so the jump that triggered the regression is visually obvious.
-        ax.plot(
-            [hist_x[-1], x_current],
-            [hist[-1], spec["curr_mean"]],
-            linestyle=":",
-            color=verdict_color,
-            linewidth=1.2,
-            alpha=0.8,
-        )
-
-    if len(curr_samples) > 1:
-        ax.scatter(
-            [x_current] * len(curr_samples),
-            curr_samples,
-            color=verdict_color,
-            alpha=0.35,
-            s=18,
-        )
-    ax.scatter(
-        [x_current],
-        [spec["curr_mean"]],
-        color=verdict_color,
-        s=70,
-        zorder=5,
-        edgecolor="black",
-        linewidth=0.7,
-        label=f"current={spec['curr_mean']:.3g}",
-    )
-
-    # Extra margin on the right so the current marker isn't clipped by the frame.
-    ax.margins(x=0.08)
-
-    ax.set_xlabel(spec["xlabel"])
-    ax.set_ylabel(spec["ylabel"])
-    ax.grid(True, linestyle=":", alpha=0.5)
-    ax.set_title(spec["title"], color=verdict_color, fontsize=10, fontweight="bold")
-    ax.legend(loc="upper left", fontsize=7, framealpha=0.85, ncol=2)
-
-    if spec["xticks"] is not None:
-        ticks, labels = zip(*spec["xticks"])
-        ax.set_xticks(list(ticks))
-        ax.set_xticklabels(list(labels), rotation=30, ha="right")
-    elif len(hist_x) > 0 and np.issubdtype(np.asarray(hist_x).dtype, np.datetime64):
-        fig.autofmt_xdate(rotation=30)
-
+    fig = hv.render(overlay, backend="matplotlib")
     fig.savefig(path_str, dpi=dpi)
     plt.close(fig)
     return path_str

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -53,6 +53,10 @@ class RegressionResult:
     details: str
     band_lower: float | None = None
     band_upper: float | None = None
+    # Optional second acceptance band (dual-band adaptive). When both bands are
+    # populated a value must lie outside BOTH to count as a regression.
+    percent_band_lower: float | None = None
+    percent_band_upper: float | None = None
     # Arrays retained so the result can be replotted without re-running detection.
     historical: np.ndarray | None = None
     current_samples: np.ndarray | None = None
@@ -252,6 +256,11 @@ def _regression_plot_spec(
             if result.band_lower is not None and result.band_upper is not None
             else None
         ),
+        "percent_band": (
+            (result.percent_band_lower, result.percent_band_upper)
+            if result.percent_band_lower is not None and result.percent_band_upper is not None
+            else None
+        ),
         "baseline": result.baseline_value,
         "verdict_color": verdict_color,
         "title": title,
@@ -303,6 +312,15 @@ def build_regression_overlay(
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
             ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+        )
+    if spec["percent_band"] is not None:
+        plo, phi = spec["percent_band"]
+        layers.append(
+            hv.Area(
+                ([x_start, x_end], [plo, plo], [phi, phi]),
+                kdims=[spec["xlabel"]],
+                vdims=[spec["ylabel"], "pct_band_upper"],
+            ).opts(color="#9467bd", alpha=0.08, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -412,7 +430,11 @@ def render_regression_png(
 
     if spec["band"] is not None:
         lo, hi = spec["band"]
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
+        mad_label = "MAD band" if spec["percent_band"] is not None else "acceptance band"
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label=mad_label)
+    if spec["percent_band"] is not None:
+        plo, phi = spec["percent_band"]
+        ax.axhspan(plo, phi, color="#9467bd", alpha=0.08, label="percent band")
 
     ax.axhline(
         spec["baseline"],
@@ -689,6 +711,7 @@ def detect_adaptive(
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
     historical_samples: np.ndarray | None = None,
+    percent_floor: float | None = None,
 ) -> RegressionResult:
     """Robust regression detection combining step and drift tests.
 
@@ -720,6 +743,11 @@ def detect_adaptive(
             delegated ``ttest``/``percentage`` methods see the same input they
             would have received from ``detect_regressions`` directly. Falls
             back to ``historical_time_means`` when not provided.
+        percent_floor: Optional minimum percent change required to flag a
+            regression. When set, acts as a second acceptance band: a
+            regression fires only when BOTH the MAD test and the percent
+            change exceed their thresholds. Suppresses noise-floor false
+            positives on metrics with few repeats or very tight history.
     """
     if drift_threshold is None:
         drift_threshold = _DRIFT_FRAC * z_threshold
@@ -756,7 +784,7 @@ def detect_adaptive(
 
     # Step test — current mean vs robust baseline in MAD-sigma units.
     z_step = (curr_mean - baseline) / noise_floor
-    step_regressed = _is_regression(z_step, direction) and abs(z_step) > z_threshold
+    step_mad = _is_regression(z_step, direction) and abs(z_step) > z_threshold
 
     # Drift test — Theil–Sen slope on Hampel-filtered history, MK significance.
     # Use residual (detrended) noise as the denominator so a real drift can't
@@ -777,13 +805,33 @@ def detect_adaptive(
     z_drift = drift_total / drift_noise
     _, mk_p = kendalltau(indices, filtered)
     mk_p = float(mk_p) if not np.isnan(mk_p) else 1.0
-    drift_regressed = (
+    drift_mad = (
         _is_regression(z_drift, direction) and abs(z_drift) > drift_threshold and mk_p < mk_alpha
     )
 
+    change = _safe_change_percent(curr_mean, baseline)
+
+    # Dual-band gate: when percent_floor is set, each test must also be
+    # confirmed by a percent-change gate. The step gate uses the observed
+    # current-vs-baseline change; the drift gate uses the projected end-of-
+    # history drift so a trend that doesn't cumulatively move more than the
+    # floor is treated as inside the band.
+    if percent_floor is not None:
+        step_pct_ok = _exceeds_directional_threshold(change, percent_floor, direction)
+        drift_change = _safe_change_percent(baseline + drift_total, baseline)
+        drift_pct_ok = _exceeds_directional_threshold(drift_change, percent_floor, direction)
+        percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
+        percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+    else:
+        step_pct_ok = True
+        drift_pct_ok = True
+        percent_band_lower = None
+        percent_band_upper = None
+
+    step_regressed = step_mad and step_pct_ok
+    drift_regressed = drift_mad and drift_pct_ok
     regressed = step_regressed or drift_regressed
 
-    change = _safe_change_percent(curr_mean, baseline)
     fired = []
     if step_regressed:
         fired.append("step")
@@ -796,6 +844,8 @@ def detect_adaptive(
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
     )
+    if percent_floor is not None:
+        details += f", pct_floor={percent_floor}% (change={change:+.2f}%)"
 
     return RegressionResult(
         variable=variable,
@@ -809,6 +859,8 @@ def detect_adaptive(
         details=details,
         band_lower=baseline - z_threshold * noise_floor,
         band_upper=baseline + z_threshold * noise_floor,
+        percent_band_lower=percent_band_lower,
+        percent_band_upper=percent_band_upper,
     )
 
 
@@ -841,6 +893,8 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     # Use per-method default when no explicit threshold is provided.
     if threshold is None:
         threshold = _METHOD_DEFAULTS.get(method, 5.0)
+
+    percent_floor = getattr(run_cfg, "regression_percent_floor", None)
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -885,6 +939,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 z_threshold=threshold,
                 direction=direction,
                 historical_samples=historical_clean,
+                percent_floor=percent_floor,
             )
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -1,9 +1,9 @@
 """Benchmark regression detection for over-time benchmarks.
 
 Provides statistical methods to detect if benchmark values have changed
-significantly between runs. Supports percentage threshold, IQR-based outlier
-detection, and an adaptive MAD-based detector with an optional percent
-floor for dual-band suppression.
+significantly between runs. Supports a percentage threshold and an
+adaptive MAD-based detector with an optional percent floor for dual-band
+suppression.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 # Default thresholds per method — used when the user hasn't explicitly set a threshold.
 _METHOD_DEFAULTS = {
     "percentage": 5.0,  # percent change
-    "iqr": 1.5,  # IQR multiplier
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
@@ -244,6 +243,37 @@ def _regression_plot_spec(
     )
     title = f"{result.variable} — {result.method} — {verdict_label}  (Δ {change_str})"
 
+    mad_band = (
+        (result.band_lower, result.band_upper)
+        if result.band_lower is not None and result.band_upper is not None
+        else None
+    )
+    pct_band = (
+        (result.percent_band_lower, result.percent_band_upper)
+        if result.percent_band_lower is not None and result.percent_band_upper is not None
+        else None
+    )
+
+    # Shared declarative band layers — both matplotlib and holoviews iterate
+    # this list so the two backends render the same thing by construction.
+    # Each entry is (lo, hi, color, alpha, label).
+    band_layers: list[tuple[float, float, str, float, str]] = []
+    if mad_band is not None and pct_band is not None:
+        band_layers.append(
+            (mad_band[0], mad_band[1], verdict_color, 0.15, "MAD band")
+        )
+        band_layers.append(
+            (pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band")
+        )
+    elif mad_band is not None:
+        band_layers.append(
+            (mad_band[0], mad_band[1], verdict_color, 0.15, "acceptance band")
+        )
+    elif pct_band is not None:
+        band_layers.append(
+            (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
+        )
+
     return {
         "hist": hist,
         "hist_x": hist_x,
@@ -251,16 +281,7 @@ def _regression_plot_spec(
         "curr_samples": curr_samples,
         "curr_mean": curr_mean,
         "x_current": x_current,
-        "band": (
-            (result.band_lower, result.band_upper)
-            if result.band_lower is not None and result.band_upper is not None
-            else None
-        ),
-        "percent_band": (
-            (result.percent_band_lower, result.percent_band_upper)
-            if result.percent_band_lower is not None and result.percent_band_upper is not None
-            else None
-        ),
+        "band_layers": band_layers,
         "baseline": result.baseline_value,
         "verdict_color": verdict_color,
         "title": title,
@@ -304,49 +325,13 @@ def build_regression_overlay(
     x_end = x_current
 
     layers = []
-    mad_band = spec["band"]
-    pct_band = spec["percent_band"]
-    if mad_band is not None and pct_band is not None:
-        # Combined acceptance band (AND gate -> accept if inside either band
-        # => the union is the effective acceptance region).
-        lo = min(mad_band[0], pct_band[0])
-        hi = max(mad_band[1], pct_band[1])
+    for lo, hi, color, alpha, _label in spec["band_layers"]:
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
                 kdims=[spec["xlabel"]],
                 vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
-        )
-        for edge in (mad_band[0], mad_band[1]):
-            layers.append(
-                hv.Curve(
-                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
-                ).opts(color="#888888", line_dash="dotted", line_width=0.8)
-            )
-        for edge in (pct_band[0], pct_band[1]):
-            layers.append(
-                hv.Curve(
-                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
-                ).opts(color="#9467bd", line_dash="dashed", line_width=0.8)
-            )
-    elif mad_band is not None:
-        lo, hi = mad_band
-        layers.append(
-            hv.Area(
-                ([x_start, x_end], [lo, lo], [hi, hi]),
-                kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
-        )
-    elif pct_band is not None:
-        plo, phi = pct_band
-        layers.append(
-            hv.Area(
-                ([x_start, x_end], [plo, plo], [phi, phi]),
-                kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "band_upper"],
-            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+            ).opts(color=color, alpha=alpha, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -418,7 +403,7 @@ def render_regression_png(
     Args:
         result: The :class:`RegressionResult` produced by a ``detect_*`` call.
         historical: 1-D array of the historical per-time-point means (the same
-            sequence fed into ``detect_adaptive`` / ``detect_iqr``). Pass an
+            sequence fed into ``detect_adaptive``). Pass an
             empty array if no history is available — only the current marker,
             baseline, and band are drawn in that case.
         current: Current-run sample(s). If ``None``, ``result.current_value``
@@ -454,28 +439,8 @@ def render_regression_png(
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
 
-    mad_band = spec["band"]
-    pct_band = spec["percent_band"]
-    if mad_band is not None and pct_band is not None:
-        # AND gate means a point is accepted if it sits inside EITHER band,
-        # so the effective acceptance region is the union of the two.
-        lo = min(mad_band[0], pct_band[0])
-        hi = max(mad_band[1], pct_band[1])
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band (MAD ∪ %)")
-        ax.axhline(
-            mad_band[0], color="#888888", linestyle=":", linewidth=0.8, label="MAD edge"
-        )
-        ax.axhline(mad_band[1], color="#888888", linestyle=":", linewidth=0.8)
-        ax.axhline(
-            pct_band[0], color="#9467bd", linestyle="--", linewidth=0.8, label="percent edge"
-        )
-        ax.axhline(pct_band[1], color="#9467bd", linestyle="--", linewidth=0.8)
-    elif mad_band is not None:
-        lo, hi = mad_band
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
-    elif pct_band is not None:
-        plo, phi = pct_band
-        ax.axhspan(plo, phi, color=verdict_color, alpha=0.10, label="acceptance band")
+    for lo, hi, color, alpha, label in spec["band_layers"]:
+        ax.axhspan(lo, hi, color=color, alpha=alpha, label=label)
 
     ax.axhline(
         spec["baseline"],
@@ -614,63 +579,6 @@ def detect_percentage(
     )
 
 
-def detect_iqr(
-    variable: str,
-    historical_time_means: np.ndarray,
-    current: np.ndarray,
-    iqr_scale: float = 1.5,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """IQR outlier detection using per-time-point means from history.
-
-    Args:
-        variable: Name of the result variable being checked.
-        historical_time_means: Array of per-time-point mean values from history.
-        current: Current run values (will be averaged).
-        iqr_scale: Multiplier for IQR to define outlier bounds (default 1.5).
-        direction: Optimization direction from the result variable.
-    """
-    clean = _clean_1d(historical_time_means)
-    curr_mean = float(np.nanmean(current))
-
-    if len(clean) < 4:
-        # Not enough time points for robust IQR; fall back to percentage using
-        # the default percentage threshold so the comparison stays meaningful.
-        return detect_percentage(
-            variable,
-            clean,
-            current,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
-            direction=direction,
-        )
-
-    q1 = float(np.percentile(clean, 25))
-    q3 = float(np.percentile(clean, 75))
-    iqr = q3 - q1
-    lower = q1 - iqr_scale * iqr
-    upper = q3 + iqr_scale * iqr
-
-    hist_mean = float(np.nanmean(clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-
-    outside_bounds = curr_mean > upper or curr_mean < lower
-    regressed = outside_bounds and _is_regression(change, direction)
-
-    return RegressionResult(
-        variable=variable,
-        method="iqr",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=iqr_scale,
-        direction=direction.value,
-        details=f"IQR bounds [{lower:.4g}, {upper:.4g}], current={curr_mean:.4g}",
-        band_lower=lower,
-        band_upper=upper,
-    )
-
-
 def _robust_scale(values: np.ndarray) -> tuple[float, float]:
     """Return (median, MAD-based sigma) for a 1-D numeric array.
 
@@ -706,7 +614,7 @@ def detect_adaptive(
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
     historical_samples: np.ndarray | None = None,
-    percent_floor: float | None = None,
+    regression_percentage: float | None = None,
 ) -> RegressionResult:
     """Robust regression detection combining step and drift tests.
 
@@ -738,8 +646,9 @@ def detect_adaptive(
             delegated ``percentage`` detector sees the same input it would
             have received from ``detect_regressions`` directly. Falls back to
             ``historical_time_means`` when not provided.
-        percent_floor: Optional minimum percent change required to flag a
-            regression. When set, acts as a second acceptance band: a
+        regression_percentage: Optional minimum percent change required to
+            flag a regression (directional, i.e. interpreted against
+            ``direction``). When set, acts as a second acceptance band: a
             regression fires only when BOTH the MAD test and the percent
             change exceed their thresholds. Suppresses noise-floor false
             positives on metrics with few repeats or very tight history.
@@ -758,10 +667,14 @@ def detect_adaptive(
         fallback_hist = (
             _clean_1d(historical_samples) if historical_samples is not None else hist_clean
         )
-        # Sparse history -> percentage check. When ``percent_floor`` is set it
-        # doubles as the percentage threshold so the sparse regime honours the
-        # same floor the user configured for dual-band suppression.
-        effective_pct = percent_floor if percent_floor is not None else _METHOD_DEFAULTS["percentage"]
+        # Sparse history -> percentage check. When ``regression_percentage`` is
+        # set it doubles as the percentage threshold so the sparse regime honours
+        # the same knob the user configured for dual-band suppression.
+        effective_pct = (
+            regression_percentage
+            if regression_percentage is not None
+            else _METHOD_DEFAULTS["percentage"]
+        )
         result = detect_percentage(
             variable,
             fallback_hist,
@@ -769,10 +682,10 @@ def detect_adaptive(
             threshold_percent=effective_pct,
             direction=direction,
         )
-        if percent_floor is not None:
+        if regression_percentage is not None:
             baseline = result.baseline_value
-            result.percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
-            result.percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+            result.percent_band_lower = baseline * (1.0 - regression_percentage / 100.0)
+            result.percent_band_upper = baseline * (1.0 + regression_percentage / 100.0)
         return result
 
     baseline, mad_sigma = _robust_scale(hist_clean)
@@ -807,17 +720,19 @@ def detect_adaptive(
 
     change = _safe_change_percent(curr_mean, baseline)
 
-    # Dual-band gate: when percent_floor is set, each test must also be
-    # confirmed by a percent-change gate. The step gate uses the observed
+    # Dual-band gate: when regression_percentage is set, each test must also
+    # be confirmed by a percent-change gate. The step gate uses the observed
     # current-vs-baseline change; the drift gate uses the projected end-of-
     # history drift so a trend that doesn't cumulatively move more than the
-    # floor is treated as inside the band.
-    if percent_floor is not None:
-        step_pct_ok = _exceeds_directional_threshold(change, percent_floor, direction)
+    # threshold is treated as inside the band.
+    if regression_percentage is not None:
+        step_pct_ok = _exceeds_directional_threshold(change, regression_percentage, direction)
         drift_change = _safe_change_percent(baseline + drift_total, baseline)
-        drift_pct_ok = _exceeds_directional_threshold(drift_change, percent_floor, direction)
-        percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
-        percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+        drift_pct_ok = _exceeds_directional_threshold(
+            drift_change, regression_percentage, direction
+        )
+        percent_band_lower = baseline * (1.0 - regression_percentage / 100.0)
+        percent_band_upper = baseline * (1.0 + regression_percentage / 100.0)
     else:
         step_pct_ok = True
         drift_pct_ok = True
@@ -840,8 +755,8 @@ def detect_adaptive(
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
     )
-    if percent_floor is not None:
-        details += f", pct_floor={percent_floor}% (change={change:+.2f}%)"
+    if regression_percentage is not None:
+        details += f", pct={regression_percentage}% (change={change:+.2f}%)"
 
     return RegressionResult(
         variable=variable,
@@ -890,7 +805,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     if threshold is None:
         threshold = _METHOD_DEFAULTS.get(method, 5.0)
 
-    percent_floor = getattr(run_cfg, "regression_percent_floor", None)
+    regression_percentage = getattr(run_cfg, "regression_percentage", None)
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -911,7 +826,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             continue
 
         time_means_arr: np.ndarray | None = None
-        if method in ("iqr", "adaptive"):
+        if method == "adaptive":
             reduce_dims = [d for d in da.dims if d != "over_time"]
             time_means_arr = (
                 da.isel(over_time=slice(None, -1))
@@ -923,8 +838,6 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             result = detect_percentage(
                 var_name, historical_clean, current_clean, threshold, direction
             )
-        elif method == "iqr":
-            result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
@@ -933,7 +846,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 z_threshold=threshold,
                 direction=direction,
                 historical_samples=historical_clean,
-                percent_floor=percent_floor,
+                regression_percentage=regression_percentage,
             )
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -283,10 +283,17 @@ def _regression_plot_spec(
     # shades green: it represents the *valid* region, not the pass/fail
     # verdict (verdict colouring lives on the current marker + connector).
     valid_color = "#2ca02c"
+    # Light blue for the secondary (percentage) band — clearly distinct from
+    # the green MAD band after alpha blending, and distinct from the darker
+    # blue (#1f77b4) used for the history line so it doesn't read as part of
+    # the data series.
+    valid_color_light = "#6baed6"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
         band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "MAD band"))
-        band_layers.append((pct_band[0], pct_band[1], "#9467bd", 0.15, "percentage band"))
+        band_layers.append(
+            (pct_band[0], pct_band[1], valid_color_light, 0.15, "percentage band")
+        )
     elif mad_band is not None:
         band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band"))
     elif pct_band is not None:
@@ -408,6 +415,18 @@ def build_regression_overlay(
     # connector) are label-less so the legend stays compact.
     layers = []
     for lo, hi, color, alpha, label in spec["band_layers"]:
+        # Holoviews' matplotlib backend silently drops ``color`` opts on
+        # hv.Area (Curve/Scatter honour it, Area does not), which made every
+        # band render in whatever matplotlib colour-cycled next — so a
+        # non-regressed acceptance band rendered pink. Setting facecolor on
+        # the PolyCollection via a hook is the only path that actually sticks.
+        def _area_color_hook(plot, _element, _fc=color, _alpha=alpha):
+            artist = plot.handles.get("artist")
+            if artist is not None:
+                artist.set_facecolor(_fc)
+                artist.set_edgecolor("none")
+                artist.set_alpha(_alpha)
+
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
@@ -416,7 +435,7 @@ def build_regression_overlay(
                 label=label,
             ).opts(
                 hv.opts.Area(backend="bokeh", color=color, alpha=alpha, line_alpha=0),
-                hv.opts.Area(backend="matplotlib", color=color, alpha=alpha, linewidth=0),
+                hv.opts.Area(backend="matplotlib", hooks=[_area_color_hook]),
             )
         )
     layers.append(

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -291,9 +291,7 @@ def _regression_plot_spec(
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
         band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "MAD band"))
-        band_layers.append(
-            (pct_band[0], pct_band[1], valid_color_light, 0.15, "percentage band")
-        )
+        band_layers.append((pct_band[0], pct_band[1], valid_color_light, 0.15, "percentage band"))
     elif mad_band is not None:
         band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band"))
     elif pct_band is not None:

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -2,7 +2,8 @@
 
 Provides statistical methods to detect if benchmark values have changed
 significantly between runs. Supports percentage threshold, IQR-based outlier
-detection, and Welch's t-test.
+detection, and an adaptive MAD-based detector with an optional percent
+floor for dual-band suppression.
 """
 
 from __future__ import annotations
@@ -20,7 +21,6 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 _METHOD_DEFAULTS = {
     "percentage": 5.0,  # percent change
     "iqr": 1.5,  # IQR multiplier
-    "ttest": 0.05,  # significance level alpha
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
@@ -304,8 +304,13 @@ def build_regression_overlay(
     x_end = x_current
 
     layers = []
-    if spec["band"] is not None:
-        lo, hi = spec["band"]
+    mad_band = spec["band"]
+    pct_band = spec["percent_band"]
+    if mad_band is not None and pct_band is not None:
+        # Combined acceptance band (AND gate -> accept if inside either band
+        # => the union is the effective acceptance region).
+        lo = min(mad_band[0], pct_band[0])
+        hi = max(mad_band[1], pct_band[1])
         layers.append(
             hv.Area(
                 ([x_start, x_end], [lo, lo], [hi, hi]),
@@ -313,14 +318,35 @@ def build_regression_overlay(
                 vdims=[spec["ylabel"], "band_upper"],
             ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
         )
-    if spec["percent_band"] is not None:
-        plo, phi = spec["percent_band"]
+        for edge in (mad_band[0], mad_band[1]):
+            layers.append(
+                hv.Curve(
+                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
+                ).opts(color="#888888", line_dash="dotted", line_width=0.8)
+            )
+        for edge in (pct_band[0], pct_band[1]):
+            layers.append(
+                hv.Curve(
+                    [(x_start, edge), (x_end, edge)], spec["xlabel"], spec["ylabel"]
+                ).opts(color="#9467bd", line_dash="dashed", line_width=0.8)
+            )
+    elif mad_band is not None:
+        lo, hi = mad_band
+        layers.append(
+            hv.Area(
+                ([x_start, x_end], [lo, lo], [hi, hi]),
+                kdims=[spec["xlabel"]],
+                vdims=[spec["ylabel"], "band_upper"],
+            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
+        )
+    elif pct_band is not None:
+        plo, phi = pct_band
         layers.append(
             hv.Area(
                 ([x_start, x_end], [plo, plo], [phi, phi]),
                 kdims=[spec["xlabel"]],
-                vdims=[spec["ylabel"], "pct_band_upper"],
-            ).opts(color="#9467bd", alpha=0.08, line_alpha=0)
+                vdims=[spec["ylabel"], "band_upper"],
+            ).opts(color=verdict_color, alpha=0.10, line_alpha=0)
         )
     layers.append(
         hv.Curve(
@@ -428,13 +454,28 @@ def render_regression_png(
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     fig.subplots_adjust(left=0.12, right=0.98, top=0.88, bottom=0.2)
 
-    if spec["band"] is not None:
-        lo, hi = spec["band"]
-        mad_label = "MAD band" if spec["percent_band"] is not None else "acceptance band"
-        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label=mad_label)
-    if spec["percent_band"] is not None:
-        plo, phi = spec["percent_band"]
-        ax.axhspan(plo, phi, color="#9467bd", alpha=0.08, label="percent band")
+    mad_band = spec["band"]
+    pct_band = spec["percent_band"]
+    if mad_band is not None and pct_band is not None:
+        # AND gate means a point is accepted if it sits inside EITHER band,
+        # so the effective acceptance region is the union of the two.
+        lo = min(mad_band[0], pct_band[0])
+        hi = max(mad_band[1], pct_band[1])
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band (MAD ∪ %)")
+        ax.axhline(
+            mad_band[0], color="#888888", linestyle=":", linewidth=0.8, label="MAD edge"
+        )
+        ax.axhline(mad_band[1], color="#888888", linestyle=":", linewidth=0.8)
+        ax.axhline(
+            pct_band[0], color="#9467bd", linestyle="--", linewidth=0.8, label="percent edge"
+        )
+        ax.axhline(pct_band[1], color="#9467bd", linestyle="--", linewidth=0.8)
+    elif mad_band is not None:
+        lo, hi = mad_band
+        ax.axhspan(lo, hi, color=verdict_color, alpha=0.10, label="acceptance band")
+    elif pct_band is not None:
+        plo, phi = pct_band
+        ax.axhspan(plo, phi, color=verdict_color, alpha=0.10, label="acceptance band")
 
     ax.axhline(
         spec["baseline"],
@@ -630,52 +671,6 @@ def detect_iqr(
     )
 
 
-def detect_ttest(
-    variable: str,
-    historical: np.ndarray,
-    current: np.ndarray,
-    alpha: float = 0.05,
-    direction: OptDir = OptDir.minimize,
-) -> RegressionResult:
-    """Welch's t-test between historical and current samples."""
-    hist_clean = _clean_1d(historical)
-    curr_clean = _clean_1d(current)
-
-    if len(hist_clean) < 2 or len(curr_clean) < 2:
-        # Fall back to percentage with alpha-based threshold
-        return detect_percentage(
-            variable, hist_clean, curr_clean, threshold_percent=alpha * 100, direction=direction
-        )
-
-    from scipy.stats import ttest_ind
-
-    if direction == OptDir.minimize:
-        alt = "greater"  # regression = current > historical
-    elif direction == OptDir.maximize:
-        alt = "less"  # regression = current < historical
-    else:
-        alt = "two-sided"
-
-    stat, pvalue = ttest_ind(curr_clean, hist_clean, equal_var=False, alternative=alt)
-
-    hist_mean = float(np.nanmean(hist_clean))
-    curr_mean = float(np.nanmean(curr_clean))
-    change = _safe_change_percent(curr_mean, hist_mean)
-    regressed = pvalue < alpha
-
-    return RegressionResult(
-        variable=variable,
-        method="ttest",
-        regressed=regressed,
-        current_value=curr_mean,
-        baseline_value=hist_mean,
-        change_percent=change,
-        threshold=alpha,
-        direction=direction.value,
-        details=f"t-stat={stat:.4g}, p-value={pvalue:.4g}, alpha={alpha}",
-    )
-
-
 def _robust_scale(values: np.ndarray) -> tuple[float, float]:
     """Return (median, MAD-based sigma) for a 1-D numeric array.
 
@@ -740,9 +735,9 @@ def detect_adaptive(
         direction: Optimization direction from the result variable.
         historical_samples: Optional flat array of all historical samples
             (not per-time means). Used for the sparse-history fallback so the
-            delegated ``ttest``/``percentage`` methods see the same input they
-            would have received from ``detect_regressions`` directly. Falls
-            back to ``historical_time_means`` when not provided.
+            delegated ``percentage`` detector sees the same input it would
+            have received from ``detect_regressions`` directly. Falls back to
+            ``historical_time_means`` when not provided.
         percent_floor: Optional minimum percent change required to flag a
             regression. When set, acts as a second acceptance band: a
             regression fires only when BOTH the MAD test and the percent
@@ -756,28 +751,29 @@ def detect_adaptive(
     curr_clean = _clean_1d(current)
     curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
 
-    # Not enough history for a robust scale — fall back to less strict checks.
-    # Use the full per-sample history when available so the fallback behaves
-    # like a direct call to detect_ttest/detect_percentage.
+    # Not enough history for a robust scale — fall back to a percentage
+    # check. Use the full per-sample history when available so the fallback
+    # behaves like a direct call to detect_percentage.
     if len(hist_clean) < 4:
         fallback_hist = (
             _clean_1d(historical_samples) if historical_samples is not None else hist_clean
         )
-        if len(fallback_hist) >= 2 and len(curr_clean) >= 2:
-            return detect_ttest(
-                variable,
-                fallback_hist,
-                curr_clean,
-                alpha=_METHOD_DEFAULTS["ttest"],
-                direction=direction,
-            )
-        return detect_percentage(
+        # Sparse history -> percentage check. When ``percent_floor`` is set it
+        # doubles as the percentage threshold so the sparse regime honours the
+        # same floor the user configured for dual-band suppression.
+        effective_pct = percent_floor if percent_floor is not None else _METHOD_DEFAULTS["percentage"]
+        result = detect_percentage(
             variable,
             fallback_hist,
             curr_clean,
-            threshold_percent=_METHOD_DEFAULTS["percentage"],
+            threshold_percent=effective_pct,
             direction=direction,
         )
+        if percent_floor is not None:
+            baseline = result.baseline_value
+            result.percent_band_lower = baseline * (1.0 - percent_floor / 100.0)
+            result.percent_band_upper = baseline * (1.0 + percent_floor / 100.0)
+        return result
 
     baseline, mad_sigma = _robust_scale(hist_clean)
     noise_floor = max(mad_sigma, 1e-6 * abs(baseline), 1e-12)
@@ -929,8 +925,6 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             )
         elif method == "iqr":
             result = detect_iqr(var_name, time_means_arr, current_clean, threshold, direction)
-        elif method == "ttest":
-            result = detect_ttest(var_name, historical_clean, current_clean, threshold, direction)
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
@@ -957,10 +951,10 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             result.current_x = time_coord[-1]
         else:
             result.historical = historical_clean
-            # percentage/ttest pass the flat history (repeat * over_time); we
-            # only record over_time coords when they line up with the flat
-            # history length — otherwise pair current_x with the integer
-            # indices used by the plot and leave both unset.
+            # percentage passes the flat history (repeat * over_time); only
+            # record over_time coords when they line up with the flat history
+            # length — otherwise pair current_x with the integer indices used
+            # by the plot and leave both unset.
             if len(time_coord) - 1 == len(historical_clean):
                 result.historical_x = time_coord[:-1]
                 result.current_x = time_coord[-1]

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -19,14 +19,14 @@ from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
 
 # Default thresholds per method — used when the user hasn't explicitly set a threshold.
 _METHOD_DEFAULTS = {
-    "percentage": 5.0,  # percent change
+    "percentage": 10.0,  # percent change
     "adaptive": 3.5,  # robust z-score threshold in MAD units
 }
 
 # Consistency factor so MAD estimates the standard deviation of a Gaussian.
 _MAD_TO_SIGMA = 1.4826
 
-# Drift threshold defaults to this fraction of z_threshold when not set by caller.
+# Drift threshold defaults to this fraction of regression_mad when not set by caller.
 _DRIFT_FRAC = 0.85
 
 # Hampel filter cutoff (in MAD units) used to drop outliers from the slope fit.
@@ -59,6 +59,11 @@ class RegressionResult:
     # Arrays retained so the result can be replotted without re-running detection.
     historical: np.ndarray | None = None
     current_samples: np.ndarray | None = None
+    # Optional per-sample historical data (flat: all repeats from all historical
+    # time points) with paired x-coords — used to render a scatter overlay
+    # showing the full spread at each time point, not just the per-time mean.
+    historical_all: np.ndarray | None = None
+    historical_all_x: np.ndarray | None = None
     # x-axis coordinates for the historical and current points (typically the
     # ``over_time`` datetimes). Optional: falls back to integer indices.
     historical_x: np.ndarray | None = None
@@ -243,13 +248,31 @@ def _regression_plot_spec(
     )
     title = f"{result.variable} — {result.method} — {verdict_label}  (Δ {change_str})"
 
+    baseline = result.baseline_value
+
+    def _clip(band: tuple[float, float] | None) -> tuple[float, float] | None:
+        """Clip the band to the side(s) that actually gate regressions.
+
+        Stored bands are symmetric around the baseline, but for directional
+        metrics only one side flags a regression. Minimize only trips on
+        values above baseline; maximize only trips on values below. None
+        flags either side, so the full symmetric band stays."""
+        if band is None:
+            return None
+        lo, hi = band
+        if result.direction == OptDir.minimize.value:
+            return (baseline, hi)
+        if result.direction == OptDir.maximize.value:
+            return (lo, baseline)
+        return (lo, hi)
+
     mad_band = (
-        (result.band_lower, result.band_upper)
+        _clip((result.band_lower, result.band_upper))
         if result.band_lower is not None and result.band_upper is not None
         else None
     )
     pct_band = (
-        (result.percent_band_lower, result.percent_band_upper)
+        _clip((result.percent_band_lower, result.percent_band_upper))
         if result.percent_band_lower is not None and result.percent_band_upper is not None
         else None
     )
@@ -274,9 +297,32 @@ def _regression_plot_spec(
             (pct_band[0], pct_band[1], verdict_color, 0.15, "acceptance band")
         )
 
+    # Per-sample historical scatter: only plot if the x-coords align with the
+    # primary hist_x dtype (so strings/categorical fallbacks don't break the
+    # axis). Falls back to None when there is no alignment.
+    hist_scatter_x: np.ndarray | None = None
+    hist_scatter_y: np.ndarray | None = None
+    if (
+        result.historical_all is not None
+        and result.historical_all_x is not None
+        and len(result.historical_all) == len(result.historical_all_x)
+        and len(result.historical_all) > 0
+        and xticks is None
+    ):
+        raw = np.asarray(result.historical_all_x)
+        hist_is_dt = np.issubdtype(hist_x.dtype, np.datetime64)
+        raw_is_dt = np.issubdtype(raw.dtype, np.datetime64)
+        hist_is_num = np.issubdtype(hist_x.dtype, np.number)
+        raw_is_num = np.issubdtype(raw.dtype, np.number)
+        if (hist_is_dt and raw_is_dt) or (hist_is_num and raw_is_num):
+            hist_scatter_x = raw
+            hist_scatter_y = np.asarray(result.historical_all, dtype=float)
+
     return {
         "hist": hist,
         "hist_x": hist_x,
+        "hist_scatter_x": hist_scatter_x,
+        "hist_scatter_y": hist_scatter_y,
         "xticks": xticks,
         "curr_samples": curr_samples,
         "curr_mean": curr_mean,
@@ -340,6 +386,14 @@ def build_regression_overlay(
             spec["ylabel"],
         ).opts(color="#555555", line_dash="dashed", line_width=1)
     )
+    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
+        layers.append(
+            hv.Scatter(
+                list(zip(spec["hist_scatter_x"], spec["hist_scatter_y"])),
+                spec["xlabel"],
+                spec["ylabel"],
+            ).opts(color="#1f77b4", alpha=0.35, size=5)
+        )
     if len(hist) > 0:
         layers.append(
             hv.Curve(list(zip(hist_x, hist)), spec["xlabel"], spec["ylabel"]).opts(
@@ -450,6 +504,15 @@ def render_regression_png(
         label=f"baseline={spec['baseline']:.3g}",
     )
 
+    if spec["hist_scatter_x"] is not None and spec["hist_scatter_y"] is not None:
+        ax.scatter(
+            spec["hist_scatter_x"],
+            spec["hist_scatter_y"],
+            color="#1f77b4",
+            alpha=0.35,
+            s=18,
+            label="history samples",
+        )
     if len(hist) > 0:
         ax.plot(
             hist_x,
@@ -609,7 +672,7 @@ def detect_adaptive(
     variable: str,
     historical_time_means: np.ndarray,
     current: np.ndarray,
-    z_threshold: float = 3.5,
+    regression_mad: float = 3.5,
     drift_threshold: float | None = None,
     mk_alpha: float = 0.1,
     direction: OptDir = OptDir.minimize,
@@ -623,7 +686,7 @@ def detect_adaptive(
     run's deviation in those noise units. Two orthogonal tests run in parallel:
 
     * **Short-term step** — flags if ``(current_mean - baseline) / noise_floor``
-      exceeds ``z_threshold`` in the regression direction.
+      exceeds ``regression_mad`` in the regression direction.
     * **Long-term drift** — fits a Theil–Sen slope on the historical time-point
       means (after a Hampel filter removes isolated outliers) and flags if the
       total projected drift, scaled by ``noise_floor``, exceeds
@@ -635,9 +698,9 @@ def detect_adaptive(
         historical_time_means: 1-D array of per-time-point mean values from
             history (one entry per prior run).
         current: Current run values (will be averaged).
-        z_threshold: Step-test threshold in MAD-sigma units.
+        regression_mad: Step-test threshold in MAD-sigma units.
         drift_threshold: Drift-test threshold in MAD-sigma units. If ``None``,
-            defaults to ``_DRIFT_FRAC * z_threshold`` so users need to tune
+            defaults to ``_DRIFT_FRAC * regression_mad`` so users need to tune
             only one knob.
         mk_alpha: Significance level for the Mann–Kendall trend guard.
         direction: Optimization direction from the result variable.
@@ -654,7 +717,7 @@ def detect_adaptive(
             positives on metrics with few repeats or very tight history.
     """
     if drift_threshold is None:
-        drift_threshold = _DRIFT_FRAC * z_threshold
+        drift_threshold = _DRIFT_FRAC * regression_mad
 
     hist_clean = _clean_1d(historical_time_means)
     curr_clean = _clean_1d(current)
@@ -693,7 +756,7 @@ def detect_adaptive(
 
     # Step test — current mean vs robust baseline in MAD-sigma units.
     z_step = (curr_mean - baseline) / noise_floor
-    step_mad = _is_regression(z_step, direction) and abs(z_step) > z_threshold
+    step_mad = _is_regression(z_step, direction) and abs(z_step) > regression_mad
 
     # Drift test — Theil–Sen slope on Hampel-filtered history, MK significance.
     # Use residual (detrended) noise as the denominator so a real drift can't
@@ -750,7 +813,7 @@ def detect_adaptive(
         fired.append("drift")
     fired_str = "+".join(fired) if fired else "none"
     details = (
-        f"fired={fired_str}, z_step={z_step:+.2f} (|z|>{z_threshold}), "
+        f"fired={fired_str}, z_step={z_step:+.2f} (|z|>{regression_mad}), "
         f"z_drift={z_drift:+.2f} (|z|>{drift_threshold:.2f}), "
         f"mk_p={mk_p:.3g} (<{mk_alpha}), "
         f"baseline={baseline:.4g}, noise={noise_floor:.4g}"
@@ -765,11 +828,11 @@ def detect_adaptive(
         current_value=curr_mean,
         baseline_value=baseline,
         change_percent=change,
-        threshold=z_threshold,
+        threshold=regression_mad,
         direction=direction.value,
         details=details,
-        band_lower=baseline - z_threshold * noise_floor,
-        band_upper=baseline + z_threshold * noise_floor,
+        band_lower=baseline - regression_mad * noise_floor,
+        band_upper=baseline + regression_mad * noise_floor,
         percent_band_lower=percent_band_lower,
         percent_band_upper=percent_band_upper,
     )
@@ -799,13 +862,12 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         return report
 
     method = run_cfg.regression_method
-    threshold = run_cfg.regression_threshold
-
-    # Use per-method default when no explicit threshold is provided.
-    if threshold is None:
-        threshold = _METHOD_DEFAULTS.get(method, 5.0)
-
+    regression_mad = getattr(run_cfg, "regression_mad", None)
+    if regression_mad is None:
+        regression_mad = _METHOD_DEFAULTS["adaptive"]
     regression_percentage = getattr(run_cfg, "regression_percentage", None)
+    if regression_percentage is None:
+        regression_percentage = _METHOD_DEFAULTS["percentage"]
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -836,14 +898,14 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
 
         if method == "percentage":
             result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
+                var_name, historical_clean, current_clean, regression_percentage, direction
             )
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
                 time_means_arr,
                 current_clean,
-                z_threshold=threshold,
+                regression_mad=regression_mad,
                 direction=direction,
                 historical_samples=historical_clean,
                 regression_percentage=regression_percentage,
@@ -851,7 +913,7 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")
             result = detect_percentage(
-                var_name, historical_clean, current_clean, threshold, direction
+                var_name, historical_clean, current_clean, regression_percentage, direction
             )
 
         # Retain the arrays used for plotting so downstream consumers (reports,
@@ -872,6 +934,22 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 result.historical_x = time_coord[:-1]
                 result.current_x = time_coord[-1]
         result.current_samples = current_clean
+
+        # Per-sample historical scatter: flatten the 2D slice (all repeats at
+        # every historical time point) and broadcast the time coords so the
+        # renderers can show every sample as a dot at its real x position.
+        hist_slice = da.isel(over_time=slice(None, -1))
+        if hist_slice.size > 0:
+            hist_2d = np.moveaxis(
+                np.asarray(hist_slice.values, dtype=float),
+                list(hist_slice.dims).index("over_time"),
+                0,
+            ).reshape(hist_slice.sizes["over_time"], -1)
+            hist_samples_flat = hist_2d.ravel()
+            hist_x_flat = np.repeat(time_coord[:-1], hist_2d.shape[1])
+            mask = ~np.isnan(hist_samples_flat)
+            result.historical_all = hist_samples_flat[mask]
+            result.historical_all_x = hist_x_flat[mask]
 
         report.results.append(result)
 

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -996,24 +996,35 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         if len(current_clean) == 0 or len(historical_clean) == 0:
             continue
 
-        time_means_arr: np.ndarray | None = None
-        if method == "adaptive":
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
+        # Aggregate every non-time dim (parameter grid, repeats) into a single
+        # scalar per time point before handing the series to any detector.
+        # Without this, a 2-D param sweep over time threads both detection and
+        # the history plot through parameter-grid structure — the line zigzags
+        # through cells instead of showing time drift, and the baseline/band
+        # end up wildly out of scale relative to individual cells.
+        reduce_dims = [d for d in da.dims if d != "over_time"]
+        time_means_arr = (
+            da.isel(over_time=slice(None, -1))
+            .mean(dim=reduce_dims, skipna=True)
+            .values.astype(float)
+        )
+        current_mean_scalar = np.array(
+            [float(da.isel(over_time=-1).mean(skipna=True).values)]
+        )
 
         if method == "percentage":
             result = detect_percentage(
-                var_name, historical_clean, current_clean, regression_percentage, direction
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
             )
         elif method == "adaptive":
             result = detect_adaptive(
                 var_name,
                 time_means_arr,
-                current_clean,
+                current_mean_scalar,
                 regression_mad=regression_mad,
                 direction=direction,
                 historical_samples=historical_clean,
@@ -1022,26 +1033,20 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         else:
             logging.warning(f"Unknown regression method '{method}', falling back to percentage")
             result = detect_percentage(
-                var_name, historical_clean, current_clean, regression_percentage, direction
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
             )
 
         # Retain the arrays used for plotting so downstream consumers (reports,
         # bot comments) can rebuild the diagnostic without re-running detection.
         time_coord = dataset["over_time"].values
-        if time_means_arr is not None:
-            result.historical = time_means_arr
-            # Per-time means are aligned with over_time, one value per time point.
-            result.historical_x = time_coord[:-1]
-            result.current_x = time_coord[-1]
-        else:
-            result.historical = historical_clean
-            # percentage passes the flat history (repeat * over_time); only
-            # record over_time coords when they line up with the flat history
-            # length — otherwise pair current_x with the integer indices used
-            # by the plot and leave both unset.
-            if len(time_coord) - 1 == len(historical_clean):
-                result.historical_x = time_coord[:-1]
-                result.current_x = time_coord[-1]
+        result.historical = time_means_arr
+        # Per-time means are aligned with over_time, one value per time point.
+        result.historical_x = time_coord[:-1]
+        result.current_x = time_coord[-1]
         result.current_samples = current_clean
 
         # Per-sample historical scatter: flatten the 2D slice (all repeats at

--- a/pixi.lock
+++ b/pixi.lock
@@ -69,7 +69,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -130,7 +130,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -143,7 +143,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -165,7 +165,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -245,7 +245,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -305,7 +305,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -318,7 +318,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -341,7 +341,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
@@ -422,7 +422,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -483,7 +483,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -496,7 +496,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -518,7 +518,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -598,7 +598,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -659,7 +659,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -672,7 +672,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -694,7 +694,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -773,7 +773,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
@@ -834,7 +834,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
@@ -847,7 +847,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
@@ -869,7 +869,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -1475,7 +1475,7 @@ packages:
 - pypi: ./
   name: holobench
   version: 1.88.0
-  sha256: 6df428054a0fcd1ebd4c1239d8f79181cdf0b51676d09020f89983aa91bde7d2
+  sha256: 5cedfab218f061100b756de012f9a6954fbc2eb523a785e942007ba1161c4567
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -1498,13 +1498,13 @@ packages:
   - jupyter-bokeh ; extra == 'test'
   - pylint>=3.2.5,<=4.0.5 ; extra == 'test'
   - pytest-cov>=4.1,<=7.1.0 ; extra == 'test'
-  - pytest>=7.4,<=9.0.2 ; extra == 'test'
-  - hypothesis>=6.104.2,<=6.151.10 ; extra == 'test'
-  - ruff>=0.5.0,<=0.15.8 ; extra == 'test'
+  - pytest>=7.4,<=9.0.3 ; extra == 'test'
+  - hypothesis>=6.104.2,<=6.152.1 ; extra == 'test'
+  - ruff>=0.5.0,<=0.15.11 ; extra == 'test'
   - sphinxcontrib-mermaid>=1.0,<2.0 ; extra == 'test'
   - coverage>=7.5.4,<=7.13.5 ; extra == 'test'
   - prek>=0.2.28,<0.4.0 ; extra == 'test'
-  - ty>=0.0.13,<=0.0.27 ; extra == 'test'
+  - ty>=0.0.13,<=0.0.31 ; extra == 'test'
   - rerun-sdk>=0.31.1,<=0.31.1 ; extra == 'rerun'
   - rerun-notebook>=0.31.1,<=0.31.1 ; extra == 'rerun'
   requires_python: '>=3.10,<3.14'
@@ -1707,10 +1707,10 @@ packages:
   - nbval ; extra == 'tests-nb'
   - pytest-xdist ; extra == 'tests-nb'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/40/da/439bb2e451979f5e88c13bbebc3e9e17754429cfb528c93677b2bd81783b/hypothesis-6.151.10-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
   name: hypothesis
-  version: 6.151.10
-  sha256: b0d7728f0c8c2be009f89fcdd6066f70c5439aa0f94adbb06e98261d05f49b05
+  version: 6.152.1
+  sha256: 40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e
   requires_dist:
   - exceptiongroup>=1.0.0 ; python_full_version < '3.11'
   - sortedcontainers>=2.1.0,<3.0.0
@@ -1729,7 +1729,7 @@ packages:
   - redis>=3.0.0 ; extra == 'redis'
   - hypothesis-crosshair>=0.0.27 ; extra == 'crosshair'
   - crosshair-tool>=0.0.102 ; extra == 'crosshair'
-  - tzdata>=2025.3 ; (sys_platform == 'emscripten' and extra == 'zoneinfo') or (sys_platform == 'win32' and extra == 'zoneinfo')
+  - tzdata>=2026.1 ; (sys_platform == 'emscripten' and extra == 'zoneinfo') or (sys_platform == 'win32' and extra == 'zoneinfo')
   - django>=4.2 ; extra == 'django'
   - watchdog>=4.0.0 ; extra == 'watchdog'
   - black>=20.8b0 ; extra == 'all'
@@ -1747,7 +1747,7 @@ packages:
   - pytz>=2014.1 ; extra == 'all'
   - redis>=3.0.0 ; extra == 'all'
   - rich>=9.0.0 ; extra == 'all'
-  - tzdata>=2025.3 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
+  - tzdata>=2026.1 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
   - watchdog>=4.0.0 ; extra == 'all'
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
@@ -3706,10 +3706,10 @@ packages:
   - railroad-diagrams ; extra == 'diagrams'
   - jinja2 ; extra == 'diagrams'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
   name: pytest
-  version: 9.0.2
-  sha256: 711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b
+  version: 9.0.3
+  sha256: 2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
   requires_dist:
   - colorama>=0.4 ; sys_platform == 'win32'
   - exceptiongroup>=1 ; python_full_version < '3.11'
@@ -4043,10 +4043,10 @@ packages:
   version: 0.30.0
   sha256: 33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ruff
-  version: 0.15.8
-  sha256: 0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1
+  version: 0.15.11
+  sha256: 1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431
   requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: scikit-learn
@@ -4916,10 +4916,10 @@ packages:
   - pytest-mypy-testing ; extra == 'test'
   - pytest>=7.0,<8.2 ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: ty
-  version: 0.0.27
-  sha256: 924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f
+  version: 0.0.31
+  sha256: c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
   name: typing-extensions

--- a/pixi.lock
+++ b/pixi.lock
@@ -102,7 +102,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -277,7 +277,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -455,7 +455,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -631,7 +631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -806,7 +806,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
@@ -1474,8 +1474,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.86.0
-  sha256: 6d3a35e41f361d8365c56a72d93c42a7c079c6f67b2af2a70d0d5498de5ffeaf
+  version: 1.88.0
+  sha256: 6df428054a0fcd1ebd4c1239d8f79181cdf0b51676d09020f89983aa91bde7d2
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -2660,10 +2660,10 @@ packages:
   - flake8-implicit-str-concat==0.4.0 ; extra == 'lint'
   - isort>=5.12 ; extra == 'lint'
   - pre-commit>=3.3 ; extra == 'lint'
-- pypi: https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl
   name: narwhals
-  version: 2.19.0
-  sha256: 1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b
+  version: 2.20.0
+  sha256: 16e750ea5507d4ba6e8d03455b5f93a535e0405976561baea235bca5dc9f475d
   requires_dist:
   - cudf-cu12>=24.10.0 ; extra == 'cudf'
   - dask[dataframe]>=2024.8 ; extra == 'dask'

--- a/pixi.lock
+++ b/pixi.lock
@@ -117,7 +117,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
@@ -139,8 +139,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -154,7 +154,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -292,7 +292,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
@@ -315,8 +315,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -329,7 +329,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/1e/410dd499c039deacff395eec01a9da057125fcd0c97e3badc252c6a2d6a7/sqlalchemy-2.0.49-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -470,7 +470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
@@ -492,8 +492,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -507,7 +507,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/61/0722511d98c54de95acb327824cb759e8653789af2b1944ab1cc69d32565/sqlalchemy-2.0.49-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -646,7 +646,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
@@ -668,8 +668,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -683,7 +683,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -821,7 +821,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/5a/54117316e98ff62a14911ad1488a3a0945530242a2ce3e92f7a40b6ccc02/prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
@@ -843,8 +843,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -858,7 +858,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -1475,7 +1475,7 @@ packages:
 - pypi: ./
   name: holobench
   version: 1.88.0
-  sha256: 5cedfab218f061100b756de012f9a6954fbc2eb523a785e942007ba1161c4567
+  sha256: c94c759c311de8642712f4ccb2db4eb3a9f877af58576f721d6d5f80b8547cd8
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -1485,7 +1485,7 @@ packages:
   - diskcache>=5.6,<=5.6.3
   - optuna>=3.2,<=4.8.0
   - xarray>=2023.7,<=2025.6.1
-  - plotly>=5.15,<=6.6.0
+  - plotly>=5.15,<=6.7.0
   - pandas>=2.0,<=3.0.0
   - strenum>=0.4.0,<=0.4.15
   - scikit-learn>=1.2,<=1.7.2
@@ -1501,12 +1501,12 @@ packages:
   - pytest>=7.4,<=9.0.3 ; extra == 'test'
   - hypothesis>=6.104.2,<=6.152.1 ; extra == 'test'
   - ruff>=0.5.0,<=0.15.11 ; extra == 'test'
-  - sphinxcontrib-mermaid>=1.0,<2.0 ; extra == 'test'
+  - sphinxcontrib-mermaid>=1.0,<3.0 ; extra == 'test'
   - coverage>=7.5.4,<=7.13.5 ; extra == 'test'
   - prek>=0.2.28,<0.4.0 ; extra == 'test'
   - ty>=0.0.13,<=0.0.31 ; extra == 'test'
-  - rerun-sdk>=0.31.1,<=0.31.1 ; extra == 'rerun'
-  - rerun-notebook>=0.31.1,<=0.31.1 ; extra == 'rerun'
+  - rerun-sdk>=0.31.1,<=0.31.3 ; extra == 'rerun'
+  - rerun-notebook>=0.31.1,<=0.31.3 ; extra == 'rerun'
   requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
   name: holoviews
@@ -3497,29 +3497,57 @@ packages:
   purls: []
   size: 2450462
   timestamp: 1775458000688
-- pypi: https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
   name: plotly
-  version: 6.6.0
-  sha256: 8d6daf0f87412e0c0bfe72e809d615217ab57cc715899a1e5145135a7800d1d0
+  version: 6.7.0
+  sha256: ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0
   requires_dist:
   - narwhals>=1.15.1
   - packaging
-  - numpy ; extra == 'express'
-  - kaleido>=1.1.0 ; extra == 'kaleido'
+  - anywidget ; extra == 'dev'
+  - build ; extra == 'dev'
+  - colorcet ; extra == 'dev'
+  - fiona<=1.9.6 ; python_full_version < '3.9' and extra == 'dev'
+  - geopandas ; extra == 'dev'
+  - inflect ; extra == 'dev'
+  - jupyterlab ; extra == 'dev'
+  - kaleido>=1.1.0 ; extra == 'dev'
+  - numpy>=1.22 ; extra == 'dev'
+  - orjson ; extra == 'dev'
+  - pandas ; extra == 'dev'
+  - pdfrw ; extra == 'dev'
+  - pillow ; extra == 'dev'
+  - plotly-geo ; extra == 'dev'
+  - polars[timezone] ; extra == 'dev'
+  - pyarrow ; extra == 'dev'
+  - pyshp ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytz ; extra == 'dev'
+  - requests ; extra == 'dev'
+  - ruff==0.11.12 ; extra == 'dev'
+  - scikit-image ; extra == 'dev'
+  - scipy ; extra == 'dev'
+  - shapely ; extra == 'dev'
+  - statsmodels ; extra == 'dev'
+  - vaex ; python_full_version < '3.10' and extra == 'dev'
+  - xarray ; extra == 'dev'
+  - build ; extra == 'dev-build'
+  - jupyterlab ; extra == 'dev-build'
+  - pytest ; extra == 'dev-build'
+  - requests ; extra == 'dev-build'
+  - ruff==0.11.12 ; extra == 'dev-build'
   - pytest ; extra == 'dev-core'
   - requests ; extra == 'dev-core'
   - ruff==0.11.12 ; extra == 'dev-core'
-  - plotly[dev-core] ; extra == 'dev-build'
-  - build ; extra == 'dev-build'
-  - jupyter ; extra == 'dev-build'
-  - plotly[dev-build] ; extra == 'dev-optional'
-  - plotly[kaleido] ; extra == 'dev-optional'
   - anywidget ; extra == 'dev-optional'
+  - build ; extra == 'dev-optional'
   - colorcet ; extra == 'dev-optional'
   - fiona<=1.9.6 ; python_full_version < '3.9' and extra == 'dev-optional'
   - geopandas ; extra == 'dev-optional'
   - inflect ; extra == 'dev-optional'
-  - numpy ; extra == 'dev-optional'
+  - jupyterlab ; extra == 'dev-optional'
+  - kaleido>=1.1.0 ; extra == 'dev-optional'
+  - numpy>=1.22 ; extra == 'dev-optional'
   - orjson ; extra == 'dev-optional'
   - pandas ; extra == 'dev-optional'
   - pdfrw ; extra == 'dev-optional'
@@ -3528,14 +3556,18 @@ packages:
   - polars[timezone] ; extra == 'dev-optional'
   - pyarrow ; extra == 'dev-optional'
   - pyshp ; extra == 'dev-optional'
+  - pytest ; extra == 'dev-optional'
   - pytz ; extra == 'dev-optional'
+  - requests ; extra == 'dev-optional'
+  - ruff==0.11.12 ; extra == 'dev-optional'
   - scikit-image ; extra == 'dev-optional'
   - scipy ; extra == 'dev-optional'
   - shapely ; extra == 'dev-optional'
   - statsmodels ; extra == 'dev-optional'
   - vaex ; python_full_version < '3.10' and extra == 'dev-optional'
   - xarray ; extra == 'dev-optional'
-  - plotly[dev-optional] ; extra == 'dev'
+  - numpy>=1.22 ; extra == 'express'
+  - kaleido>=1.1.0 ; extra == 'kaleido'
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
   name: pluggy
@@ -3978,10 +4010,10 @@ packages:
   - pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
   - chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/9a/f7/d0ddfb709e7044c2bf4e6e44e3f1ff4e7fa9995f21215b39900c287ee829/rerun_notebook-0.31.1-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/48/1b/66526e18cd6ed43e4cd0436df5bba76abe0e136593cf73309c19270bc0ae/rerun_notebook-0.31.3-py2.py3-none-any.whl
   name: rerun-notebook
-  version: 0.31.1
-  sha256: 47a10e813a2e3b0784fe794e15b8211ffc218420f975fe82e1e1d1be910afb24
+  version: 0.31.3
+  sha256: 73a74e694f1bf3ffe62789725ccb433256dd41184125e3338e8ff5971b6eb230
   requires_dist:
   - anywidget
   - ipykernel<7.0.0
@@ -3989,10 +4021,10 @@ packages:
   - hatch ; extra == 'dev'
   - jupyterlab ; extra == 'dev'
   - watchfiles ; extra == 'dev'
-- pypi: https://files.pythonhosted.org/packages/f3/ea/cb4fec43e4b34c872bd88823cb5b1c9f6cbf82975dc9380e1ab29daf8d41/rerun_sdk-0.31.1-cp310-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/f7/f4/d4350829d5bd74005ff08b194a21c24a570c9db67d90c14ca29cf0b063bf/rerun_sdk-0.31.3-cp310-abi3-manylinux_2_28_x86_64.whl
   name: rerun-sdk
-  version: 0.31.1
-  sha256: e06f4a40f2d0913b3d225640befc722b468a491d24ed6c0ee4e6511abe6b4057
+  version: 0.31.3
+  sha256: b285dda76f4bf01d617204c09bab8543cddd224cc8fe159f3bf38458bf398998
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2
@@ -4009,14 +4041,14 @@ packages:
   - tomli==2.0.1 ; extra == 'tests'
   - torch>=2.5 ; extra == 'tests'
   - datafusion==52.3.0 ; extra == 'tests'
-  - rerun-notebook==0.31.1 ; extra == 'notebook'
+  - rerun-notebook==0.31.3 ; extra == 'notebook'
   - datafusion==52.3.0 ; extra == 'datafusion'
   - pandas>=2 ; extra == 'datafusion'
   - datafusion==52.3.0 ; extra == 'dataplatform'
   - pandas>=2 ; extra == 'dataplatform'
   - datafusion==52.3.0 ; extra == 'all'
   - pandas>=2 ; extra == 'all'
-  - rerun-notebook==0.31.1 ; extra == 'all'
+  - rerun-notebook==0.31.3 ; extra == 'all'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
   name: roman-numerals
@@ -4621,11 +4653,12 @@ packages:
   - flake8 ; extra == 'test'
   - mypy ; extra == 'test'
   requires_python: '>=3.5'
-- pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/03/46/25d64bcd7821c8d6f1080e1c43d5fcdfc442a18f759a230b5ccdc891093e/sphinxcontrib_mermaid-2.0.1-py3-none-any.whl
   name: sphinxcontrib-mermaid
-  version: 1.2.3
-  sha256: 5be782b27026bef97bfb15ccb2f7868b674a1afc0982b54cb149702cfc25aa02
+  version: 2.0.1
+  sha256: 9dca7fbe827bad5e7e2b97c4047682cfd26e3e07398cfdc96c7a8842ae7f06e7
   requires_dist:
+  - jinja2
   - sphinx
   - pyyaml
   - defusedxml ; extra == 'test'
@@ -4633,7 +4666,7 @@ packages:
   - pytest ; extra == 'test'
   - ruff ; extra == 'test'
   - sphinx ; extra == 'test'
-  requires_python: '>=3.8'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
   name: sphinxcontrib-qthelp
   version: 2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.87.0"
+version = "1.88.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -359,7 +359,12 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None, regression_percentage=None):
+    def _make_cfg(
+        result_vars,
+        method="percentage",
+        regression_mad=None,
+        regression_percentage=None,
+    ):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -367,12 +372,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold, regression_percentage):
+            def __init__(self, method, regression_mad, regression_percentage):
                 self.regression_method = method
-                self.regression_threshold = threshold
+                self.regression_mad = regression_mad
                 self.regression_percentage = regression_percentage
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, regression_percentage)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, regression_mad, regression_percentage)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -412,7 +417,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert report.results[0].variable == "metric"
@@ -432,7 +437,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions
 
@@ -445,7 +450,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions, report.summary()
 
@@ -460,7 +465,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "step" in report.results[0].details
@@ -476,12 +481,12 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.maximize)
         rv.name = "metric"
 
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         without_pct = detect_regressions(ds, bench_cfg, run_cfg)
         assert without_pct.has_regressions
 
         bench_cfg, run_cfg = self._make_cfg(
-            [rv], method="adaptive", threshold=3.5, regression_percentage=40.0
+            [rv], method="adaptive", regression_mad=3.5, regression_percentage=40.0
         )
         with_pct = detect_regressions(ds, bench_cfg, run_cfg)
         assert not with_pct.has_regressions
@@ -499,7 +504,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", regression_mad=3.5)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "drift" in report.results[0].details
@@ -532,7 +537,7 @@ class TestDetectRegressions:
         rv_a.name = "metric_a"
         rv_b = ResultFloat(units="s", direction=OptDir.minimize)
         rv_b.name = "metric_b"
-        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 2
         assert report.has_regressions
@@ -548,7 +553,7 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="bogus", threshold=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="bogus", regression_percentage=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert report.results[0].method == "percentage"
@@ -587,11 +592,11 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
 
-        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", threshold=5.0)
+        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
         report_strict = detect_regressions(ds, bench_cfg_strict, run_cfg_strict)
         assert report_strict.has_regressions
 
-        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", threshold=15.0)
+        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", regression_percentage=15.0)
         report_loose = detect_regressions(ds, bench_cfg_loose, run_cfg_loose)
         assert not report_loose.has_regressions
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -13,7 +13,6 @@ from bencher.regression import (
     RegressionResult,
     build_regression_overlay,
     detect_adaptive,
-    detect_iqr,
     detect_percentage,
     detect_regressions,
     render_regression_png,
@@ -100,44 +99,6 @@ class TestDetectPercentage:
             "x", hist, curr, threshold_percent=5.0, direction=OptDir.minimize
         )
         assert not result.regressed
-
-
-# ── detect_iqr ─────────────────────────────────────────────────────────────
-
-
-class TestDetectIqr:
-    def test_within_bounds(self):
-        time_means = np.array([100.0, 101.0, 99.0, 100.5, 98.5])
-        curr = np.array([101.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_outlier_above_minimize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([20.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_outlier_below_maximize(self):
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_improvement_not_regression_minimize(self):
-        """For minimize, an outlier below bounds is an improvement, not a regression."""
-        time_means = np.array([10.0, 10.1, 10.2, 10.0, 9.9])
-        curr = np.array([1.0])  # well below — improvement for minimize
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_fallback_with_few_points(self):
-        """With <4 historical time points, should fall back to percentage."""
-        time_means = np.array([100.0, 101.0])
-        curr = np.array([200.0])
-        result = detect_iqr("x", time_means, curr, iqr_scale=1.5, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back
-        assert result.regressed
 
 
 # ── detect_adaptive ────────────────────────────────────────────────────────
@@ -266,44 +227,52 @@ class TestDetectAdaptive:
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
-    # ---- dual-band (percent_floor) ----
+    # ---- dual-band (regression_percentage) ----
 
-    def test_percent_floor_suppresses_mad_only_fire(self):
-        """Tight MAD-derived noise flagged a small change; percent floor blocks it."""
+    def test_regression_percentage_suppresses_mad_only_fire(self):
+        """Tight MAD-derived noise flagged a small change; percentage gate blocks it."""
         hist = np.array([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
         # 20% change at 10 sigma — MAD would normally fire.
         curr = np.array([12.0])
-        without_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert without_floor.regressed
-        with_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=30.0)
-        assert not with_floor.regressed
-        assert with_floor.percent_band_lower is not None
-        assert with_floor.percent_band_upper is not None
+        without_pct = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert without_pct.regressed
+        with_pct = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=30.0
+        )
+        assert not with_pct.regressed
+        assert with_pct.percent_band_lower is not None
+        assert with_pct.percent_band_upper is not None
 
-    def test_percent_floor_allows_real_regression(self):
+    def test_regression_percentage_allows_real_regression(self):
         """When both MAD and percent thresholds are exceeded, still fires."""
         hist = 100.0 + np.random.default_rng(0).normal(0, 1.0, 20)
         curr = np.array([200.0])  # 100% change and huge z
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        result = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=10.0
+        )
         assert result.regressed
 
-    def test_percent_floor_none_preserves_behavior(self):
+    def test_regression_percentage_none_preserves_behavior(self):
         """Passing None is identical to leaving it unset (current behavior)."""
         rng = np.random.default_rng(0)
         hist = 100.0 + rng.normal(0, 15.0, 20)
         curr = 150.0 + rng.normal(0, 15.0, 10)
-        with_none = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=None)
+        with_none = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=None
+        )
         baseline = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert with_none.regressed == baseline.regressed
         assert with_none.percent_band_lower is None
 
-    def test_percent_floor_direction_aware_improvement(self):
+    def test_regression_percentage_direction_aware_improvement(self):
         """Percent gate respects optimization direction."""
         hist = np.array([10.0] * 20)
         # 20% decrease — for minimize this is improvement (never regression),
         # and the gate shouldn't change that.
         curr = np.array([8.0])
-        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        result = detect_adaptive(
+            "x", hist, curr, direction=OptDir.minimize, regression_percentage=10.0
+        )
         assert not result.regressed
 
     def test_sparse_fallback_uses_full_samples(self):
@@ -390,7 +359,7 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None, percent_floor=None):
+    def _make_cfg(result_vars, method="percentage", threshold=None, regression_percentage=None):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -398,12 +367,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold, percent_floor):
+            def __init__(self, method, threshold, regression_percentage):
                 self.regression_method = method
                 self.regression_threshold = threshold
-                self.regression_percent_floor = percent_floor
+                self.regression_percentage = regression_percentage
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, percent_floor)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, regression_percentage)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -467,26 +436,6 @@ class TestDetectRegressions:
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert not report.has_regressions
 
-    def test_iqr_method(self):
-        values = np.array(
-            [
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [10.0, 10.0],
-                [50.0, 50.0],
-            ]
-        )
-        ds = self._make_dataset(n_times=6, n_repeats=2, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="iqr", threshold=1.5)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
     def test_adaptive_method_no_false_positive_on_noisy_stable(self):
         """Adaptive must not trip on a noisy-but-stable signal (user's pain point)."""
         rng = np.random.default_rng(0)
@@ -516,9 +465,9 @@ class TestDetectRegressions:
         assert report.has_regressions
         assert "step" in report.results[0].details
 
-    def test_adaptive_percent_floor_suppresses_single_repeat_fire(self):
+    def test_adaptive_regression_percentage_suppresses_single_repeat_fire(self):
         """Single-repeat variable with stable history + modest drop is suppressed
-        when a percent floor is set, but would otherwise fire on MAD alone."""
+        when a regression percentage is set, but would otherwise fire on MAD alone."""
         # Tight history at 10 with one earlier dip; current=7 (-30%).
         values = np.array([[10.0], [10.0], [6.0], [10.0], [10.0], [7.0]])
         ds = self._make_dataset(n_times=6, n_repeats=1, values=values)
@@ -528,15 +477,15 @@ class TestDetectRegressions:
         rv.name = "metric"
 
         bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
-        without_floor = detect_regressions(ds, bench_cfg, run_cfg)
-        assert without_floor.has_regressions
+        without_pct = detect_regressions(ds, bench_cfg, run_cfg)
+        assert without_pct.has_regressions
 
         bench_cfg, run_cfg = self._make_cfg(
-            [rv], method="adaptive", threshold=3.5, percent_floor=40.0
+            [rv], method="adaptive", threshold=3.5, regression_percentage=40.0
         )
-        with_floor = detect_regressions(ds, bench_cfg, run_cfg)
-        assert not with_floor.has_regressions
-        assert with_floor.results[0].percent_band_lower is not None
+        with_pct = detect_regressions(ds, bench_cfg, run_cfg)
+        assert not with_pct.has_regressions
+        assert with_pct.results[0].percent_band_lower is not None
 
     def test_adaptive_method_detects_gradual_drift(self):
         """Adaptive fires on slow drift where no single step exceeds percentage."""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -537,7 +537,9 @@ class TestDetectRegressions:
         rv_a.name = "metric_a"
         rv_b = ResultFloat(units="s", direction=OptDir.minimize)
         rv_b.name = "metric_b"
-        bench_cfg, run_cfg = self._make_cfg([rv_a, rv_b], method="percentage", regression_percentage=5.0)
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv_a, rv_b], method="percentage", regression_percentage=5.0
+        )
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 2
         assert report.has_regressions
@@ -592,11 +594,15 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
 
-        bench_cfg_strict, run_cfg_strict = self._make_cfg([rv], method="percentage", regression_percentage=5.0)
+        bench_cfg_strict, run_cfg_strict = self._make_cfg(
+            [rv], method="percentage", regression_percentage=5.0
+        )
         report_strict = detect_regressions(ds, bench_cfg_strict, run_cfg_strict)
         assert report_strict.has_regressions
 
-        bench_cfg_loose, run_cfg_loose = self._make_cfg([rv], method="percentage", regression_percentage=15.0)
+        bench_cfg_loose, run_cfg_loose = self._make_cfg(
+            [rv], method="percentage", regression_percentage=15.0
+        )
         report_loose = detect_regressions(ds, bench_cfg_loose, run_cfg_loose)
         assert not report_loose.has_regressions
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -308,6 +308,46 @@ class TestDetectAdaptive:
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
         assert not result.regressed
 
+    # ---- dual-band (percent_floor) ----
+
+    def test_percent_floor_suppresses_mad_only_fire(self):
+        """Tight MAD-derived noise flagged a small change; percent floor blocks it."""
+        hist = np.array([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0])
+        # 20% change at 10 sigma — MAD would normally fire.
+        curr = np.array([12.0])
+        without_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert without_floor.regressed
+        with_floor = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=30.0)
+        assert not with_floor.regressed
+        assert with_floor.percent_band_lower is not None
+        assert with_floor.percent_band_upper is not None
+
+    def test_percent_floor_allows_real_regression(self):
+        """When both MAD and percent thresholds are exceeded, still fires."""
+        hist = 100.0 + np.random.default_rng(0).normal(0, 1.0, 20)
+        curr = np.array([200.0])  # 100% change and huge z
+        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        assert result.regressed
+
+    def test_percent_floor_none_preserves_behavior(self):
+        """Passing None is identical to leaving it unset (current behavior)."""
+        rng = np.random.default_rng(0)
+        hist = 100.0 + rng.normal(0, 15.0, 20)
+        curr = 150.0 + rng.normal(0, 15.0, 10)
+        with_none = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=None)
+        baseline = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
+        assert with_none.regressed == baseline.regressed
+        assert with_none.percent_band_lower is None
+
+    def test_percent_floor_direction_aware_improvement(self):
+        """Percent gate respects optimization direction."""
+        hist = np.array([10.0] * 20)
+        # 20% decrease — for minimize this is improvement (never regression),
+        # and the gate shouldn't change that.
+        curr = np.array([8.0])
+        result = detect_adaptive("x", hist, curr, direction=OptDir.minimize, percent_floor=10.0)
+        assert not result.regressed
+
     def test_sparse_fallback_uses_full_samples(self):
         """Fallback must honour `historical_samples` so it sees all raw values.
 
@@ -392,7 +432,7 @@ class TestDetectRegressions:
         return ds
 
     @staticmethod
-    def _make_cfg(result_vars, method="percentage", threshold=None):
+    def _make_cfg(result_vars, method="percentage", threshold=None, percent_floor=None):
         """Create minimal bench_cfg and run_cfg mocks."""
 
         class FakeBenchCfg:
@@ -400,11 +440,12 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, threshold):
+            def __init__(self, method, threshold, percent_floor):
                 self.regression_method = method
                 self.regression_threshold = threshold
+                self.regression_percent_floor = percent_floor
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold)
+        return FakeBenchCfg(result_vars), FakeRunCfg(method, threshold, percent_floor)
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -530,6 +571,28 @@ class TestDetectRegressions:
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
         assert "step" in report.results[0].details
+
+    def test_adaptive_percent_floor_suppresses_single_repeat_fire(self):
+        """Single-repeat variable with stable history + modest drop is suppressed
+        when a percent floor is set, but would otherwise fire on MAD alone."""
+        # Tight history at 10 with one earlier dip; current=7 (-30%).
+        values = np.array([[10.0], [10.0], [6.0], [10.0], [10.0], [7.0]])
+        ds = self._make_dataset(n_times=6, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.maximize)
+        rv.name = "metric"
+
+        bench_cfg, run_cfg = self._make_cfg([rv], method="adaptive", threshold=3.5)
+        without_floor = detect_regressions(ds, bench_cfg, run_cfg)
+        assert without_floor.has_regressions
+
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv], method="adaptive", threshold=3.5, percent_floor=40.0
+        )
+        with_floor = detect_regressions(ds, bench_cfg, run_cfg)
+        assert not with_floor.has_regressions
+        assert with_floor.results[0].percent_band_lower is not None
 
     def test_adaptive_method_detects_gradual_drift(self):
         """Adaptive fires on slow drift where no single step exceeds percentage."""

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -16,7 +16,6 @@ from bencher.regression import (
     detect_iqr,
     detect_percentage,
     detect_regressions,
-    detect_ttest,
     render_regression_png,
 )
 from bencher.variables.results import OptDir
@@ -141,47 +140,6 @@ class TestDetectIqr:
         assert result.regressed
 
 
-# ── detect_ttest ───────────────────────────────────────────────────────────
-
-
-class TestDetectTtest:
-    def test_no_significant_difference(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(100, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert not result.regressed
-
-    def test_significant_increase_minimize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.regressed
-
-    def test_significant_decrease_maximize(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(90, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.maximize)
-        assert result.regressed
-
-    def test_fallback_single_sample(self):
-        hist = np.array([100.0])
-        curr = np.array([200.0])
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.minimize)
-        assert result.method == "percentage"  # fell back to percentage-based check
-        assert result.regressed  # still correctly detected as regression
-        assert result.change_percent > 0.0  # percentage change indicates degradation for minimize
-
-    def test_direction_none_two_sided(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, 30)
-        curr = rng.normal(110, 1, 30)
-        result = detect_ttest("x", hist, curr, alpha=0.05, direction=OptDir.none)
-        assert result.regressed
-
-
 # ── detect_adaptive ────────────────────────────────────────────────────────
 
 
@@ -285,7 +243,7 @@ class TestDetectAdaptive:
         hist = np.array([100.0, 101.0, 99.0])
         curr = np.array([100.0, 102.0])
         result = detect_adaptive("x", hist, curr, direction=OptDir.minimize)
-        assert result.method in ("ttest", "percentage")
+        assert result.method == "percentage"
 
     def test_sparse_history_single_current_falls_back(self):
         hist = np.array([100.0, 200.0])
@@ -351,9 +309,10 @@ class TestDetectAdaptive:
     def test_sparse_fallback_uses_full_samples(self):
         """Fallback must honour `historical_samples` so it sees all raw values.
 
-        With 3 time points but many samples per point, ttest has enough data
-        to be statistically meaningful — whereas passing only per-time means
-        would leave ttest with just 3 points.
+        With 3 time points but many samples per point, the sparse-history
+        fallback should still detect a clear regression via the percentage
+        check — passing only per-time means would leave it blind to the
+        per-sample variance.
         """
         rng = self._rng()
         hist_time_means = np.array([100.0, 100.0, 100.0])
@@ -366,8 +325,7 @@ class TestDetectAdaptive:
             direction=OptDir.minimize,
             historical_samples=hist_samples,
         )
-        # Must fall back to ttest since we have plenty of samples.
-        assert result.method == "ttest"
+        assert result.method == "percentage"
         assert result.regressed
 
 
@@ -526,20 +484,6 @@ class TestDetectRegressions:
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
         bench_cfg, run_cfg = self._make_cfg([rv], method="iqr", threshold=1.5)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert report.has_regressions
-
-    def test_ttest_method(self):
-        rng = np.random.RandomState(42)
-        hist = rng.normal(100, 1, (5, 10))
-        curr = rng.normal(200, 1, (1, 10))
-        values = np.vstack([hist, curr])
-        ds = self._make_dataset(n_times=6, n_repeats=10, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="ttest", threshold=0.05)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.has_regressions
 


### PR DESCRIPTION
## Summary

Supersedes #918 and #917 (will close both) — combines the regression detection work from those PRs with a rewrite of the diagnostic plot pipeline.

### Detection
- Adaptive MAD-sigma detector with step + drift tests, drift-detrended residual noise, Mann–Kendall trend guard, Hampel outlier filter
- Optional percentage acceptance band that AND-gates the MAD verdict (dual-band)
- `regression_percent_floor` / `regression_percentage` API; IQR and Welch's t-test methods dropped
- `detect_regressions` always aggregates non-time dims to a per-time scalar before detection (previously the percentage method saw the flat sample array and zigzagged through parameter-grid structure)

### Plot rendering
- Single overlay builder drives both the in-report bokeh plot and the PNG export (matplotlib backend via `hv.render` + `fig.savefig`) — no more parallel renderers to keep in sync
- History always shows mean line + raw alpha scatter; regression-specific layers (acceptance band, baseline, verdict-coloured current marker/connector, title) are conditional
- Scatter fallback so the alpha cloud renders even on categorical x-axes (git_time_event strings) and when `detect_*` is called directly without `detect_regressions`
- Compact fonts, wider figure, plot hook stretches axes to fill `fig_inches`, matplotlib xtick-label hook so string time events actually appear (holoviews' matplotlib backend ignores the `(pos, label)` tuple form)
- Legend + title rebuilt via proxy handles in a plot hook — holoviews silently drops Element `label=` on Area/Curve for matplotlib, so the legend was missing most entries
- Acceptance band is always green (valid region); verdict colouring lives on the current marker, connector, and title
- MAD band = `#2ca02c`, percentage band = `#6baed6` — distinct hues that survive alpha blending

### Known holoviews quirks worked around
- `.opts(hv.opts.Area(backend='matplotlib', color=...))` is silently dropped (Curve/Scatter honour it, Area does not) → facecolor applied via plot hook
- `xticks=[(pos, label), ...]` tuple form is bokeh-specific → labels re-applied via matplotlib hook
- `hv.renderer('matplotlib').save` aggressively tightens the bbox and collapses the figure ~square → switched to `hv.render` + `fig.savefig`
- Mixing bare opts with explicit-type opt blocks raises → every element style is wrapped in `hv.opts.<Type>(backend=...)`

### Examples regenerated
- `example_regression_tuning_{step,drift,noise}.py` — 2D `n_times × n_repeats` samples with git_time_event-style string labels
- `example_regression_percentage.py` — drops manual `regression_method="percentage"` override, uses default (adaptive)

## Test plan
- [x] `pixi run pytest test/test_regression.py` — 60 passed
- [x] Rendered each tuning example + percentage example PNG, verified band colours, legend, axes, string time labels
- [ ] Sourcery review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify regression detection configuration around adaptive MAD and percentage thresholds while overhauling the regression diagnostic plotting to share a single holoviews-based overlay for both bokeh and matplotlib backends.

New Features:
- Introduce dual-band regression detection by combining MAD-based and percentage-based acceptance bands via regression_mad and regression_percentage settings.
- Add per-sample historical scatter support and categorical time-axis handling so regression plots can show full sample distributions over time across both backends.

Bug Fixes:
- Ensure acceptance bands are consistently coloured as valid regions and that legends, titles, and string x-axis labels render correctly in the matplotlib output.

Enhancements:
- Simplify regression methods by removing IQR and t-test options, standardising on adaptive MAD and percentage detectors with sensible defaults.
- Aggregate non-time dimensions to per-time means before regression detection to provide more intuitive behaviour on multi-parameter grids.
- Refactor regression plotting to build a backend-agnostic holoviews overlay with backend-specific styling and hooks, then reuse it for PNG export via matplotlib.
- Improve adaptive detector behaviour on sparse and noisy histories, including explicit percentage-based fallback and direction-aware percent change gating.

Build:
- Bump project version to 1.88.0 to reflect the new regression detection and plotting capabilities.

Documentation:
- Refresh generated regression tuning and percentage examples to showcase the new adaptive configuration, dual-band tuning, and improved plots with string time labels.

Tests:
- Update and expand regression tests to cover dual-band behaviour, sparse-history fallbacks, and the revised configuration API while removing tests for dropped methods.