### PR TITLE
fix: Show all repeat recordings for media results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.101.0] - 2026-05-19
+
+### Fixed
+- Media results (`ResultRerun`, `ResultVideo`, `ResultImage`) with `repeats > 1` now render every repeat instead of silently dropping all but one. Previously the repeat dimension was peeled by generic pane recursion and `zero_dim_da_to_val` quietly returned `values[0]`, leaving N-1 recordings on disk but invisible in the report.
+
+### Changed
+- `zero_dim_da_to_val` is now strict: it raises `ValueError` when handed a DataArray with a multi-valued dimension, instead of silently collapsing it. Callers must peel multi-valued dims (via recursion, `isel`, or `_pane_media_grid`) first.
+- Extracted shared `_render_media_cell` helper used by both `_pane_media_grid` and `_pane_over_time_slider` so new media types only need to be wired up in one place.
+- Generalised the over-time-specific grid into `_pane_media_grid`, which iterates the cartesian product of every surviving multi-valued dim (`over_time`, `repeat`, future custom dims) and lays out cells as a `pn.Row` (1-D) or `pn.GridBox` with `ncols` (N-D). `_pane_over_time_grid` is kept as a thin shim.
+
+### Added
+- `example_rerun_repeat.py` — standalone gallery example demonstrating `ResultRerun` with `repeats > 1`.
+
+### Tests
+- `TestMediaGridShowsAllRepeats` — end-to-end test that a `ResultImage` sweep with `repeats=3` renders all three image paths in the final Panel layout.
+- `TestPaneRepeatGrid` — verifies the `repeat` dim survives SQUEEZE on a `ResultRerun` sweep with `repeats=3` and is squeezed away when `repeats=1`.
+- `TestZeroDimDaToValMultiRepeat` — unit tests covering the strict multi-valued-dim guard, size-1 dims, zero-dim scalars, and the post-`isel` scalar-coord case.
+
 ## [1.100.0] - 2026-05-15
 
 ### Added

--- a/bencher/example/generated/rerun/example_rerun_repeat.py
+++ b/bencher/example/generated/rerun/example_rerun_repeat.py
@@ -1,6 +1,5 @@
 """Auto-generated example: Rerun Repeat — multiple recordings per sweep point."""
 
-import math
 import rerun as rr
 import bencher as bn
 

--- a/bencher/example/generated/rerun/example_rerun_repeat.py
+++ b/bencher/example/generated/rerun/example_rerun_repeat.py
@@ -1,0 +1,45 @@
+"""Auto-generated example: Rerun Repeat — multiple recordings per sweep point."""
+
+import math
+import rerun as rr
+import bencher as bn
+
+
+class RerunRepeatSweep(bn.ParametrizedSweep):
+    """Sweep that produces a rerun recording for each repeat.
+
+    Each call to ``benchmark()`` logs a box whose size varies with the
+    repeat index (via a class counter) so the recordings are visually
+    distinct.  With ``repeats > 1`` and no input sweep, the report
+    should display a grid of labelled recordings — one per repeat.
+    """
+
+    out_val = bn.ResultFloat(units="v", doc="box half-size used")
+    out_rerun = bn.ResultRerun(width=400, height=400)
+
+    _call_count = 0
+
+    def benchmark(self):
+        RerunRepeatSweep._call_count += 1
+        size = float(self._call_count)
+        self.out_val = size
+        rr.log("boxes", rr.Boxes2D(half_sizes=[size, 1]))
+        self.out_rerun = bn.capture_rerun_window()
+
+
+def example_rerun_repeat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Repeat — one recording per repeat, all visible in the report."""
+    bench = RerunRepeatSweep().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[],
+        result_vars=["out_val", "out_rerun"],
+        description="Demonstrates that ``ResultRerun`` works correctly with "
+        "``repeats > 1``.  Each repeat produces a distinct recording "
+        "and the report renders all of them as a labelled grid.",
+    )
+    return bench
+
+
+if __name__ == "__main__":
+    RerunRepeatSweep._call_count = 0
+    bn.run(example_rerun_repeat, repeats=3)

--- a/bencher/example/generated/rerun/example_rerun_repeat.py
+++ b/bencher/example/generated/rerun/example_rerun_repeat.py
@@ -1,4 +1,4 @@
-"""Auto-generated example: Rerun Repeat — multiple recordings per sweep point."""
+"""Auto-generated example: Rerun Repeat — one recording per repeat, all visible in the report."""
 
 import rerun as rr
 import bencher as bn
@@ -28,6 +28,7 @@ class RerunRepeatSweep(bn.ParametrizedSweep):
 
 def example_rerun_repeat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Rerun Repeat — one recording per repeat, all visible in the report."""
