### PR TITLE
Restrict heatmap auto-plot to 2+ float vars

### DIFF
--- a/bencher/results/holoview_results/heatmap_result.py
+++ b/bencher/results/holoview_results/heatmap_result.py
@@ -70,7 +70,7 @@ class HeatmapResult(HoloviewResult):
 
         return self.filter(
             heatmap_cb,
-            float_range=VarRange(0, None),
+            float_range=VarRange(2, None),
             cat_range=VarRange(0, None),
             input_range=VarRange(2, None),
             panel_range=VarRange(0, None),
@@ -80,6 +80,14 @@ class HeatmapResult(HoloviewResult):
             override=override,
             **kwargs,
         )
+
+    def _pick_xy_axes(self) -> tuple[str, str]:
+        """Pick x/y axis names, preferring float vars then falling back to cat vars."""
+        axes = list(self.plt_cnt_cfg.float_vars)
+        for iv in self.bench_cfg.input_vars:
+            if iv not in axes:
+                axes.append(iv)
+        return axes[0].name, axes[1].name
 
     def to_heatmap_ds(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs
@@ -101,8 +109,7 @@ class HeatmapResult(HoloviewResult):
         if len(dataset.dims) < 2:
             return None
 
-        x = self.bench_cfg.input_vars[0].name
-        y = self.bench_cfg.input_vars[1].name
+        x, y = self._pick_xy_axes()
         C = result_var.name
         title = f"Heatmap of {result_var.name}"
 
@@ -147,8 +154,7 @@ class HeatmapResult(HoloviewResult):
         Returns:
             pn.Row: A panel row containing the interactive heatmap and tap info.
         """
-        x = self.bench_cfg.input_vars[0].name
-        y = self.bench_cfg.input_vars[1].name
+        x, y = self._pick_xy_axes()
         C = result_var.name
         title = f"Heatmap of {result_var.name}"
         df = dataset[C].to_dataframe().reset_index()
@@ -192,10 +198,11 @@ class HeatmapResult(HoloviewResult):
             xrotation=30,
         )
         htmap_posxy = hv.streams.Tap(source=htmap, x=0, y=0)
+        x_name, y_name = self._pick_xy_axes()
 
         def tap_plot(x, y):
-            kwargs[self.bench_cfg.input_vars[0].name] = x
-            kwargs[self.bench_cfg.input_vars[1].name] = y
+            kwargs[x_name] = x
+            kwargs[y_name] = y
             return self.get_nearest_holomap(**kwargs).opts(width=width, height=height)
 
         tap_htmap = hv.DynamicMap(tap_plot, streams=[htmap_posxy])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.94.0"
+version = "1.95.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_heatmap_result.py
+++ b/test/test_heatmap_result.py
@@ -65,3 +65,22 @@ class TestHeatmapResult(unittest.TestCase):
         # Pass list tap_var with use_tap=False to exercise list-handling (lines 99-112)
         result = self.res_2d.to_heatmap(tap_var=[rv], use_tap=False)
         self.assertIsNotNone(result)
+
+    def test_to_heatmap_suppressed_for_cat_only_inputs(self):
+        """Heatmap auto-plot must not fire when there are <2 float vars (cat-only inputs).
+
+        For 2 cats / 0 floats the new filter rejects, so the auto path returns
+        a Markdown debug panel (or None) rather than a HoloViews heatmap pane.
+        """
+        import holoviews as hv
+
+        bench_cat = BenchableObject().to_bench(bn.BenchRunCfg(repeats=1))
+        res_cat = bench_cat.plot_sweep(
+            "test_hm_cat_only",
+            input_vars=[BenchableObject.param.wave, BenchableObject.param.variant],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        result = res_cat.to_heatmap(override=False)
+        self.assertNotIsInstance(result, (hv.HeatMap, hv.HoloMap))


### PR DESCRIPTION
## Summary
- Raise `HeatmapResult.to_heatmap` filter from `float_range=VarRange(0, None)` to `VarRange(2, None)` so heatmaps no longer auto-fire on cat-only or 1-float-1-cat data — bar and line already cover those shapes more legibly.
- New `_pick_xy_axes()` helper picks axes float-first, then falls back to other input vars, so explicit `to_heatmap(override=True)` calls on cat-only data still work. Applied across `to_heatmap_ds`, `_to_heatmap_tap_ds`, and `to_heatmap_tap`.
- Bump holobench to 1.95.0.

## Test plan
- [x] `pixi run pytest test/test_heatmap_result.py` (8/8 pass, including new `test_to_heatmap_suppressed_for_cat_only_inputs`)
- [x] `pixi run pytest test/` (1351 pass, 5 skipped)
- [ ] Visually verify on a 2-cat sweep that no heatmap appears in `to_auto_plots`, and on a 2-float sweep that the heatmap still renders with float axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restrict automatic heatmap generation to sweeps with at least two float input variables and improve axis selection for heatmap plots.

Bug Fixes:
- Ensure heatmap auto-plotting is suppressed for sweeps with only categorical inputs or fewer than two float variables.

Enhancements:
- Introduce a shared helper to choose x/y heatmap axes preferring float variables and reuse it across dataset and tap-based heatmap paths.
- Improve tap-based heatmap interaction by aligning tap argument names with the selected heatmap axes.

Build:
- Bump the holobench package version to 1.95.0.

Tests:
- Add a regression test verifying that heatmap auto-plotting does not trigger for categorical-only input sweeps.