### PR TITLE
Make .rrd base64 inlining opt-in via portable parameter

### DIFF
--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -18,12 +18,16 @@ from bencher.bench_plot_server import BenchPlotServer
 from bencher.bench_cfg import BenchRunCfg
 
 
-def _inline_rrd(html_path: Path, rrd_base: Path | None = None) -> None:
+def _inline_rrd(
+    html_path: Path,
+    rrd_base: Path | None = None,
+    inline_data: bool = False,
+) -> None:
     """Inline .rrd data in a saved HTML report (no-op if no rerun iframes)."""
     try:
         from bencher.utils_rrd import inline_rrd_iframes
 
-        inline_rrd_iframes(html_path, rrd_base=rrd_base)
+        inline_rrd_iframes(html_path, rrd_base=rrd_base, inline_data=inline_data)
     except Exception:  # pylint: disable=broad-except
         logging.warning("inline_rrd_iframes failed for %s", html_path, exc_info=True)
 
@@ -158,6 +162,7 @@ class BenchReport(BenchPlotServer):
         directory: str | Path = "cachedir",
         filename: str | None = None,
         in_html_folder: bool = True,
+        portable: bool = False,
         **kwargs,
     ) -> Path:
         """Save the result to a html file.
@@ -170,6 +175,11 @@ class BenchReport(BenchPlotServer):
             directory (str | Path, optional): base folder to save to. Defaults to "cachedir" which should be ignored by git.
             filename (str, optional): The name of the html file. Defaults to the name of the benchmark
             in_html_folder (bool, optional): Put the saved files in a html subfolder to help keep the results separate from source code. Defaults to True.
+            portable (bool, optional): When True, base64-encode .rrd data
+                directly into the viewer HTML so the report works from
+                ``file://`` without any server.  When False (default), .rrd
+                files are copied as sidecar files and loaded via relative
+                URLs — the report must be served over HTTP.
 
         Returns:
             Path: the save path
@@ -195,7 +205,7 @@ class BenchReport(BenchPlotServer):
                 # Save inner content directly so the Tabs sidebar is not rendered
                 content = self.pane[0] if len(self.pane) == 1 else self.pane
                 content.save(filename=index_path, progress=True, embed=True, **kwargs)
-                _inline_rrd(index_path)
+                _inline_rrd(index_path, inline_data=portable)
                 return index_path
 
             # Save each tab to its own HTML so HoloMap sliders don't collide.
@@ -213,7 +223,7 @@ class BenchReport(BenchPlotServer):
                 tab_path = tab_dir / tab_file
                 logging.info(f"saving tab '{tab_name}' to: {tab_path.absolute()}")
                 pn.Column(tab).save(filename=tab_path, progress=True, embed=True, **kwargs)
-                _inline_rrd(tab_path, rrd_base=base_path)
+                _inline_rrd(tab_path, rrd_base=base_path, inline_data=portable)
                 tab_files.append((tab_name, f"_tabs/{tab_file}"))
 
             # Generate an index page with tab buttons and an iframe.

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -21,13 +21,18 @@ from bencher.bench_cfg import BenchRunCfg
 def _inline_rrd(
     html_path: Path,
     rrd_base: Path | None = None,
-    inline_data: bool = False,
+    portable: bool = False,
 ) -> None:
-    """Inline .rrd data in a saved HTML report (no-op if no rerun iframes)."""
+    """Rewrite .rrd viewer iframes in a saved HTML report for static hosting.
+
+    By default copies .rrd files as sidecars (fast, works on any HTTP server).
+    With ``portable=True``, base64-encodes the data into the viewer HTML so
+    the report works from ``file://`` without a server.
+    """
     try:
         from bencher.utils_rrd import inline_rrd_iframes
 
-        inline_rrd_iframes(html_path, rrd_base=rrd_base, inline_data=inline_data)
+        inline_rrd_iframes(html_path, rrd_base=rrd_base, portable=portable)
     except Exception:  # pylint: disable=broad-except
         logging.warning("inline_rrd_iframes failed for %s", html_path, exc_info=True)
 
@@ -205,7 +210,7 @@ class BenchReport(BenchPlotServer):
                 # Save inner content directly so the Tabs sidebar is not rendered
                 content = self.pane[0] if len(self.pane) == 1 else self.pane
                 content.save(filename=index_path, progress=True, embed=True, **kwargs)
-                _inline_rrd(index_path, inline_data=portable)
+                _inline_rrd(index_path, portable=portable)
                 return index_path
 
             # Save each tab to its own HTML so HoloMap sliders don't collide.
@@ -223,7 +228,7 @@ class BenchReport(BenchPlotServer):
                 tab_path = tab_dir / tab_file
                 logging.info(f"saving tab '{tab_name}' to: {tab_path.absolute()}")
                 pn.Column(tab).save(filename=tab_path, progress=True, embed=True, **kwargs)
-                _inline_rrd(tab_path, rrd_base=base_path, inline_data=portable)
+                _inline_rrd(tab_path, rrd_base=base_path, portable=portable)
                 tab_files.append((tab_name, f"_tabs/{tab_file}"))
 
             # Generate an index page with tab buttons and an iframe.

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -484,7 +484,7 @@ class BenchRunner:
         if show_mode is ShowMode.LIVE:
             self.servers.append(report.show(self.run_cfg))
         elif show_mode is ShowMode.HTML:
-            path = report.save()  # default: cachedir/html/<bench_name>.html
+            path = report.save(portable=True)  # file:// needs inline .rrd data
             try:
                 webbrowser.open(path.resolve().as_uri())
             except Exception:  # pylint: disable=broad-exception-caught

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -309,7 +309,7 @@ def _write_inline_viewer(rrd_path: Path, version: str, dest_dir: Path) -> str:
 def inline_rrd_iframes(
     html_path: Path,
     rrd_base: Path | None = None,
-    inline_data: bool = False,
+    portable: bool = False,
 ) -> None:
     """Post-process a saved HTML report for static hosting.
 