+    RerunRepeatSweep._call_count = 0
     bench = RerunRepeatSweep().to_bench(run_cfg)
     bench.plot_sweep(
         input_vars=[],
@@ -36,9 +37,9 @@ def example_rerun_repeat(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
         "``repeats > 1``.  Each repeat produces a distinct recording "
         "and the report renders all of them as a labelled grid.",
     )
+
     return bench
 
 
 if __name__ == "__main__":
-    RerunRepeatSweep._call_count = 0
     bn.run(example_rerun_repeat, repeats=3)

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -1,9 +1,10 @@
 """Meta-generator: Rerun visualization integration examples.
 
-Generates three rerun examples:
+Generates four rerun examples:
 - capture_window: basic rerun capture in a single sweep
 - regression: 0 input vars, 3 over-time snapshots with regression on the 3rd
 - sweep: 1 input var (damping_ratio), single sweep, no over_time
+- repeat: 0 input vars, repeats > 1 — exercises the media-grid renderer
 """
 
 import bencher as bn
@@ -15,6 +16,7 @@ RERUN_EXAMPLES = [
     "capture_window",
     "regression",
     "sweep",
+    "repeat",
 ]
 
 
@@ -30,6 +32,8 @@ class MetaRerun(MetaGeneratorBase):
             self._generate_regression()
         elif self.example == "sweep":
             self._generate_sweep()
+        elif self.example == "repeat":
+            self._generate_repeat()
 
     def _generate_capture_window(self):
         """Capture a rerun viewer window as a Panel widget inside a sweep."""
@@ -144,6 +148,52 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             run_kwargs={"subsampling_divisions": 3},
+        )
+
+    def _generate_repeat(self):
+        """0 input vars, repeats > 1 — every repeat must render in the report."""
+        imports = "import rerun as rr\nimport bencher as bn"
+        class_code = '''
+class RerunRepeatSweep(bn.ParametrizedSweep):
+    """Sweep that produces a rerun recording for each repeat.
+
+    Each call to ``benchmark()`` logs a box whose size varies with the
+    repeat index (via a class counter) so the recordings are visually
+    distinct.  With ``repeats > 1`` and no input sweep, the report
+    should display a grid of labelled recordings — one per repeat.
+    """
+
+    out_val = bn.ResultFloat(units="v", doc="box half-size used")
+    out_rerun = bn.ResultRerun(width=400, height=400)
+
+    _call_count = 0
+
+    def benchmark(self):
+        RerunRepeatSweep._call_count += 1
+        size = float(self._call_count)
+        self.out_val = size
+        rr.log("boxes", rr.Boxes2D(half_sizes=[size, 1]))
+        self.out_rerun = bn.capture_rerun_window()'''
+        body = """\
+RerunRepeatSweep._call_count = 0
+bench = RerunRepeatSweep().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=[],
+    result_vars=["out_val", "out_rerun"],
+    description="Demonstrates that ``ResultRerun`` works correctly with "
+    "``repeats > 1``.  Each repeat produces a distinct recording "
+    "and the report renders all of them as a labelled grid.",
+)
+"""
+        self.generate_example(
+            title="Rerun Repeat — one recording per repeat, all visible in the report",
+            output_dir=OUTPUT_DIR,
+            filename="example_rerun_repeat",
+            function_name="example_rerun_repeat",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"repeats": 3},
         )
 
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -803,6 +803,17 @@ class BenchResultBase:
             pane_dims = [d for d in dims if d != "over_time"]
         else:
             pane_dims = dims
