### PR TITLE
Add aggregate and repeats support to optimize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.98.0] - 2026-04-27
+
+### Added
+- `aggregate`, `agg_fn`, and `repeats` parameters for `optimize()`, matching the `plot_sweep()` API. Aggregated dimensions are looped inside the Optuna objective so the optimizer sees robust metrics (e.g. mean loss across seeds or repeated boolean outcomes).
+- `AGG_FN_MAP` in `bencher/utils.py` — NaN-safe numpy aggregation functions for objective-level aggregation.
+- Example `example_optimize_aggregate.py` demonstrating sweep-then-optimize with dimension aggregation and repeats.
+
+### Fixed
+- Missing `skipna=True` on `REDUCE` and `MINMAX` repeat aggregation in `bench_result_base.py`.
+- `np.mean` → `np.nanmean` in `optuna_result.py` aggregation to match xarray's NaN-safe behavior.
+
 ## [1.97.0] - 2026-04-27
 
 ### Fixed

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -53,6 +53,15 @@ for handler in logging.root.handlers:
     handler.setFormatter(formatter)
 
 
+def _agg_job_args(kwargs, agg_vars, combo):
+    """Build job_args dict by merging Optuna-suggested kwargs with aggregate combo values."""
+    job_args = dict(kwargs)
+    if agg_vars:
+        for v, val in zip(agg_vars, combo):
+            job_args[v.name] = val
+    return job_args
+
+
 class Bench(BenchPlotServer):
     def __init__(
         self,
@@ -1068,19 +1077,15 @@ class Bench(BenchPlotServer):
         constant_inputs = self.define_const_inputs(const_vars_in) or {}
 
         # --- resolve aggregation ----------------------------------------
-        input_var_names = [iv.name for iv in input_vars_in]
-        agg_over_dims = resolve_aggregate(aggregate, input_var_names)
-
-        if agg_over_dims:
-            agg_set = set(agg_over_dims)
-            optuna_vars = [iv for iv in input_vars_in if iv.name not in agg_set]
-            agg_vars = [iv for iv in input_vars_in if iv.name in agg_set]
-        else:
-            optuna_vars = input_vars_in
-            agg_vars = []
+        optuna_vars, agg_vars = self._split_optuna_and_agg_vars(input_vars_in, aggregate)
 
         needs_agg = bool(agg_vars) or repeats > 1
-        agg_callable = AGG_FN_MAP[agg_fn] if needs_agg else None
+        if needs_agg:
+            if agg_fn not in AGG_FN_MAP:
+                raise ValueError(f"Unknown agg_fn={agg_fn!r}, must be one of {sorted(AGG_FN_MAP)}")
+            agg_callable = AGG_FN_MAP[agg_fn]
+        else:
+            agg_callable = None
 
         if title is None:
             title = "Optimize " + " vs ".join(iv.name for iv in input_vars_in)
@@ -1337,6 +1342,36 @@ class Bench(BenchPlotServer):
         )
         return added
 
