### PR TITLE
Add static and published display modes to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.93.0] - 2026-04-25
+
+### Added
+- `ShowMode` StrEnum (`live`, `html`, `published`, `none`) exported from the top-level `bencher` package. `bn.run(show=bn.ShowMode.HTML)` gives autocomplete and typo detection while plain strings (`show="html"`) and booleans (`show=True`) keep working. The old `"static"` spelling is accepted as an alias for `ShowMode.HTML`.
+
+### Changed
+- The `show` parameter on `bn.run()`, `BenchRunner.run()`, `BenchRunner.show()`, and `BenchPlotSrvCfg` now accepts `ShowMode` in addition to `bool | str`.
+- Renamed the `"static"` display mode to `"html"` (`"static"` remains supported via alias).
+
 ## [1.92.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.92.0] - 2026-04-22
 
 ### Added
+- `show` parameter on `bn.run()`, `BenchRunner.run()`, and `BenchRunner.show()` now accepts string display modes in addition to `bool`: `"live"` (start Panel server, blocks — same as `True`), `"static"` (save an embedded HTML file and open in the browser, returns immediately), `"published"` (open the published URL — requires `publish=True`), and `"none"` (display nothing — same as `False`).
 - Public `MethodCells` dataclass and `method_cells(result)` helper in `bencher.regression`, re-exported from the top-level `bencher` package. Downstream report builders can now call `method_cells(r)` to get pre-rendered, method-aware display strings (change, baseline, threshold, summary lead) for a `RegressionResult` and embed them in a custom layout — custom columns, non-markdown output, CI comments with status decoration, etc. — without reimplementing per-method dispatch (and drifting when new detection methods are added).
 
 ### Removed

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -3,6 +3,7 @@ import warnings
 warnings.filterwarnings("ignore", message="Unable to import Axes3D", category=UserWarning)
 
 from .bencher import Bench, BenchCfg, BenchRunCfg
+from .bench_cfg import ShowMode
 from .bench_runner import BenchRunner
 from .example.benchmark_data import ExampleBenchCfg
 from .bench_plot_server import BenchPlotServer

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 import param
 import panel as pn
@@ -21,17 +21,22 @@ from bencher.results.laxtex_result import to_latex
 T = TypeVar("T")  # Generic type variable
 
 
-SHOW_MODES = ("live", "static", "published", "none")
-_SHOW_ALIASES = {True: "live", False: "none", None: "none"}
+ShowMode = Literal["live", "static", "published", "none"]
+SHOW_MODES: tuple[ShowMode, ...] = ("live", "static", "published", "none")
+SHOW_ALIASES: dict[bool | None, ShowMode] = {True: "live", False: "none", None: "none"}
 
 
-def normalize_show(value) -> str:
+def normalize_show(value: bool | str | None) -> ShowMode:
     """Normalize a ``show`` argument to one of :data:`SHOW_MODES`.
 
-    Accepts ``True``/``False``/``None`` or the literal strings in
-    :data:`SHOW_MODES`. Raises :class:`ValueError` for anything else.
+    Accepts :class:`bool`, :class:`str`, or ``None``:
+    ``True``/``False``/``None`` or the literal strings in :data:`SHOW_MODES`.
+    Raises :class:`ValueError` for anything else.
     """
-    v = _SHOW_ALIASES.get(value, value)
+    try:
+        v = SHOW_ALIASES.get(value, value)
+    except TypeError:
+        v = value
     if v not in SHOW_MODES:
         raise ValueError(f"show must be one of {list(SHOW_MODES)} or bool, got {value!r}")
     return v
@@ -59,8 +64,9 @@ class BenchPlotSrvCfg(param.Parameterized):
         False,
         doc="Add the port to the whitelist, (warning will disable remote access if set to true)",
     )