+
+        # Media results handle the repeat dim via _pane_media_grid, not
+        # pane recursion — exclude it so _iter_pane_slices doesn't peel
+        # it before the media grid can render all repeats.
+        if (
+            "repeat" in pane_dims
+            and dataset.sizes.get("repeat", 0) > 1
+            and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
+        ):
+            pane_dims = [d for d in pane_dims if d != "repeat"]
+
         num_pane_dims = len(pane_dims)
 
         if num_pane_dims > target_dimension and num_pane_dims != 0:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1001,9 +1001,6 @@ class BenchResultBase:
         reduction.  This method iterates each repeat and renders a panel
         so all recordings are visible, not just the first/last.
         """
-        from bencher.utils_rrd import rrd_file_to_pane
-
-        is_rerun = isinstance(result_var, ResultRerun)
         repeat_vals = list(dataset.coords["repeat"].values)
 
         items = []
@@ -1013,12 +1010,16 @@ class BenchResultBase:
             if filepath == "NAN" or not os.path.isfile(filepath):
                 continue
             label = f"Repeat {repeat_val}"
-            if is_rerun:
+            if isinstance(result_var, ResultRerun):
+                from bencher.utils_rrd import rrd_file_to_pane
+
                 pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
             elif isinstance(result_var, ResultVideo):
                 pane = pn.pane.Video(filepath, width=getattr(result_var, "width", 400))
-            else:
+            elif isinstance(result_var, ResultImage):
                 pane = pn.pane.PNG(filepath, width=getattr(result_var, "width", 400))
+            else:
+                pane = pn.pane.Markdown(f"`{filepath}`")
             items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
 
         if not items:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -803,15 +803,6 @@ class BenchResultBase:
             pane_dims = [d for d in dims if d != "over_time"]
         else:
             pane_dims = dims
-
-        # repeat dim for media results is handled by _pane_repeat_grid, not pane recursion
-        if (
-            "repeat" in pane_dims
-            and dataset.sizes.get("repeat", 0) > 1
-            and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
-        ):
-            pane_dims = [d for d in pane_dims if d != "repeat"]
-
         num_pane_dims = len(pane_dims)
 
         if num_pane_dims > target_dimension and num_pane_dims != 0:
@@ -858,26 +849,21 @@ class BenchResultBase:
                 for c in outer_container.container:
                     c[0].width = max_len * 7
         else:
-            # When over_time is active with >1 time points, the dataset still
-            # contains the over_time dimension (it was excluded from pane recursion
-            # so hvplot numeric plots can use groupby).  For pane-type results
-            # (images, videos) we need to build a Panel slider manually because
-            # they are not HoloViews objects and cannot use hv.HoloMap.
-            if (
-                self.bench_cfg.over_time
-                and "over_time" in list(dataset.sizes)
-                and dataset.sizes["over_time"] > 1
-                and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
-            ):
-                if isinstance(result_var, ResultRerun):
-                    return self._pane_over_time_grid(dataset, result_var)
-                return self._pane_over_time_slider(dataset, result_var)
-            if (
-                "repeat" in list(dataset.sizes)
-                and dataset.sizes["repeat"] > 1
-                and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
-            ):
-                return self._pane_repeat_grid(dataset, result_var)
+            # When the recursion leaves any multi-valued dim behind (e.g.
+            # ``over_time`` is excluded from pane recursion so numeric plots
+            # can use hvplot groupby, or ``repeat`` survives a non-zero
+            # target_dimension), a pane-type result must still render every
+            # cell — otherwise samples are silently dropped.  Dispatch to the
+            # generic media grid (or the legacy over-time slider for the
+            # single-dim Video/Image case, where the slider UX is preserved).
+            if isinstance(result_var, (ResultVideo, ResultImage, ResultRerun)):
+                multi_dims = [d for d in dataset.sizes if dataset.sizes[d] > 1]
+                if multi_dims:
+                    if multi_dims == ["over_time"] and isinstance(
+                        result_var, (ResultVideo, ResultImage)
+                    ):
+                        return self._pane_over_time_slider(dataset, result_var)
+                    return self._pane_media_grid(dataset, result_var)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
         return outer_container.render()
@@ -917,6 +903,12 @@ class BenchResultBase:
         html_list = []
         for idx, _t in enumerate(time_vals):
             ds_t = dataset.isel(over_time=idx)
+            # Peel any other surviving multi-valued dim (e.g. ``repeat``)
+            # by taking the most recent entry — the slider is 1-D so it can
+            # only show one cell per time point.  Multi-dim media should
+            # use _pane_media_grid (dispatched separately for that case).
+            for d in [d for d in ds_t.dims if ds_t.sizes[d] > 1]:
+                ds_t = ds_t.isel({d: -1})
             filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
             if filepath == "NAN" or not os.path.isfile(filepath):
                 html_list.append(_NO_DATA_HTML)
@@ -964,82 +956,102 @@ class BenchResultBase:
         dataset: xr.Dataset,
         result_var,
     ) -> pn.Row | pn.pane.Markdown:
-        """Render over_time pane results as a grid of labelled panels.
+        """Backwards-compatible shim for the over_time-specific grid."""
+        return self._pane_media_grid(dataset, result_var)
 
-        Used for ResultRerun because rerun iframes do not work inside a
-        Bokeh JS slider swap (the viewer fails to re-initialise).
-        """
-        from bencher.utils_rrd import rrd_file_to_pane
+    @staticmethod
+    def _format_coord_label(value) -> str:
+        """Format a single coord value for a media-grid cell label."""
+        if isinstance(value, np.datetime64) or (
+            hasattr(value, "dtype") and np.issubdtype(value.dtype, np.datetime64)
+        ):
+            return str(pd.to_datetime(value))
+        return str(value)
 
-        time_vals = list(dataset.coords["over_time"].values)
-        over_time_dtype = dataset.coords["over_time"].dtype
-        is_datetime = np.issubdtype(over_time_dtype, np.datetime64)
-        labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
+    def _render_media_cell(self, ds_cell: xr.Dataset, result_var) -> pn.viewable.Viewable | None:
+        """Render a single, fully-sliced media-result cell, or return None
+        when the underlying file is missing/NAN."""
+        filepath = str(self.zero_dim_da_to_val(ds_cell[result_var.name]))
+        if filepath in ("NAN", "nan") or not os.path.isfile(filepath):
+            return None
+        if isinstance(result_var, ResultRerun):
+            from bencher.utils_rrd import rrd_file_to_pane
 
-        items = []
-        for idx, label in enumerate(labels):
-            ds_t = dataset.isel(over_time=idx)
-            filepath = str(self.zero_dim_da_to_val(ds_t[result_var.name]))
-            if filepath == "NAN" or not os.path.isfile(filepath):
-                continue
-            pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
-            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
+            return rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
+        if isinstance(result_var, ResultVideo):
+            return pn.pane.Video(filepath)
+        if isinstance(result_var, ResultImage):
+            return pn.pane.Image(filepath)
+        # Fallback for other path-like results.
+        return pn.pane.Markdown(f"`{filepath}`")
 
-        if not items:
-            return pn.pane.Markdown("*No rerun data available*")
-        return pn.Row(*items)
-
-    def _pane_repeat_grid(
+    def _pane_media_grid(
         self,
         dataset: xr.Dataset,
         result_var,
-    ) -> pn.Row | pn.pane.Markdown:
-        """Render multi-repeat pane results as a grid of labelled panels.
+    ) -> pn.viewable.Viewable:
+        """Render every (multi-valued dim) combination of a media result as
+        a labelled grid.  Handles any mix of surviving dims (``over_time``,
+        ``repeat``, future custom dims) so we never silently drop a sample.
 
-        When repeats > 1 and the result is a media type (ResultRerun,
-        ResultVideo, ResultImage), the repeat dimension survives SQUEEZE
-        reduction.  This method iterates each repeat and renders a panel
-        so all recordings are visible, not just the first/last.
+        Returns a Markdown placeholder if no files are available.
         """