+    @staticmethod
+    def _split_optuna_and_agg_vars(input_vars, aggregate):
+        """Partition *input_vars* into Optuna-tuned and aggregated lists."""
+        input_var_names = [iv.name for iv in input_vars]
+        agg_over_dims = resolve_aggregate(aggregate, input_var_names)
+        if agg_over_dims:
+            agg_set = set(agg_over_dims)
+            optuna_vars = [iv for iv in input_vars if iv.name not in agg_set]
+            agg_vars = [iv for iv in input_vars if iv.name in agg_set]
+        else:
+            optuna_vars = input_vars
+            agg_vars = []
+        return optuna_vars, agg_vars
+
+    def _run_optuna_job(self, trial, job_args, repeat, constant_inputs, tag):
+        """Submit a single worker evaluation and return the result dict."""
+        full_input = dict(job_args)
+        full_input.update(constant_inputs)
+        full_input["repeat"] = repeat
+
+        cache_key = self._build_cache_key(full_input, tag)
+        job = Job(
+            job_id=f"optimize:trial_{trial.number}",
+            function=self.worker,
+            job_args=job_args,
+            job_key=cache_key,
+            tag=tag,
+        )
+        return self.sample_cache.submit(job).result()
+
     def _make_optuna_objective(
         self,
         input_vars,
@@ -1354,45 +1389,16 @@ class Bench(BenchPlotServer):
 
             if agg_vars or repeats > 1:
                 agg_combos = list(product(*(v.values() for v in agg_vars))) if agg_vars else [()]
-                all_results = []
-                for combo in agg_combos:
-                    for rep in range(1, repeats + 1):
-                        job_args = dict(kwargs)
-                        if agg_vars:
-                            for v, val in zip(agg_vars, combo):
-                                job_args[v.name] = val
-
-                        full_input = dict(job_args)
-                        full_input.update(constant_inputs)
-                        full_input["repeat"] = rep
-
-                        cache_key = self._build_cache_key(full_input, tag)
-                        job = Job(
-                            job_id=f"optimize:trial_{trial.number}",
-                            function=self.worker,
-                            job_args=job_args,
-                            job_key=cache_key,
-                            tag=tag,
-                        )
-                        job_future = self.sample_cache.submit(job)
-                        all_results.append(job_future.result())
-
+                all_results = [
+                    self._run_optuna_job(
+                        trial, _agg_job_args(kwargs, agg_vars, combo), rep, constant_inputs, tag
+                    )
+                    for combo in agg_combos
+                    for rep in range(1, repeats + 1)
+                ]
                 output = [agg_callable([r[tn] for r in all_results]) for tn in target_names]
             else:
-                full_input = dict(kwargs)
-                full_input.update(constant_inputs)
-                full_input["repeat"] = 1
-
-                cache_key = self._build_cache_key(full_input, tag)
-                job = Job(
-                    job_id=f"optimize:trial_{trial.number}",
-                    function=self.worker,
-                    job_args=kwargs,
-                    job_key=cache_key,
-                    tag=tag,
-                )
-                job_future = self.sample_cache.submit(job)
-                result_dict = job_future.result()
+                result_dict = self._run_optuna_job(trial, kwargs, 1, constant_inputs, tag)
                 output = [result_dict[tn] for tn in target_names]
 
             return tuple(output) if len(output) > 1 else output[0]

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -32,7 +32,7 @@ from bencher.variables.results import ResultHmap
 from bencher.results.bench_result import BenchResult
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.job import Job, FutureCache, JobFuture, Executors
-from bencher.utils import params_to_str, resolve_aggregate
+from bencher.utils import params_to_str, resolve_aggregate, AGG_FN_MAP
 from bencher.sample_order import SampleOrder
 from bencher.regression import detect_regressions, RegressionError
 from bencher.sweep_timings import SweepTimings, phase_timer
@@ -1022,6 +1022,9 @@ class Bench(BenchPlotServer):
         n_trials: int = 100,
         sampler: optuna.samplers.BaseSampler | None = None,
         warm_start: bool = True,
+        aggregate: bool | int | list[str] | None = None,
+        agg_fn: str = "mean",
+        repeats: int = 1,
         tag: str = "",
         run_cfg: BenchRunCfg | None = None,
         plot: bool = True,
@@ -1037,6 +1040,17 @@ class Bench(BenchPlotServer):
             n_trials: Number of new optuna trials to run.
             sampler: Optuna sampler.  Defaults to ``TPESampler``.
             warm_start: Seed the study with previously cached evaluations.
+            aggregate: Dimensions to aggregate inside the objective function.
+                Same semantics as ``plot_sweep``: *True* aggregates all but the
+                first input dim, an *int N* aggregates the last N dims, or a
+                *list[str]* names specific dims.  Aggregated dims are looped
+                over internally so Optuna sees the aggregated value.
+            agg_fn: Aggregation function name (``"mean"``, ``"sum"``, ``"max"``,
+                ``"min"``, ``"median"``).  Applied when *aggregate* is set or
+                *repeats* > 1.
+            repeats: Number of times to evaluate each parameter combination.
+                Each repeat uses a different ``repeat`` index and gets its own
+                cache key.  Results are aggregated with *agg_fn*.
             tag: Cache tag (same semantics as ``plot_sweep``).
             run_cfg: Run configuration.  Defaults to ``BenchRunCfg()``.
             plot: If *True*, append visualisation to ``self.report``.
@@ -1052,6 +1066,21 @@ class Bench(BenchPlotServer):
             input_vars, result_vars, const_vars, run_cfg
         )
         constant_inputs = self.define_const_inputs(const_vars_in) or {}