@@ -325,7 +325,7 @@ def inline_rrd_iframes(
         Directory where ``_rrd/`` should be created.  When ``None``
         (default), uses ``html_path.parent``.  Pass the top-level report
         directory for multi-tab saves so all tabs share one ``_rrd/``.
-    inline_data:
+    portable:
         When ``True``, base64-encode the ``.rrd`` data directly into the
         viewer HTML so the report works from ``file://`` without any
         server.  This can be very slow for large recordings (hundreds of
@@ -354,7 +354,7 @@ def inline_rrd_iframes(
             logging.warning("inline_rrd_iframes: %s not found, skipping", rrd_path)
             return m.group(0)
 
-        if inline_data:
+        if portable:
             viewer_name = _write_inline_viewer(rrd_path, version, rrd_dir)
             relative_url = f"{rrd_rel_prefix}/{viewer_name}"
         else:

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -306,13 +306,16 @@ def _write_inline_viewer(rrd_path: Path, version: str, dest_dir: Path) -> str:
     return filename
 
 
-def inline_rrd_iframes(html_path: Path, rrd_base: Path | None = None) -> None:
+def inline_rrd_iframes(
+    html_path: Path,
+    rrd_base: Path | None = None,
+    inline_data: bool = False,
+) -> None:
     """Post-process a saved HTML report for static hosting.
 
     Scans the HTML file for rerun viewer iframes (those pointing at
-    ``/rrd_static/``), generates self-contained viewer pages with the
-    ``.rrd`` data inlined as base64, and rewrites the iframe ``src`` to
-    point to them.  The result works from ``file://`` without a server.
+    ``/rrd_static/``), copies the ``.rrd`` files next to the report, and
+    rewrites the iframe ``src`` to relative URLs.
 
     Parameters
     ----------
@@ -322,6 +325,13 @@ def inline_rrd_iframes(html_path: Path, rrd_base: Path | None = None) -> None:
         Directory where ``_rrd/`` should be created.  When ``None``
         (default), uses ``html_path.parent``.  Pass the top-level report
         directory for multi-tab saves so all tabs share one ``_rrd/``.
+    inline_data:
+        When ``True``, base64-encode the ``.rrd`` data directly into the
+        viewer HTML so the report works from ``file://`` without any
+        server.  This can be very slow for large recordings (hundreds of
+        MB or more).  When ``False`` (default), the ``.rrd`` is copied as
+        a sidecar file and loaded via a relative URL — the report must be
+        served over HTTP (any static server works).
 
     Called automatically by ``BenchReport.save()``.
     """
@@ -344,9 +354,13 @@ def inline_rrd_iframes(html_path: Path, rrd_base: Path | None = None) -> None:
             logging.warning("inline_rrd_iframes: %s not found, skipping", rrd_path)
             return m.group(0)
 
-        viewer_name = _write_inline_viewer(rrd_path, version, rrd_dir)
+        if inline_data:
+            viewer_name = _write_inline_viewer(rrd_path, version, rrd_dir)
+            relative_url = f"{rrd_rel_prefix}/{viewer_name}"
+        else:
+            viewer_name, rrd_name = _write_rrd_sidecar(rrd_path, version, rrd_dir)
+            relative_url = f"{rrd_rel_prefix}/{viewer_name}?url={quote(rrd_name)}"
 
-        relative_url = f"{rrd_rel_prefix}/{viewer_name}"
         changed = True
         return (
             f"&amp;lt;iframe src=&amp;quot;{relative_url}&amp;quot;"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.95.0"
+version = "1.96.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary

- `inline_rrd_iframes()` now defaults to sidecar mode (copy .rrd as separate file) instead of base64-encoding the entire .rrd into the viewer HTML
- Base64 inline mode is still available via `inline_data=True` and is used automatically by `ShowMode.HTML` (file:// viewing)
- `BenchReport.save()` exposes this as `portable=True` for callers that need fully self-contained HTML

## Motivation

The base64 inline approach introduced in #929 doesn't scale for large rerun recordings (hundreds of MB or more). Encoding a GB-sized .rrd to base64 is slow, adds ~33% size overhead, and the resulting HTML is too large for browsers to render efficiently.

The sidecar approach copies the .rrd as a separate file and references it via a relative URL in the viewer HTML. This works on any static HTTP server and is much faster for large files.

## Test plan

- [ ] Verify `save()` produces working reports with sidecar .rrd files
- [ ] Verify `save(portable=True)` still base64-inlines .rrd data
- [ ] Verify `show="html"` auto-sets `portable=True` for file:// viewing

## Summary by Sourcery

Make RRD iframe inlining default to sidecar files and add an opt-in portable mode for fully self-contained HTML reports.

New Features:
- Add an inline_data option to inline_rrd_iframes and BenchReport.save to control whether .rrd data is base64-inlined or referenced as sidecar files.
- Expose a portable flag on BenchReport.save to generate fully self-contained HTML reports when needed.

Enhancements:
- Change default RRD iframe handling to copy .rrd files as sidecar resources referenced via relative URLs for better scalability.
- Make HTML show mode use the portable save option so file:// viewing still works without a server.