-        repeat_vals = list(dataset.coords["repeat"].values)
+        from itertools import product
 
-        items = []
-        for idx, repeat_val in enumerate(repeat_vals):
-            ds_r = dataset.isel(repeat=idx)
-            filepath = str(self.zero_dim_da_to_val(ds_r[result_var.name]))
-            if filepath == "NAN" or not os.path.isfile(filepath):
+        # Pick up any dim still carrying more than one entry — this is where
+        # silent drops used to happen.  Order is preserved so the outer dim
+        # (e.g. over_time) varies along the column axis.
+        grid_dims = [d for d in dataset.dims if dataset.sizes[d] > 1]
+
+        if not grid_dims:
+            cell = self._render_media_cell(dataset, result_var)
+            return cell if cell is not None else pn.pane.Markdown("*No media data available*")
+
+        coord_lists = [list(dataset.coords[d].values) for d in grid_dims]
+        items: list[pn.viewable.Viewable] = []
+        for combo in product(*coord_lists):
+            sel = dict(zip(grid_dims, combo))
+            ds_cell = dataset.sel(sel)
+            cell = self._render_media_cell(ds_cell, result_var)
+            if cell is None:
                 continue
-            label = f"Repeat {repeat_val}"
-            if isinstance(result_var, ResultRerun):
-                from bencher.utils_rrd import rrd_file_to_pane
-
-                pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
-            elif isinstance(result_var, ResultVideo):
-                pane = pn.pane.Video(filepath, width=getattr(result_var, "width", 400))
-            elif isinstance(result_var, ResultImage):
-                pane = pn.pane.PNG(filepath, width=getattr(result_var, "width", 400))
-            else:
-                pane = pn.pane.Markdown(f"`{filepath}`")
-            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
+            label = ", ".join(f"{d}={self._format_coord_label(v)}" for d, v in sel.items())
+            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), cell))
 
         if not items:
-            return pn.pane.Markdown("*No media data available for repeats*")
-        return pn.Row(*items)
+            return pn.pane.Markdown("*No media data available*")
+        # 1-D layout: row.  N-D: GridBox wrapped to the size of the last dim
+        # so each row corresponds to one value of the outer dims.
+        if len(grid_dims) == 1:
+            return pn.Row(*items)
+        ncols = dataset.sizes[grid_dims[-1]]
+        return pn.GridBox(*items, ncols=ncols)
 
     def zero_dim_da_to_val(self, da_ds: xr.DataArray | xr.Dataset) -> Any:
-        # todo this is really horrible, need to improve
+        """Extract a single value from a zero-dimensional xarray.
+
+        Multi-valued dims must be peeled by the caller (via recursion,
+        ``isel``, or :meth:`_pane_media_grid`) — passing one through is a
+        bug because it would silently collapse a dimension and drop every
+        other sample.  Raises ``ValueError`` in that case so the bug is
+        caught at the source rather than producing a degraded plot.
+        """
         if isinstance(da_ds, xr.Dataset):
             var_name = list(da_ds.keys())[0]
             da = da_ds[var_name]
         else:
             da = da_ds
 
-        # When the recursion in _to_panes_da hasn't peeled every dim (e.g. a
-        # surviving multi-valued 'repeat' dim with a media-type result), take
-        # the last entry along each remaining dim so we don't silently return
-        # values[0] and drop every later repeat / time sample.
-        for dim_name in list(da.dims):
-            da = da.isel({dim_name: -1})
+        multi_dims = [d for d in da.dims if da.sizes[d] > 1]
+        if multi_dims:
+            raise ValueError(
+                f"zero_dim_da_to_val received DataArray with multi-valued dim(s) "
+                f"{multi_dims}; caller must peel them first "
+                f"(e.g. via isel) or use _pane_media_grid for media results."
+            )
+
+        # Squeeze remaining size-1 dims to land on a true scalar.
+        da = da.squeeze(drop=False)
 
         if not da.coords:
             return da.values.squeeze().item()

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -976,18 +976,22 @@ class BenchResultBase:
 
     def zero_dim_da_to_val(self, da_ds: xr.DataArray | xr.Dataset) -> Any:
         # todo this is really horrible, need to improve
-        dim = None
         if isinstance(da_ds, xr.Dataset):
-            dim = list(da_ds.keys())[0]
-            da = da_ds[dim]
+            var_name = list(da_ds.keys())[0]
+            da = da_ds[var_name]
         else:
             da = da_ds
 