+
+        # --- resolve aggregation ----------------------------------------
+        input_var_names = [iv.name for iv in input_vars_in]
+        agg_over_dims = resolve_aggregate(aggregate, input_var_names)
+
+        if agg_over_dims:
+            agg_set = set(agg_over_dims)
+            optuna_vars = [iv for iv in input_vars_in if iv.name not in agg_set]
+            agg_vars = [iv for iv in input_vars_in if iv.name in agg_set]
+        else:
+            optuna_vars = input_vars_in
+            agg_vars = []
+
+        needs_agg = bool(agg_vars) or repeats > 1
+        agg_callable = AGG_FN_MAP[agg_fn] if needs_agg else None
 
         if title is None:
             title = "Optimize " + " vs ".join(iv.name for iv in input_vars_in)
@@ -1108,7 +1137,13 @@ class Bench(BenchPlotServer):
 
         # --- run optimisation -------------------------------------------
         objective = self._make_optuna_objective(
-            input_vars_in, constant_inputs, target_names, bench_cfg.tag
+            optuna_vars,
+            constant_inputs,
+            target_names,
+            bench_cfg.tag,
+            agg_vars=agg_vars,
+            agg_callable=agg_callable,
+            repeats=repeats,
         )
         study.optimize(objective, n_trials=n_trials)
 
@@ -1302,31 +1337,64 @@ class Bench(BenchPlotServer):
         )
         return added
 
-    def _make_optuna_objective(self, input_vars, constant_inputs, target_names, tag):
+    def _make_optuna_objective(
+        self,
+        input_vars,
+        constant_inputs,
+        target_names,
+        tag,
+        agg_vars=None,
+        agg_callable=None,
+        repeats=1,
+    ):
         """Return an objective function compatible with ``study.optimize()``."""
 
         def objective(trial: optuna.trial.Trial):
-            kwargs = {}
-            for iv in input_vars:
-                kwargs[iv.name] = sweep_var_to_suggest(iv, trial)
+            kwargs = {iv.name: sweep_var_to_suggest(iv, trial) for iv in input_vars}
 
-            full_input = dict(kwargs)
-            full_input.update(constant_inputs)
-            full_input["repeat"] = 1
+            if agg_vars or repeats > 1:
+                agg_combos = list(product(*(v.values() for v in agg_vars))) if agg_vars else [()]
+                all_results = []
+                for combo in agg_combos:
+                    for rep in range(1, repeats + 1):
+                        job_args = dict(kwargs)
+                        if agg_vars:
+                            for v, val in zip(agg_vars, combo):
+                                job_args[v.name] = val
 
-            cache_key = self._build_cache_key(full_input, tag)
+                        full_input = dict(job_args)
+                        full_input.update(constant_inputs)
+                        full_input["repeat"] = rep
 
-            job = Job(
-                job_id=f"optimize:trial_{trial.number}",
-                function=self.worker,
-                job_args=kwargs,
-                job_key=cache_key,
-                tag=tag,
-            )
-            job_future = self.sample_cache.submit(job)
-            result_dict = job_future.result()
+                        cache_key = self._build_cache_key(full_input, tag)
+                        job = Job(
+                            job_id=f"optimize:trial_{trial.number}",
+                            function=self.worker,
+                            job_args=job_args,
+                            job_key=cache_key,
+                            tag=tag,
+                        )
+                        job_future = self.sample_cache.submit(job)
+                        all_results.append(job_future.result())
 
