### PR TITLE
Add regression_delta and regression_absolute additive guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.89.0] - 2026-04-21
+
+### Added
+- `BenchRunCfg.regression_delta` and `BenchRunCfg.regression_absolute`: two optional additive regression guards that run alongside whichever `regression_method` is active.
+  - `regression_delta` caps the absolute-unit change of the current run's mean vs the mean of all historical per-time means, respecting the result variable's `OptDir`. Useful when a percent threshold obscures sensitivity at tiny baselines or when CI wants a flat unit ceiling on drift.
+  - `regression_absolute` enforces a hard directional threshold (ceiling for `OptDir.minimize`, floor for `OptDir.maximize`) against the current run's mean. No history required — fires on the very first recording.
+- `detect_delta()` and `detect_absolute()` public detectors in `bencher.regression`, mirroring the `detect_percentage` / `detect_adaptive` shape so they participate in the shared plot/report pipeline.
+- `detect_regressions()` now runs with a single `over_time` point when `regression_absolute` is set, so contractual limits can gate even the initial benchmark run.
+- Gallery examples `example_regression_delta` and `example_regression_absolute` demonstrating the new guards.
+
 ## [1.87.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.89.0] - 2026-04-21
 
 ### Added
-- `BenchRunCfg.regression_delta` and `BenchRunCfg.regression_absolute`: two optional additive regression guards that run alongside whichever `regression_method` is active.
-  - `regression_delta` caps the absolute-unit change of the current run's mean vs the mean of all historical per-time means, respecting the result variable's `OptDir`. Useful when a percent threshold obscures sensitivity at tiny baselines or when CI wants a flat unit ceiling on drift.
-  - `regression_absolute` enforces a hard directional threshold (ceiling for `OptDir.minimize`, floor for `OptDir.maximize`) against the current run's mean. No history required — fires on the very first recording.
+- Two new values for `BenchRunCfg.regression_method`: `"delta"` and `"absolute"`. Each selects a dedicated detector and its threshold comes from a new `BenchRunCfg` field:
+  - `"delta"` uses `regression_delta`: largest acceptable absolute-unit change of the current run's mean from the mean of all historical per-time means, respecting the result variable's `OptDir`. Useful when a percent threshold obscures sensitivity at tiny baselines or when CI wants a flat unit ceiling on drift.
+  - `"absolute"` uses `regression_absolute`: hard directional threshold (ceiling for `OptDir.minimize`, floor for `OptDir.maximize`) against the current run's mean. No history required — fires on the very first recording.
 - `detect_delta()` and `detect_absolute()` public detectors in `bencher.regression`, mirroring the `detect_percentage` / `detect_adaptive` shape so they participate in the shared plot/report pipeline.