-    show = param.Parameter(
+    show = param.ObjectSelector(
         True,
+        objects=[True, False, None, "live", "static", "published", "none"],
         doc=(
             "Where to view the report. True/'live' (default) starts a Panel server and "
             "blocks. 'static' saves an embedded HTML file and opens it in the browser, "

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -21,6 +21,22 @@ from bencher.results.laxtex_result import to_latex
 T = TypeVar("T")  # Generic type variable
 
 
+SHOW_MODES = ("live", "static", "published", "none")
+_SHOW_ALIASES = {True: "live", False: "none", None: "none"}
+
+
+def normalize_show(value) -> str:
+    """Normalize a ``show`` argument to one of :data:`SHOW_MODES`.
+
+    Accepts ``True``/``False``/``None`` or the literal strings in
+    :data:`SHOW_MODES`. Raises :class:`ValueError` for anything else.
+    """
+    v = _SHOW_ALIASES.get(value, value)
+    if v not in SHOW_MODES:
+        raise ValueError(f"show must be one of {list(SHOW_MODES)} or bool, got {value!r}")
+    return v
+
+
 class BenchPlotSrvCfg(param.Parameterized):
     """Configuration for the benchmarking plot server.
 
@@ -31,7 +47,11 @@ class BenchPlotSrvCfg(param.Parameterized):
         port (int): The port to launch panel with
         allow_ws_origin (bool): Add the port to the whitelist (warning will disable remote
                                access if set to true)
-        show (bool): Open the served page in a web browser
+        show (bool | str): Where to view the report. ``True``/``"live"`` (default) starts a
+                           Panel server and blocks. ``"static"`` saves an embedded HTML file
+                           and opens it in the browser, returning immediately. ``"published"``
+                           opens the published URL after ``publish=True`` (requires publish).
+                           ``False``/``"none"`` displays nothing.
     """
 
     port: int | None = param.Integer(None, doc="The port to launch panel with")
@@ -39,7 +59,15 @@ class BenchPlotSrvCfg(param.Parameterized):
         False,
         doc="Add the port to the whitelist, (warning will disable remote access if set to true)",
     )
-    show: bool = param.Boolean(True, doc="Open the served page in a web browser")
+    show = param.Parameter(
+        True,
+        doc=(
+            "Where to view the report. True/'live' (default) starts a Panel server and "
+            "blocks. 'static' saves an embedded HTML file and opens it in the browser, "
+            "returning immediately. 'published' opens the published URL after publish=True "
+            "(requires publish=True). False/'none' displays nothing."
+        ),
+    )
 
 
 class BenchRunCfg(BenchPlotSrvCfg):

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 import logging
+from enum import auto
+from strenum import LowercaseStrEnum
 
-from typing import Any, Literal, TypeVar
+from typing import Any, TypeVar
 
 import param
 import panel as pn
@@ -21,25 +23,40 @@ from bencher.results.laxtex_result import to_latex
 T = TypeVar("T")  # Generic type variable
 
 
-ShowMode = Literal["live", "static", "published", "none"]
-SHOW_MODES: tuple[ShowMode, ...] = ("live", "static", "published", "none")
-SHOW_ALIASES: dict[bool | None, ShowMode] = {True: "live", False: "none", None: "none"}
+class ShowMode(LowercaseStrEnum):
+    """Display mode for benchmark reports."""
+
+    LIVE = auto()
+    HTML = auto()
+    PUBLISHED = auto()
+    NONE = auto()
 
 
-def normalize_show(value: bool | str | None) -> ShowMode:
-    """Normalize a ``show`` argument to one of :data:`SHOW_MODES`.
+_SHOW_ALIASES: dict[bool | None | str, ShowMode] = {
+    True: ShowMode.LIVE,
+    False: ShowMode.NONE,
+    None: ShowMode.NONE,
+    "static": ShowMode.HTML,
+}
 
-    Accepts :class:`bool`, :class:`str`, or ``None``:
-    ``True``/``False``/``None`` or the literal strings in :data:`SHOW_MODES`.
-    Raises :class:`ValueError` for anything else.
+
+def normalize_show(value: bool | str | ShowMode | None) -> ShowMode:
+    """Normalize a ``show`` argument to a :class:`ShowMode`.
+
+    Accepts ``True``/``False``/``None``, any :class:`ShowMode` member, or
+    the corresponding string value.  Raises :class:`ValueError` for
+    anything else.
     """
     try:
-        v = SHOW_ALIASES.get(value, value)
+        v = _SHOW_ALIASES.get(value, value)
     except TypeError:
         v = value
-    if v not in SHOW_MODES:
-        raise ValueError(f"show must be one of {list(SHOW_MODES)} or bool, got {value!r}")
-    return v
+    try:
+        return ShowMode(v)
+    except ValueError:
+        raise ValueError(
+            f"show must be one of {[m.value for m in ShowMode]} or bool, got {value!r}"
+        ) from None
 
 
 class BenchPlotSrvCfg(param.Parameterized):
@@ -52,11 +69,12 @@ class BenchPlotSrvCfg(param.Parameterized):
         port (int): The port to launch panel with
         allow_ws_origin (bool): Add the port to the whitelist (warning will disable remote
                                access if set to true)
-        show (bool | str): Where to view the report. ``True``/``"live"`` (default) starts a
-                           Panel server and blocks. ``"static"`` saves an embedded HTML file
-                           and opens it in the browser, returning immediately. ``"published"``
-                           opens the published URL after ``publish=True`` (requires publish).
-                           ``False``/``"none"`` displays nothing.
+        show (bool | str | ShowMode): Where to view the report.
+            ``True``/``ShowMode.LIVE`` (default) starts a Panel server and blocks.
+            ``ShowMode.HTML`` saves an embedded HTML file and opens it in the browser,
+            returning immediately.  ``ShowMode.PUBLISHED`` opens the published URL after
+            ``publish=True`` (requires publish).  ``False``/``ShowMode.NONE`` displays
+            nothing.
     """
 
     port: int | None = param.Integer(None, doc="The port to launch panel with")
@@ -68,10 +86,10 @@ class BenchPlotSrvCfg(param.Parameterized):
         True,
         objects=[True, False, None, "live", "static", "published", "none"],
         doc=(
-            "Where to view the report. True/'live' (default) starts a Panel server and "
-            "blocks. 'static' saves an embedded HTML file and opens it in the browser, "
-            "returning immediately. 'published' opens the published URL after publish=True "
-            "(requires publish=True). False/'none' displays nothing."
+            "Where to view the report. True/ShowMode.LIVE (default) starts a Panel server "
+            "and blocks. ShowMode.HTML saves an embedded HTML file and opens it in the "
+            "browser, returning immediately. ShowMode.PUBLISHED opens the published URL "
+            "after publish=True (requires publish=True). False/ShowMode.NONE displays nothing."
         ),
     )
 

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -14,7 +14,7 @@ import panel as pn
 from diskcache import Cache
 from tornado.web import StaticFileHandler
 
-from bencher.bench_cfg import BenchCfg, BenchPlotSrvCfg
+from bencher.bench_cfg import BenchCfg, BenchPlotSrvCfg, normalize_show
 
 logging.basicConfig(level=logging.INFO)
 
@@ -76,7 +76,10 @@ class BenchPlotServer:
         if plot_cfg.port is not None and plot_cfg.allow_ws_origin:
             os.environ["BOKEH_ALLOW_WS_ORIGIN"] = f"localhost:{plot_cfg.port}"
 
-        return self.serve(bench_name, plots_instance, port=plot_cfg.port, show=plot_cfg.show)
+        # ``show`` accepts the display-mode enum as well as bool; coerce to the bool
+        # that ``pn.serve(show=...)`` expects (auto-open browser only in live mode).
+        auto_open = normalize_show(plot_cfg.show) == "live"
+        return self.serve(bench_name, plots_instance, port=plot_cfg.port, show=auto_open)
 
     def load_data_from_cache(self, bench_name: str) -> tuple[BenchCfg, list[pn.panel]] | None:
         """Load previously calculated benchmark data from the database and start a plot server to display it

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -14,7 +14,7 @@ import panel as pn
 from diskcache import Cache
 from tornado.web import StaticFileHandler
 
-from bencher.bench_cfg import BenchCfg, BenchPlotSrvCfg, normalize_show
+from bencher.bench_cfg import BenchCfg, BenchPlotSrvCfg, ShowMode, normalize_show
 
 logging.basicConfig(level=logging.INFO)
 
@@ -76,9 +76,7 @@ class BenchPlotServer:
         if plot_cfg.port is not None and plot_cfg.allow_ws_origin:
             os.environ["BOKEH_ALLOW_WS_ORIGIN"] = f"localhost:{plot_cfg.port}"
 
-        # ``show`` accepts the display-mode enum as well as bool; coerce to the bool
-        # that ``pn.serve(show=...)`` expects (auto-open browser only in live mode).
-        auto_open = normalize_show(plot_cfg.show) == "live"
+        auto_open = normalize_show(plot_cfg.show) is ShowMode.LIVE
         return self.serve(bench_name, plots_instance, port=plot_cfg.port, show=auto_open)
 
     def load_data_from_cache(self, bench_name: str) -> tuple[BenchCfg, list[pn.panel]] | None:

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Callable, Protocol, runtime_checkable
 import logging
 import warnings
+import webbrowser
 import inspect
 from datetime import datetime
-from bencher.bench_cfg import BenchRunCfg, BenchCfg
+from bencher.bench_cfg import BenchRunCfg, BenchCfg, normalize_show
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.bencher import Bench
 from bencher.bench_report import BenchReport, GithubPagesCfg, Publisher
@@ -290,7 +291,7 @@ class BenchRunner:
         run_cfg: BenchRunCfg | None = None,
         publish: bool = False,
         debug: bool = False,
-        show: bool = False,
+        show: bool | str = False,
         save: bool = False,
         grouped: bool = False,
         cache_samples: bool | None = None,
@@ -318,7 +319,10 @@ class BenchRunner:
             run_cfg (BenchRunCfg, optional): benchmark run configuration. Defaults to None.
             publish (bool, optional): Publish the results to git, requires a publish url to be set up. Defaults to False.
             debug (bool, optional): Enable debug output during publishing. Defaults to False.
-            show (bool, optional): show the results in the local web browser. Defaults to False.
+            show (bool | str, optional): How to display results. ``True``/``"live"`` starts a
+                Panel server (blocks); ``"static"`` saves HTML and opens it in the browser
+                (returns); ``"published"`` opens the published URL (requires ``publish=True``);
+                ``False``/``"none"`` displays nothing. Defaults to False.
             save (bool, optional): save the results to disk in index.html. Defaults to False.
             grouped (bool, optional): Produce a single html page with all the benchmarks included. Defaults to False.
             cache_samples (bool | None, optional): Use the sample cache to reuse previous results.
@@ -432,41 +436,72 @@ class BenchRunner:
         return self.results
 
     def show_publish(
-        self, report: BenchReport, show: bool, publish: bool, save: bool, debug: bool
+        self,
+        report: BenchReport,
+        show: bool | str,
+        publish: bool,
+        save: bool,
+        debug: bool,
     ) -> None:
         """Handle publishing, saving, and displaying of a benchmark report.
 
         Args:
             report (BenchReport): The benchmark report to process
-            show (bool): Whether to display the report in a browser
+            show (bool | str): How to display the report. See
+                :func:`bencher.bench_cfg.normalize_show` for accepted values.
             publish (bool): Whether to publish the report
             save (bool): Whether to save the report to disk
             debug (bool): Whether to enable debug mode for publishing
         """
+        show_mode = normalize_show(show)
+
         if save:
             report.save(
                 directory="reports", filename=f"{report.bench_name}.html", in_html_folder=False
             )
+
+        published_url: str | None = None
         if publish and self.publisher is not None:
             if isinstance(self.publisher, GithubPagesCfg):
                 p = self.publisher
-                report.publish_gh_pages(p.github_user, p.repo_name, p.folder_name, p.branch_name)
+                published_url = report.publish_gh_pages(
+                    p.github_user, p.repo_name, p.folder_name, p.branch_name
+                )
             elif isinstance(self.publisher, Publisher):
                 try:
-                    url = self.publisher.publish(report)
-                    if url:
-                        logging.info("Benchmark report published at %s", url)
+                    published_url = self.publisher.publish(report)
+                    if published_url:
+                        logging.info("Benchmark report published at %s", published_url)
                 except Exception:  # pylint: disable=broad-except
                     logging.exception("Publisher.publish() failed — continuing benchmark")
             else:
-                report.publish(remote_callback=self.publisher, debug=debug)
-        if show:
+                published_url = report.publish(remote_callback=self.publisher, debug=debug)
+
+        if show_mode == "live":
             self.servers.append(report.show(self.run_cfg))
+        elif show_mode == "static":
+            path = report.save()  # default: cachedir/html/<bench_name>.html
+            try:
+                webbrowser.open(path.resolve().as_uri())
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.exception("Failed to open browser for %s", path)
+        elif show_mode == "published":
+            if published_url:
+                try:
+                    webbrowser.open(published_url)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    logging.exception("Failed to open %s", published_url)
+            else:
+                logging.warning(
+                    "show='published' but no publish URL is available "
+                    "(publish=False or the publisher returned None) — nothing to open"
+                )
+        # show_mode == "none" → no-op
 
     def show(
         self,
         report: BenchReport | None = None,
-        show: bool = True,
+        show: bool | str = True,
         publish: bool = False,
         save: bool = False,
         debug: bool = False,
@@ -478,7 +513,8 @@ class BenchRunner:
 
         Args:
             report (BenchReport, optional): The report to process. Defaults to None (most recent).
-            show (bool, optional): Whether to display in browser. Defaults to True.
+            show (bool | str, optional): How to display. See :meth:`run` for accepted values.
+                Defaults to True.
             publish (bool, optional): Whether to publish the report. Defaults to False.
             save (bool, optional): Whether to save to disk. Defaults to False.
             debug (bool, optional): Enable debug mode for publishing. Defaults to False.

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -6,7 +6,7 @@ import warnings
 import webbrowser
 import inspect
 from datetime import datetime
-from bencher.bench_cfg import BenchRunCfg, BenchCfg, normalize_show
+from bencher.bench_cfg import BenchRunCfg, BenchCfg, ShowMode, normalize_show
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.bencher import Bench
 from bencher.bench_report import BenchReport, GithubPagesCfg, Publisher
@@ -291,7 +291,7 @@ class BenchRunner:
         run_cfg: BenchRunCfg | None = None,
         publish: bool = False,
         debug: bool = False,
-        show: bool | str = False,
+        show: bool | str | ShowMode = False,
         save: bool = False,
         grouped: bool = False,
         cache_samples: bool | None = None,
@@ -319,10 +319,11 @@ class BenchRunner:
             run_cfg (BenchRunCfg, optional): benchmark run configuration. Defaults to None.
             publish (bool, optional): Publish the results to git, requires a publish url to be set up. Defaults to False.
             debug (bool, optional): Enable debug output during publishing. Defaults to False.
-            show (bool | str, optional): How to display results. ``True``/``"live"`` starts a
-                Panel server (blocks); ``"static"`` saves HTML and opens it in the browser
-                (returns); ``"published"`` opens the published URL (requires ``publish=True``);
-                ``False``/``"none"`` displays nothing. Defaults to False.
+            show (bool | str | ShowMode, optional): How to display results.
+                ``True``/``ShowMode.LIVE`` starts a Panel server (blocks);
+                ``ShowMode.HTML`` saves HTML and opens it in the browser (returns);
+                ``ShowMode.PUBLISHED`` opens the published URL (requires ``publish=True``);
+                ``False``/``ShowMode.NONE`` displays nothing. Defaults to False.
             save (bool, optional): save the results to disk in index.html. Defaults to False.
             grouped (bool, optional): Produce a single html page with all the benchmarks included. Defaults to False.
             cache_samples (bool | None, optional): Use the sample cache to reuse previous results.
@@ -438,7 +439,7 @@ class BenchRunner:
     def show_publish(
         self,
         report: BenchReport,
-        show: bool | str,
+        show: bool | str | ShowMode,
         publish: bool,
         save: bool,
         debug: bool,
@@ -447,7 +448,7 @@ class BenchRunner:
 
         Args:
             report (BenchReport): The benchmark report to process
-            show (bool | str): How to display the report. See
+            show (bool | str | ShowMode): How to display the report. See
                 :func:`bencher.bench_cfg.normalize_show` for accepted values.
             publish (bool): Whether to publish the report
             save (bool): Whether to save the report to disk
@@ -480,15 +481,15 @@ class BenchRunner:
             else:
                 published_url = report.publish(remote_callback=self.publisher, debug=debug)
 
-        if show_mode == "live":
+        if show_mode is ShowMode.LIVE:
             self.servers.append(report.show(self.run_cfg))
-        elif show_mode == "static":
+        elif show_mode is ShowMode.HTML:
             path = report.save()  # default: cachedir/html/<bench_name>.html
             try:
                 webbrowser.open(path.resolve().as_uri())
             except Exception:  # pylint: disable=broad-exception-caught
                 logging.exception("Failed to open browser for %s", path)
-        elif show_mode == "published":
+        elif show_mode is ShowMode.PUBLISHED:
             if published_url:
                 try:
                     webbrowser.open(published_url)
@@ -499,12 +500,11 @@ class BenchRunner:
                     "show='published' but no publish URL is available "
                     "(publish=False or the publisher returned None) — nothing to open"
                 )
-        # show_mode == "none" → no-op
 
     def show(
         self,
         report: BenchReport | None = None,
-        show: bool | str = True,
+        show: bool | str | ShowMode = True,
         publish: bool = False,
         save: bool = False,
         debug: bool = False,
@@ -516,8 +516,8 @@ class BenchRunner:
 
         Args:
             report (BenchReport, optional): The report to process. Defaults to None (most recent).
-            show (bool | str, optional): How to display. See :meth:`run` for accepted values.
-                Defaults to True.
+            show (bool | str | ShowMode, optional): How to display. See :meth:`run` for
+                accepted values. Defaults to True.
             publish (bool, optional): Whether to publish the report. Defaults to False.
             save (bool, optional): Whether to save to disk. Defaults to False.
             debug (bool, optional): Enable debug mode for publishing. Defaults to False.

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -455,6 +455,9 @@ class BenchRunner:
         """
         show_mode = normalize_show(show)
 
+        if show_mode == "published" and not publish:
+            raise ValueError("show='published' requires publish=True")
+
         if save:
             report.save(
                 directory="reports", filename=f"{report.bench_name}.html", in_html_folder=False

--- a/bencher/example/example_image.py
+++ b/bencher/example/example_image.py
@@ -71,4 +71,4 @@ def example_image(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
 
 
 if __name__ == "__main__":
-    bn.run(example_image, level=3)
+    bn.run(example_image, level=3, show=bn.ShowMode.HTML)

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -223,7 +223,7 @@ def run(
                 results = br.run(show=False, **_run_kwargs)
             # Context has exited — resources are released. Now display the report.
             if show_mode != "none":
-                br.show(show=show)
+                br.show(show=show, publish=publish)
     finally:
         if bench_to_close is not None:
             try:

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -10,7 +10,7 @@ import time
 from contextlib import AbstractContextManager
 from typing import Any, Callable, TYPE_CHECKING
 
-from bencher.bench_cfg import BenchRunCfg, BenchCfg
+from bencher.bench_cfg import BenchRunCfg, BenchCfg, normalize_show
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ def run(
     max_level: int | None = None,
     max_repeats: int | None = None,
     run_cfg: BenchRunCfg | None = None,
-    show: bool = True,
+    show: bool | str = True,
     save: bool = False,
     publish: bool = False,
     publisher: Publisher | GithubPagesCfg | Callable | None = None,
@@ -96,7 +96,11 @@ def run(
         max_level: Maximum level for progressive runs. Defaults to None (single level).
         max_repeats: Maximum repeats for progressive runs. Defaults to None (single repeat count).
         run_cfg: Optional explicit BenchRunCfg. Defaults to None.
-        show: Show results in browser. Defaults to True.
+        show: Where to view the report. Accepts ``True``/``"live"`` (default — start a Panel
+            server and block on ``input()`` until the user presses Enter), ``"static"``
+            (save an embedded HTML file and open it in the browser, then return),
+            ``"published"`` (open the URL returned by publish — requires ``publish=True``),
+            or ``False``/``"none"`` (display nothing).
         save: Save results to disk. Defaults to False.
         publish: Publish results. Defaults to False.
         publisher: An object conforming to the :class:`Publisher` protocol (i.e. has a
@@ -133,6 +137,10 @@ def run(
         list[BenchCfg]: A list of benchmark configuration objects with results.
     """
     from bencher.bench_runner import BenchRunner, _resolve_cache_samples
+
+    show_mode = normalize_show(show)
+    if show_mode == "published" and not publish:
+        raise ValueError("show='published' requires publish=True")
 
     cache_samples = _resolve_cache_samples(cache_samples, kwargs, stacklevel=1)
 
@@ -213,9 +221,9 @@ def run(
             # while the context is still active.
             with sampling_context:
                 results = br.run(show=False, **_run_kwargs)
-            # Context has exited — resources are released. Now start the server.
-            if show:
-                br.show()
+            # Context has exited — resources are released. Now display the report.
+            if show_mode != "none":
+                br.show(show=show)
     finally:
         if bench_to_close is not None:
             try:
@@ -223,7 +231,7 @@ def run(
             except Exception:  # pylint: disable=broad-exception-caught
                 logging.exception("Error closing bench")
 
-    if show and br.servers:
+    if show_mode == "live" and br.servers:
         # Always register so atexit/SIGTERM can clean up as a safety net.
         _active_runners.append(br)
         _install_sigterm_handler()

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -10,7 +10,7 @@ import time
 from contextlib import AbstractContextManager
 from typing import Any, Callable, TYPE_CHECKING
 
-from bencher.bench_cfg import BenchRunCfg, BenchCfg, normalize_show
+from bencher.bench_cfg import BenchRunCfg, BenchCfg, ShowMode, normalize_show
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ def run(
     max_level: int | None = None,
     max_repeats: int | None = None,
     run_cfg: BenchRunCfg | None = None,
-    show: bool | str = True,
+    show: bool | str | ShowMode = True,
     save: bool = False,
     publish: bool = False,
     publisher: Publisher | GithubPagesCfg | Callable | None = None,
@@ -96,11 +96,11 @@ def run(
         max_level: Maximum level for progressive runs. Defaults to None (single level).
         max_repeats: Maximum repeats for progressive runs. Defaults to None (single repeat count).
         run_cfg: Optional explicit BenchRunCfg. Defaults to None.
-        show: Where to view the report. Accepts ``True``/``"live"`` (default — start a Panel
-            server and block on ``input()`` until the user presses Enter), ``"static"``
-            (save an embedded HTML file and open it in the browser, then return),
-            ``"published"`` (open the URL returned by publish — requires ``publish=True``),
-            or ``False``/``"none"`` (display nothing).
+        show: Where to view the report. Accepts ``True``/``ShowMode.LIVE`` (default — start
+            a Panel server and block on ``input()`` until the user presses Enter),
+            ``ShowMode.HTML`` (save an embedded HTML file and open it in the browser, then
+            return), ``ShowMode.PUBLISHED`` (open the URL returned by publish — requires
+            ``publish=True``), or ``False``/``ShowMode.NONE`` (display nothing).
         save: Save results to disk. Defaults to False.
         publish: Publish results. Defaults to False.
         publisher: An object conforming to the :class:`Publisher` protocol (i.e. has a
@@ -139,7 +139,7 @@ def run(
     from bencher.bench_runner import BenchRunner, _resolve_cache_samples
 
     show_mode = normalize_show(show)
-    if show_mode == "published" and not publish:
+    if show_mode is ShowMode.PUBLISHED and not publish:
         raise ValueError("show='published' requires publish=True")
 
     cache_samples = _resolve_cache_samples(cache_samples, kwargs, stacklevel=1)
@@ -222,7 +222,7 @@ def run(
             with sampling_context:
                 results = br.run(show=False, **_run_kwargs)
             # Context has exited — resources are released. Now display the report.
-            if show_mode != "none":
+            if show_mode is not ShowMode.NONE:
                 br.show(show=show, publish=publish)
     finally:
         if bench_to_close is not None:
@@ -231,7 +231,7 @@ def run(
             except Exception:  # pylint: disable=broad-exception-caught
                 logging.exception("Error closing bench")
 
-    if show_mode == "live" and br.servers:
+    if show_mode is ShowMode.LIVE and br.servers:
         # Always register so atexit/SIGTERM can clean up as a safety net.
         _active_runners.append(br)
         _install_sigterm_handler()

--- a/pixi.lock
+++ b/pixi.lock
@@ -1474,8 +1474,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.92.0
-  sha256: c46a1093b100e0879d22f2608fbc4b888578c06efd4c33b0e98819f8d92f8ddb
+  version: 1.93.0
+  sha256: 8a961d3343e97a3c5b850b51e2b92ffd340b5aafef987555675523c87403ff8c
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.92.0"
+version = "1.93.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -148,8 +148,6 @@ class TestShowEnum(unittest.TestCase):
 
     def test_show_static_opens_browser_and_returns(self):
         """show='static' saves an HTML file, opens the browser, and does not leave a server."""
-        from bencher.run import _active_runners
-
         with patch("bencher.bench_runner.webbrowser.open") as mock_open:
             results = bn.run(example_simple_float, show="static")
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -138,8 +138,9 @@ class TestShowEnum(unittest.TestCase):
     def test_normalize_show_rejects_bogus(self):
         from bencher.bench_cfg import normalize_show
 
-        with self.assertRaises(ValueError):
-            normalize_show("bogus")
+        for bad in ("bogus", 2, [], object()):
+            with self.assertRaises(ValueError):
+                normalize_show(bad)
 
     def test_published_without_publish_raises(self):
         with self.assertRaises(ValueError):
@@ -147,6 +148,8 @@ class TestShowEnum(unittest.TestCase):
 
     def test_show_static_opens_browser_and_returns(self):
         """show='static' saves an HTML file, opens the browser, and does not leave a server."""
+        from bencher.run import _active_runners
+
         with patch("bencher.bench_runner.webbrowser.open") as mock_open:
             results = bn.run(example_simple_float, show="static")
 
@@ -156,6 +159,7 @@ class TestShowEnum(unittest.TestCase):
         opened_uri = mock_open.call_args[0][0]
         self.assertTrue(opened_uri.startswith("file://"))
         self.assertTrue(opened_uri.endswith(".html"))
+        self.assertEqual(len(_active_runners), 0)
 
     def test_show_none_string_equivalent_to_false(self):
         """show='none' behaves like show=False — no server, no browser."""

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -123,6 +123,48 @@ class TestRun(unittest.TestCase):
             self.assertTrue(hasattr(r, "report"))
 
 
+class TestShowEnum(unittest.TestCase):
+    """Tests for the bool | str ``show`` enum on bn.run() / BenchRunner."""
+
+    def test_normalize_show_aliases(self):
+        from bencher.bench_cfg import normalize_show
+
+        self.assertEqual(normalize_show(True), "live")
+        self.assertEqual(normalize_show(False), "none")
+        self.assertEqual(normalize_show(None), "none")
+        for v in ("live", "static", "published", "none"):
+            self.assertEqual(normalize_show(v), v)
+
+    def test_normalize_show_rejects_bogus(self):
+        from bencher.bench_cfg import normalize_show
+
+        with self.assertRaises(ValueError):
+            normalize_show("bogus")
+
+    def test_published_without_publish_raises(self):
+        with self.assertRaises(ValueError):
+            bn.run(example_simple_float, show="published", publish=False)
+
+    def test_show_static_opens_browser_and_returns(self):
+        """show='static' saves an HTML file, opens the browser, and does not leave a server."""
+        with patch("bencher.bench_runner.webbrowser.open") as mock_open:
+            results = bn.run(example_simple_float, show="static")
+
+        self.assertIsInstance(results, list)
+        self.assertGreater(len(results), 0)
+        mock_open.assert_called()
+        opened_uri = mock_open.call_args[0][0]
+        self.assertTrue(opened_uri.startswith("file://"))
+        self.assertTrue(opened_uri.endswith(".html"))
+
+    def test_show_none_string_equivalent_to_false(self):
+        """show='none' behaves like show=False — no server, no browser."""
+        with patch("bencher.bench_runner.webbrowser.open") as mock_open:
+            results = bn.run(example_simple_float, show="none")
+        mock_open.assert_not_called()
+        self.assertIsInstance(results, list)
+
+
 class TestAddRunDeprecation(unittest.TestCase):
     """Tests for the add_run() deprecation warning."""
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -127,13 +127,15 @@ class TestShowEnum(unittest.TestCase):
     """Tests for the bool | str ``show`` enum on bn.run() / BenchRunner."""
 
     def test_normalize_show_aliases(self):
-        from bencher.bench_cfg import normalize_show
+        from bencher.bench_cfg import ShowMode, normalize_show
 
-        self.assertEqual(normalize_show(True), "live")
-        self.assertEqual(normalize_show(False), "none")
-        self.assertEqual(normalize_show(None), "none")
-        for v in ("live", "static", "published", "none"):
-            self.assertEqual(normalize_show(v), v)
+        self.assertIs(normalize_show(True), ShowMode.LIVE)
+        self.assertIs(normalize_show(False), ShowMode.NONE)
+        self.assertIs(normalize_show(None), ShowMode.NONE)
+        self.assertIs(normalize_show("static"), ShowMode.HTML)
+        for mode in ShowMode:
+            self.assertIs(normalize_show(mode), mode)
+            self.assertIs(normalize_show(mode.value), mode)
 
     def test_normalize_show_rejects_bogus(self):
         from bencher.bench_cfg import normalize_show
@@ -149,7 +151,7 @@ class TestShowEnum(unittest.TestCase):
     def test_show_static_opens_browser_and_returns(self):
         """show='static' saves an HTML file, opens the browser, and does not leave a server."""
         with patch("bencher.bench_runner.webbrowser.open") as mock_open:
-            results = bn.run(example_simple_float, show="static")
+            results = bn.run(example_simple_float, show="html")
 
         self.assertIsInstance(results, list)
         self.assertGreater(len(results), 0)


### PR DESCRIPTION
## Summary
- The `show` parameter on `bn.run()`, `BenchRunner.run()`, and `BenchRunner.show()` now accepts string display modes: `"live"` (Panel server, blocks — same as `True`), `"static"` (save HTML and open in browser, returns immediately), `"published"` (open published URL), and `"none"` (display nothing — same as `False`). Backward-compatible: `True`/`False` still work.
- Public `MethodCells` dataclass and `method_cells()` helper exposed from `bencher.regression` and re-exported from top-level `bencher` package.
- Removed private `_MethodCells`/`_method_cells` aliases (replaced by public names).
- Fixed bug where `show='published'` with `sampling_context` would lose the published URL.

## Test plan
- [x] `normalize_show` accepts bool, None, and all string modes; rejects invalid values
- [x] `show='published'` without `publish=True` raises `ValueError` eagerly
- [x] `show='static'` saves HTML, opens browser via `webbrowser.open`, returns without blocking
- [x] `show='none'` equivalent to `False` — no server, no browser
- [x] `MethodCells` and `method_cells` importable from `bencher` package
- [x] Per-method cell rendering (percentage, adaptive, delta, absolute) covered
- [x] Full CI passes (1350 tests, ruff, pylint 10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support multiple display modes for benchmark reports and centralize handling of how results are shown, including static and published views.

New Features:
- Allow the bn.run(), BenchRunner.run(), BenchRunner.show(), and BenchPlotSrvCfg.show parameters to accept string-based display modes (live, static, published, none) in addition to booleans.

Enhancements:
- Route all show handling through a normalize_show helper and adjust BenchRunner and plot server behavior to respect the selected display mode, including non-blocking static rendering and published URL viewing.

Documentation:
- Document the new show display modes and behavior in the changelog.

Tests:
- Add tests covering normalize_show, validation of invalid show values, published-without-publish error handling, static HTML display behavior, and the none mode behaving like False.