### PR TITLE
Fix aggregate duplicating pane-type results; rename VideoResult to PaneResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.97.0] - 2026-04-27
+
+### Fixed
+- `aggregate=True` no longer duplicates pane-type results (rerun, image, video). Pane results store file paths that cannot be numerically aggregated, so they now only render in the non-aggregated view.
+- Line plotter crash when aggregating: `plt_cnt_cfg` still referenced collapsed dimensions, causing holoviews `DataError` on missing dimension names. Swapped to post-aggregation config during `map_plot_panes` calls.
+- `remove_plots` no longer raises `ValueError` when combined with `numeric_only`.
+
+### Changed
+- Renamed `VideoResult` to `PaneResult` to reflect that it handles all pane types (rerun, image, video), not just video.
+
+### Added
+- Image and video aggregate examples (`example_result_image_aggregate`, `example_result_video_aggregate`) to exercise and demonstrate pane-result aggregation.
+- `omega_n` sweep added to `ControlSystemSweep` for multi-input rerun testing.
+
 ## [1.94.0] - 2026-04-25
 
 ### Fixed

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -144,7 +144,8 @@ from .cache_management import (
 )
 from .results.bench_result import BenchResult
 from .results.optimize_result import OptimizeResult
-from .results.video_result import VideoResult
+from .results.pane_result import PaneResult
+VideoResult = PaneResult
 from .results.holoview_results.holoview_result import ReduceType, HoloviewResult
 from .bench_report import BenchReport, GithubPagesCfg, Publisher
 from .job import Executors

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -145,6 +145,7 @@ from .cache_management import (
 from .results.bench_result import BenchResult
 from .results.optimize_result import OptimizeResult
 from .results.pane_result import PaneResult
+
 VideoResult = PaneResult
 from .results.holoview_results.holoview_result import ReduceType, HoloviewResult
 from .bench_report import BenchReport, GithubPagesCfg, Publisher

--- a/bencher/example/example_rerun_over_time.py
+++ b/bencher/example/example_rerun_over_time.py
@@ -27,6 +27,9 @@ class ControlSystemSweep(bn.ParametrizedSweep):
     damping_ratio = bn.FloatSweep(
         default=0.7, bounds=[0.1, 2.0], doc="Damping ratio (zeta)", samples=5
     )
+    omega_n = bn.FloatSweep(
+        default=5.0, bounds=[2.0, 10.0], doc="Natural frequency (rad/s)", samples=3
+    )
 
     out_overshoot = bn.ResultFloat(units="%", doc="peak overshoot", direction=bn.OptDir.minimize)
     out_settling_time = bn.ResultFloat(
@@ -40,7 +43,7 @@ class ControlSystemSweep(bn.ParametrizedSweep):
         n_steps = 200
         dt = 0.02
         setpoint = 1.0
-        omega_n = 5.0  # natural frequency  rad/s
+        omega_n = self.omega_n
         zeta = max(0.05, self.damping_ratio - self._degradation)
 
         y, dy = 0.0, 0.0

--- a/bencher/example/generated/rerun/example_rerun_sweep.py
+++ b/bencher/example/generated/rerun/example_rerun_sweep.py
@@ -5,14 +5,15 @@ from bencher.example.example_rerun_over_time import ControlSystemSweep
 
 
 def example_rerun_sweep(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Rerun Sweep — control system response across damping ratios."""
+    """Rerun Sweep — control system response across damping ratios and natural frequencies."""
     bench = ControlSystemSweep().to_bench(run_cfg)
     bench.plot_sweep(
-        input_vars=["damping_ratio"],
+        input_vars=["damping_ratio", "omega_n"],
         result_vars=["out_overshoot", "out_settling_time", "out_rerun"],
-        description="Sweep the damping ratio of a second-order control system and "
-        "visualise each step response in the rerun viewer.  Low damping causes "
-        "overshoot and ringing; high damping is sluggish but stable.",
+        description="Sweep the damping ratio and natural frequency of a second-order "
+        "control system.  aggregate=True collapses omega_n so you can see the "
+        "mean ± std across frequencies for each damping ratio.",
+        aggregate=True,
     )
 
     return bench

--- a/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
+++ b/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
@@ -24,6 +24,7 @@ def _draw_polygon_image(points, color, linewidth, size=200):
 
 class PolygonRenderer(bn.ParametrizedSweep):
     """Renders polygon images with configurable sides, radius, and color."""
+
     sides = bn.IntSweep(default=3, bounds=(3, 7), doc="Number of polygon sides")
     radius = bn.FloatSweep(default=0.6, bounds=(0.2, 1.0), doc="Polygon radius")
     color = bn.StringSweep(["red", "green", "blue"], doc="Line color")

--- a/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
+++ b/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
@@ -1,0 +1,60 @@
+"""Auto-generated example: ResultImage: Aggregate with Mixed Image and Scalar."""
+
+import bencher as bn
+import math
+import numpy as np
+from PIL import Image, ImageDraw
+
+
+def _polygon_points(radius, sides, start_angle=0.0):
+    points = []
+    for ang in np.linspace(0, 360, sides + 1):
+        angle = math.radians(start_angle + ang)
+        points.append([math.sin(angle) * radius, math.cos(angle) * radius])
+    return points
+
+
+def _draw_polygon_image(points, color, linewidth, size=200):
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    scaled = [((p[0] + 1) * size / 2, (1 - p[1]) * size / 2) for p in points]
+    draw.line(scaled, fill=color, width=int(linewidth))
+    return img
+
+
+class PolygonRenderer(bn.ParametrizedSweep):
+    """Renders polygon images with configurable sides, radius, and color."""
+    sides = bn.IntSweep(default=3, bounds=(3, 7), doc="Number of polygon sides")
+    radius = bn.FloatSweep(default=0.6, bounds=(0.2, 1.0), doc="Polygon radius")
+    color = bn.StringSweep(["red", "green", "blue"], doc="Line color")
+    polygon = bn.ResultImage(doc="Rendered polygon image")
+    area = bn.ResultFloat("u^2", doc="Polygon area")
+
+    def benchmark(self):
+        points = _polygon_points(self.radius, self.sides)
+        img = _draw_polygon_image(points, self.color, linewidth=3)
+        filepath = bn.gen_image_path("polygon")
+        img.save(filepath, "PNG")
+        self.polygon = str(filepath)
+        self.area = (self.sides * (2 * self.radius * math.sin(math.pi / self.sides)) ** 2) / (
+            4 * math.tan(math.pi / self.sides)
+        )
+
+
+def example_result_image_aggregate(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """ResultImage: Aggregate with Mixed Image and Scalar."""
+    bench = PolygonRenderer().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["sides", "color"],
+        result_vars=["polygon", "area"],
+        description="aggregate=True collapses the color dimension. The area scalar is "
+        "averaged over colors (mean ± std), but polygon images should only appear "
+        "once in the non-aggregated view.",
+        aggregate=True,
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_result_image_aggregate, level=3)

--- a/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
@@ -24,6 +24,7 @@ def _draw_polygon_image(points, color, linewidth, size=200):
 
 class PolygonAnimator(bn.ParametrizedSweep):
     """Renders rotating polygon animations."""
+
     sides = bn.IntSweep(default=4, bounds=(3, 7), doc="Number of polygon sides")
     speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
     animation = bn.ResultVideo(doc="Rotating polygon video")

--- a/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
@@ -1,0 +1,62 @@
+"""Auto-generated example: ResultVideo: Aggregate with Mixed Video and Image."""
+
+import bencher as bn
+import math
+import numpy as np
+from PIL import Image, ImageDraw
+
+
+def _polygon_points(radius, sides, start_angle=0.0):
+    points = []
+    for ang in np.linspace(0, 360, sides + 1):
+        angle = math.radians(start_angle + ang)
+        points.append([math.sin(angle) * radius, math.cos(angle) * radius])
+    return points
+
+
+def _draw_polygon_image(points, color, linewidth, size=200):
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    scaled = [((p[0] + 1) * size / 2, (1 - p[1]) * size / 2) for p in points]
+    draw.line(scaled, fill=color, width=int(linewidth))
+    return img
+
+
+class PolygonAnimator(bn.ParametrizedSweep):
+    """Renders rotating polygon animations."""
+    sides = bn.IntSweep(default=4, bounds=(3, 7), doc="Number of polygon sides")
+    speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
+    animation = bn.ResultVideo(doc="Rotating polygon video")
+    frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
+    max_angle = bn.ResultFloat(units="deg", doc="Maximum rotation angle in the animation")
+
+    def benchmark(self):
+        vid_writer = bn.VideoWriter()
+        num_frames = 8
+        for i in range(num_frames):
+            angle = self.speed * (360.0 * i / num_frames)
+            points = _polygon_points(0.7, self.sides, start_angle=angle)
+            img = _draw_polygon_image(points, "white", linewidth=3, size=200)
+            vid_writer.append(np.array(img.convert("RGB")))
+        self.animation = vid_writer.write()
+        self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
+        self.max_angle = self.speed * 360.0 * (num_frames - 1) / num_frames
+
+
+def example_result_video_aggregate(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """ResultVideo: Aggregate with Mixed Video and Image."""
+    bench = PolygonAnimator().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["sides", "speed"],
+        result_vars=["animation", "frame_snapshot", "max_angle"],
+        description="aggregate=True collapses the speed dimension. Videos and images "
+        "should only appear once in the non-aggregated view, not duplicated "
+        "in the aggregated view.",
+        aggregate=True,
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_result_video_aggregate, level=2)

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -61,6 +61,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
+    max_angle = bn.ResultFloat(units="deg", doc="Maximum rotation angle in the animation")
 
     def benchmark(self):
         vid_writer = bn.VideoWriter()
@@ -71,7 +72,8 @@ class PolygonAnimator(bn.ParametrizedSweep):
             img = _draw_polygon_image(points, "white", linewidth=3, size=200)
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
-        self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)"""
+        self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
+        self.max_angle = self.speed * 360.0 * (num_frames - 1) / num_frames"""
 )
 
 _EXTRA_IMPORTS = ["import math", "import numpy as np", "from PIL import Image, ImageDraw"]
@@ -147,6 +149,8 @@ class MetaImageVideoRich(MetaGeneratorBase):
             "result_image_to_video",
             "result_image_composable",
             "result_image_over_time",
+            "result_image_aggregate",
+            "result_video_aggregate",
         ],
         doc="Rich example to generate",
     )
@@ -159,6 +163,8 @@ class MetaImageVideoRich(MetaGeneratorBase):
             "result_image_to_video": self._gen_to_video,
             "result_image_composable": self._gen_composable,
             "result_image_over_time": self._gen_over_time,
+            "result_image_aggregate": self._gen_image_aggregate,
+            "result_video_aggregate": self._gen_video_aggregate,
         }[name]
         generator()
 
@@ -340,6 +346,59 @@ class MetaImageVideoRich(MetaGeneratorBase):
         )
 
 
+    # -- Image aggregate -------------------------------------------------------
+
+    def _gen_image_aggregate(self):
+        imports = "\n".join(["import bencher as bn"] + _EXTRA_IMPORTS)
+        body = (
+            "bench = PolygonRenderer().to_bench(run_cfg)\n"
+            "bench.plot_sweep(\n"
+            '    input_vars=["sides", "color"],\n'
+            '    result_vars=["polygon", "area"],\n'
+            '    description="aggregate=True collapses the color dimension. '\
+            "The area scalar is averaged over colors (mean \\u00b1 std), "
+            'but polygon images should only appear once in the non-aggregated view.",\n'
+            "    aggregate=True,\n"
+            ")\n"
+        )
+        self.generate_example(
+            title="ResultImage: Aggregate with Mixed Image and Scalar",
+            output_dir=f"{OUTPUT_DIR}/result_image",
+            filename="example_result_image_aggregate",
+            function_name="example_result_image_aggregate",
+            imports=imports,
+            body=body,
+            class_code=_IMAGE_CLASS_CODE,
+            run_kwargs={"level": 3},
+        )
+
+    # -- Video aggregate -------------------------------------------------------
+
+    def _gen_video_aggregate(self):
+        imports = "\n".join(["import bencher as bn"] + _EXTRA_IMPORTS)
+        body = (
+            "bench = PolygonAnimator().to_bench(run_cfg)\n"
+            "bench.plot_sweep(\n"
+            '    input_vars=["sides", "speed"],\n'
+            '    result_vars=["animation", "frame_snapshot", "max_angle"],\n'
+            '    description="aggregate=True collapses the speed dimension. '\
+            "Videos and images should only appear once in the non-aggregated view, "
+            'not duplicated in the aggregated view.",\n'
+            "    aggregate=True,\n"
+            ")\n"
+        )
+        self.generate_example(
+            title="ResultVideo: Aggregate with Mixed Video and Image",
+            output_dir=f"{OUTPUT_DIR}/result_video",
+            filename="example_result_video_aggregate",
+            function_name="example_result_video_aggregate",
+            imports=imports,
+            body=body,
+            class_code=_VIDEO_CLASS_CODE,
+            run_kwargs={"level": 2},
+        )
+
+
 # --- Entry point -----------------------------------------------------------
 
 
@@ -368,6 +427,8 @@ def example_meta_image_video(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
                     "result_image_to_video",
                     "result_image_composable",
                     "result_image_over_time",
+                    "result_image_aggregate",
+                    "result_video_aggregate",
                 ],
             ),
         ],

--- a/bencher/example/meta/generate_meta_image_video.py
+++ b/bencher/example/meta/generate_meta_image_video.py
@@ -345,7 +345,6 @@ class MetaImageVideoRich(MetaGeneratorBase):
             run_kwargs={"level": 2},
         )
 
-
     # -- Image aggregate -------------------------------------------------------
 
     def _gen_image_aggregate(self):
@@ -355,7 +354,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
             "bench.plot_sweep(\n"
             '    input_vars=["sides", "color"],\n'
             '    result_vars=["polygon", "area"],\n'
-            '    description="aggregate=True collapses the color dimension. '\
+            '    description="aggregate=True collapses the color dimension. '
             "The area scalar is averaged over colors (mean \\u00b1 std), "
             'but polygon images should only appear once in the non-aggregated view.",\n'
             "    aggregate=True,\n"
@@ -381,7 +380,7 @@ class MetaImageVideoRich(MetaGeneratorBase):
             "bench.plot_sweep(\n"
             '    input_vars=["sides", "speed"],\n'
             '    result_vars=["animation", "frame_snapshot", "max_angle"],\n'
-            '    description="aggregate=True collapses the speed dimension. '\
+            '    description="aggregate=True collapses the speed dimension. '
             "Videos and images should only appear once in the non-aggregated view, "
             'not duplicated in the aggregated view.",\n'
             "    aggregate=True,\n"

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -120,7 +120,7 @@ for i, deg in enumerate(degradations):
         )
 
     def _generate_sweep(self):
-        """1 input var (damping_ratio), single sweep, no over_time."""
+        """2 input vars (damping_ratio, omega_n), single sweep, aggregate=True."""
         imports = (
             "import bencher as bn\n"
             "from bencher.example.example_rerun_over_time import ControlSystemSweep"
@@ -128,11 +128,12 @@ for i, deg in enumerate(degradations):
         body = """\
 bench = ControlSystemSweep().to_bench(run_cfg)
 bench.plot_sweep(
-    input_vars=["damping_ratio"],
+    input_vars=["damping_ratio", "omega_n"],
     result_vars=["out_overshoot", "out_settling_time", "out_rerun"],
-    description="Sweep the damping ratio of a second-order control system and "
-    "visualise each step response in the rerun viewer.  Low damping causes "
-    "overshoot and ringing; high damping is sluggish but stable.",
+    description="Sweep the damping ratio and natural frequency of a second-order "
+    "control system.  aggregate=True collapses omega_n so you can see the "
+    "mean \\u00b1 std across frequencies for each damping ratio.",
+    aggregate=True,
 )
 """
         self.generate_example(

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
 
 
 from bencher.results.video_summary import VideoSummaryResult
-from bencher.results.video_result import VideoResult
+from bencher.results.pane_result import PaneResult
 from bencher.results.volume_result import VolumeResult
 from bencher.results.holoview_results.holoview_result import HoloviewResult
 
@@ -138,7 +138,7 @@ class BenchResult(
             HistogramResult.to_plot,
             VolumeResult.to_plot,
             # PanelResult.to_video,
-            VideoResult.to_panes,
+            PaneResult.to_panes,
         ]
 
     @staticmethod
@@ -169,6 +169,7 @@ class BenchResult(
         remove_plots: list[callable] | None = None,
         default_container=pn.Column,
         override: bool = False,  # false so that plots that are not supported are not shown
+        numeric_only: bool = False,
         **kwargs,
     ) -> list[pn.panel]:
         """Automatically generate plots based on the provided plot callbacks.
@@ -178,6 +179,9 @@ class BenchResult(
             remove_plots (list[callable], optional): List of plot callback functions to exclude. Defaults to None.
             default_container (type, optional): Default container type for the plots. Defaults to pn.Column.
             override (bool, optional): Whether to override unsupported plots. Defaults to False.
+            numeric_only (bool, optional): When True, skip pane-type result callbacks
+                (images, videos, rerun, etc.) that cannot be numerically aggregated.
+                Defaults to False.
             **kwargs: Additional keyword arguments for plot configuration.
 
         Returns:
@@ -189,6 +193,8 @@ class BenchResult(
 
         if plot_list is None:
             plot_list = BenchResult.default_plot_callbacks()
+        if numeric_only:
+            plot_list = [cb for cb in plot_list if cb is not PaneResult.to_panes]
         if remove_plots is not None:
             for p in remove_plots:
                 plot_list.remove(p)
@@ -289,6 +295,7 @@ class BenchResult(
                 }
                 plot_cols.append(
                     self.to_auto(
+                        numeric_only=True,
                         agg_over_dims=self.bench_cfg.agg_over_dims,
                         agg_fn=self.bench_cfg.agg_fn,
                         **agg_kwargs,

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -197,7 +197,8 @@ class BenchResult(
             plot_list = [cb for cb in plot_list if cb is not PaneResult.to_panes]
         if remove_plots is not None:
             for p in remove_plots:
-                plot_list.remove(p)
+                if p in plot_list:
+                    plot_list.remove(p)
 
         kwargs = self.set_plot_size(**kwargs)
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -709,17 +709,23 @@ class BenchResultBase:
                     hv_dataset = self.to_hv_dataset(
                         reduce=reduce, agg_over_dims=agg_dims, agg_fn=agg_fn
                     )
-            return self.map_plot_panes(
-                plot_callback=plot_callback,
-                hv_dataset=hv_dataset,
-                target_dimension=target_dimension,
-                result_var=result_var,
-                result_types=result_types,
-                pane_collection=pane_collection,
-                reduce=reduce,
-                pane_layout=pane_layout,
-                **kwargs,
-            )
+            prev_cfg = self.plt_cnt_cfg
+            if agg_over_dims:
+                self.plt_cnt_cfg = check_cfg
+            try:
+                return self.map_plot_panes(
+                    plot_callback=plot_callback,
+                    hv_dataset=hv_dataset,
+                    target_dimension=target_dimension,
+                    result_var=result_var,
+                    result_types=result_types,
+                    pane_collection=pane_collection,
+                    reduce=reduce,
+                    pane_layout=pane_layout,
+                    **kwargs,
+                )
+            finally:
+                self.plt_cnt_cfg = prev_cfg
         return matches_res.to_panel()
 
     def to_panes_multi_panel(

--- a/bencher/results/explorer_result.py
+++ b/bencher/results/explorer_result.py
@@ -3,10 +3,10 @@ import panel as pn
 import hvplot.xarray  # noqa pylint: disable=duplicate-code,unused-import
 import hvplot.pandas  # noqa pylint: disable=duplicate-code,unused-import
 
-from bencher.results.video_result import VideoResult
+from bencher.results.pane_result import PaneResult
 
 
-class ExplorerResult(VideoResult):
+class ExplorerResult(PaneResult):
     def to_plot(self, **kwargs) -> pn.pane.Pane:  # noqa pylint: disable=unused-argument
         """Produces a hvplot explorer instance to explore the generated dataset
         see: https://hvplot.holoviz.org/getting_started/explorer.html

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -15,7 +15,7 @@ from bencher.utils import (
     get_nearest_coords,
     listify,
 )
-from bencher.results.video_result import VideoResult
+from bencher.results.pane_result import PaneResult
 from bencher.results.bench_result_base import ReduceType
 
 from bencher.variables.results import ResultFloat, ResultImage, ResultVideo
@@ -28,7 +28,7 @@ use_tap = True
 _AGG_TITLE = "All Time Points (aggregated)"
 
 
-class HoloviewResult(VideoResult):
+class HoloviewResult(PaneResult):
     @staticmethod
     def set_default_opts(width: int = 600, height: int = 600) -> dict:
         """Set default options for HoloViews visualizations.

--- a/bencher/results/pane_result.py
+++ b/bencher/results/pane_result.py
@@ -11,7 +11,7 @@ from bencher.variables.results import (
 )
 
 
-class VideoResult(BenchResultBase):
+class PaneResult(BenchResultBase):
     def to_video(self, result_var: Parameter | None = None, **kwargs):
         vc = VideoControls()
         return pn.Column(

--- a/pixi.lock
+++ b/pixi.lock
@@ -65,7 +65,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
@@ -114,11 +114,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -240,7 +240,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/42/09/7dbe3d7023f57d9b580cfa832109d521988112fd59dddfda3fddda8218f9/fonttools-4.62.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
@@ -288,11 +288,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -416,7 +416,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/a1/40a5c4d8e28b0851d53a8eeeb46fbd73c325a2a9a165f290a5ed90e6c597/fonttools-4.62.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
@@ -465,11 +465,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -591,7 +591,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
@@ -640,11 +640,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -765,7 +765,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4f/ab/a6aa43d45ceb88adc0e8c1358fa6935c6e6a5895537431dec67524ca2ccd/holoviews-1.22.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl
@@ -814,11 +814,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
@@ -1419,13 +1419,14 @@ packages:
   sha256: 6d541e0951dbbeeb8165d2e9209dc1ede41001bdbc8b7ad1f7464ce242a28c1a
   md5: 5cf0c191d87ec18a0db448881da5e771
   license: Apache-2.0
+  license_family: APACHE
   purls: []
   size: 13093885
   timestamp: 1776894219860
-- pypi: https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
-  version: 3.4.0
-  sha256: a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc
+  version: 3.5.0
+  sha256: 9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c
   requires_dist:
   - sphinx ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -1433,10 +1434,10 @@ packages:
   - psutil ; extra == 'test'
   - setuptools ; extra == 'test'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
-  version: 3.4.0
-  sha256: f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf
+  version: 3.5.0
+  sha256: 2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13
   requires_dist:
   - sphinx ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -1444,10 +1445,10 @@ packages:
   - psutil ; extra == 'test'
   - setuptools ; extra == 'test'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
-  version: 3.4.0
-  sha256: 523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398
+  version: 3.5.0
+  sha256: 4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb
   requires_dist:
   - sphinx ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -1455,10 +1456,10 @@ packages:
   - psutil ; extra == 'test'
   - setuptools ; extra == 'test'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
-  version: 3.4.0
-  sha256: c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83
+  version: 3.5.0
+  sha256: 0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662
   requires_dist:
   - sphinx ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -1468,8 +1469,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.94.0
-  sha256: 181836b1ca4f0258c9e70798490aa4117b99a7ef9dff4c8b96fcd34ecaeb613b
+  version: 1.96.0
+  sha256: b444496fa884d3fa71701ba2debf9b854899b40c8d908efe87f2529d2fb3ce6a
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1
@@ -3425,11 +3426,11 @@ packages:
   - typing-extensions ; python_full_version < '3.10' and extra == 'typing'
   - defusedxml ; extra == 'xmp'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl
   name: pip
-  version: 26.0.1
-  sha256: bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b
-  requires_python: '>=3.9'
+  version: '26.1'
+  sha256: 4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
   name: platformdirs
   version: 4.9.6
@@ -3529,10 +3530,10 @@ packages:
   - pytest-benchmark ; extra == 'testing'
   - coverage ; extra == 'testing'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/c4/14/552b239d99fdd09fd6664b69089359340778f84a9f866a1fecc38b66c811/prek-0.3.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek
-  version: 0.3.10
-  sha256: 5a9a446e178562e2c3cfc71c8f0b21043b571209533a104042b6b9e36662849e
+  version: 0.3.11
+  sha256: e4f0cc07d2cdb5fe2882015d5fdafc9af98b4c560d4caa1ae948caeab4341b79
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
   name: proglog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.96.0"
+version = "1.97.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary

- **Bug fix**: `aggregate=True` was rendering pane-type results (rerun, image, video) in both the aggregated and non-aggregated views. Pane results are file paths that can't be numerically aggregated (mean/std), so the aggregated view now skips them via a new `numeric_only` parameter on `to_auto()`.
- **Bug fix**: The line plotter crashed during aggregation because `plt_cnt_cfg` still referenced collapsed dimensions (e.g. `color` after it was aggregated away), causing a holoviews `DataError`. Now `plt_cnt_cfg` is temporarily swapped to the post-aggregation config during `map_plot_panes` calls.
- **Rename**: `VideoResult` -> `PaneResult` since the class handles all pane types (images, rerun, video, paths, strings), not just video. Backward-compat alias `VideoResult = PaneResult` kept in `__init__.py`.
- **New examples**: `example_result_image_aggregate.py`, `example_result_video_aggregate.py`, and updated `example_rerun_sweep.py` to exercise multi-input aggregation with pane results.

## Test plan

- [ ] Run `pixi run ci` (lint + tests)
- [ ] Run `pixi run python bencher/example/generated/rerun/example_rerun_sweep.py` — rerun windows appear once (non-aggregated), scalar plots show aggregated mean ± std
- [ ] Run `pixi run python bencher/example/generated/result_types/result_image/example_result_image_aggregate.py` — images appear once, area scalar is aggregated
- [ ] Run `pixi run python bencher/example/generated/result_types/result_video/example_result_video_aggregate.py` — videos appear once, max_angle scalar is aggregated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename video pane handling to a generic pane result and ensure aggregation only plots numeric results while avoiding pane duplication, adding new aggregation-focused examples and updating rerun sweeps accordingly.

New Features:
- Add a numeric_only option to automatic plotting to restrict aggregation views to numeric result types.
- Introduce aggregated image and video example scripts exercising mixed pane and scalar aggregation.
- Extend rerun sweep examples to support an additional input dimension and aggregated views.

Bug Fixes:
- Prevent pane-type results (images, videos, rerun, etc.) from being duplicated in aggregated views by skipping them during numeric aggregation.
- Avoid line plotting crashes during aggregation by temporarily using the post-aggregation plotting configuration when mapping plot panes.

Enhancements:
- Generalize VideoResult to a PaneResult base used by explorer and holoview results, keeping an alias for backward compatibility.
- Update bench result plotting defaults to route pane rendering through the new PaneResult type.
- Expand polygon animation/image meta generators and rerun examples to better demonstrate aggregation behavior.