### PR TITLE
Add fullscreen + open-in-new-tab controls to rerun viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.100.0] - 2026-05-15
+
+### Added
+- Overlay controls on each embedded rerun recording: a fullscreen button (⛶) that calls `iframe.requestFullscreen()` and an open-in-new-tab link (↗) that opens the same chromeless viewer in a new browser tab. Useful when comparing multiple recordings side-by-side and you want to expand one. Controls are positioned top-center to avoid the viewer's own corner UI.
+
 ## [1.99.0] - 2026-05-15
 
 ### Changed

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -127,7 +127,7 @@ def rrd_file_to_pane(  # pragma: no cover
         f' frameborder="0" allowfullscreen></iframe>'
     )
     return pn.pane.HTML(
-        _wrap_viewer_controls(iframe, width, height),
+        _wrap_viewer_controls(iframe, viewer_url, width, height),
         width=width,
         height=height,
     )
@@ -188,13 +188,16 @@ try {{
 """
 
 
-def _wrap_viewer_controls(iframe_html: str, width: int, height: int) -> str:
+def _wrap_viewer_controls(iframe_html: str, viewer_url: str, width: int, height: int) -> str:
     """Wrap a rerun-viewer iframe with fullscreen and open-in-new-tab controls.
 
-    Controls float at the top-center (away from the viewer's own corner UI)
-    and read their target from the wrapped iframe's DOM, so portable/inline
-    URL rewriting in ``inline_rrd_iframes()`` keeps working without touching
-    the buttons.
+    Controls float at the top-center (away from the viewer's own corner UI).
+    The anchor's ``href`` is set to *viewer_url* directly so middle-click,
+    Cmd/Ctrl-click, and the context-menu "Open in new tab" all see the right
+    target — not just plain left-click.  ``inline_rrd_iframes()`` rewrites
+    both the iframe ``src`` and the anchor ``href`` when a report is saved.
+    A real anchor (rather than ``window.open()``) avoids popup-blocker false
+    positives that silently swallow the click in some browsers.
     """
     btn = (
         "background:rgba(0,0,0,0.55);color:white;border:0;"
@@ -202,11 +205,6 @@ def _wrap_viewer_controls(iframe_html: str, width: int, height: int) -> str:
     )
     link = btn + ";text-decoration:none;display:inline-block;line-height:1.4"
     fs_js = "this.closest('.bencher-rrd-wrap').querySelector('iframe').requestFullscreen()"
-    # Anchor with target=_blank rather than window.open(): the latter is silently
-    # blocked by popup-blockers in some browsers even from a user click.  The
-    # onclick sets href to the iframe's current src so portable/inline URL
-    # rewriting in inline_rrd_iframes() (which only touches the iframe) is fine.
-    nt_js = "this.href=this.closest('.bencher-rrd-wrap').querySelector('iframe').src"
     return (
         f'<div class="bencher-rrd-wrap"'
         f' style="position:relative;display:inline-block;width:{width}px;height:{height}px">'
@@ -214,8 +212,8 @@ def _wrap_viewer_controls(iframe_html: str, width: int, height: int) -> str:
         f'<div style="position:absolute;top:4px;left:50%;transform:translateX(-50%);'
         f'display:flex;gap:4px;z-index:10">'
         f'<button title="Fullscreen" style="{btn}" onclick="{fs_js}">⛶</button>'
-        f'<a title="Open in new tab" href="about:blank" target="_blank" rel="noopener"'
-        f' style="{link}" onclick="{nt_js}">↗</a>'
+        f'<a title="Open in new tab" href="{viewer_url}" target="_blank" rel="noopener"'
+        f' style="{link}">↗</a>'
         f"</div></div>"
     )
 
@@ -302,7 +300,7 @@ def _portable_rrd_pane(
         f' frameborder="0" allowfullscreen></iframe>'
     )
     return pn.pane.HTML(
-        _wrap_viewer_controls(iframe, width, height),
+        _wrap_viewer_controls(iframe, viewer_url, width, height),
         width=width,
         height=height,
     )
@@ -310,22 +308,20 @@ def _portable_rrd_pane(
 
 # --- Static .rrd support for saved reports ---
 
-# Regex matching rerun viewer iframes in Panel-saved HTML.
-# Panel's Bokeh serialization double-escapes: < → &amp;lt; " → &amp;quot;
-# Captures: (1) viewer version, (2) rrd file relative path, (3) width, (4) height.
+# Regex matching a quoted ``/rrd_static/viewer_<ver>.html?url=/rrd_static/<rrd>``
+# URL in Panel-saved HTML.  Panel's Bokeh serialization double-escapes: " → &amp;quot;
+# Captures: (1) viewer version, (2) rrd file relative path.
 #
-# FRAGILE: This pattern depends on Bokeh's exact double-entity-encoding behaviour
-# (tested with Bokeh 3.9 / Panel 1.6).  If Bokeh changes its serialization (attribute
-# order, quoting style, escaping depth), this regex will silently miss iframes.
-# inline_rrd_iframes() logs a warning when it detects /rrd_static/ references but
-# the regex finds no matches.
-_RRD_IFRAME_RE = re.compile(
-    r"&amp;lt;iframe src=&amp;quot;/rrd_static/viewer_([0-9A-Za-z._-]+)\.html"
+# Matches the URL wherever it appears as an attribute value — both the iframe
+# ``src`` and the open-in-new-tab anchor ``href`` written by
+# ``_wrap_viewer_controls`` — in a single ``re.sub`` pass.
+#
+# FRAGILE: depends on Bokeh's exact double-entity-encoding behaviour (tested
+# with Bokeh 3.9 / Panel 1.6).  inline_rrd_iframes() logs a warning when it
+# detects /rrd_static/ references but matches nothing.
+_RRD_URL_RE = re.compile(
+    r"&amp;quot;/rrd_static/viewer_([0-9A-Za-z._-]+)\.html"
     r"\?url=/rrd_static/([^&]+\.rrd)&amp;quot;"
-    r" width=&amp;quot;(\d+)&amp;quot;"
-    r" height=&amp;quot;(\d+)&amp;quot;"
-    r" frameborder=&amp;quot;0&amp;quot;"
-    r" allowfullscreen&amp;gt;&amp;lt;/iframe&amp;gt;"
 )
 
 
@@ -384,37 +380,39 @@ def inline_rrd_iframes(
     rrd_rel_prefix = os.path.relpath(rrd_dir, report_dir).replace("\\", "/")
 
     changed = False
+    # The same URL appears twice per recording — once in the iframe ``src``,
+    # once in the open-in-new-tab anchor ``href`` — so memoize the per-rrd
+    # work to avoid writing the viewer/.rrd file twice.
+    url_cache: dict[tuple[Path, str], str] = {}
 
     def _replace(m: re.Match) -> str:
         nonlocal changed
-        version, rrd_rel, width, height = m.group(1), m.group(2), m.group(3), m.group(4)
+        version, rrd_rel = m.group(1), m.group(2)
         rrd_path = cache_root / rrd_rel
         if not rrd_path.is_file():
             logging.warning("inline_rrd_iframes: %s not found, skipping", rrd_path)
             return m.group(0)
 
-        if portable:
-            viewer_name = _write_inline_viewer(rrd_path, version, rrd_dir)
-            relative_url = f"{rrd_rel_prefix}/{viewer_name}"
-        else:
-            viewer_name, rrd_name = _write_rrd_sidecar(rrd_path, version, rrd_dir)
-            relative_url = f"{rrd_rel_prefix}/{viewer_name}?url={quote(rrd_name)}"
+        key = (rrd_path, version)
+        relative_url = url_cache.get(key)
+        if relative_url is None:
+            if portable:
+                viewer_name = _write_inline_viewer(rrd_path, version, rrd_dir)
+                relative_url = f"{rrd_rel_prefix}/{viewer_name}"
+            else:
+                viewer_name, rrd_name = _write_rrd_sidecar(rrd_path, version, rrd_dir)
+                relative_url = f"{rrd_rel_prefix}/{viewer_name}?url={quote(rrd_name)}"
+            url_cache[key] = relative_url
 
         changed = True
-        return (
-            f"&amp;lt;iframe src=&amp;quot;{relative_url}&amp;quot;"
-            f" width=&amp;quot;{width}&amp;quot;"
-            f" height=&amp;quot;{height}&amp;quot;"
-            f" frameborder=&amp;quot;0&amp;quot;"
-            f" allowfullscreen&amp;gt;&amp;lt;/iframe&amp;gt;"
-        )
+        return f"&amp;quot;{relative_url}&amp;quot;"
 
-    new_html = _RRD_IFRAME_RE.sub(_replace, html)
+    new_html = _RRD_URL_RE.sub(_replace, html)
     if changed:
         html_path.write_text(new_html, encoding="utf-8")
     elif "/rrd_static/" in html:
         logging.warning(
-            "inline_rrd_iframes: %s contains /rrd_static/ references but the iframe "
-            "regex matched nothing — Bokeh's HTML encoding may have changed",
+            "inline_rrd_iframes: %s contains /rrd_static/ references but the "
+            "URL regex matched nothing — Bokeh's HTML encoding may have changed",
             html_path,
         )

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -122,9 +122,12 @@ def rrd_file_to_pane(  # pragma: no cover
 
     # CDN viewer page is served from the same Panel origin — relative URL works.
     viewer_url = _cdn_viewer_url(relative, viewer_version)
-    return pn.pane.HTML(
+    iframe = (
         f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
-        f' frameborder="0" allowfullscreen></iframe>',
+        f' frameborder="0" allowfullscreen></iframe>'
+    )
+    return pn.pane.HTML(
+        _wrap_viewer_controls(iframe, width, height),
         width=width,
         height=height,
     )
@@ -183,6 +186,39 @@ try {{
 }}
 </script></body></html>
 """
+
+
+def _wrap_viewer_controls(iframe_html: str, width: int, height: int) -> str:
+    """Wrap a rerun-viewer iframe with fullscreen and open-in-new-tab controls.
+
+    Controls float at the top-center (away from the viewer's own corner UI)
+    and read their target from the wrapped iframe's DOM, so portable/inline
+    URL rewriting in ``inline_rrd_iframes()`` keeps working without touching
+    the buttons.
+    """
+    btn = (
+        "background:rgba(0,0,0,0.55);color:white;border:0;"
+        "padding:2px 7px;cursor:pointer;border-radius:3px;font:14px/1 sans-serif"
+    )
+    link = btn + ";text-decoration:none;display:inline-block;line-height:1.4"
+    fs_js = "this.closest('.bencher-rrd-wrap').querySelector('iframe').requestFullscreen()"
+    # Anchor with target=_blank rather than window.open(): the latter is silently
+    # blocked by popup-blockers in some browsers even from a user click.  The
+    # onclick sets href to the iframe's current src so portable/inline URL
+    # rewriting in inline_rrd_iframes() (which only touches the iframe) is fine.
+    nt_js = "this.href=this.closest('.bencher-rrd-wrap').querySelector('iframe').src"
+    return (
+        f'<div class="bencher-rrd-wrap"'
+        f' style="position:relative;display:inline-block;width:{width}px;height:{height}px">'
+        f"{iframe_html}"
+        f'<div style="position:absolute;top:4px;left:50%;transform:translateX(-50%);'
+        f'display:flex;gap:4px;z-index:10">'
+        f'<button title="Fullscreen" style="{btn}" onclick="{fs_js}">⛶</button>'
+        f'<a title="Open in new tab" href="about:blank" target="_blank" rel="noopener"'
+        f' style="{link}" onclick="{nt_js}">↗</a>'
+        f"</div></div>"
+    )
+
 
 # Cache of written viewer page filenames, keyed by version (for /rrd_static/ URLs).
 _cdn_viewer_files: dict[str, str] = {}
@@ -261,9 +297,12 @@ def _portable_rrd_pane(
     viewer_name, rrd_name = _write_rrd_sidecar(rrd_path, version, rrd_subdir)
 
     viewer_url = f"_rrd/{viewer_name}?url={quote(rrd_name)}"
-    return pn.pane.HTML(
+    iframe = (
         f'<iframe src="{viewer_url}" width="{width}" height="{height}"'
-        f' frameborder="0" allowfullscreen></iframe>',
+        f' frameborder="0" allowfullscreen></iframe>'
+    )
+    return pn.pane.HTML(
+        _wrap_viewer_controls(iframe, width, height),
         width=width,
         height=height,
     )

--- a/bencher/utils_rrd.py
+++ b/bencher/utils_rrd.py
@@ -199,11 +199,15 @@ def _wrap_viewer_controls(iframe_html: str, viewer_url: str, width: int, height:
     A real anchor (rather than ``window.open()``) avoids popup-blocker false
     positives that silently swallow the click in some browsers.
     """
+    # Shared style for both controls.  ``font: 14px/1`` (size/line-height) keeps
+    # the button and the anchor the same height — without that the anchor's
+    # default ``line-height`` differs and the two icons render at different
+    # sizes side-by-side.
     btn = (
         "background:rgba(0,0,0,0.55);color:white;border:0;"
         "padding:2px 7px;cursor:pointer;border-radius:3px;font:14px/1 sans-serif"
     )
-    link = btn + ";text-decoration:none;display:inline-block;line-height:1.4"
+    link = btn + ";text-decoration:none;display:inline-block"
     fs_js = "this.closest('.bencher-rrd-wrap').querySelector('iframe').requestFullscreen()"
     return (
         f'<div class="bencher-rrd-wrap"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.99.0"
+version = "1.100.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_rrd_inline.py
+++ b/test/test_rrd_inline.py
@@ -1,0 +1,191 @@
+"""Tests for the rerun-viewer wrapper and saved-report URL rewriting."""
+
+import html
+import re
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from bencher.utils_rrd import (
+    _RRD_URL_RE,
+    _wrap_viewer_controls,
+    inline_rrd_iframes,
+)
+
+
+class TestWrapViewerControls(unittest.TestCase):
+    """``_wrap_viewer_controls`` builds the iframe + control overlay HTML."""
+
+    def test_contains_both_controls(self):
+        iframe = (
+            '<iframe src="A" width="400" height="400" frameborder="0" allowfullscreen></iframe>'
+        )
+        out = _wrap_viewer_controls(iframe, "A", 400, 400)
+        self.assertIn("requestFullscreen()", out)
+        self.assertIn('target="_blank"', out)
+
+    def test_anchor_href_is_set_at_construction(self):
+        """Middle-click / Cmd-click rely on a real ``href`` attribute, not onclick."""
+        iframe = '<iframe src="/some/url" width="100" height="100" frameborder="0" allowfullscreen></iframe>'
+        out = _wrap_viewer_controls(iframe, "/some/url", 100, 100)
+        # Anchor must carry the URL directly, not a placeholder filled in by JS.
+        self.assertIn('href="/some/url"', out)
+        self.assertNotIn("about:blank", out)
+        # The new-tab anchor must not depend on onclick — only the fullscreen
+        # button should have an onclick handler.
+        self.assertEqual(out.count("onclick="), 1)
+
+    def test_preserves_iframe_html_verbatim(self):
+        iframe = '<iframe src="X" width="1" height="2" frameborder="0" allowfullscreen></iframe>'
+        out = _wrap_viewer_controls(iframe, "X", 1, 2)
+        self.assertIn(iframe, out)
+
+
+class TestRrdUrlRegex(unittest.TestCase):
+    """``_RRD_URL_RE`` finds the URL in Bokeh's double-escaped saved HTML."""
+
+    def test_matches_both_iframe_and_anchor_occurrences(self):
+        iframe = '<iframe src="/rrd_static/viewer_0.32.0.html?url=/rrd_static/job/foo.rrd" width="400" height="400" frameborder="0" allowfullscreen></iframe>'
+        wrapped = _wrap_viewer_controls(
+            iframe, "/rrd_static/viewer_0.32.0.html?url=/rrd_static/job/foo.rrd", 400, 400
+        )
+        # Bokeh serialises HTML inside JSON, producing a double-entity encoding.
+        bokeh_encoded = html.escape(html.escape(wrapped))
+        matches = _RRD_URL_RE.findall(bokeh_encoded)
+        self.assertEqual(matches, [("0.32.0", "job/foo.rrd"), ("0.32.0", "job/foo.rrd")])
+
+    def test_does_not_match_outside_quotes(self):
+        # A bare /rrd_static/... reference (not wrapped in &amp;quot;) should
+        # not match — otherwise debug log lines could be mangled.
+        bare = "see /rrd_static/viewer_0.32.0.html?url=/rrd_static/job/foo.rrd in logs"
+        self.assertIsNone(_RRD_URL_RE.search(bare))
+
+
+class TestInlineRrdIframes(unittest.TestCase):
+    """End-to-end: build a fake saved HTML, run the post-processor, check rewrites."""
+
+    def setUp(self):
+        # Run inside a fresh tempdir so we can drop a fake cachedir/rrd/<job>/foo.rrd
+        # without disturbing the real one.
+        self._cwd_patch = mock.patch("os.getcwd")
+        self.tmp = Path(tempfile.mkdtemp())
+        (self.tmp / "cachedir" / "rrd" / "jobA").mkdir(parents=True)
+        self.rrd_path = self.tmp / "cachedir" / "rrd" / "jobA" / "foo.rrd"
+        self.rrd_path.write_bytes(b"fake rrd contents")
+
+        # _RRD_CACHE_DIR.resolve() in utils_rrd anchors to cwd, so chdir.
+        self._orig_cwd = Path.cwd()
+        import os
+
+        os.chdir(self.tmp)
+
+    def tearDown(self):
+        import os
+
+        os.chdir(self._orig_cwd)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _build_saved_html(self, viewer_url: str) -> str:
+        iframe = (
+            f'<iframe src="{viewer_url}" width="400" height="400"'
+            f' frameborder="0" allowfullscreen></iframe>'
+        )
+        wrapped = _wrap_viewer_controls(iframe, viewer_url, 400, 400)
+        # Mimic the double-entity encoding Bokeh applies on save.
+        return f"<html><body>{html.escape(html.escape(wrapped))}</body></html>"
+
+    def test_rewrites_iframe_and_anchor_in_one_pass(self):
+        viewer_url = "/rrd_static/viewer_0.32.0.html?url=/rrd_static/jobA/foo.rrd"
+        report_dir = self.tmp / "report"
+        report_dir.mkdir()
+        html_path = report_dir / "index.html"
+        html_path.write_text(self._build_saved_html(viewer_url), encoding="utf-8")
+
+        inline_rrd_iframes(html_path)
+
+        rewritten = html_path.read_text(encoding="utf-8")
+        # No /rrd_static/ URLs should remain — both iframe src and anchor href
+        # must be rewritten to the relative ``_rrd/...`` path.
+        self.assertNotIn("/rrd_static/", rewritten)
+        # The sidecar viewer + rrd should now exist next to the report.
+        self.assertTrue((report_dir / "_rrd" / "viewer_0.32.0.html").is_file())
+        self.assertTrue((report_dir / "_rrd" / "jobA" / "foo.rrd").is_file())
+        # The relative path should appear twice — once for the iframe, once for
+        # the anchor href.
+        relative = "_rrd/viewer_0.32.0.html?url=jobA/foo.rrd"
+        self.assertEqual(rewritten.count(relative), 2)
+
+    def test_idempotent_per_recording(self):
+        """Memoization avoids writing the sidecar files twice per recording."""
+        viewer_url = "/rrd_static/viewer_0.32.0.html?url=/rrd_static/jobA/foo.rrd"
+        report_dir = self.tmp / "report2"
+        report_dir.mkdir()
+        html_path = report_dir / "index.html"
+        html_path.write_text(self._build_saved_html(viewer_url), encoding="utf-8")
+
+        # The iframe src and anchor href both contain the same URL.  Patch
+        # _write_rrd_sidecar to count invocations.
+        import bencher.utils_rrd as mod
+
+        original = mod._write_rrd_sidecar
+        call_count = 0
+
+        def counting(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return original(*args, **kwargs)
+
+        with mock.patch.object(mod, "_write_rrd_sidecar", counting):
+            inline_rrd_iframes(html_path)
+
+        self.assertEqual(
+            call_count,
+            1,
+            "_write_rrd_sidecar should run once per recording, not once per URL match",
+        )
+
+    def test_logs_warning_when_url_present_but_regex_misses(self):
+        """If Bokeh's encoding changes, we want a visible warning, not silent success."""
+        report_dir = self.tmp / "report3"
+        report_dir.mkdir()
+        html_path = report_dir / "index.html"
+        # Mangled encoding: /rrd_static/ is present but not wrapped in the
+        # expected double-entity quoting, so the regex misses.
+        html_path.write_text(
+            "<html><body>see /rrd_static/viewer_0.32.0.html in logs</body></html>",
+            encoding="utf-8",
+        )
+
+        with self.assertLogs("root", level="WARNING") as captured:
+            inline_rrd_iframes(html_path)
+
+        joined = "\n".join(captured.output)
+        self.assertIn("/rrd_static/", joined)
+        self.assertIn("URL regex matched nothing", joined)
+
+
+# --- Extra guards on the wrapper output ---
+
+
+class TestWrapperOutputShape(unittest.TestCase):
+    def test_wrapper_class_used_consistently(self):
+        """The JS selectors look for ``.bencher-rrd-wrap`` — the wrapper must use it."""
+        iframe = '<iframe src="X" width="1" height="2" frameborder="0" allowfullscreen></iframe>'
+        out = _wrap_viewer_controls(iframe, "X", 1, 2)
+        self.assertIn('class="bencher-rrd-wrap"', out)
+        # The fullscreen onclick references the class — check the literal that
+        # appears in the rendered HTML.
+        self.assertIn(".bencher-rrd-wrap", out)
+
+    def test_dimensions_propagate_to_wrapper(self):
+        iframe = (
+            '<iframe src="X" width="321" height="123" frameborder="0" allowfullscreen></iframe>'
+        )
+        out = _wrap_viewer_controls(iframe, "X", 321, 123)
+        self.assertRegex(out, re.compile(r"width:321px;height:123px"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_rrd_inline.py
+++ b/test/test_rrd_inline.py
@@ -127,6 +127,7 @@ class TestInlineRrdIframes(unittest.TestCase):
 
         # The iframe src and anchor href both contain the same URL.  Patch
         # _write_rrd_sidecar to count invocations.
+        # pylint: disable=protected-access
         import bencher.utils_rrd as mod
 
         original = mod._write_rrd_sidecar


### PR DESCRIPTION
## Summary
- Embedded rerun recordings now show two small overlay controls at top-center: ⛶ for fullscreen and ↗ to open the same chromeless viewer in a new tab. Useful when an over_time sweep renders multiple recordings side-by-side and you want to expand one without losing the others.
- New tab uses a real \`<a target="_blank">\` (with the href populated on click from the iframe's current src), not \`window.open\` — popup blockers leave anchor clicks alone but silently drop \`window.open\` in some browsers.
- Controls read their target from the iframe DOM, so the existing URL rewriting in \`inline_rrd_iframes()\` for sidecar/portable saves still only needs to touch the iframe. Verified the post-processing regex still matches after wrapping.
- Bumps version to \`1.100.0\` and adds a CHANGELOG entry.

## Test plan
- [x] \`pixi run lint\` — clean
- [x] Manual: live Panel server rendering an over_time sweep — fullscreen button enters/exits fullscreen, open-in-new-tab opens the chromeless viewer in a new tab.
- [ ] Verify saved (sidecar) and portable (inline-base64) reports still rewrite iframe URLs correctly with the wrapper present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add overlay controls to embedded rerun viewer iframes for fullscreen and opening the viewer in a new tab, and bump the package version.

New Features:
- Provide a wrapper around rerun viewer iframes that adds top-centered overlay controls for fullscreen and opening the viewer in a new browser tab.

Enhancements:
- Ensure embedded and portable rerun viewer panes use the new iframe wrapper while preserving existing URL rewriting behavior.

Build:
- Bump the project version from 1.99.0 to 1.100.0.

Documentation:
- Document the new overlay controls and behavior in the changelog for version 1.100.0.