-            output = [result_dict[tn] for tn in target_names]
+                output = [agg_callable([r[tn] for r in all_results]) for tn in target_names]
+            else:
+                full_input = dict(kwargs)
+                full_input.update(constant_inputs)
+                full_input["repeat"] = 1
+
+                cache_key = self._build_cache_key(full_input, tag)
+                job = Job(
+                    job_id=f"optimize:trial_{trial.number}",
+                    function=self.worker,
+                    job_args=kwargs,
+                    job_key=cache_key,
+                    tag=tag,
+                )
+                job_future = self.sample_cache.submit(job)
+                result_dict = job_future.result()
+                output = [result_dict[tn] for tn in target_names]
+
             return tuple(output) if len(output) > 1 else output[0]
 
         return objective

--- a/bencher/example/generated/rerun/example_rerun_sweep.py
+++ b/bencher/example/generated/rerun/example_rerun_sweep.py
@@ -5,14 +5,14 @@ from bencher.example.example_rerun_over_time import ControlSystemSweep
 
 
 def example_rerun_sweep(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
-    """Rerun Sweep — control system response across damping ratios and natural frequencies."""
+    """Rerun Sweep — control system response across damping ratios."""
     bench = ControlSystemSweep().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=["damping_ratio", "omega_n"],
         result_vars=["out_overshoot", "out_settling_time", "out_rerun"],
         description="Sweep the damping ratio and natural frequency of a second-order "
         "control system.  aggregate=True collapses omega_n so you can see the "
-        "mean ± std across frequencies for each damping ratio.",
+        "mean \u00b1 std across frequencies for each damping ratio.",
         aggregate=True,
     )
 