-        for k in da.coords.keys():
-            dim = k
-            break
-        if dim is None:
-            return da_ds.values.squeeze().item()
+        # When the recursion in _to_panes_da hasn't peeled every dim (e.g. a
+        # surviving multi-valued 'repeat' dim with a media-type result), take
+        # the last entry along each remaining dim so we don't silently return
+        # values[0] and drop every later repeat / time sample.
+        for dim_name in list(da.dims):
+            da = da.isel({dim_name: -1})
+
+        if not da.coords:
+            return da.values.squeeze().item()
+        dim = next(iter(da.coords.keys()))
         return da.expand_dims(dim).values[0]
 
     def ds_to_container(  # pylint: disable=too-many-return-statements

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -803,6 +803,15 @@ class BenchResultBase:
             pane_dims = [d for d in dims if d != "over_time"]
         else:
             pane_dims = dims
+
+        # repeat dim for media results is handled by _pane_repeat_grid, not pane recursion
+        if (
+            "repeat" in pane_dims
+            and dataset.sizes.get("repeat", 0) > 1
+            and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
+        ):
+            pane_dims = [d for d in pane_dims if d != "repeat"]
+
         num_pane_dims = len(pane_dims)
 
         if num_pane_dims > target_dimension and num_pane_dims != 0:
@@ -863,6 +872,12 @@ class BenchResultBase:
                 if isinstance(result_var, ResultRerun):
                     return self._pane_over_time_grid(dataset, result_var)
                 return self._pane_over_time_slider(dataset, result_var)
+            if (
+                "repeat" in list(dataset.sizes)
+                and dataset.sizes["repeat"] > 1
+                and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
+            ):
+                return self._pane_repeat_grid(dataset, result_var)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
         return outer_container.render()
@@ -972,6 +987,42 @@ class BenchResultBase:
 
         if not items:
             return pn.pane.Markdown("*No rerun data available*")
+        return pn.Row(*items)
+
+    def _pane_repeat_grid(
+        self,
+        dataset: xr.Dataset,
+        result_var,
+    ) -> pn.Row | pn.pane.Markdown:
+        """Render multi-repeat pane results as a grid of labelled panels.
+
+        When repeats > 1 and the result is a media type (ResultRerun,
+        ResultVideo, ResultImage), the repeat dimension survives SQUEEZE
+        reduction.  This method iterates each repeat and renders a panel
+        so all recordings are visible, not just the first/last.
+        """
+        from bencher.utils_rrd import rrd_file_to_pane
+
+        is_rerun = isinstance(result_var, ResultRerun)
+        repeat_vals = list(dataset.coords["repeat"].values)
+
+        items = []
+        for idx, repeat_val in enumerate(repeat_vals):
+            ds_r = dataset.isel(repeat=idx)
+            filepath = str(self.zero_dim_da_to_val(ds_r[result_var.name]))
+            if filepath == "NAN" or not os.path.isfile(filepath):
+                continue
+            label = f"Repeat {repeat_val}"
+            if is_rerun:
+                pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
+            elif isinstance(result_var, ResultVideo):
+                pane = pn.pane.Video(filepath, width=getattr(result_var, "width", 400))
+            else:
+                pane = pn.pane.PNG(filepath, width=getattr(result_var, "width", 400))
+            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
+
+        if not items:
+            return pn.pane.Markdown("*No media data available for repeats*")
         return pn.Row(*items)
 
     def zero_dim_da_to_val(self, da_ds: xr.DataArray | xr.Dataset) -> Any:

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -427,6 +427,12 @@ class HoloviewResult(PaneResult):
                         kdims[d.name] = k
                 for rv, cont in zip(result_var_plots, cont_instances):
                     val = dataset[rv.name].sel(**kdims)
+                    # Tap selects on input dims only — any remaining
+                    # multi-valued dim (e.g. ``repeat``) must be peeled
+                    # explicitly or zero_dim_da_to_val will refuse to
+                    # silently collapse it.
+                    for d in [d for d in val.dims if val.sizes[d] > 1]:
+                        val = val.isel({d: -1})
                     item = self.zero_dim_da_to_val(val)
                     title.object = "Selected: " + ", ".join(f"{k}:{v}" for k, v in kdims.items())
                     cont.object = item

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.100.0"
+version = "1.101.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -593,6 +593,59 @@ class TestZeroDimDaToValMultiRepeat(unittest.TestCase):
         self.assertEqual(val, "only.rrd")
 
 
+class _RerunRepeatBench(bn.ParametrizedSweep):
+    """Helper that produces a ResultRerun per repeat."""
+
+    out_val = bn.ResultFloat()
+    out_rerun = bn.ResultRerun(width=200, height=200)
+    _counter = 0
+
+    def benchmark(self):
+        import rerun as rr
+
+        _RerunRepeatBench._counter += 1
+        self.out_val = float(self._counter)
+        rr.log("test", rr.Scalars(self.out_val))
+        self.out_rerun = bn.capture_rerun_window()
+
+
+class TestPaneRepeatGrid(unittest.TestCase):
+    """_pane_repeat_grid renders all repeats for media results."""
+
+    def test_rerun_repeat_grid_renders_all_repeats(self):
+        """With repeats=3 and ResultRerun, the report should contain all 3 recordings."""
+        _RerunRepeatBench._counter = 0
+        bench = _RerunRepeatBench().to_bench()
+        res = bench.plot_sweep(
+            "repeat_grid_test",
+            input_vars=[],
+            result_vars=[_RerunRepeatBench.param.out_val, _RerunRepeatBench.param.out_rerun],
+            run_cfg=bn.BenchRunCfg(repeats=3),
+            plot_callbacks=False,
+        )
+        ds = res.to_dataset(reduce=ReduceType.SQUEEZE)
+        self.assertIn("repeat", ds.dims)
+        self.assertEqual(ds.sizes["repeat"], 3)
+        paths = [str(v) for v in ds["out_rerun"].values]
+        self.assertEqual(len(paths), 3)
+        for p in paths:
+            self.assertNotEqual(p, "NAN")
+
+    def test_single_repeat_no_grid(self):
+        """With repeats=1 the repeat dim is squeezed out — no grid needed."""
+        _RerunRepeatBench._counter = 0
+        bench = _RerunRepeatBench().to_bench()
+        res = bench.plot_sweep(
+            "single_repeat_test",
+            input_vars=[],
+            result_vars=[_RerunRepeatBench.param.out_val, _RerunRepeatBench.param.out_rerun],
+            run_cfg=bn.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+        ds = res.to_dataset(reduce=ReduceType.SQUEEZE)
+        self.assertNotIn("repeat", ds.dims)
+
+
 class _IndependentAxisBench(bn.ParametrizedSweep):
     """Helper with two result vars that opt out of shared axes."""
 

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -549,12 +549,14 @@ class TestBenchResultBase(unittest.TestCase):
         self.assertIsNot(ds1, ds2)
 
 
-class TestZeroDimDaToValMultiRepeat(unittest.TestCase):
-    """Guard against silently dropping repeats in zero_dim_da_to_val.
+class TestZeroDimDaToValStrict(unittest.TestCase):
+    """``zero_dim_da_to_val`` is contract-checked: it refuses multi-valued dims.
 
-    With repeats > 1 and a media-type result (ResultRerun/Video/Image), the
-    DataArray passed in still has a multi-valued ``repeat`` dim. The function
-    must not silently return ``values[0]`` — that drops every later repeat.
+    Multi-valued dims must be peeled by the caller (recursion, ``isel``, or
+    the media-grid helper) — otherwise the function would silently collapse a
+    dimension and drop every other repeat / time sample.  Making it strict
+    catches that class of bug at the source instead of silently degrading
+    visualisations.
     """
 
     @staticmethod
@@ -565,9 +567,20 @@ class TestZeroDimDaToValMultiRepeat(unittest.TestCase):
         cfg.result_hmaps = []
         return BenchResultBase(cfg)
 
-    def test_multi_valued_repeat_returns_latest(self):
-        """With a surviving multi-valued ``repeat`` dim, return the most
-        recent value (``values[-1]``), not the first."""
+    def test_zero_dim_unchanged(self):
+        """A truly zero-dim DataArray must still return its scalar value."""
+        res = self._make_base()
+        da = xr.DataArray(42.0, name="out_val")
+        self.assertEqual(res.zero_dim_da_to_val(da), 42.0)
+
+    def test_size_one_dim_returns_single_value(self):
+        """A dim of size 1 should return that single value (it is effectively scalar)."""
+        res = self._make_base()
+        da = xr.DataArray(["only.rrd"], dims=["repeat"], coords={"repeat": [1]}, name="out_rerun")
+        self.assertEqual(res.zero_dim_da_to_val(da), "only.rrd")
+
+    def test_multi_valued_dim_raises(self):
+        """Refuse to silently collapse a multi-valued dim — caller must peel it."""
         res = self._make_base()
         da = xr.DataArray(
             ["path1.rrd", "path2.rrd", "path3.rrd"],
@@ -575,22 +588,94 @@ class TestZeroDimDaToValMultiRepeat(unittest.TestCase):
             coords={"repeat": [1, 2, 3]},
             name="out_rerun",
         )
-        val = res.zero_dim_da_to_val(da)
-        self.assertEqual(val, "path3.rrd")
+        with self.assertRaisesRegex(ValueError, "repeat"):
+            res.zero_dim_da_to_val(da)
 
-    def test_zero_dim_unchanged(self):
-        """A truly zero-dim DataArray must still return its scalar value."""
+    def test_scalar_coord_extracted_after_isel(self):
+        """After ``isel`` peels a dim, the leftover scalar coord must still extract."""
         res = self._make_base()
-        da = xr.DataArray(42.0, name="out_val")
-        val = res.zero_dim_da_to_val(da)
-        self.assertEqual(val, 42.0)
+        da = xr.DataArray(
+            ["p1.rrd", "p2.rrd", "p3.rrd"],
+            dims=["repeat"],
+            coords={"repeat": [1, 2, 3]},
+            name="out_rerun",
+        )
+        sliced = da.isel(repeat=-1)  # scalar coord 'repeat' = 3
+        self.assertEqual(res.zero_dim_da_to_val(sliced), "p3.rrd")
 
-    def test_size_one_repeat_returns_single_value(self):
-        """A repeat dim of size 1 should return that single value."""
-        res = self._make_base()
-        da = xr.DataArray(["only.rrd"], dims=["repeat"], coords={"repeat": [1]}, name="out_rerun")
-        val = res.zero_dim_da_to_val(da)
-        self.assertEqual(val, "only.rrd")
+
+class _RepeatImageBench(bn.ParametrizedSweep):
+    """Minimal benchmark that produces a unique ResultImage per call."""
+
+    out_image = bn.ResultImage()
+
+    def benchmark(self):
+        from PIL import Image
+
+        path = bn.gen_image_path("repeat_test")
+        img = Image.new("RGB", (4, 4), (0, 0, 0))
+        img.save(path, "PNG")
+        self.out_image = str(path)
+
+
+class TestMediaGridShowsAllRepeats(unittest.TestCase):
+    """End-to-end: a media result with repeats > 1 must show every repeat,
+    not silently drop all but one.  Future code paths that don't peel
+    ``repeat`` via recursion (e.g. callers with target_dimension >= 1, or
+    new layouts) must still produce one labelled cell per repeat."""
+
+    def _stored_paths(self, res):
+        return sorted({str(v) for v in res.ds["out_image"].values.flatten() if v})
+
+    @staticmethod
+    def _collect_strings(node, acc):
+        if hasattr(node, "object") and isinstance(node.object, str):
+            acc.append(node.object)
+        if hasattr(node, "__iter__"):
+            try:
+                for child in node:
+                    TestMediaGridShowsAllRepeats._collect_strings(child, acc)
+            except TypeError:
+                pass
+        return acc
+
+    def test_panes_renders_all_repeat_paths(self):
+        bench = _RepeatImageBench().to_bench(bn.BenchRunCfg(repeats=3, cache_results=False))
+        res = bench.plot_sweep(plot_callbacks=False)
+
+        stored = self._stored_paths(res)
+        self.assertEqual(len(stored), 3, f"expected 3 distinct image paths, got {stored}")
+
+        from bencher.results.pane_result import PaneResult
+
+        pr = PaneResult(res.bench_cfg)
+        pr.ds = res.ds
+        pr.plt_cnt_cfg = res.plt_cnt_cfg
+        panel = pr.to_panes()
+        self.assertIsNotNone(panel)
+
+        rendered = "\n".join(self._collect_strings(panel, []))
+        for p in stored:
+            self.assertIn(
+                p,
+                rendered,
+                f"image path {p} missing from rendered panel — repeats are being dropped",
+            )
+
+    def test_pane_media_grid_helper_emits_one_cell_per_repeat(self):
+        """The grid helper must produce one labelled pane per repeat coord
+        when called with a surviving multi-valued repeat dim."""
+        bench = _RepeatImageBench().to_bench(bn.BenchRunCfg(repeats=3, cache_results=False))
+        res = bench.plot_sweep(plot_callbacks=False)
+        rv = res.bench_cfg.result_vars[0]
+
+        # pylint: disable=protected-access
+        grid = res._pane_media_grid(res.ds, rv)
+
+        stored = self._stored_paths(res)
+        rendered_str = "\n".join(self._collect_strings(grid, []))
+        for p in stored:
+            self.assertIn(p, rendered_str, f"grid missing {p}")
 
 
 class _RerunRepeatBench(bn.ParametrizedSweep):
@@ -610,11 +695,11 @@ class _RerunRepeatBench(bn.ParametrizedSweep):
 
 
 class TestPaneRepeatGrid(unittest.TestCase):
-    """_pane_repeat_grid renders all repeats for media results."""
+    """_pane_media_grid renders all repeats for media results."""
 
     def test_rerun_repeat_grid_renders_all_repeats(self):
         """With repeats=3 and ResultRerun, the report should contain all 3 recordings."""
-        _RerunRepeatBench._counter = 0
+        _RerunRepeatBench._counter = 0  # pylint: disable=protected-access
         bench = _RerunRepeatBench().to_bench()
         res = bench.plot_sweep(
             "repeat_grid_test",
@@ -633,7 +718,7 @@ class TestPaneRepeatGrid(unittest.TestCase):
 
     def test_single_repeat_no_grid(self):
         """With repeats=1 the repeat dim is squeezed out — no grid needed."""
-        _RerunRepeatBench._counter = 0
+        _RerunRepeatBench._counter = 0  # pylint: disable=protected-access
         bench = _RerunRepeatBench().to_bench()
         res = bench.plot_sweep(
             "single_repeat_test",

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -1,11 +1,12 @@
 import unittest
 import bencher as bn
 import numpy as np
+import xarray as xr
 import holoviews as hv
 import panel as pn
 
 from bencher.example.meta.example_meta import BenchableObject
-from bencher.results.bench_result_base import ReduceType
+from bencher.results.bench_result_base import BenchResultBase, ReduceType
 
 
 class TstBench(bn.ParametrizedSweep):
@@ -284,8 +285,6 @@ class TestBenchResultBase(unittest.TestCase):
         rv = res.bench_cfg.result_vars[0]
         da = res.get_optimal_value_indices(rv)
         self.assertIsNotNone(da)
-        import xarray as xr
-
         self.assertIsInstance(da, xr.DataArray)
 
     def test_get_optimal_vec(self):
@@ -548,6 +547,50 @@ class TestBenchResultBase(unittest.TestCase):
         self.assertEqual(len(res._to_dataset_cache), 0)  # pylint: disable=protected-access
         ds2 = res.to_dataset(deep=False)
         self.assertIsNot(ds1, ds2)
+
+
+class TestZeroDimDaToValMultiRepeat(unittest.TestCase):
+    """Guard against silently dropping repeats in zero_dim_da_to_val.
+
+    With repeats > 1 and a media-type result (ResultRerun/Video/Image), the
+    DataArray passed in still has a multi-valued ``repeat`` dim. The function
+    must not silently return ``values[0]`` — that drops every later repeat.
+    """
+
+    @staticmethod
+    def _make_base():
+        # BenchResultBase.__init__ only reads bench_cfg.result_hmaps, so a
+        # minimal stub works without spinning up a full sweep.
+        cfg = bn.BenchCfg()
+        cfg.result_hmaps = []
+        return BenchResultBase(cfg)
+
+    def test_multi_valued_repeat_returns_latest(self):
+        """With a surviving multi-valued ``repeat`` dim, return the most
+        recent value (``values[-1]``), not the first."""
+        res = self._make_base()
+        da = xr.DataArray(
+            ["path1.rrd", "path2.rrd", "path3.rrd"],
+            dims=["repeat"],
+            coords={"repeat": [1, 2, 3]},
+            name="out_rerun",
+        )
+        val = res.zero_dim_da_to_val(da)
+        self.assertEqual(val, "path3.rrd")
+
+    def test_zero_dim_unchanged(self):
+        """A truly zero-dim DataArray must still return its scalar value."""
+        res = self._make_base()
+        da = xr.DataArray(42.0, name="out_val")
+        val = res.zero_dim_da_to_val(da)
+        self.assertEqual(val, 42.0)
+
+    def test_size_one_repeat_returns_single_value(self):
+        """A repeat dim of size 1 should return that single value."""
+        res = self._make_base()
+        da = xr.DataArray(["only.rrd"], dims=["repeat"], coords={"repeat": [1]}, name="out_rerun")
+        val = res.zero_dim_da_to_val(da)
+        self.assertEqual(val, "only.rrd")
 
 
 class _IndependentAxisBench(bn.ParametrizedSweep):


### PR DESCRIPTION
## Problem

With `repeats > 1`, the bencher report only showed one recording for `ResultRerun`, `ResultVideo`, and `ResultImage` results — even though all recordings were correctly created on disk and stored in the xarray dataset.

**Root cause**: Two interacting issues in `_to_panes_da`:

1. **Pane recursion peeled the repeat dimension** — `_to_panes_da` treated `repeat` like any other dimension and iterated over it via `_iter_pane_slices`, calling `ds_to_container` for each individual repeat. `ds_to_container` → `zero_dim_da_to_val` then extracted a single scalar value, so each repeat rendered independently but only the first was visible in the final layout.

2. **`zero_dim_da_to_val` picked `values[0]`** — Even when the repeat dimension survived (e.g. via SQUEEZE in the rerun path at `rerun_result.py:86`), the function always returned the first element.

The `over_time` dimension already had special handling for this exact scenario (`_pane_over_time_grid` / `_pane_over_time_slider`), but the `repeat` dimension had no equivalent.

## Fix

Three changes in `bench_result_base.py`:

1. **Exclude `repeat` from pane recursion for media results** — mirrors the existing `over_time` exclusion. Prevents `_to_panes_da` from peeling the repeat dimension before the grid handler can process it.

2. **Route to `_pane_repeat_grid`** — after the over_time check, checks for a surviving repeat dimension on media results and delegates to the new grid method.

3. **`_pane_repeat_grid` method** — iterates each repeat value and renders a labelled `pn.Row` of panels. Handles `ResultRerun` (via `rrd_file_to_pane`), `ResultVideo` (via `pn.pane.Video`), and `ResultImage` (via `pn.pane.PNG`) with a fallback for unknown types.

The existing `zero_dim_da_to_val` fix (taking last instead of first) acts as a safety net for any path that doesn't hit the grid.

## Futureproofing

- **`over_time` + `repeat` combo**: If both dimensions survive, `over_time` is handled first (returns early). The repeat grid only fires when over_time is absent or has been consumed.
- **New media result types**: The grid has explicit branches for Rerun/Video/Image with a Markdown fallback.
- **`repeats=1`**: SQUEEZE drops the repeat dimension entirely — no behavioral change.
- **Numeric results unaffected**: The `isinstance` guard ensures only media types bypass pane recursion.

## Test plan

- [ ] Add standalone example with `ResultRerun` + `repeats > 1` (no external dependencies)
- [ ] Add unit test verifying `_pane_repeat_grid` is called when repeat dim > 1 for media results
- [ ] Verify upstream `example_rerun_sweep.py` still works (no repeat dimension)
- [x] Validated with real benchmarks using `repeats=2` and `repeats=5` — all recordings visible