-- `detect_regressions()` now runs with a single `over_time` point when `regression_absolute` is set, so contractual limits can gate even the initial benchmark run.
-- Gallery examples `example_regression_delta` and `example_regression_absolute` demonstrating the new guards.
+- `detect_regressions()` now runs with a single `over_time` point when `regression_method="absolute"`, so contractual limits can gate even the initial benchmark run.
+- Gallery examples `example_regression_delta` and `example_regression_absolute` demonstrating the new methods.
+
+### Changed
+- Regression diagnostic plot: when the adaptive detector produces both a MAD band and a percent band, they are now merged into a single combined acceptance band (the union of both — matching the adaptive gate, which flags a regression only when both tests fail). Previously the plot layered two separately-coloured bands.
 
 ## [1.87.0] - 2026-04-19
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -352,9 +352,12 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     regression_method: str = param.Selector(
         default="adaptive",
-        objects=["percentage", "adaptive"],
-        doc="Detection method: 'percentage' (mean comparison) or "
-        "'adaptive' (robust MAD-based step + drift test for noisy metrics).",
+        objects=["percentage", "adaptive", "delta", "absolute"],
+        doc="Detection method. 'percentage': mean comparison vs historical mean. "
+        "'adaptive': robust MAD-based step + drift test for noisy metrics. "
+        "'delta': absolute-unit change vs historical mean (uses regression_delta). "
+        "'absolute': hard directional threshold, no history required (uses "
+        "regression_absolute).",
     )
 
     regression_mad: float = param.Number(
@@ -378,20 +381,21 @@ class BenchRunCfg(BenchPlotSrvCfg):
     regression_delta: float = param.Number(
         default=None,
         allow_None=True,
-        doc="Largest acceptable absolute-unit delta of the current run's mean "
-        "from the mean of all historical per-time means, respecting the result "
-        "variable's OptDir (minimize: curr - hist must not exceed; maximize: "
-        "hist - curr must not exceed). Runs in addition to regression_method. "
-        "None disables this check.",
+        doc="Threshold for regression_method='delta'. Largest acceptable "
+        "absolute-unit delta of the current run's mean from the mean of all "
+        "historical per-time means, respecting the result variable's OptDir "
+        "(minimize: curr - hist must not exceed; maximize: hist - curr must "
+        "not exceed). Ignored when regression_method is not 'delta'.",
     )
 
     regression_absolute: float = param.Number(
         default=None,
         allow_None=True,
-        doc="Hard absolute threshold that the current run's mean must not "
-        "violate in the direction of the result variable's OptDir (minimize: "
-        "ceiling; maximize: floor). No history required. Runs in addition to "
-        "regression_method. None disables this check.",
+        doc="Threshold for regression_method='absolute'. Hard directional limit "
+        "the current run's mean must not violate in the direction of the result "
+        "variable's OptDir (minimize: ceiling; maximize: floor). No history "
+        "required — fires on the first recording. Ignored when regression_method "
+        "is not 'absolute'.",
     )
 
     regression_fail: bool = param.Boolean(

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -375,6 +375,25 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "collapse to zero.",
     )
 
+    regression_delta: float = param.Number(
+        default=None,
+        allow_None=True,
+        doc="Largest acceptable absolute-unit delta of the current run's mean "
+        "from the mean of all historical per-time means, respecting the result "
+        "variable's OptDir (minimize: curr - hist must not exceed; maximize: "
+        "hist - curr must not exceed). Runs in addition to regression_method. "
+        "None disables this check.",
+    )
+
+    regression_absolute: float = param.Number(
+        default=None,
+        allow_None=True,
+        doc="Hard absolute threshold that the current run's mean must not "
+        "violate in the direction of the result variable's OptDir (minimize: "
+        "ceiling; maximize: floor). No history required. Runs in addition to "
+        "regression_method. None disables this check.",
+    )
+
     regression_fail: bool = param.Boolean(
         False,
         doc="If True, raise RegressionError when a regression is detected. "

--- a/bencher/example/generated/regression/example_regression_absolute.py
+++ b/bencher/example/generated/regression/example_regression_absolute.py
@@ -24,6 +24,7 @@ def example_regression_absolute(run_cfg: bn.BenchRunCfg | None = None) -> bn.Ben
     """Regression detection — hard absolute ceiling."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.regression_detection = True
+    run_cfg.regression_method = "absolute"
     # SLA: response_time must stay below 25 ms no matter what history says.
     run_cfg.regression_absolute = 25.0
     run_cfg.regression_fail = False

--- a/bencher/example/generated/regression/example_regression_absolute.py
+++ b/bencher/example/generated/regression/example_regression_absolute.py
@@ -1,0 +1,56 @@
+"""Auto-generated example: Regression detection — hard absolute ceiling."""
+
+from datetime import datetime, timedelta
+
+import bencher as bn
+
+
+class SlaBenchmark(bn.ParametrizedSweep):
+    """SLA benchmark with a hard response-time ceiling."""
+
+    connections = bn.FloatSweep(default=50, bounds=[10, 200], doc="Concurrent clients")
+    payload_kb = bn.FloatSweep(default=64, bounds=[1, 256], doc="Request payload size in KB")
+
+    response_time = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
+        self.response_time = base_rt * (1.0 + self._time_offset)
+
+
+def example_regression_absolute(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Regression detection — hard absolute ceiling."""
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
+    run_cfg.regression_detection = True
+    # SLA: response_time must stay below 25 ms no matter what history says.
+    run_cfg.regression_absolute = 25.0
+    run_cfg.regression_fail = False
+
+    benchable = SlaBenchmark()
+    bench = benchable.to_bench(run_cfg)
+
+    # Each successive release scales response time up until the SLA ceiling is breached.
+    releases = [0.0, 0.05, 0.1, 0.2, 0.4, 0.8, 1.5]
+
+    base_time = datetime(2024, 1, 1)
+    for i, offset in enumerate(releases):
+        benchable._time_offset = offset
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        run_cfg.auto_plot = i == len(releases) - 1
+        bench.plot_sweep(
+            "regression_absolute",
+            input_vars=["connections", "payload_kb"],
+            result_vars=["response_time"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+            aggregate=True,
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_regression_absolute, over_time=True)

--- a/bencher/example/generated/regression/example_regression_delta.py
+++ b/bencher/example/generated/regression/example_regression_delta.py
@@ -26,10 +26,8 @@ def example_regression_delta(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Regression detection — absolute delta guard."""
     run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
     run_cfg.regression_detection = True
-    # Loose percentage threshold to show it stays quiet, while the delta guard
-    # fires on the additive ms step.
-    run_cfg.regression_percentage = 20.0
-    run_cfg.regression_delta = 2.0  # ms
+    run_cfg.regression_method = "delta"
+    run_cfg.regression_delta = 2.0  # ms — max acceptable change vs historical mean
     run_cfg.regression_fail = False
 
     benchable = LatencyBenchmark()

--- a/bencher/example/generated/regression/example_regression_delta.py
+++ b/bencher/example/generated/regression/example_regression_delta.py
@@ -1,0 +1,60 @@
+"""Auto-generated example: Regression detection — absolute delta guard."""
+
+from datetime import datetime, timedelta
+
+import bencher as bn
+
+
+class LatencyBenchmark(bn.ParametrizedSweep):
+    """Latency benchmark with a small absolute step the delta guard catches."""
+
+    connections = bn.FloatSweep(default=50, bounds=[10, 200], doc="Concurrent clients")
+    payload_kb = bn.FloatSweep(default=64, bounds=[1, 256], doc="Request payload size in KB")
+
+    response_time = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
+        # Additive ms step per release — percent change stays tiny at high
+        # baselines, but the absolute delta exceeds the guard.
+        self.response_time = base_rt + self._time_offset
+
+
+def example_regression_delta(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Regression detection — absolute delta guard."""
+    run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
+    run_cfg.regression_detection = True
+    # Loose percentage threshold to show it stays quiet, while the delta guard
+    # fires on the additive ms step.
+    run_cfg.regression_percentage = 20.0
+    run_cfg.regression_delta = 2.0  # ms
+    run_cfg.regression_fail = False
+
+    benchable = LatencyBenchmark()
+    bench = benchable.to_bench(run_cfg)
+
+    # Stable baseline, then a +3 ms absolute step that's under 20% but over 2 ms.
+    releases = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0]
+
+    base_time = datetime(2024, 1, 1)
+    for i, offset in enumerate(releases):
+        benchable._time_offset = offset
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        run_cfg.auto_plot = i == len(releases) - 1
+        bench.plot_sweep(
+            "regression_delta",
+            input_vars=["connections", "payload_kb"],
+            result_vars=["response_time"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+            aggregate=True,
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_regression_delta, over_time=True)

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -348,10 +348,8 @@ class LatencyBenchmark(bn.ParametrizedSweep):
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True
-# Loose percentage threshold to show it stays quiet, while the delta guard
-# fires on the additive ms step.
-run_cfg.regression_percentage = 20.0
-run_cfg.regression_delta = 2.0  # ms
+run_cfg.regression_method = "delta"
+run_cfg.regression_delta = 2.0  # ms — max acceptable change vs historical mean
 run_cfg.regression_fail = False
 
 benchable = LatencyBenchmark()
@@ -407,6 +405,7 @@ class SlaBenchmark(bn.ParametrizedSweep):
         body = """\
 run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
 run_cfg.regression_detection = True
+run_cfg.regression_method = "absolute"
 # SLA: response_time must stay below 25 ms no matter what history says.
 run_cfg.regression_absolute = 25.0
 run_cfg.regression_fail = False

--- a/bencher/example/meta/generate_meta_regression.py
+++ b/bencher/example/meta/generate_meta_regression.py
@@ -241,6 +241,8 @@ class AdaptiveNoiseRobustness(bn.ParametrizedSweep):
 
 REGRESSION_EXAMPLES = [
     "regression_percentage",
+    "regression_delta",
+    "regression_absolute",
     *[f"regression_{tuning}" for tuning in _TUNING],
 ]
 
@@ -253,6 +255,12 @@ class MetaRegression(MetaGeneratorBase):
     def benchmark(self):
         if self.example == "regression_percentage":
             self._generate_percentage_over_time()
+            return
+        if self.example == "regression_delta":
+            self._generate_delta_over_time()
+            return
+        if self.example == "regression_absolute":
+            self._generate_absolute_over_time()
             return
 
         for tuning, spec in _TUNING.items():
@@ -311,6 +319,124 @@ for i, offset in enumerate(releases):
             output_dir=OUTPUT_DIR,
             filename="example_regression_percentage",
             function_name="example_regression_percentage",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"over_time": True},
+        )
+
+    def _generate_delta_over_time(self):
+        """Over_time example where the delta guard fires on an absolute-unit change
+        the percentage method would tolerate."""
+        imports = "from datetime import datetime, timedelta\n\nimport bencher as bn"
+        class_code = '''\
+class LatencyBenchmark(bn.ParametrizedSweep):
+    """Latency benchmark with a small absolute step the delta guard catches."""
+
+    connections = bn.FloatSweep(default=50, bounds=[10, 200], doc="Concurrent clients")
+    payload_kb = bn.FloatSweep(default=64, bounds=[1, 256], doc="Request payload size in KB")
+
+    response_time = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
+        # Additive ms step per release — percent change stays tiny at high
+        # baselines, but the absolute delta exceeds the guard.
+        self.response_time = base_rt + self._time_offset'''
+        body = """\
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
+run_cfg.regression_detection = True
+# Loose percentage threshold to show it stays quiet, while the delta guard
+# fires on the additive ms step.
+run_cfg.regression_percentage = 20.0
+run_cfg.regression_delta = 2.0  # ms
+run_cfg.regression_fail = False
+
+benchable = LatencyBenchmark()
+bench = benchable.to_bench(run_cfg)
+
+# Stable baseline, then a +3 ms absolute step that's under 20% but over 2 ms.
+releases = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0]
+
+base_time = datetime(2024, 1, 1)
+for i, offset in enumerate(releases):
+    benchable._time_offset = offset
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    run_cfg.auto_plot = i == len(releases) - 1
+    bench.plot_sweep(
+        "regression_delta",
+        input_vars=["connections", "payload_kb"],
+        result_vars=["response_time"],
+        run_cfg=run_cfg,
+        time_src=base_time + timedelta(seconds=i),
+        aggregate=True,
+    )
+"""
+        self.generate_example(
+            title="Regression detection — absolute delta guard",
+            output_dir=OUTPUT_DIR,
+            filename="example_regression_delta",
+            function_name="example_regression_delta",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"over_time": True},
+        )
+
+    def _generate_absolute_over_time(self):
+        """Over_time example where the absolute guard enforces a hard ceiling
+        regardless of history."""
+        imports = "from datetime import datetime, timedelta\n\nimport bencher as bn"
+        class_code = '''\
+class SlaBenchmark(bn.ParametrizedSweep):
+    """SLA benchmark with a hard response-time ceiling."""
+
+    connections = bn.FloatSweep(default=50, bounds=[10, 200], doc="Concurrent clients")
+    payload_kb = bn.FloatSweep(default=64, bounds=[1, 256], doc="Request payload size in KB")
+
+    response_time = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+
+    _time_offset = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        base_rt = 5.0 + 0.15 * self.connections + 0.08 * self.payload_kb
+        self.response_time = base_rt * (1.0 + self._time_offset)'''
+        body = """\
+run_cfg = bn.BenchRunCfg.with_defaults(run_cfg, repeats=2)
+run_cfg.regression_detection = True
+# SLA: response_time must stay below 25 ms no matter what history says.
+run_cfg.regression_absolute = 25.0
+run_cfg.regression_fail = False
+
+benchable = SlaBenchmark()
+bench = benchable.to_bench(run_cfg)
+
+# Each successive release scales response time up until the SLA ceiling is breached.
+releases = [0.0, 0.05, 0.1, 0.2, 0.4, 0.8, 1.5]
+
+base_time = datetime(2024, 1, 1)
+for i, offset in enumerate(releases):
+    benchable._time_offset = offset
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    run_cfg.auto_plot = i == len(releases) - 1
+    bench.plot_sweep(
+        "regression_absolute",
+        input_vars=["connections", "payload_kb"],
+        result_vars=["response_time"],
+        run_cfg=run_cfg,
+        time_src=base_time + timedelta(seconds=i),
+        aggregate=True,
+    )
+"""
+        self.generate_example(
+            title="Regression detection — hard absolute ceiling",
+            output_dir=OUTPUT_DIR,
+            filename="example_regression_absolute",
+            function_name="example_regression_absolute",
             imports=imports,
             body=body,
             class_code=class_code,

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -239,7 +239,16 @@ def _regression_plot_spec(
         x_current = 0
 
     verdict_color = "#d62728" if result.regressed else "#2ca02c"
-    verdict_label = "REGRESSED" if result.regressed else "OK"
+    if result.regressed:
+        # For adaptive, surface which sub-test triggered so drift-only
+        # regressions (where the current value may sit inside the step-test
+        # band) aren't visually confusing.
+        fired = ""
+        if "fired=" in result.details:
+            fired = result.details.split("fired=")[1].split(",")[0]
+        verdict_label = f"REGRESSED ({fired})" if fired else "REGRESSED"
+    else:
+        verdict_label = "OK"
 
     change_str = (
         f"{result.change_percent:+.1f}%"

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -279,19 +279,20 @@ def _regression_plot_spec(
 
     # Shared declarative band layers — both matplotlib and holoviews iterate
     # this list so the two backends render the same thing by construction.
-    # Each entry is (lo, hi, color, alpha, label). The acceptance band always
-    # shades green: it represents the *valid* region, not the pass/fail
-    # verdict (verdict colouring lives on the current marker + connector).
+    # Each entry is (lo, hi, color, alpha, label). The acceptance band shades
+    # green: it represents the *valid* region, not the pass/fail verdict
+    # (verdict colouring lives on the current marker + connector).
+    #
+    # When the detector produces two bands (adaptive's dual-band gate: MAD and
+    # percent), a value is acceptable iff it lies inside EITHER band, so the
+    # combined acceptance region is the union — [min(lows), max(highs)]. A
+    # single merged band keeps the plot readable.
     valid_color = "#2ca02c"
-    # Light blue for the secondary (percentage) band — clearly distinct from
-    # the green MAD band after alpha blending, and distinct from the darker
-    # blue (#1f77b4) used for the history line so it doesn't read as part of
-    # the data series.
-    valid_color_light = "#6baed6"
     band_layers: list[tuple[float, float, str, float, str]] = []
     if mad_band is not None and pct_band is not None:
-        band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "MAD band"))
-        band_layers.append((pct_band[0], pct_band[1], valid_color_light, 0.15, "percentage band"))
+        combined_lo = min(mad_band[0], pct_band[0])
+        combined_hi = max(mad_band[1], pct_band[1])
+        band_layers.append((combined_lo, combined_hi, valid_color, 0.15, "acceptance band"))
     elif mad_band is not None:
         band_layers.append((mad_band[0], mad_band[1], valid_color, 0.15, "acceptance band"))
     elif pct_band is not None:
@@ -1002,8 +1003,7 @@ def detect_delta(
     ``hist_mean - curr > max_delta``; ``none`` uses the absolute delta and fails
     on either side. Baseline is the mean of all historical per-time means, so
     this compares the current scalar against a flat historical average in
-    absolute units (not percent). Intended as an additive guard alongside the
-    statistical methods.
+    absolute units (not percent). Selected via ``regression_method='delta'``.
     """
     hist_clean = _clean_1d(historical_time_means)
     hist_mean = float(np.nanmean(hist_clean)) if len(hist_clean) else float("nan")
@@ -1128,18 +1128,19 @@ def _attach_plot_metadata(
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
     """Run regression detection on a dataset with over_time dimension.
 
-    For each numeric result variable, splits the dataset at the last over_time
-    index, runs the configured statistical method (percentage/adaptive), and
-    layers the optional additive guards (regression_delta, regression_absolute)
-    on top. regression_absolute runs even with a single over_time point since
-    it needs no baseline.
+    For each numeric result variable, dispatches to the detector chosen by
+    ``run_cfg.regression_method`` (``percentage``, ``adaptive``, ``delta``, or
+    ``absolute``). ``absolute`` runs even with a single over_time point since
+    it needs no baseline; every other method requires history.
 
     Args:
         dataset: xarray Dataset with an over_time dimension.
         bench_cfg: BenchCfg with ``result_vars`` list.
-        run_cfg: BenchRunCfg. Reads ``regression_method``, ``regression_mad``,
-            ``regression_percentage``, ``regression_delta`` and
-            ``regression_absolute``.
+        run_cfg: BenchRunCfg. Reads ``regression_method`` and its
+            method-specific threshold: ``regression_percentage`` for
+            ``percentage``; ``regression_mad`` (plus ``regression_percentage``
+            as a dual-band gate) for ``adaptive``; ``regression_delta`` for
+            ``delta``; ``regression_absolute`` for ``absolute``.
 
     Returns:
         RegressionReport with one result per variable per fired detector/guard.
@@ -1149,21 +1150,34 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     if "over_time" not in dataset.dims:
         return report
 
+    method = run_cfg.regression_method
     n_times = dataset.sizes["over_time"]
-    regression_absolute = getattr(run_cfg, "regression_absolute", None)
-    regression_delta = getattr(run_cfg, "regression_delta", None)
 
-    # With no history, only the absolute guard has anything to compare against.
-    if n_times < 2 and regression_absolute is None:
+    # Only the 'absolute' method can run without history.
+    if n_times < 2 and method != "absolute":
         return report
 
-    method = run_cfg.regression_method
     regression_mad = getattr(run_cfg, "regression_mad", None)
     if regression_mad is None:
         regression_mad = _METHOD_DEFAULTS["adaptive"]
     regression_percentage = getattr(run_cfg, "regression_percentage", None)
     if regression_percentage is None:
         regression_percentage = _METHOD_DEFAULTS["percentage"]
+    regression_delta = getattr(run_cfg, "regression_delta", None)
+    regression_absolute = getattr(run_cfg, "regression_absolute", None)
+
+    # Method-specific thresholds without a value disable detection for that var.
+    if method == "delta" and regression_delta is None:
+        logging.warning(
+            "regression_method='delta' requires regression_delta to be set; skipping detection"
+        )
+        return report
+    if method == "absolute" and regression_absolute is None:
+        logging.warning(
+            "regression_method='absolute' requires regression_absolute to be set; "
+            "skipping detection"
+        )
+        return report
 
     time_coord = dataset["over_time"].values
 
@@ -1189,83 +1203,67 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         time_means_arr, hist_samples_flat, hist_x_flat = _compute_history_arrays(da)
         history_available = time_means_arr is not None and len(historical_clean) > 0
 
-        if history_available:
-            if method == "percentage":
-                result = detect_percentage(
-                    var_name,
-                    time_means_arr,
-                    current_mean_scalar,
-                    regression_percentage,
-                    direction,
-                )
-            elif method == "adaptive":
-                result = detect_adaptive(
-                    var_name,
-                    time_means_arr,
-                    current_mean_scalar,
-                    regression_mad=regression_mad,
-                    direction=direction,
-                    historical_samples=historical_clean,
-                    regression_percentage=regression_percentage,
-                )
-            else:
-                logging.warning(f"Unknown regression method '{method}', falling back to percentage")
-                result = detect_percentage(
-                    var_name,
-                    time_means_arr,
-                    current_mean_scalar,
-                    regression_percentage,
-                    direction,
-                )
-            _attach_plot_metadata(
-                result,
-                time_coord=time_coord,
-                current_samples=current_clean,
-                time_means=time_means_arr,
-                hist_samples_flat=hist_samples_flat,
-                hist_x_flat=hist_x_flat,
-            )
-            report.results.append(result)
+        # 'absolute' runs with or without history; every other method needs a baseline.
+        if method != "absolute" and not history_available:
+            continue
 
-        # Additive guards — run independently of the statistical method.
-        if regression_delta is not None and history_available:
-            delta_result = detect_delta(
+        if method == "percentage":
+            result = detect_percentage(
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
+            )
+        elif method == "adaptive":
+            result = detect_adaptive(
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_mad=regression_mad,
+                direction=direction,
+                historical_samples=historical_clean,
+                regression_percentage=regression_percentage,
+            )
+        elif method == "delta":
+            result = detect_delta(
                 var_name,
                 time_means_arr,
                 current_mean_scalar,
                 max_delta=regression_delta,
                 direction=direction,
             )
-            _attach_plot_metadata(
-                delta_result,
-                time_coord=time_coord,
-                current_samples=current_clean,
-                time_means=time_means_arr,
-                hist_samples_flat=hist_samples_flat,
-                hist_x_flat=hist_x_flat,
-            )
-            report.results.append(delta_result)
-
-        if regression_absolute is not None:
+        elif method == "absolute":
             if direction == OptDir.none:
                 logging.warning(
-                    f"regression_absolute skipped for '{var_name}': OptDir.none has no direction"
+                    f"regression_method='absolute' skipped for '{var_name}': "
+                    "OptDir.none has no direction"
                 )
-            else:
-                abs_result = detect_absolute(
-                    var_name,
-                    current_mean_scalar,
-                    limit=regression_absolute,
-                    direction=direction,
-                )
-                _attach_plot_metadata(
-                    abs_result,
-                    time_coord=time_coord,
-                    current_samples=current_clean,
-                    time_means=None,
-                    hist_samples_flat=None,
-                    hist_x_flat=None,
-                )
-                report.results.append(abs_result)
+                continue
+            result = detect_absolute(
+                var_name,
+                current_mean_scalar,
+                limit=regression_absolute,
+                direction=direction,
+            )
+        else:
+            logging.warning(f"Unknown regression method '{method}', falling back to percentage")
+            result = detect_percentage(
+                var_name,
+                time_means_arr,
+                current_mean_scalar,
+                regression_percentage,
+                direction,
+            )
+
+        _attach_plot_metadata(
+            result,
+            time_coord=time_coord,
+            current_samples=current_clean,
+            time_means=time_means_arr if method != "absolute" else None,
+            hist_samples_flat=hist_samples_flat if method != "absolute" else None,
+            hist_x_flat=hist_x_flat if method != "absolute" else None,
+        )
+        report.results.append(result)
 
     return report

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -1067,6 +1067,60 @@ def detect_absolute(
     )
 
 
+def _compute_history_arrays(
+    da: xr.DataArray,
+) -> tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None]:
+    """Aggregate history into per-time means + per-sample scatter arrays.
+
+    Returns ``(time_means, hist_samples_flat, hist_x_flat)`` or all-``None``
+    when there is no history to summarise. Per-time means collapse every
+    non-time dim into one scalar per run so detection and plotting both see
+    a 1-D series; the scatter arrays preserve per-repeat spread broadcast
+    against the historical over_time coords.
+    """
+    if da.sizes.get("over_time", 0) < 2:
+        return None, None, None
+
+    reduce_dims = [d for d in da.dims if d != "over_time"]
+    time_means = (
+        da.isel(over_time=slice(None, -1)).mean(dim=reduce_dims, skipna=True).values.astype(float)
+    )
+
+    hist_slice = da.isel(over_time=slice(None, -1))
+    if hist_slice.size == 0:
+        return time_means, None, None
+
+    hist_2d = np.moveaxis(
+        np.asarray(hist_slice.values, dtype=float),
+        list(hist_slice.dims).index("over_time"),
+        0,
+    ).reshape(hist_slice.sizes["over_time"], -1)
+    hist_samples_flat = hist_2d.ravel()
+    hist_x_flat = np.repeat(da["over_time"].values[:-1], hist_2d.shape[1])
+    return time_means, hist_samples_flat, hist_x_flat
+
+
+def _attach_plot_metadata(
+    result: RegressionResult,
+    *,
+    time_coord: np.ndarray,
+    current_samples: np.ndarray,
+    time_means: np.ndarray | None,
+    hist_samples_flat: np.ndarray | None,
+    hist_x_flat: np.ndarray | None,
+) -> None:
+    """Attach the history/current arrays a RegressionResult needs for replay plotting."""
+    result.current_x = time_coord[-1]
+    result.current_samples = current_samples
+    if time_means is not None:
+        result.historical = time_means
+        result.historical_x = time_coord[:-1]
+    if hist_samples_flat is not None and hist_x_flat is not None:
+        mask = ~np.isnan(hist_samples_flat)
+        result.historical_all = hist_samples_flat[mask]
+        result.historical_all_x = hist_x_flat[mask]
+
+
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
     """Run regression detection on a dataset with over_time dimension.
 
@@ -1121,28 +1175,12 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
 
         if len(current_clean) == 0:
             continue
-        history_available = len(historical_clean) > 0
 
         current_mean_scalar = np.array([float(da.isel(over_time=-1).mean(skipna=True).values)])
-
-        time_means_arr: np.ndarray | None = None
-        hist_samples_flat: np.ndarray | None = None
-        hist_x_flat: np.ndarray | None = None
+        time_means_arr, hist_samples_flat, hist_x_flat = _compute_history_arrays(da)
+        history_available = time_means_arr is not None and len(historical_clean) > 0
 
         if history_available:
-            # Aggregate every non-time dim (parameter grid, repeats) into a single
-            # scalar per time point before handing the series to any detector.
-            # Without this, a 2-D param sweep over time threads both detection and
-            # the history plot through parameter-grid structure — the line zigzags
-            # through cells instead of showing time drift, and the baseline/band
-            # end up wildly out of scale relative to individual cells.
-            reduce_dims = [d for d in da.dims if d != "over_time"]
-            time_means_arr = (
-                da.isel(over_time=slice(None, -1))
-                .mean(dim=reduce_dims, skipna=True)
-                .values.astype(float)
-            )
-
             if method == "percentage":
                 result = detect_percentage(
                     var_name,
@@ -1170,32 +1208,14 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                     regression_percentage,
                     direction,
                 )
-
-            # Retain the arrays used for plotting so downstream consumers
-            # (reports, bot comments) can rebuild the diagnostic without
-            # re-running detection.
-            result.historical = time_means_arr
-            result.historical_x = time_coord[:-1]
-            result.current_x = time_coord[-1]
-            result.current_samples = current_clean
-
-            # Per-sample historical scatter: flatten the 2D slice (all repeats
-            # at every historical time point) and broadcast the time coords so
-            # the renderers can show every sample as a dot at its real x
-            # position.
-            hist_slice = da.isel(over_time=slice(None, -1))
-            if hist_slice.size > 0:
-                hist_2d = np.moveaxis(
-                    np.asarray(hist_slice.values, dtype=float),
-                    list(hist_slice.dims).index("over_time"),
-                    0,
-                ).reshape(hist_slice.sizes["over_time"], -1)
-                hist_samples_flat = hist_2d.ravel()
-                hist_x_flat = np.repeat(time_coord[:-1], hist_2d.shape[1])
-                mask = ~np.isnan(hist_samples_flat)
-                result.historical_all = hist_samples_flat[mask]
-                result.historical_all_x = hist_x_flat[mask]
-
+            _attach_plot_metadata(
+                result,
+                time_coord=time_coord,
+                current_samples=current_clean,
+                time_means=time_means_arr,
+                hist_samples_flat=hist_samples_flat,
+                hist_x_flat=hist_x_flat,
+            )
             report.results.append(result)
 
         # Additive guards — run independently of the statistical method.
@@ -1207,14 +1227,14 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                 max_delta=regression_delta,
                 direction=direction,
             )
-            delta_result.historical = time_means_arr
-            delta_result.historical_x = time_coord[:-1]
-            delta_result.current_x = time_coord[-1]
-            delta_result.current_samples = current_clean
-            if hist_samples_flat is not None and hist_x_flat is not None:
-                mask = ~np.isnan(hist_samples_flat)
-                delta_result.historical_all = hist_samples_flat[mask]
-                delta_result.historical_all_x = hist_x_flat[mask]
+            _attach_plot_metadata(
+                delta_result,
+                time_coord=time_coord,
+                current_samples=current_clean,
+                time_means=time_means_arr,
+                hist_samples_flat=hist_samples_flat,
+                hist_x_flat=hist_x_flat,
+            )
             report.results.append(delta_result)
 
         if regression_absolute is not None:
@@ -1229,12 +1249,14 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
                     limit=regression_absolute,
                     direction=direction,
                 )
-                if history_available:
-                    abs_result.historical_x = time_coord[:-1]
-                    abs_result.current_x = time_coord[-1]
-                else:
-                    abs_result.current_x = time_coord[-1]
-                abs_result.current_samples = current_clean
+                _attach_plot_metadata(
+                    abs_result,
+                    time_coord=time_coord,
+                    current_samples=current_clean,
+                    time_means=None,
+                    hist_samples_flat=None,
+                    hist_x_flat=None,
+                )
                 report.results.append(abs_result)
 
     return report

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -988,6 +988,85 @@ def detect_adaptive(
     )
 
 
+def detect_delta(
+    variable: str,
+    historical_time_means: np.ndarray,
+    current: np.ndarray,
+    max_delta: float,
+    direction: OptDir = OptDir.minimize,
+) -> RegressionResult:
+    """Fail when |curr - hist_mean| exceeds ``max_delta`` in the direction of OptDir.
+
+    Baseline is the mean of all historical per-time means, so this compares the
+    current scalar against a flat historical average in absolute units (not
+    percent). Intended as an additive guard alongside the statistical methods.
+    """
+    hist_clean = _clean_1d(historical_time_means)
+    hist_mean = float(np.nanmean(hist_clean)) if len(hist_clean) else float("nan")
+    curr_clean = _clean_1d(current)
+    curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
+    delta = curr_mean - hist_mean
+
+    if direction == OptDir.minimize:
+        regressed = delta > max_delta
+    elif direction == OptDir.maximize:
+        regressed = delta < -max_delta
+    else:
+        regressed = abs(delta) > max_delta
+
+    return RegressionResult(
+        variable=variable,
+        method="delta",
+        regressed=regressed,
+        current_value=curr_mean,
+        baseline_value=hist_mean,
+        change_percent=_safe_change_percent(curr_mean, hist_mean),
+        threshold=max_delta,
+        direction=direction.value,
+        details=f"delta={delta:+.4g} vs max |{max_delta}|",
+        band_lower=hist_mean - max_delta,
+        band_upper=hist_mean + max_delta,
+    )
+
+
+def detect_absolute(
+    variable: str,
+    current: np.ndarray,
+    limit: float,
+    direction: OptDir = OptDir.minimize,
+) -> RegressionResult:
+    """Fail when current mean violates an absolute limit in the direction of OptDir.
+
+    Needs no historical data. For ``OptDir.minimize`` ``limit`` is a ceiling;
+    for ``OptDir.maximize`` it's a floor. ``OptDir.none`` has no direction so
+    the guard records a non-regressed result and leaves it to the caller to log.
+    """
+    curr_clean = _clean_1d(current)
+    curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
+
+    if direction == OptDir.minimize:
+        regressed = curr_mean > limit
+        detail = f"current={curr_mean:.4g} vs ceiling {limit}"
+    elif direction == OptDir.maximize:
+        regressed = curr_mean < limit
+        detail = f"current={curr_mean:.4g} vs floor {limit}"
+    else:
+        regressed = False
+        detail = f"OptDir.none: absolute guard skipped (current={curr_mean:.4g})"
+
+    return RegressionResult(
+        variable=variable,
+        method="absolute",
+        regressed=regressed,
+        current_value=curr_mean,
+        baseline_value=float(limit),
+        change_percent=float("nan"),
+        threshold=float(limit),
+        direction=direction.value,
+        details=detail,
+    )
+
+
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
     """Run regression detection on a dataset with over_time dimension.
 
@@ -1008,7 +1087,11 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         return report
 
     n_times = dataset.sizes["over_time"]
-    if n_times < 2:
+    regression_absolute = getattr(run_cfg, "regression_absolute", None)
+    regression_delta = getattr(run_cfg, "regression_delta", None)
+
+    # With no history, only the absolute guard has anything to compare against.
+    if n_times < 2 and regression_absolute is None:
         return report
 
     method = run_cfg.regression_method
@@ -1018,6 +1101,8 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     regression_percentage = getattr(run_cfg, "regression_percentage", None)
     if regression_percentage is None:
         regression_percentage = _METHOD_DEFAULTS["percentage"]
+
+    time_coord = dataset["over_time"].values
 
     for rv in bench_cfg.result_vars:
         if not isinstance(rv, SCALAR_RESULT_TYPES):
@@ -1034,76 +1119,122 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         current_clean = _clean_1d(da.isel(over_time=-1).values)
         historical_clean = _clean_1d(da.isel(over_time=slice(None, -1)).values)
 
-        if len(current_clean) == 0 or len(historical_clean) == 0:
+        if len(current_clean) == 0:
             continue
+        history_available = len(historical_clean) > 0
 
-        # Aggregate every non-time dim (parameter grid, repeats) into a single
-        # scalar per time point before handing the series to any detector.
-        # Without this, a 2-D param sweep over time threads both detection and
-        # the history plot through parameter-grid structure — the line zigzags
-        # through cells instead of showing time drift, and the baseline/band
-        # end up wildly out of scale relative to individual cells.
-        reduce_dims = [d for d in da.dims if d != "over_time"]
-        time_means_arr = (
-            da.isel(over_time=slice(None, -1))
-            .mean(dim=reduce_dims, skipna=True)
-            .values.astype(float)
-        )
         current_mean_scalar = np.array([float(da.isel(over_time=-1).mean(skipna=True).values)])
 
-        if method == "percentage":
-            result = detect_percentage(
-                var_name,
-                time_means_arr,
-                current_mean_scalar,
-                regression_percentage,
-                direction,
+        time_means_arr: np.ndarray | None = None
+        hist_samples_flat: np.ndarray | None = None
+        hist_x_flat: np.ndarray | None = None
+
+        if history_available:
+            # Aggregate every non-time dim (parameter grid, repeats) into a single
+            # scalar per time point before handing the series to any detector.
+            # Without this, a 2-D param sweep over time threads both detection and
+            # the history plot through parameter-grid structure — the line zigzags
+            # through cells instead of showing time drift, and the baseline/band
+            # end up wildly out of scale relative to individual cells.
+            reduce_dims = [d for d in da.dims if d != "over_time"]
+            time_means_arr = (
+                da.isel(over_time=slice(None, -1))
+                .mean(dim=reduce_dims, skipna=True)
+                .values.astype(float)
             )
-        elif method == "adaptive":
-            result = detect_adaptive(
+
+            if method == "percentage":
+                result = detect_percentage(
+                    var_name,
+                    time_means_arr,
+                    current_mean_scalar,
+                    regression_percentage,
+                    direction,
+                )
+            elif method == "adaptive":
+                result = detect_adaptive(
+                    var_name,
+                    time_means_arr,
+                    current_mean_scalar,
+                    regression_mad=regression_mad,
+                    direction=direction,
+                    historical_samples=historical_clean,
+                    regression_percentage=regression_percentage,
+                )
+            else:
+                logging.warning(f"Unknown regression method '{method}', falling back to percentage")
+                result = detect_percentage(
+                    var_name,
+                    time_means_arr,
+                    current_mean_scalar,
+                    regression_percentage,
+                    direction,
+                )
+
+            # Retain the arrays used for plotting so downstream consumers
+            # (reports, bot comments) can rebuild the diagnostic without
+            # re-running detection.
+            result.historical = time_means_arr
+            result.historical_x = time_coord[:-1]
+            result.current_x = time_coord[-1]
+            result.current_samples = current_clean
+
+            # Per-sample historical scatter: flatten the 2D slice (all repeats
+            # at every historical time point) and broadcast the time coords so
+            # the renderers can show every sample as a dot at its real x
+            # position.
+            hist_slice = da.isel(over_time=slice(None, -1))
+            if hist_slice.size > 0:
+                hist_2d = np.moveaxis(
+                    np.asarray(hist_slice.values, dtype=float),
+                    list(hist_slice.dims).index("over_time"),
+                    0,
+                ).reshape(hist_slice.sizes["over_time"], -1)
+                hist_samples_flat = hist_2d.ravel()
+                hist_x_flat = np.repeat(time_coord[:-1], hist_2d.shape[1])
+                mask = ~np.isnan(hist_samples_flat)
+                result.historical_all = hist_samples_flat[mask]
+                result.historical_all_x = hist_x_flat[mask]
+
+            report.results.append(result)
+
+        # Additive guards — run independently of the statistical method.
+        if regression_delta is not None and history_available:
+            delta_result = detect_delta(
                 var_name,
                 time_means_arr,
                 current_mean_scalar,
-                regression_mad=regression_mad,
+                max_delta=regression_delta,
                 direction=direction,
-                historical_samples=historical_clean,
-                regression_percentage=regression_percentage,
             )
-        else:
-            logging.warning(f"Unknown regression method '{method}', falling back to percentage")
-            result = detect_percentage(
-                var_name,
-                time_means_arr,
-                current_mean_scalar,
-                regression_percentage,
-                direction,
-            )
+            delta_result.historical = time_means_arr
+            delta_result.historical_x = time_coord[:-1]
+            delta_result.current_x = time_coord[-1]
+            delta_result.current_samples = current_clean
+            if hist_samples_flat is not None and hist_x_flat is not None:
+                mask = ~np.isnan(hist_samples_flat)
+                delta_result.historical_all = hist_samples_flat[mask]
+                delta_result.historical_all_x = hist_x_flat[mask]
+            report.results.append(delta_result)
 
-        # Retain the arrays used for plotting so downstream consumers (reports,
-        # bot comments) can rebuild the diagnostic without re-running detection.
-        time_coord = dataset["over_time"].values
-        result.historical = time_means_arr
-        # Per-time means are aligned with over_time, one value per time point.
-        result.historical_x = time_coord[:-1]
-        result.current_x = time_coord[-1]
-        result.current_samples = current_clean
-
-        # Per-sample historical scatter: flatten the 2D slice (all repeats at
-        # every historical time point) and broadcast the time coords so the
-        # renderers can show every sample as a dot at its real x position.
-        hist_slice = da.isel(over_time=slice(None, -1))
-        if hist_slice.size > 0:
-            hist_2d = np.moveaxis(
-                np.asarray(hist_slice.values, dtype=float),
-                list(hist_slice.dims).index("over_time"),
-                0,
-            ).reshape(hist_slice.sizes["over_time"], -1)
-            hist_samples_flat = hist_2d.ravel()
-            hist_x_flat = np.repeat(time_coord[:-1], hist_2d.shape[1])
-            mask = ~np.isnan(hist_samples_flat)
-            result.historical_all = hist_samples_flat[mask]
-            result.historical_all_x = hist_x_flat[mask]
-
-        report.results.append(result)
+        if regression_absolute is not None:
+            if direction == OptDir.none:
+                logging.warning(
+                    f"regression_absolute skipped for '{var_name}': OptDir.none has no direction"
+                )
+            else:
+                abs_result = detect_absolute(
+                    var_name,
+                    current_mean_scalar,
+                    limit=regression_absolute,
+                    direction=direction,
+                )
+                if history_available:
+                    abs_result.historical_x = time_coord[:-1]
+                    abs_result.current_x = time_coord[-1]
+                else:
+                    abs_result.current_x = time_coord[-1]
+                abs_result.current_samples = current_clean
+                report.results.append(abs_result)
 
     return report

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -995,11 +995,15 @@ def detect_delta(
     max_delta: float,
     direction: OptDir = OptDir.minimize,
 ) -> RegressionResult:
-    """Fail when |curr - hist_mean| exceeds ``max_delta`` in the direction of OptDir.
+    """Fail when the current mean's delta from history exceeds ``max_delta``.
 
-    Baseline is the mean of all historical per-time means, so this compares the
-    current scalar against a flat historical average in absolute units (not
-    percent). Intended as an additive guard alongside the statistical methods.
+    The comparison respects ``direction``: ``minimize`` fails when
+    ``curr - hist_mean > max_delta``; ``maximize`` fails when
+    ``hist_mean - curr > max_delta``; ``none`` uses the absolute delta and fails
+    on either side. Baseline is the mean of all historical per-time means, so
+    this compares the current scalar against a flat historical average in
+    absolute units (not percent). Intended as an additive guard alongside the
+    statistical methods.
     """
     hist_clean = _clean_1d(historical_time_means)
     hist_mean = float(np.nanmean(hist_clean)) if len(hist_clean) else float("nan")
@@ -1124,16 +1128,21 @@ def _attach_plot_metadata(
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
     """Run regression detection on a dataset with over_time dimension.
 
-    For each numeric result variable, splits the dataset at the last over_time index,
-    runs the configured detection method, and collects results into a report.
+    For each numeric result variable, splits the dataset at the last over_time
+    index, runs the configured statistical method (percentage/adaptive), and
+    layers the optional additive guards (regression_delta, regression_absolute)
+    on top. regression_absolute runs even with a single over_time point since
+    it needs no baseline.
 
     Args:
-        dataset: xarray Dataset with over_time dimension.
-        bench_cfg: BenchCfg with result_vars list.
-        run_cfg: BenchRunCfg with regression_method, regression_threshold.
+        dataset: xarray Dataset with an over_time dimension.
+        bench_cfg: BenchCfg with ``result_vars`` list.
+        run_cfg: BenchRunCfg. Reads ``regression_method``, ``regression_mad``,
+            ``regression_percentage``, ``regression_delta`` and
+            ``regression_absolute``.
 
     Returns:
-        RegressionReport with results for each variable.
+        RegressionReport with one result per variable per fired detector/guard.
     """
     report = RegressionReport()
 

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -769,9 +769,17 @@ def detect_percentage(
     threshold_percent: float = 5.0,
     direction: OptDir = OptDir.minimize,
 ) -> RegressionResult:
-    """Compare current mean vs historical mean by percentage threshold."""
-    hist_mean = float(np.nanmean(historical))
-    curr_mean = float(np.nanmean(current))
+    """Compare current mean vs historical mean by percentage threshold.
+
+    Simple escape hatch: one directional rule comparing the current mean
+    against the historical mean. Same shape as :func:`detect_delta` and
+    :func:`detect_absolute`; contrast with :func:`detect_adaptive` which
+    layers noise modelling, drift test, and a dual-band AND gate.
+    """
+    hist_clean = _clean_1d(historical)
+    curr_clean = _clean_1d(current)
+    hist_mean = float(np.mean(hist_clean)) if len(hist_clean) else float("nan")
+    curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")
     change = _safe_change_percent(curr_mean, hist_mean)
 
     exceeds = _exceeds_directional_threshold(change, threshold_percent, direction)
@@ -998,12 +1006,13 @@ def detect_delta(
 ) -> RegressionResult:
     """Fail when the current mean's delta from history exceeds ``max_delta``.
 
-    The comparison respects ``direction``: ``minimize`` fails when
-    ``curr - hist_mean > max_delta``; ``maximize`` fails when
-    ``hist_mean - curr > max_delta``; ``none`` uses the absolute delta and fails
-    on either side. Baseline is the mean of all historical per-time means, so
-    this compares the current scalar against a flat historical average in
-    absolute units (not percent). Selected via ``regression_method='delta'``.
+    Simple escape hatch: one directional rule on the absolute-unit delta
+    between the current mean and the mean of all historical per-time means.
+    ``minimize`` fails when ``curr - hist_mean > max_delta``; ``maximize``
+    fails when ``hist_mean - curr > max_delta``; ``none`` uses ``|delta|``.
+    Same shape as :func:`detect_percentage` and :func:`detect_absolute`;
+    contrast with :func:`detect_adaptive` which layers noise modelling and
+    drift testing. Selected via ``regression_method='delta'``.
     """
     hist_clean = _clean_1d(historical_time_means)
     hist_mean = float(np.nanmean(hist_clean)) if len(hist_clean) else float("nan")
@@ -1041,9 +1050,12 @@ def detect_absolute(
 ) -> RegressionResult:
     """Fail when current mean violates an absolute limit in the direction of OptDir.
 
-    Needs no historical data. For ``OptDir.minimize`` ``limit`` is a ceiling;
-    for ``OptDir.maximize`` it's a floor. ``OptDir.none`` has no direction so
-    the guard records a non-regressed result and leaves it to the caller to log.
+    Simple escape hatch: one directional rule against a fixed limit — no
+    historical data required. For ``OptDir.minimize`` ``limit`` is a ceiling;
+    for ``OptDir.maximize`` it's a floor; ``OptDir.none`` records a
+    non-regressed result and leaves it to the caller to log. Same shape as
+    :func:`detect_percentage` and :func:`detect_delta`; contrast with
+    :func:`detect_adaptive` which needs history to estimate noise.
     """
     curr_clean = _clean_1d(current)
     curr_mean = float(np.mean(curr_clean)) if len(curr_clean) else float("nan")

--- a/pixi.lock
+++ b/pixi.lock
@@ -1474,8 +1474,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.88.0
-  sha256: c94c759c311de8642712f4ccb2db4eb3a9f877af58576f721d6d5f80b8547cd8
+  version: 1.89.0
+  sha256: b6df9db458b6322f6a72934ba9d0ef95ef15d0c6b1d18d33c3f8473551203e52
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.88.0"
+version = "1.89.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -12,7 +12,9 @@ from bencher.regression import (
     RegressionReport,
     RegressionResult,
     build_regression_overlay,
+    detect_absolute,
     detect_adaptive,
+    detect_delta,
     detect_percentage,
     detect_regressions,
     render_regression_png,
@@ -298,6 +300,101 @@ class TestDetectAdaptive:
         assert result.regressed
 
 
+# ── detect_delta ───────────────────────────────────────────────────────────
+
+
+class TestDetectDelta:
+    def test_within_tolerance_no_regression(self):
+        hist = np.array([100.0, 101.0, 99.0, 100.5])
+        curr = np.array([101.0, 102.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.minimize)
+        assert not result.regressed
+        assert result.method == "delta"
+
+    def test_regression_above_delta_minimize(self):
+        hist = np.array([100.0, 100.0, 100.0])
+        curr = np.array([110.0, 112.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.minimize)
+        assert result.regressed
+        # Band is symmetric around historical mean.
+        assert result.band_lower == 95.0
+        assert result.band_upper == 105.0
+
+    def test_regression_below_delta_maximize(self):
+        hist = np.array([100.0, 100.0, 100.0])
+        curr = np.array([90.0, 88.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.maximize)
+        assert result.regressed
+
+    def test_improvement_not_regression_minimize(self):
+        hist = np.array([100.0, 100.0])
+        curr = np.array([80.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.minimize)
+        assert not result.regressed
+
+    def test_improvement_not_regression_maximize(self):
+        hist = np.array([100.0, 100.0])
+        curr = np.array([120.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.maximize)
+        assert not result.regressed
+
+    def test_direction_none_symmetric(self):
+        hist = np.array([100.0, 100.0])
+        result_above = detect_delta(
+            "x", hist, np.array([108.0]), max_delta=5.0, direction=OptDir.none
+        )
+        result_below = detect_delta(
+            "x", hist, np.array([92.0]), max_delta=5.0, direction=OptDir.none
+        )
+        assert result_above.regressed
+        assert result_below.regressed
+
+    def test_nan_handling(self):
+        hist = np.array([100.0, np.nan, 100.0])
+        curr = np.array([105.0, np.nan])
+        result = detect_delta("x", hist, curr, max_delta=10.0, direction=OptDir.minimize)
+        assert not result.regressed
+
+    def test_exactly_at_delta_is_not_regression(self):
+        hist = np.array([100.0, 100.0])
+        curr = np.array([105.0])
+        result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.minimize)
+        assert not result.regressed  # strict '>'
+
+
+# ── detect_absolute ────────────────────────────────────────────────────────
+
+
+class TestDetectAbsolute:
+    def test_under_ceiling_minimize_not_regression(self):
+        result = detect_absolute("x", np.array([40.0]), limit=50.0, direction=OptDir.minimize)
+        assert not result.regressed
+        assert result.method == "absolute"
+        assert result.baseline_value == 50.0
+
+    def test_over_ceiling_minimize_regression(self):
+        result = detect_absolute("x", np.array([60.0]), limit=50.0, direction=OptDir.minimize)
+        assert result.regressed
+
+    def test_over_floor_maximize_not_regression(self):
+        result = detect_absolute("x", np.array([120.0]), limit=100.0, direction=OptDir.maximize)
+        assert not result.regressed
+
+    def test_under_floor_maximize_regression(self):
+        result = detect_absolute("x", np.array([80.0]), limit=100.0, direction=OptDir.maximize)
+        assert result.regressed
+
+    def test_direction_none_not_regression(self):
+        result = detect_absolute("x", np.array([1000.0]), limit=50.0, direction=OptDir.none)
+        assert not result.regressed
+        assert "skipped" in result.details
+
+    def test_nan_only_current(self):
+        result = detect_absolute("x", np.array([np.nan]), limit=50.0, direction=OptDir.minimize)
+        # nan > 50 is False; guard should not flag.
+        assert not result.regressed
+
+
 # ── RegressionReport ───────────────────────────────────────────────────────
 
 
@@ -364,6 +461,8 @@ class TestDetectRegressions:
         method="percentage",
         regression_mad=None,
         regression_percentage=None,
+        regression_delta=None,
+        regression_absolute=None,
     ):
         """Create minimal bench_cfg and run_cfg mocks."""
 
@@ -372,12 +471,30 @@ class TestDetectRegressions:
                 self.result_vars = result_vars
 
         class FakeRunCfg:
-            def __init__(self, method, regression_mad, regression_percentage):
+            def __init__(
+                self,
+                method,
+                regression_mad,
+                regression_percentage,
+                regression_delta,
+                regression_absolute,
+            ):
                 self.regression_method = method
                 self.regression_mad = regression_mad
                 self.regression_percentage = regression_percentage
+                self.regression_delta = regression_delta
+                self.regression_absolute = regression_absolute
 
-        return FakeBenchCfg(result_vars), FakeRunCfg(method, regression_mad, regression_percentage)
+        return (
+            FakeBenchCfg(result_vars),
+            FakeRunCfg(
+                method,
+                regression_mad,
+                regression_percentage,
+                regression_delta,
+                regression_absolute,
+            ),
+        )
 
     def test_no_over_time_dim(self):
         ds = xr.Dataset({"x": (["repeat"], [1.0, 2.0])})
@@ -630,6 +747,102 @@ class TestDetectRegressions:
         assert isinstance(result.regressed, bool)
         assert result.regressed is True
         assert result.method is not None
+
+    def test_delta_guard_runs_alongside_method(self):
+        """Delta guard produces its own result entry in addition to the statistical method."""
+        values = np.array([[100.0], [100.0], [108.0]])  # +8 from baseline
+        ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv],
+            method="percentage",
+            regression_percentage=20.0,  # +8% is under 20%, so percentage passes
+            regression_delta=5.0,  # +8 > 5, so delta fires
+        )
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        methods = {r.method: r for r in report.results}
+        assert "percentage" in methods
+        assert "delta" in methods
+        assert methods["percentage"].regressed is False
+        assert methods["delta"].regressed is True
+
+    def test_absolute_guard_runs_alongside_method(self):
+        values = np.array([[10.0], [10.0], [12.0]])
+        ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv],
+            method="percentage",
+            regression_percentage=50.0,  # percentage stays quiet
+            regression_absolute=11.0,  # 12 > 11 ceiling
+        )
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        methods = {r.method: r for r in report.results}
+        assert methods["percentage"].regressed is False
+        assert methods["absolute"].regressed is True
+        assert methods["absolute"].baseline_value == 11.0
+
+    def test_absolute_guard_without_history(self):
+        """Absolute guard works even with a single over_time point (no history)."""
+        values = np.array([[60.0, 70.0]])
+        ds = self._make_dataset(n_times=1, n_repeats=2, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg([rv], regression_absolute=50.0)
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        assert len(report.results) == 1
+        assert report.results[0].method == "absolute"
+        assert report.results[0].regressed is True
+
+    def test_guards_default_disabled(self):
+        """With no delta/absolute set, behavior matches pre-guard output."""
+        values = np.array([[100.0], [100.0], [105.0]])
+        ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=10.0)
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        assert len(report.results) == 1
+        assert report.results[0].method == "percentage"
+
+    def test_absolute_opt_dir_none_skipped(self, caplog):
+        import logging as _logging
+
+        values = np.array([[10.0], [10.0], [10.0]])
+        ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.none)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg([rv], regression_absolute=5.0)
+        with caplog.at_level(_logging.WARNING):
+            report = detect_regressions(ds, bench_cfg, run_cfg)
+        assert not any(r.method == "absolute" for r in report.results)
+        assert any("OptDir.none" in rec.message for rec in caplog.records)
+
+    def test_delta_guard_skipped_without_history(self):
+        values = np.array([[100.0]])
+        ds = self._make_dataset(n_times=1, n_repeats=1, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg([rv], regression_delta=1.0, regression_absolute=50.0)
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        methods = [r.method for r in report.results]
+        # Delta needs history; only absolute runs with n_times=1.
+        assert "delta" not in methods
+        assert "absolute" in methods
 
 
 # ── RegressionError ────────────────────────────────────────────────────────

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,5 +1,6 @@
 """Tests for bencher.regression module."""
 
+import math
 import os
 
 import numpy as np
@@ -361,6 +362,23 @@ class TestDetectDelta:
         result = detect_delta("x", hist, curr, max_delta=5.0, direction=OptDir.minimize)
         assert not result.regressed  # strict '>'
 
+    def test_empty_hist_is_not_regression(self):
+        """Empty history → no baseline to compare against, guard disables itself."""
+        result = detect_delta(
+            "x", np.array([]), np.array([105.0]), max_delta=10.0, direction=OptDir.minimize
+        )
+        assert not result.regressed
+
+    def test_all_nan_hist_is_not_regression(self):
+        result = detect_delta(
+            "x",
+            np.array([np.nan, np.nan]),
+            np.array([105.0]),
+            max_delta=10.0,
+            direction=OptDir.minimize,
+        )
+        assert not result.regressed
+
 
 # ── detect_absolute ────────────────────────────────────────────────────────
 
@@ -393,6 +411,8 @@ class TestDetectAbsolute:
         result = detect_absolute("x", np.array([np.nan]), limit=50.0, direction=OptDir.minimize)
         # nan > 50 is False; guard should not flag.
         assert not result.regressed
+        assert math.isnan(result.current_value)
+        assert result.baseline_value == 50.0
 
 
 # ── RegressionReport ───────────────────────────────────────────────────────
@@ -843,6 +863,36 @@ class TestDetectRegressions:
         # Delta needs history; only absolute runs with n_times=1.
         assert "delta" not in methods
         assert "absolute" in methods
+
+    def test_guards_run_with_adaptive_method(self):
+        """Delta + absolute guards produce their own results alongside the adaptive detector."""
+        rng = np.random.default_rng(0)
+        stable = 100.0 + rng.normal(0, 2.0, size=(20, 4))
+        jump = 150.0 + rng.normal(0, 2.0, size=(1, 4))
+        values = np.vstack([stable, jump])
+        ds = self._make_dataset(n_times=21, n_repeats=4, values=values)
+        from bencher.variables.results import ResultFloat
+
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "metric"
+        bench_cfg, run_cfg = self._make_cfg(
+            [rv],
+            method="adaptive",
+            regression_mad=3.5,
+            regression_delta=5.0,  # +50 jump easily trips
+            regression_absolute=120.0,  # current mean ~150 > ceiling
+        )
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        methods = {r.method: r for r in report.results}
+        assert "adaptive" in methods
+        assert "delta" in methods
+        assert "absolute" in methods
+        assert methods["adaptive"].regressed is True
+        assert methods["delta"].regressed is True
+        assert methods["absolute"].regressed is True
+        # Adaptive still carries history metadata for replay plots even when guards are layered.
+        assert methods["adaptive"].historical is not None
+        assert methods["delta"].historical is not None
 
 
 # ── RegressionError ────────────────────────────────────────────────────────

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -768,74 +768,64 @@ class TestDetectRegressions:
         assert result.regressed is True
         assert result.method is not None
 
-    def test_delta_guard_runs_alongside_method(self):
-        """Delta guard produces its own result entry in addition to the statistical method."""
+    def test_method_delta_dispatches_only_delta(self):
+        """regression_method='delta' runs the delta detector alone, no percentage result."""
         values = np.array([[100.0], [100.0], [108.0]])  # +8 from baseline
         ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg(
-            [rv],
-            method="percentage",
-            regression_percentage=20.0,  # +8% is under 20%, so percentage passes
-            regression_delta=5.0,  # +8 > 5, so delta fires
-        )
+        bench_cfg, run_cfg = self._make_cfg([rv], method="delta", regression_delta=5.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
-        methods = {r.method: r for r in report.results}
-        assert "percentage" in methods
-        assert "delta" in methods
-        assert methods["percentage"].regressed is False
-        assert methods["delta"].regressed is True
+        assert len(report.results) == 1
+        assert report.results[0].method == "delta"
+        assert report.results[0].regressed is True
 
-    def test_absolute_guard_runs_alongside_method(self):
+    def test_method_absolute_dispatches_only_absolute(self):
         values = np.array([[10.0], [10.0], [12.0]])
         ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg(
-            [rv],
-            method="percentage",
-            regression_percentage=50.0,  # percentage stays quiet
-            regression_absolute=11.0,  # 12 > 11 ceiling
-        )
+        bench_cfg, run_cfg = self._make_cfg([rv], method="absolute", regression_absolute=11.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
-        methods = {r.method: r for r in report.results}
-        assert methods["percentage"].regressed is False
-        assert methods["absolute"].regressed is True
-        assert methods["absolute"].baseline_value == 11.0
+        assert len(report.results) == 1
+        assert report.results[0].method == "absolute"
+        assert report.results[0].regressed is True
+        assert report.results[0].baseline_value == 11.0
 
-    def test_absolute_guard_without_history(self):
-        """Absolute guard works even with a single over_time point (no history)."""
+    def test_method_absolute_without_history(self):
+        """'absolute' runs even with a single over_time point — needs no baseline."""
         values = np.array([[60.0, 70.0]])
         ds = self._make_dataset(n_times=1, n_repeats=2, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], regression_absolute=50.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="absolute", regression_absolute=50.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert len(report.results) == 1
         assert report.results[0].method == "absolute"
         assert report.results[0].regressed is True
 
-    def test_guards_default_disabled(self):
-        """With no delta/absolute set, behavior matches pre-guard output."""
-        values = np.array([[100.0], [100.0], [105.0]])
+    def test_method_delta_missing_threshold_skipped(self, caplog):
+        import logging as _logging
+
+        values = np.array([[100.0], [100.0], [108.0]])
         ds = self._make_dataset(n_times=3, n_repeats=1, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], method="percentage", regression_percentage=10.0)
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert len(report.results) == 1
-        assert report.results[0].method == "percentage"
+        bench_cfg, run_cfg = self._make_cfg([rv], method="delta", regression_delta=None)
+        with caplog.at_level(_logging.WARNING):
+            report = detect_regressions(ds, bench_cfg, run_cfg)
+        assert report.results == []
+        assert any("regression_delta" in rec.message for rec in caplog.records)
 
-    def test_absolute_opt_dir_none_skipped(self, caplog):
+    def test_method_absolute_opt_dir_none_skipped(self, caplog):
         import logging as _logging
 
         values = np.array([[10.0], [10.0], [10.0]])
@@ -844,55 +834,23 @@ class TestDetectRegressions:
 
         rv = ResultFloat(units="s", direction=OptDir.none)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], regression_absolute=5.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="absolute", regression_absolute=5.0)
         with caplog.at_level(_logging.WARNING):
             report = detect_regressions(ds, bench_cfg, run_cfg)
-        assert not any(r.method == "absolute" for r in report.results)
+        assert report.results == []
         assert any("OptDir.none" in rec.message for rec in caplog.records)
 
-    def test_delta_guard_skipped_without_history(self):
+    def test_method_delta_skipped_without_history(self):
+        """'delta' needs a baseline — skip when n_times < 2."""
         values = np.array([[100.0]])
         ds = self._make_dataset(n_times=1, n_repeats=1, values=values)
         from bencher.variables.results import ResultFloat
 
         rv = ResultFloat(units="s", direction=OptDir.minimize)
         rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg([rv], regression_delta=1.0, regression_absolute=50.0)
+        bench_cfg, run_cfg = self._make_cfg([rv], method="delta", regression_delta=1.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
-        methods = [r.method for r in report.results]
-        # Delta needs history; only absolute runs with n_times=1.
-        assert "delta" not in methods
-        assert "absolute" in methods
-
-    def test_guards_run_with_adaptive_method(self):
-        """Delta + absolute guards produce their own results alongside the adaptive detector."""
-        rng = np.random.default_rng(0)
-        stable = 100.0 + rng.normal(0, 2.0, size=(20, 4))
-        jump = 150.0 + rng.normal(0, 2.0, size=(1, 4))
-        values = np.vstack([stable, jump])
-        ds = self._make_dataset(n_times=21, n_repeats=4, values=values)
-        from bencher.variables.results import ResultFloat
-
-        rv = ResultFloat(units="s", direction=OptDir.minimize)
-        rv.name = "metric"
-        bench_cfg, run_cfg = self._make_cfg(
-            [rv],
-            method="adaptive",
-            regression_mad=3.5,
-            regression_delta=5.0,  # +50 jump easily trips
-            regression_absolute=120.0,  # current mean ~150 > ceiling
-        )
-        report = detect_regressions(ds, bench_cfg, run_cfg)
-        methods = {r.method: r for r in report.results}
-        assert "adaptive" in methods
-        assert "delta" in methods
-        assert "absolute" in methods
-        assert methods["adaptive"].regressed is True
-        assert methods["delta"].regressed is True
-        assert methods["absolute"].regressed is True
-        # Adaptive still carries history metadata for replay plots even when guards are layered.
-        assert methods["adaptive"].historical is not None
-        assert methods["delta"].historical is not None
+        assert report.results == []
 
 
 # ── RegressionError ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `BenchRunCfg.regression_delta` (absolute-unit change from mean of historical per-time means) and `BenchRunCfg.regression_absolute` (directional hard limit, no history required) as optional additive guards that run alongside whichever `regression_method` is configured. Both default to `None` (disabled).
- Add `detect_delta()` and `detect_absolute()` public detectors in `bencher.regression` mirroring the existing detector shape so they feed into the shared plot/report pipeline (`band_lower/upper`, history/current arrays, x-coords).
- Relax the `n_times < 2` gate in `detect_regressions()` so `regression_absolute` fires on a lone first recording — contractual ceilings/floors don't need a baseline.
- Gallery examples `example_regression_delta` and `example_regression_absolute` demonstrating the guards firing on cases the percentage method would tolerate.

Both guards respect the result variable's `OptDir`:
- `regression_delta`: `minimize` → fails when `curr - hist > delta`; `maximize` → fails when `hist - curr > delta`; `none` → symmetric.
- `regression_absolute`: `minimize` → ceiling; `maximize` → floor; `none` → skipped with a single warning.

## Test plan
- [x] `pixi run pytest test/test_regression.py` — 80 passing (60 existing + 20 new across `TestDetectDelta`, `TestDetectAbsolute`, and `TestDetectRegressions` integrations).
- [x] `pixi run generate-docs` — regenerates gallery with both new examples; HTML reports built under `docs/_extra/reference/meta/regression/_reports/`.
- [x] `pixi run ci` — green (format, ruff, pylint, ty, coverage-report).
- [x] Spot-check: synthetic `over_time` dataset with a +3 ms step confirms `percentage` stays quiet under a 20 % threshold, `delta` trips on `+3 > 2 ms`, and `absolute` trips on `103 > 25 ms` ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional absolute-delta and hard-absolute regression guards and integrate them into regression detection, configuration, examples, and documentation.

New Features:
- Introduce detect_delta and detect_absolute regression detectors alongside existing percentage and adaptive methods.
- Add BenchRunCfg.regression_delta and BenchRunCfg.regression_absolute options to configure additive regression guards that operate in absolute units or against a fixed ceiling/floor.
- Allow regression detection to run with a single over_time point when an absolute guard is configured, so limits can apply on the first run.
- Extend regression examples with new over_time gallery demos for the delta and absolute guards.

Enhancements:
- Augment detect_regressions to emit separate RegressionResult entries for the new guards while preserving existing plotting and reporting data structures.

Build:
- Bump project version to 1.89.0 in pyproject.toml.

Documentation:
- Update CHANGELOG with the new regression guard options and add generated example scripts showcasing their behavior.

Tests:
- Add unit tests for detect_delta and detect_absolute behaviors and their integration with detect_regressions under various configuration and history scenarios.