--- a/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
+++ b/bencher/example/generated/result_types/result_image/example_result_image_aggregate.py
@@ -48,9 +48,7 @@ def example_result_image_aggregate(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     bench.plot_sweep(
         input_vars=["sides", "color"],
         result_vars=["polygon", "area"],
-        description="aggregate=True collapses the color dimension. The area scalar is "
-        "averaged over colors (mean ± std), but polygon images should only appear "
-        "once in the non-aggregated view.",
+        description="aggregate=True collapses the color dimension. The area scalar is averaged over colors (mean \u00b1 std), but polygon images should only appear once in the non-aggregated view.",
         aggregate=True,
     )
 

--- a/bencher/example/generated/result_types/result_video/example_result_video_0d.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_0d.py
@@ -30,6 +30,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
+    max_angle = bn.ResultFloat(units="deg", doc="Maximum rotation angle in the animation")
 
     def benchmark(self):
         vid_writer = bn.VideoWriter()
@@ -41,6 +42,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
+        self.max_angle = self.speed * 360.0 * (num_frames - 1) / num_frames
 
 
 def example_result_video_0d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/example_result_video_1d.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_1d.py
@@ -30,6 +30,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
+    max_angle = bn.ResultFloat(units="deg", doc="Maximum rotation angle in the animation")
 
     def benchmark(self):
         vid_writer = bn.VideoWriter()
@@ -41,6 +42,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
+        self.max_angle = self.speed * 360.0 * (num_frames - 1) / num_frames
 
 
 def example_result_video_1d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/example_result_video_2d.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_2d.py
@@ -30,6 +30,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
     speed = bn.FloatSweep(default=1.0, bounds=(0.5, 3.0), doc="Rotation speed multiplier")
     animation = bn.ResultVideo(doc="Rotating polygon video")
     frame_snapshot = bn.ResultImage(doc="Last frame snapshot")
+    max_angle = bn.ResultFloat(units="deg", doc="Maximum rotation angle in the animation")
 
     def benchmark(self):
         vid_writer = bn.VideoWriter()
@@ -41,6 +42,7 @@ class PolygonAnimator(bn.ParametrizedSweep):
             vid_writer.append(np.array(img.convert("RGB")))
         self.animation = vid_writer.write()
         self.frame_snapshot = bn.VideoWriter.extract_frame(self.animation)
+        self.max_angle = self.speed * 360.0 * (num_frames - 1) / num_frames
 
 
 def example_result_video_2d(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:

--- a/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
+++ b/bencher/example/generated/result_types/result_video/example_result_video_aggregate.py
@@ -50,9 +50,7 @@ def example_result_video_aggregate(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     bench.plot_sweep(
         input_vars=["sides", "speed"],
         result_vars=["animation", "frame_snapshot", "max_angle"],
-        description="aggregate=True collapses the speed dimension. Videos and images "
-        "should only appear once in the non-aggregated view, not duplicated "
-        "in the aggregated view.",
+        description="aggregate=True collapses the speed dimension. Videos and images should only appear once in the non-aggregated view, not duplicated in the aggregated view.",
         aggregate=True,
     )
 

--- a/bencher/example/optuna/example_optimize_aggregate.py
+++ b/bencher/example/optuna/example_optimize_aggregate.py
@@ -1,0 +1,79 @@
+"""Aggregated optimization example.
+
+Demonstrates the sweep-then-optimize workflow with aggregation:
+  1. ``plot_sweep`` with ``aggregate=["seed"]`` to visualise mean loss
+  2. ``optimize`` with the same aggregation so Optuna sees mean loss
+  3. ``optimize`` with ``repeats`` for stochastic/boolean outcomes
+"""
+
+import random
+
+import bencher as bn
+
+
+class NoisySphereWithSeed(bn.ParametrizedSweep):
+    """Sphere function with a seed dimension and stochastic noise."""
+
+    x = bn.FloatSweep(default=0, bounds=[-5, 5], samples=10)
+    y = bn.FloatSweep(default=0, bounds=[-5, 5], samples=10)
+    seed = bn.IntSweep(default=0, bounds=[0, 4], samples=5)
+
+    loss = bn.ResultFloat("ul", bn.OptDir.minimize)
+
+    def benchmark(self):
+        random.seed(self.seed)
+        noise = random.gauss(0, 0.5)
+        self.loss = float(self.x**2 + self.y**2 + noise)
+
+
+def example_optimize_aggregate(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Sweep with aggregation, then optimize with the same aggregation."""
+    cfg = NoisySphereWithSeed()
+    bench = bn.Bench("OptimizeAggregateExample", cfg, run_cfg=run_cfg)
+
+    # --- 1. Sweep with aggregation over seed -----------------------------
+    bench.plot_sweep(
+        title="Grid sweep (mean over seed)",
+        input_vars=["x", "y", "seed"],
+        result_vars=["loss"],
+        aggregate=["seed"],
+        agg_fn="mean",
+        run_cfg=run_cfg,
+    )
+
+    # --- 2. Optimize with same aggregation (warm-starts from sweep cache) -
+    result = bench.optimize(
+        n_trials=30,
+        aggregate=["seed"],
+        agg_fn="mean",
+        title="Optimize (aggregate over seed)",
+    )
+    bench.report.append_markdown(
+        f"### Optimize (aggregate over seed)\n"
+        f"Best value (mean over seeds): {result.best_value:.4f}  \n"
+        f"Best params: {result.best_params}\n\n"
+        f"Optuna only tunes x and y; seed is looped internally and "
+        f"the mean loss across all 5 seeds is reported to Optuna."
+    )
+
+    # --- 3. Optimize with repeats ----------------------------------------
+    result2 = bench.optimize(
+        n_trials=20,
+        aggregate=["seed"],
+        repeats=3,
+        agg_fn="mean",
+        title="Optimize (aggregate seed + 3 repeats)",
+    )
+    bench.report.append_markdown(
+        f"### Optimize (aggregate + repeats)\n"
+        f"Best value: {result2.best_value:.4f}  \n"
+        f"Best params: {result2.best_params}\n\n"
+        f"Each trial evaluates 5 seeds × 3 repeats = 15 function calls, "
+        f"then returns the mean loss to Optuna."
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_optimize_aggregate)

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -297,8 +297,8 @@ class BenchResultBase:
 
         match reduce:
             case ReduceType.REDUCE:
-                ds_reduce_mean = ds_out.mean(dim="repeat", keep_attrs=True)
-                ds_reduce_std = ds_out.std(dim="repeat", keep_attrs=False)
+                ds_reduce_mean = ds_out.mean(dim="repeat", skipna=True, keep_attrs=True)
+                ds_reduce_std = ds_out.std(dim="repeat", skipna=True, keep_attrs=False)
                 # For ResultBool: use binomial SE sqrt(p*(1-p)/n) instead of sample std
                 n_repeats = ds_out.sizes["repeat"]
                 for rv in self.bench_cfg.result_vars:
@@ -310,9 +310,9 @@ class BenchResultBase:
                     ds_reduce_mean[f"{var}_std"] = ds_reduce_std[var]
                 ds_out = ds_reduce_mean
             case ReduceType.MINMAX:  # TODO, need to pass mean, center of minmax, and minmax
-                ds_reduce_mean = ds_out.mean(dim="repeat", keep_attrs=True)
-                ds_reduce_min = ds_out.min(dim="repeat")
-                ds_reduce_max = ds_out.max(dim="repeat")
+                ds_reduce_mean = ds_out.mean(dim="repeat", skipna=True, keep_attrs=True)
+                ds_reduce_min = ds_out.min(dim="repeat", skipna=True)
+                ds_reduce_max = ds_out.max(dim="repeat", skipna=True)
                 # Assign range vars directly onto mean dataset (avoids xr.merge copy)
                 ds_range = ds_reduce_max - ds_reduce_min
                 for var in ds_range.data_vars:

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -49,7 +49,7 @@ def _evaluate_over_non_optimized(worker, opt_kwargs, non_opt_vars, result_vars):
                 f"Result variable '{rv.name}' must be numeric to aggregate over "
                 f"non-optimized variable combinations, but got dtype {arr.dtype}"
             )
-        aggregated.append(float(np.mean(arr)))
+        aggregated.append(float(np.nanmean(arr)))
     return tuple(aggregated)
 
 

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -379,6 +379,15 @@ def resolve_aggregate(
     )
 
 
+AGG_FN_MAP: dict[str, Callable] = {
+    "mean": lambda vals: float(np.nanmean(vals)),
+    "sum": lambda vals: float(np.nansum(vals)),
+    "max": lambda vals: float(np.nanmax(vals)),
+    "min": lambda vals: float(np.nanmin(vals)),
+    "median": lambda vals: float(np.nanmedian(vals)),
+}
+
+
 def callable_name(any_callable: Callable[..., Any]) -> str:
     """Extract the name of a callable object, handling various callable types.
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1469,8 +1469,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: holobench
-  version: 1.96.0
-  sha256: b444496fa884d3fa71701ba2debf9b854899b40c8d908efe87f2529d2fb3ce6a
+  version: 1.98.0
+  sha256: e98cc1f40802fd56db6a244b671102892340330a2572d2176584d92944b83f54
   requires_dist:
   - holoviews>=1.15,<=1.22.1
   - numpy>=1.0,<=2.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.97.0"
+version = "1.98.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -155,6 +155,72 @@ class TestAutoDetection:
         assert "y" in result.best_params
 
 
+class SphereWithSeed(bn.ParametrizedSweep):
+    """Sphere with a nuisance dimension to aggregate over."""
+
+    x = bn.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+    seed = bn.IntSweep(default=0, bounds=[0, 2], samples=3)
+
+    loss = bn.ResultFloat("ul", bn.OptDir.minimize)
+
+    def benchmark(self):
+        self.loss = float(self.x**2 + self.seed * 0.1)
+
+
+class NoisySphere(bn.ParametrizedSweep):
+    """Sphere with stochastic noise — benefits from repeat aggregation."""
+
+    x = bn.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+
+    loss = bn.ResultFloat("ul", bn.OptDir.minimize)
+
+    def benchmark(self):
+        import random
+
+        self.loss = float(self.x**2 + random.gauss(0, 0.1))
+
+
+class TestAggregateOptimize:
+    def test_optimize_with_aggregate(self):
+        bench = bn.Bench("agg_optim", SphereWithSeed(), run_cfg=_run_cfg())
+        result = bench.optimize(
+            n_trials=15,
+            aggregate=["seed"],
+            agg_fn="mean",
+            plot=False,
+        )
+        assert result is not None
+        assert result.study.best_value is not None
+        assert "seed" not in result.study.best_params
+        assert "x" in result.study.best_params
+
+    def test_optimize_with_repeats(self):
+        bench = bn.Bench("rep_optim", NoisySphere(), run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=15, repeats=3, agg_fn="mean", plot=False)
+        assert result is not None
+        assert result.study.best_value is not None
+
+    def test_optimize_with_aggregate_and_repeats(self):
+        bench = bn.Bench("agg_rep_optim", SphereWithSeed(), run_cfg=_run_cfg())
+        result = bench.optimize(
+            n_trials=10,
+            aggregate=["seed"],
+            repeats=2,
+            agg_fn="mean",
+            plot=False,
+        )
+        assert result is not None
+        assert "seed" not in result.study.best_params
+
+    def test_optimize_no_aggregate_unchanged(self):
+        """Default behavior (no aggregate, repeats=1) still works."""
+        bench = bn.Bench("no_agg_optim", SphereWithSeed(), run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=10, plot=False)
+        assert result is not None
+        assert "x" in result.study.best_params
+        assert "seed" in result.study.best_params
+
+
 class TestConvenience:
     def test_to_optimize(self):
         result = Sphere().to_optimize(n_trials=15, plot=False)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -220,6 +220,23 @@ class TestAggregateOptimize:
         assert "x" in result.study.best_params
         assert "seed" in result.study.best_params
 
+    @pytest.mark.parametrize("agg_fn", ["mean", "sum", "max", "min", "median"])
+    def test_optimize_all_agg_fns(self, agg_fn):
+        bench = bn.Bench(f"agg_fn_{agg_fn}", SphereWithSeed(), run_cfg=_run_cfg())
+        result = bench.optimize(
+            n_trials=10,
+            aggregate=["seed"],
+            agg_fn=agg_fn,
+            plot=False,
+        )
+        assert result is not None
+        assert result.study.best_value is not None
+
+    def test_optimize_invalid_agg_fn(self):
+        bench = bn.Bench("bad_agg_fn", SphereWithSeed(), run_cfg=_run_cfg())
+        with pytest.raises(ValueError, match="Unknown agg_fn"):
+            bench.optimize(n_trials=5, aggregate=["seed"], agg_fn="bogus", plot=False)
+
 
 class TestConvenience:
     def test_to_optimize(self):


### PR DESCRIPTION
## Summary
- Add `aggregate`, `agg_fn`, and `repeats` parameters to `optimize()`, matching the `plot_sweep()` API. Aggregated dimensions are looped inside the Optuna objective so the optimizer sees robust metrics (e.g. mean loss across seeds or repeated boolean outcomes).
- Add `AGG_FN_MAP` with NaN-safe numpy functions (`nanmean`, `nansum`, etc.) for objective-level aggregation.
- Fix missing `skipna=True` on `REDUCE` and `MINMAX` repeat aggregation in `bench_result_base.py`, and `np.mean` → `np.nanmean` in `optuna_result.py`.
- Add example (`example_optimize_aggregate.py`) demonstrating sweep-then-optimize with dimension aggregation and repeats.

## Test plan
- [x] 4 new tests in `test_optimize.py` covering aggregate-only, repeats-only, combined, and no-aggregate baseline
- [x] All 14 optimize tests pass
- [x] All 32 optuna result tests pass
- [x] Full CI (1357 passed)
- [x] Example runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for aggregated dimensions and repeated evaluations in optimize() so Optuna sees robust, NaN-safe objective values, and align optimization behavior with existing sweep aggregation.

New Features:
- Extend optimize() with aggregate, agg_fn, and repeats parameters to control objective-level aggregation and repeated evaluations.
- Provide a configurable aggregation function map (mean, sum, max, min, median) using NaN-safe NumPy reductions for objective aggregation.
- Add an example script demonstrating sweep-then-optimize with dimension aggregation and repeats for Optuna-based tuning.

Bug Fixes:
- Ensure repeat reduction in bench results uses skipna=True for mean, std, min, and max to handle NaNs correctly.
- Use np.nanmean instead of np.mean when aggregating over non-optimized variable combinations in Optuna results to avoid NaN issues.

Enhancements:
- Refine the Optuna objective construction to loop over aggregated input dimensions and repeats while keeping those dimensions out of the tuned parameter space.
- Add tests covering optimize() with aggregation, repeats, their combination, and the unchanged default behavior to guard the new API.