### PR TITLE
Add collect/render split for out-of-process report rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,23 @@ jobs:
         uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Re-run the suite with the collect/render split forced on, so every report
+  # build goes through save_result -> load_result -> render. Catches any divergence
+  # between in-process and split rendering (unpicklable result types, render paths
+  # that relied on live state). See bencher/render.py and test/test_render.py.
+  ci-split:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: true
+          frozen: true
+          environments: py313
+      - name: Forced collect/render split
+        run: |
+          pixi update
+          pixi run -e py313 generate-examples
+          pixi run -e py313 test-split

--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ docs/autoapi/*
 
 # Claude Code local settings (personal, not shared)
 .claude/settings.local.json
+.claude/worktrees/
 _tabs/*
 
 # Auto-generated docs (HTML reports, RST files) — examples are tracked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,14 @@ Bencher is a benchmarking framework built around these core concepts:
 - Coverage reporting with coverage.py
 - Examples serve as integration tests
 - Meta-generated examples in `bencher/example/meta/`
+- **Collect/render split coverage** (`bencher/render.py`): three layers guard the
+  out-of-process render pipeline against divergence from the normal `plot_sweep` path —
+  (A) parity tests in `test/test_render.py` assert `collect()` computes the same dataset
+  as `plot_sweep()`; (B) `test/test_split_render_examples.py` round-trips every result
+  type through save → load → render; (C) setting `BENCHER_FORCE_SPLIT_RENDER=1` reroutes
+  every auto_plot report build through that serialize/render-from-loaded path, so
+  `pixi run test-split` re-runs the *entire* suite over the split pipeline (its own CI
+  job, `ci-split`).
 
 ### Generated Example Naming Convention
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.101.0] - 2026-06-01
+
+### Added
+- Collect/render split for out-of-process report rendering. Building a report allocates large holoviews/panel/bokeh object graphs; when CPython's cyclic GC traverses them alongside foreign live C-extension state (e.g. ROS 2 `rclpy`/DDS), the process can segfault. The split lets rendering happen in a clean process that never imported the foreign extension:
+  - `plot_sweep(auto_plot=...)` — new parameter (defaults to `None`, deferring to `run_cfg.auto_plot`, itself `True`). When `False`, the sweep runs and regression detection is computed but no plotting objects are constructed.
+  - `Bench.collect(...)` — thin wrapper for `plot_sweep(auto_plot=False)`; returns a fully-populated, picklable `BenchResult` (dataset + regression report).
+  - `bencher.save_result()` / `load_result()` / `render_report()` (new `bencher.render` module) — persist a collected result and render the HTML report from it, optionally in a separate process via `python -m bencher.render <result> <out_dir>`.
+- Three test layers guarding the split against divergence from the normal `plot_sweep` path: parity tests (`collect()` computes the same dataset/regression as `plot_sweep()`), a breadth round-trip over every generated result type (save → load → render to HTML, plus a real-subprocess media test), and the `BENCHER_FORCE_SPLIT_RENDER=1` switch that reroutes every auto-plot report build through serialize/render-from-loaded so `pixi run test-split` re-runs the whole suite over the split pipeline (own parallel py313-only `ci-split` job).
+
+### Changed
+- `BenchReport.append_result()` gained an optional `render_from=` argument so a caller can register one result for identity-based tab routing while building the tab pane from another (used by the forced-split path).
+
 ## [1.100.0] - 2026-05-15
 
 ### Added

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -5,6 +5,7 @@ warnings.filterwarnings("ignore", message="Unable to import Axes3D", category=Us
 from .bencher import Bench, BenchCfg, BenchRunCfg
 from .bench_cfg import ShowMode
 from .bench_runner import BenchRunner
+from .render import render_report, save_result, load_result
 from .example.benchmark_data import ExampleBenchCfg
 from .bench_plot_server import BenchPlotServer
 from .variables.sweep_base import hash_sha1, SUBSAMPLING_DIVISIONS_SAMPLES

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -123,13 +123,17 @@ class BenchReport(BenchPlotServer):
             label = label[:57] + "..."
         return label
 
-    def append_result(self, bench_res: BenchResult) -> None:
+    def append_result(self, bench_res: BenchResult, render_from: BenchResult | None = None) -> None:
         self.bench_results.append(bench_res)
         title = bench_res.bench_cfg.title
         label = self._time_event_label(bench_res)
         if label:
             title = f"{title} [{label}]"
-        self.append_tab(bench_res.plot(), title)
+        # render_from lets callers register one result for identity-based tab
+        # routing (append_to_result) while building the pane from another — used
+        # by the BENCHER_FORCE_SPLIT_RENDER path to render from a deserialized
+        # copy without breaking routing. Defaults to bench_res (normal path).
+        self.append_tab((render_from or bench_res).plot(), title)
 
     def append_to_result(self, bench_res: BenchResult, pane: pn.panel) -> None:
         """Append *pane* to the tab that belongs to *bench_res*."""

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -281,6 +281,7 @@ class Bench(BenchPlotServer):
         sample_order: SampleOrder = SampleOrder.INORDER,
         aggregate: bool | int | list[str] | None = None,
         agg_fn: str = "mean",
+        auto_plot: bool = True,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
 
@@ -318,6 +319,13 @@ class Bench(BenchPlotServer):
                 If a list, uses the provided callbacks. Defaults to None.
             sample_order (SampleOrder, optional): Controls the traversal order of sampling only.
                 Defaults to SampleOrder.INORDER. Plotting and dataset dimension order are unchanged.
+            auto_plot (bool, optional): If True (default), build the holoviews/panel report
+                immediately after the sweep. Set False to collect samples and compute regression
+                detection WITHOUT constructing any plotting objects — the returned BenchResult is
+                fully populated (dataset + regression_report) and can be rendered later, in a
+                separate process, via :func:`bencher.render_report`. Useful when the collecting
+                process holds foreign C-extension state (e.g. ROS/rclpy) that makes in-process
+                holoviews/bokeh garbage collection unsafe. See also :meth:`Bench.collect`.
 
         Returns:
             BenchResult: An object containing all the benchmark data and results
@@ -375,6 +383,13 @@ class Bench(BenchPlotServer):
 
         if run_cfg.only_plot:
             run_cfg.cache_results = True
+
+        # auto_plot lives on BenchRunCfg (BenchCfg inherits it), so run_cfg
+        # values override the BenchCfg constructor via param.update in
+        # run_sweep. Apply the explicit plot_sweep(auto_plot=...) here so the
+        # caller's choice survives that merge. Defaults to True (unchanged
+        # behaviour); set False to collect without building any plots.
+        run_cfg.auto_plot = auto_plot
 
         self.last_run_cfg = run_cfg
 
@@ -500,6 +515,8 @@ class Bench(BenchPlotServer):
             plot_callbacks=plot_callbacks,
             agg_over_dims=agg_over_dims,
             agg_fn=agg_fn,
+            # auto_plot is applied via run_cfg (above) so it survives the
+            # run_cfg -> bench_cfg param merge in run_sweep.
         )
         if run_cfg.dry_run:
             total = 1
@@ -524,6 +541,28 @@ class Bench(BenchPlotServer):
             return BenchResult(bench_cfg)
 
         return self.run_sweep(bench_cfg, run_cfg, time_src, sample_order)
+
+    def collect(self, *args, **kwargs) -> BenchResult:
+        """Run a sweep and collect results WITHOUT building any plots.
+
+        Equivalent to :meth:`plot_sweep` with ``auto_plot=False``: it executes the sweep,
+        merges over-time history, and computes regression detection, but constructs **no**
+        holoviews/panel/bokeh objects. The returned :class:`BenchResult` is fully populated
+        (dataset + ``regression_report``) and is the safe artifact to persist
+        (:func:`bencher.save_result`) and render later — in a separate, clean process —
+        via :func:`bencher.render_report`.
+
+        This is the collection half of a collect/render split, intended for callers whose
+        process holds foreign C-extension state (e.g. ROS/rclpy/DDS) where in-process
+        holoviews/bokeh allocation and the resulting garbage collection can segfault. Accepts
+        the same arguments as :meth:`plot_sweep` (``auto_plot`` is forced to ``False``).
+
+        Returns:
+            BenchResult: Fully-populated result with no plots built.
+        """
+        if "auto_plot" in kwargs:
+            raise TypeError("collect() forces auto_plot=False; do not pass auto_plot")
+        return self.plot_sweep(*args, auto_plot=False, **kwargs)
 
     @staticmethod
     def filter_overridable_params(

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -281,7 +281,7 @@ class Bench(BenchPlotServer):
         sample_order: SampleOrder = SampleOrder.INORDER,
         aggregate: bool | int | list[str] | None = None,
         agg_fn: str = "mean",
-        auto_plot: bool = True,
+        auto_plot: bool | None = None,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
 
@@ -319,13 +319,18 @@ class Bench(BenchPlotServer):
                 If a list, uses the provided callbacks. Defaults to None.
             sample_order (SampleOrder, optional): Controls the traversal order of sampling only.
                 Defaults to SampleOrder.INORDER. Plotting and dataset dimension order are unchanged.
-            auto_plot (bool, optional): If True (default), build the holoviews/panel report
-                immediately after the sweep. Set False to collect samples and compute regression
-                detection WITHOUT constructing any plotting objects — the returned BenchResult is
-                fully populated (dataset + regression_report) and can be rendered later, in a
-                separate process, via :func:`bencher.render_report`. Useful when the collecting
-                process holds foreign C-extension state (e.g. ROS/rclpy) that makes in-process
-                holoviews/bokeh garbage collection unsafe. See also :meth:`Bench.collect`.
+            auto_plot (bool, optional): Whether to build the holoviews/panel report
+                immediately after the sweep. ``None`` (default) respects ``run_cfg.auto_plot``
+                (itself ``True`` by default), so behaviour is unchanged unless a caller opts
+                out. ``False`` collects samples and computes regression detection WITHOUT
+                constructing any plotting objects — the returned BenchResult is fully populated
+                (dataset + regression_report) and can be rendered later, in a separate process,
+                via :func:`bencher.render_report`. Useful when the collecting process holds
+                foreign C-extension state (e.g. ROS/rclpy) that makes in-process holoviews/bokeh
+                garbage collection unsafe. See also :meth:`Bench.collect`. Because ``None``
+                defers to ``run_cfg``, setting ``run_cfg.auto_plot = False`` once disables
+                plotting for every ``plot_sweep`` call that uses that config — including calls
+                nested inside benchmark functions you don't control.
 
         Returns:
             BenchResult: An object containing all the benchmark data and results
@@ -386,10 +391,12 @@ class Bench(BenchPlotServer):
 
         # auto_plot lives on BenchRunCfg (BenchCfg inherits it), so run_cfg
         # values override the BenchCfg constructor via param.update in
-        # run_sweep. Apply the explicit plot_sweep(auto_plot=...) here so the
-        # caller's choice survives that merge. Defaults to True (unchanged
-        # behaviour); set False to collect without building any plots.
-        run_cfg.auto_plot = auto_plot
+        # run_sweep. Apply an explicit plot_sweep(auto_plot=...) here so it
+        # survives that merge. auto_plot=None defers to run_cfg.auto_plot
+        # (default True) — this is what lets a caller set run_cfg.auto_plot
+        # once and have nested plot_sweep calls honour it.
+        if auto_plot is not None:
+            run_cfg.auto_plot = auto_plot
 
         self.last_run_cfg = run_cfg
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 import warnings
 from datetime import datetime
+from pathlib import Path
 from concurrent.futures import as_completed
 from itertools import product, combinations
 
@@ -755,7 +758,10 @@ class Bench(BenchPlotServer):
 
         if bench_cfg.auto_plot:
             with phase_timer() as elapsed:
-                self.report.append_result(bench_res)
+                if os.environ.get("BENCHER_FORCE_SPLIT_RENDER"):
+                    self._append_result_via_split(bench_res)
+                else:
+                    self.report.append_result(bench_res)
             timings.render_ms = elapsed()
 
         timings.total_ms = timings.compute_total()
@@ -763,6 +769,38 @@ class Bench(BenchPlotServer):
 
         self.results.append(bench_res)
         return bench_res
+
+    def _append_result_via_split(self, bench_res: BenchResult) -> None:
+        """Append a result to the report through the collect/render split.
+
+        Used only when the ``BENCHER_FORCE_SPLIT_RENDER`` env var is set. Instead
+        of rendering ``bench_res`` in-process, it round-trips the result through
+        pickle (:func:`bencher.save_result` / :func:`bencher.load_result`) and
+        rebuilds the report tab from the *deserialized* copy — the same serialize
+        then render-from-loaded steps that :func:`bencher.render_report` performs
+        out of process.
+
+        This lets a dedicated CI job re-run the entire existing test/example suite
+        with the split pipeline forced on, so any divergence between in-process and
+        split rendering (unpicklable result types, render paths that relied on live
+        state) surfaces in the existing assertions. The round-trip stays in-process
+        here so the full suite remains fast; a separate test covers the subprocess
+        boundary.
+        """
+        # Local import keeps render (and its holoviews/panel imports) out of the
+        # hot path when the switch is off.
+        from bencher.render import save_result, load_result
+
+        with tempfile.TemporaryDirectory(prefix="bencher_force_split_") as tmp:
+            path = save_result(bench_res, Path(tmp) / "result.pkl")
+            loaded = load_result(path)
+        # render_report runs post_setup on a freshly-loaded result; mirror that
+        # so the forced path matches the real out-of-process render exactly.
+        loaded.post_setup()
+        # Register the live result for tab routing (so identity-based
+        # append_to_result, e.g. optimize(plot=True), still works) but render the
+        # tab pane from the deserialized copy — that copy is what we want to test.
+        self.report.append_result(bench_res, render_from=loaded)
 
     # TODO: Remove thin wrapper methods in major version bump - callers can use helpers directly
     def convert_vars_to_params(

--- a/bencher/example/example_collect_render.py
+++ b/bencher/example/example_collect_render.py
@@ -1,0 +1,47 @@
+"""Example: collect benchmark samples, then render the report separately.
+
+Demonstrates the collect/render split. ``Bench.collect`` runs the sweep and
+computes regression detection but builds **no** holoviews/panel objects, so it
+is safe to call from a process that holds foreign C-extension state (e.g. ROS
+``rclpy``/DDS) where in-process plotting + garbage collection can segfault. The
+result is persisted and rendered later — here in the same process for brevity,
+but in practice via a fresh subprocess::
+
+    python -m bencher.render result.pkl output_dir
+"""
+
+import tempfile
+from pathlib import Path
+
+import bencher as bn
+from bencher.example.benchmark_data import ExampleBenchCfg
+
+
+def example_collect_render(
+    run_cfg: bn.BenchRunCfg | None = None, report: bn.BenchReport | None = None
+) -> bn.Bench:
+    """Collect without plotting, persist, then render the report from disk."""
+    run_cfg = run_cfg or bn.BenchRunCfg(repeats=2)
+    bench = ExampleBenchCfg().to_bench(run_cfg, report)
+
+    # Collection phase — no holoviews/bokeh objects are constructed here.
+    result = bench.collect(
+        input_vars=["theta"],
+        result_vars=["out_sin"],
+        title="Collect/render split",
+    )
+
+    out_dir = Path(tempfile.mkdtemp(prefix="bencher_collect_render_"))
+    result_path = out_dir / "result.pkl"
+    bn.save_result(result, result_path)
+
+    # Render phase — build + save the HTML report from the persisted result.
+    # In production run this in a separate process:
+    #   python -m bencher.render <result_path> <out_dir>
+    saved = bn.render_report(result_path, out_dir)
+    print(f"Saved result to {result_path}\nRendered report to {saved}")
+    return bench
+
+
+if __name__ == "__main__":
+    example_collect_render()

--- a/bencher/render.py
+++ b/bencher/render.py
@@ -1,0 +1,154 @@
+"""Out-of-process rendering for benchmark results.
+
+This module is the *render* half of bencher's collect/render split. The
+collect half (:meth:`bencher.Bench.collect`, i.e. ``plot_sweep(auto_plot=False)``)
+runs a sweep and computes regression detection **without** building any
+holoviews/panel/bokeh objects, returning a fully-populated :class:`BenchResult`.
+
+Why split: holoviews/panel/bokeh build large object graphs backed by
+C-extension wrappers (param, pandas, bokeh). When CPython's cyclic garbage
+collector traverses those wrappers while *foreign* live C-extension state
+exists in the same interpreter (e.g. ROS 2 ``rclpy``/DDS), the process can
+segfault. Rendering from a persisted result in a separate, clean process
+(one that never imported the foreign extension) makes that class of crash
+impossible by construction.
+
+Typical usage::
+
+    # Process 1 — holds rclpy/DDS; never builds plots:
+    res = bench.collect(...)            # auto_plot=False under the hood
+    bencher.save_result(res, "result.pkl")
+
+    # Process 2 — clean (only imports bencher), e.g. spawned via:
+    #   python -m bencher.render result.pkl output_dir
+    bencher.render_report("result.pkl", "output_dir")
+
+``render_report`` is also importable for in-process use when isolation is not
+required.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle
+import sys
+from pathlib import Path
+
+from bencher.results.bench_result import BenchResult
+from bencher.bench_report import BenchReport
+
+logger = logging.getLogger(__name__)
+
+
+def save_result(bench_res: BenchResult, path: str | Path) -> Path:
+    """Persist a collected :class:`BenchResult` to *path* via pickle.
+
+    Mirrors how bencher already caches results internally: the (potentially
+    non-pickleable) ``object_index`` is stripped before writing and restored
+    afterwards, so the live object is unchanged.
+
+    Args:
+        bench_res: A result from :meth:`Bench.collect` / ``plot_sweep``.
+        path: Destination file path.
+
+    Returns:
+        The path written.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    obj_index_tmp = getattr(bench_res, "object_index", None)
+    if obj_index_tmp is not None:
+        bench_res.object_index = []
+    try:
+        with path.open("wb") as fh:
+            pickle.dump(bench_res, fh, protocol=pickle.HIGHEST_PROTOCOL)
+    finally:
+        if obj_index_tmp is not None:
+            bench_res.object_index = obj_index_tmp
+    return path
+
+
+def load_result(path: str | Path) -> BenchResult:
+    """Load a :class:`BenchResult` previously written by :func:`save_result`."""
+    with Path(path).open("rb") as fh:
+        return pickle.load(fh)
+
+
+def render_report(
+    result_or_path: BenchResult | str | Path,
+    output_dir: str | Path,
+    *,
+    report: BenchReport | None = None,
+    filename: str | None = None,
+    in_html_folder: bool = False,
+    portable: bool = False,
+) -> Path:
+    """Render a collected result to an HTML report.
+
+    Reconstructs the holoviews/panel report from a result produced by
+    :meth:`Bench.collect` (or a path to one saved with :func:`save_result`)
+    and writes it under *output_dir*. This is the only step that constructs
+    plotting objects, and it is designed to run in a process free of foreign
+    C-extension state.
+
+    The result already carries its ``regression_report`` (computed during
+    collection), so no sweep re-execution happens here.
+
+    Args:
+        result_or_path: A :class:`BenchResult`, or a path to a saved one.
+        output_dir: Directory to write the report into.
+        report: An existing :class:`BenchReport` to append to. A new one is
+            created (named after the benchmark) when omitted.
+        filename: Output HTML filename. Defaults to ``<bench_name>.html``.
+        in_html_folder: Forwarded to :meth:`BenchReport.save`.
+        portable: Forwarded to :meth:`BenchReport.save` (base64-inline assets).
+
+    Returns:
+        The path to the saved report.
+    """
+    bench_res = (
+        result_or_path if isinstance(result_or_path, BenchResult) else load_result(result_or_path)
+    )
+
+    # post_setup is normally run by run_sweep before the auto_plot gate; it only
+    # touches the dataset/metadata. Re-run defensively in case the result was
+    # loaded from disk without it (idempotent).
+    bench_res.post_setup()
+
+    if report is None:
+        report = BenchReport(bench_res.bench_cfg.bench_name)
+    report.append_result(bench_res)
+
+    return report.save(
+        directory=output_dir,
+        filename=filename,
+        in_html_folder=in_html_folder,
+        portable=portable,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: ``python -m bencher.render <result_path> <output_dir>``."""
+    argv = sys.argv[1:] if argv is None else argv
+    if len(argv) != 2:
+        print(
+            "Usage: python -m bencher.render <result_path> <output_dir>",
+            file=sys.stderr,
+        )
+        return 2
+    result_path, output_dir = argv
+    if not Path(result_path).exists():
+        print(f"Result file not found: {result_path}", file=sys.stderr)
+        return 2
+    try:
+        out = render_report(result_path, output_dir)
+    except Exception:  # noqa: BLE001  pylint: disable=broad-exception-caught
+        # Top-level CLI guard: convert any render failure into a clean exit code.
+        logger.exception("Failed to render report from %s", result_path)
+        return 1
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ lint = { depends-on = ["ruff-lint", "ty", "pylint"] }
 style = { depends-on = ["format", "lint"] }
 commit-format = "git commit -a -m'autoformat code' || true"
 test = "pytest"
+# Re-run the whole suite with the collect/render split forced on: every auto_plot
+# report build is routed through save_result -> load_result -> render so any
+# pickle / render-from-loaded divergence surfaces in the existing assertions.
+test-split = { cmd = "pytest", env = { BENCHER_FORCE_SPLIT_RENDER = "1" } }
 coverage = "coverage run -m pytest && coverage xml -o coverage.xml"
 coverage-report = "coverage report -m"
 update-lock = "pixi update && git commit -a -m'update pixi.lock' || true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.100.0"
+version = "1.101.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -95,6 +95,21 @@ class TestCollect(unittest.TestCase):
         )
         self.assertGreater(len(bench.report.pane), 0)
 
+    def test_run_cfg_auto_plot_false_is_honored(self):
+        """auto_plot=None (default) must defer to run_cfg.auto_plot, so a caller
+        can disable plotting once on the run_cfg and have nested plot_sweep
+        calls honour it (without passing auto_plot to each one)."""
+        bench = _make_bench()
+        run_cfg = BenchRunCfg(repeats=1)
+        run_cfg.auto_plot = False
+        bench.plot_sweep(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=run_cfg,
+            title="run_cfg_auto_plot_false",
+        )
+        self.assertEqual(len(bench.report.pane), 0)
+
     def test_collect_rejects_explicit_auto_plot(self):
         bench = _make_bench()
         with self.assertRaises(TypeError):

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -121,6 +121,44 @@ class TestCollect(unittest.TestCase):
             )
 
 
+class TestCollectParity(unittest.TestCase):
+    """Layer A: collect() must compute the same artifacts as plot_sweep().
+
+    The split is only safe to rely on if disabling auto_plot changes *nothing*
+    about the computed result. ExampleBenchCfg is deterministic (``noisy``
+    defaults to False), so the two paths must produce byte-identical datasets.
+    """
+
+    PARITY_KWARGS = dict(
+        input_vars=[ExampleBenchCfg.param.theta],
+        result_vars=[ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos],
+        title="collect_parity",
+    )
+
+    def test_collect_dataset_matches_plot_sweep(self):
+        import xarray as xr
+
+        bench_plot, bench_collect = _make_bench(), _make_bench()
+        res_plot = bench_plot.plot_sweep(run_cfg=BenchRunCfg(repeats=2), **self.PARITY_KWARGS)
+        res_collect = bench_collect.collect(run_cfg=BenchRunCfg(repeats=2), **self.PARITY_KWARGS)
+
+        # plot_sweep built a report tab; collect built none. The *data* is equal.
+        self.assertGreater(len(bench_plot.report.pane), 0)
+        self.assertEqual(len(bench_collect.report.pane), 0)
+        xr.testing.assert_equal(res_collect.ds, res_plot.ds)
+        self.assertEqual(set(res_collect.ds.data_vars), set(res_plot.ds.data_vars))
+
+    def test_collect_regression_report_matches_plot_sweep(self):
+        res_plot = _make_bench().plot_sweep(run_cfg=BenchRunCfg(repeats=2), **self.PARITY_KWARGS)
+        res_collect = _make_bench().collect(run_cfg=BenchRunCfg(repeats=2), **self.PARITY_KWARGS)
+        # Regression detection runs during collection too; without over_time both
+        # paths leave it at the default (None).
+        self.assertEqual(
+            getattr(res_collect, "regression_report", None),
+            getattr(res_plot, "regression_report", None),
+        )
+
+
 class TestSaveLoadRender(unittest.TestCase):
     def _collect(self, bench: Bench):
         return bench.collect(

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -1,0 +1,169 @@
+"""Tests for the collect/render split: Bench.collect, save/load, render_report, CLI."""
+
+import gc
+import tempfile
+import unittest
+from pathlib import Path
+
+from bencher import Bench, BenchRunCfg, render_report, save_result, load_result
+from bencher.render import main as render_main
+from bencher.example.benchmark_data import ExampleBenchCfg
+
+
+def _count_plot_objects() -> int:
+    """Count live holoviews/bokeh *instances* (not modules)."""
+    n = 0
+    for o in gc.get_objects():
+        mod = getattr(type(o), "__module__", "")
+        if isinstance(mod, str) and mod.startswith(("holoviews.", "bokeh.")):
+            n += 1
+    return n
+
+
+def _make_bench() -> Bench:
+    return Bench("test_render", ExampleBenchCfg())
+
+
+class TestCollect(unittest.TestCase):
+    def test_collect_builds_no_report_tabs(self):
+        bench = _make_bench()
+        res = bench.collect(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="collect_no_tabs",
+        )
+        self.assertIsNotNone(res)
+        self.assertIsNotNone(res.ds)
+        # The defining property: collection appends nothing to the report.
+        self.assertEqual(len(bench.report.pane), 0)
+
+    def test_collect_constructs_far_fewer_objects_than_render(self):
+        """collect() must build dramatically fewer holoviews/bokeh objects than a render.
+
+        A full plot build creates dozens-to-hundreds of element objects per
+        result; collect() should create ~none. Measured in one process so the
+        comparison is apples-to-apples (object counts accumulate across tests).
+        """
+        gc.collect()
+        b_collect = _make_bench()
+        base = _count_plot_objects()
+        b_collect.collect(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="collect_objs",
+        )
+        collect_delta = _count_plot_objects() - base
+
+        gc.collect()
+        b_render = _make_bench()
+        base2 = _count_plot_objects()
+        b_render.plot_sweep(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="render_objs",
+        )
+        render_delta = _count_plot_objects() - base2
+
+        self.assertLess(
+            collect_delta,
+            max(10, render_delta // 4),
+            f"collect built {collect_delta} plot objects vs render {render_delta}",
+        )
+
+    def test_plot_sweep_auto_plot_false_matches_collect(self):
+        bench = _make_bench()
+        res = bench.plot_sweep(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="auto_plot_false",
+            auto_plot=False,
+        )
+        self.assertIsNotNone(res)
+        self.assertEqual(len(bench.report.pane), 0)
+
+    def test_plot_sweep_auto_plot_true_builds_report(self):
+        bench = _make_bench()
+        bench.plot_sweep(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="auto_plot_true",
+        )
+        self.assertGreater(len(bench.report.pane), 0)
+
+    def test_collect_rejects_explicit_auto_plot(self):
+        bench = _make_bench()
+        with self.assertRaises(TypeError):
+            bench.collect(
+                input_vars=[ExampleBenchCfg.param.theta],
+                result_vars=[ExampleBenchCfg.param.out_sin],
+                auto_plot=True,
+            )
+
+
+class TestSaveLoadRender(unittest.TestCase):
+    def _collect(self, bench: Bench):
+        return bench.collect(
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=[ExampleBenchCfg.param.out_sin],
+            run_cfg=BenchRunCfg(repeats=1),
+            title="roundtrip",
+        )
+
+    def test_save_load_roundtrip(self):
+        bench = _make_bench()
+        res = self._collect(bench)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "result.pkl"
+            save_result(res, path)
+            self.assertTrue(path.exists())
+            loaded = load_result(path)
+            self.assertIsNotNone(loaded.ds)
+            # Dataset round-trips with identical variables.
+            self.assertEqual(set(loaded.ds.data_vars), set(res.ds.data_vars))
+
+    def test_render_report_from_object(self):
+        bench = _make_bench()
+        res = self._collect(bench)
+        with tempfile.TemporaryDirectory() as tmp:
+            out = render_report(res, tmp)
+            self.assertTrue(Path(out).exists())
+            self.assertGreater(Path(out).stat().st_size, 0)
+
+    def test_render_report_from_path(self):
+        bench = _make_bench()
+        res = self._collect(bench)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "result.pkl"
+            save_result(res, path)
+            out_dir = Path(tmp) / "report"
+            out = render_report(path, out_dir)
+            self.assertTrue(Path(out).exists())
+            self.assertTrue(any(out_dir.rglob("*.html")))
+
+    def test_cli_main(self):
+        bench = _make_bench()
+        res = self._collect(bench)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "result.pkl"
+            save_result(res, path)
+            out_dir = Path(tmp) / "report"
+            rc = render_main([str(path), str(out_dir)])
+            self.assertEqual(rc, 0)
+            self.assertTrue(any(out_dir.rglob("*.html")))
+
+    def test_cli_bad_args(self):
+        self.assertEqual(render_main([]), 2)
+
+    def test_cli_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            rc = render_main([str(Path(tmp) / "nope.pkl"), tmp])
+            self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -4,6 +4,7 @@ import gc
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from bencher import Bench, BenchRunCfg, render_report, save_result, load_result
 from bencher.render import main as render_main
@@ -185,6 +186,23 @@ class TestSaveLoadRender(unittest.TestCase):
             rc = render_main([str(path), str(out_dir)])
             self.assertEqual(rc, 0)
             self.assertTrue(any(out_dir.rglob("*.html")))
+
+    def test_cli_render_failure_returns_1(self):
+        """A render failure must be caught by the CLI guard and reported as exit
+        code 1 (not propagated), with the error logged."""
+        bench = _make_bench()
+        res = self._collect(bench)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "result.pkl"
+            save_result(res, path)
+            out_dir = Path(tmp) / "report"
+            with (
+                mock.patch("bencher.render.render_report", side_effect=RuntimeError("boom")),
+                self.assertLogs("bencher.render", level="ERROR") as cm,
+            ):
+                rc = render_main([str(path), str(out_dir)])
+            self.assertEqual(rc, 1)
+            self.assertTrue(any("boom" in line for line in cm.output))
 
     def test_cli_bad_args(self):
         self.assertEqual(render_main([]), 2)

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -126,6 +126,21 @@ class TestSaveLoadRender(unittest.TestCase):
             # Dataset round-trips with identical variables.
             self.assertEqual(set(loaded.ds.data_vars), set(res.ds.data_vars))
 
+    def test_save_result_preserves_object_index(self):
+        """save_result must strip object_index for pickling but leave the live
+        object unchanged (it can hold non-pickleable ResultReference objects)."""
+        bench = _make_bench()
+        res = self._collect(bench)
+        # Inject a sentinel (object) so the invariant is tested deterministically
+        # regardless of whether the benchmark produced reference results.
+        sentinel = [object(), object()]
+        res.object_index = sentinel
+        with tempfile.TemporaryDirectory() as tmp:
+            save_result(res, Path(tmp) / "result.pkl")
+        # Same list identity and contents after saving.
+        self.assertIs(res.object_index, sentinel)
+        self.assertEqual(len(res.object_index), 2)
+
     def test_render_report_from_object(self):
         bench = _make_bench()
         res = self._collect(bench)

--- a/test/test_split_render_examples.py
+++ b/test/test_split_render_examples.py
@@ -1,0 +1,123 @@
+"""Layer B: exercise the collect/render split across diverse result types.
+
+The single example in ``test_render.py`` only covers a trivial float result. This
+module reuses the generated *result-type* example corpus — every ResultImage /
+ResultVideo / ResultPath / ResultDataset / ResultString / ResultBool / ResultVec /
+ResultVar shape — and pushes each result through the split pipeline:
+
+    plot_sweep -> save_result -> load_result -> render_report
+
+asserting it produces a non-empty HTML report. This catches result types that
+fail to pickle, or whose render relies on live state that did not survive
+serialization.
+
+The in-process round-trip above shares its serialize/render-from-loaded coverage
+with the ``BENCHER_FORCE_SPLIT_RENDER`` suite run, but runs unconditionally in
+normal CI and asserts on the rendered HTML directly. The final test additionally
+covers the true *process boundary*: a clean interpreter rendering a media-backed
+result via ``python -m bencher.render``, where the pickled result references media
+files written to disk during collection.
+"""
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import bencher as bn
+from bencher import save_result, render_report
+
+GENERATED_DIR = Path("bencher/example/generated")
+RESULT_TYPES_DIR = GENERATED_DIR / "result_types"
+
+
+def _discover(subdir: Path):
+    if not subdir.exists():
+        return []
+    return [f for f in sorted(subdir.rglob("*.py")) if f.name != "__init__.py"]
+
+
+_result_examples = _discover(RESULT_TYPES_DIR)
+if not _result_examples:
+    pytest.skip(
+        "No generated result-type examples found; run `pixi run generate-examples` first",
+        allow_module_level=True,
+    )
+
+
+def _run_example(example_path: Path) -> bn.Bench:
+    """Import and run a generated example, returning its Bench (mirrors test_generated_examples)."""
+    rel = example_path.relative_to(GENERATED_DIR).with_suffix("")
+    module_path = ".".join(("bencher.example.generated", *rel.parts))
+    mod = importlib.import_module(module_path)
+    fns = [v for k, v in vars(mod).items() if k.startswith("example_") and callable(v)]
+    assert fns, f"No example_* function found in {example_path}"
+
+    run_cfg = bn.BenchRunCfg()
+    run_cfg.subsampling_divisions = 2
+    run_cfg.repeats = 2
+    # Disable plotting on the run_cfg so the example's internal plot_sweep call
+    # (auto_plot=None) defers to it and takes the collect path — no holoviews/panel
+    # objects are built, so the result we pickle is the same clean artifact the real
+    # collect/render split produces. Running the example with auto_plot=True instead
+    # would cache plot accessors on the dataset that the split path never creates.
+    run_cfg.auto_plot = False
+    result = fns[0](run_cfg)
+    assert result is not None, f"{example_path} returned None"
+    assert isinstance(result, bn.Bench), f"{example_path} did not return a Bench"
+    assert result.results, f"{example_path} produced no results"
+    return result
+
+
+@pytest.mark.parametrize(
+    "example_path",
+    _result_examples,
+    ids=lambda p: str(p.relative_to(RESULT_TYPES_DIR)),
+)
+def test_split_render_roundtrip(example_path, tmp_path):
+    """Every result type survives save -> load -> render to non-empty HTML."""
+    bench = _run_example(example_path)
+    res = bench.results[-1]
+
+    path = save_result(res, tmp_path / "result.pkl")
+    assert path.exists()
+
+    out = render_report(path, tmp_path / "report")
+    assert Path(out).exists()
+    assert Path(out).stat().st_size > 0
+
+
+def _first_example_under(name: str) -> Path | None:
+    matches = [p for p in _result_examples if f"/{name}/" in str(p).replace("\\", "/")]
+    return matches[0] if matches else None
+
+
+def test_split_render_subprocess_media(tmp_path):
+    """A clean subprocess renders a media-backed result via `python -m bencher.render`.
+
+    The pickle data-sharing is exercised broadly and cheaply by the in-process
+    round-trip above (every result type, image and video included). This single
+    test covers the one thing in-process cannot: the genuine *process boundary*
+    the feature exists for. Media results pickle file *paths*, so a fresh
+    interpreter that never ran the sweep must still locate and render those files.
+    One image example is enough to prove the production path end to end.
+    """
+    example_path = _first_example_under("result_image")
+    if example_path is None:
+        pytest.skip("No generated result_image example available")
+
+    bench = _run_example(example_path)
+    res = bench.results[-1]
+    pkl = save_result(res, tmp_path / "result.pkl")
+    out_dir = tmp_path / "report"
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "bencher.render", str(pkl), str(out_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"render subprocess failed:\n{proc.stderr}"
+    assert any(out_dir.rglob("*.html")), "subprocess produced no HTML report"


### PR DESCRIPTION
## Problem

Building a report (holoviews/panel/bokeh) allocates large object graphs backed by C-extension wrappers (param, pandas, bokeh). When CPython's cyclic GC traverses those wrappers while **foreign live C-extension state** exists in the same interpreter — e.g. ROS 2 `rclpy`/DDS in a robotics benchmark — the process can **segfault** (exit -11).

Today the only entry point is `plot_sweep`, which always builds the report in-process immediately after collecting samples. So consumers running alongside such C-extensions have no way to keep holoviews out of the live process; `gc.disable()` doesn't help (it only suppresses *automatic* collection, and the report build is what creates the pressure).

## Change

Make the two phases separable so rendering can happen in a clean process that never imported the foreign extension:

- **`plot_sweep(auto_plot=...)`** — new parameter, default `True` (behaviour unchanged). When `False`, the sweep runs and regression detection is computed, but **no** holoviews/panel objects are constructed. Applied via `run_cfg` so it survives the `run_cfg → bench_cfg` param merge in `run_sweep` (`auto_plot` lives on `BenchRunCfg`, which `BenchCfg` inherits — setting it only on the `BenchCfg` constructor would be clobbered by the merge).
- **`Bench.collect(...)`** — thin wrapper for `plot_sweep(auto_plot=False)`; returns a fully-populated, picklable `BenchResult` (dataset + `regression_report`).
- **`bencher.render_report()` / `save_result()` / `load_result()`** (new `bencher/render` module) — persist a collected result and render the HTML report from it, optionally in a separate process via `python -m bencher.render <result> <out_dir>`.

The result dataset and `RegressionReport` are already serialisable (`cache_results` pickles the whole `BenchResult`; the render module strips/restores the non-picklable `object_index` the same way), so the render step needs nothing live.

## Usage

```python
# Process holding rclpy/DDS — builds no plots:
res = bench.collect(input_vars=[...], result_vars=[...])
bencher.save_result(res, "result.pkl")

# Clean process (e.g. spawned subprocess):
#   python -m bencher.render result.pkl out_dir
bencher.render_report("result.pkl", "out_dir")
```

## Validation

- New `test/test_render.py` (11 tests): `collect()` appends no report tabs and constructs far fewer holoviews/bokeh objects than a render; `auto_plot=False` via `plot_sweep` matches; `collect()` rejects an explicit `auto_plot`; save/load round-trip; `render_report` from object and from path; the `python -m bencher.render` CLI (incl. bad-args/missing-file exit codes).
- End-to-end: collect (0 plot objects) → save → **fresh subprocess** render → valid HTML.
- Existing suite unaffected (`test_bencher.py`/`test_bench_report.py`/`test_bench_result_base.py`: 91 passed, 1 skipped). ruff + pylint clean; prek hooks pass.
- New `bencher/example/example_collect_render.py`.

## Notes

Additive and backwards-compatible — the default `auto_plot=True` path is unchanged. Motivated by recurring GPU-benchmark segfaults in a ROS 2 consumer (kinisi_benchmarks); this is the upstream half of the fix so any consumer running alongside foreign C-extensions benefits.

## Summary by Sourcery

Introduce a collect/render split for benchmark reports to allow out-of-process HTML rendering and avoid in-process plotting issues with foreign C extensions.

New Features:
- Add an auto_plot flag to plot_sweep to optionally skip building plots while still computing benchmark results.
- Introduce Bench.collect as a non-plotting sweep entrypoint that returns a fully populated BenchResult for later rendering.
- Add a bencher.render module with save_result, load_result, render_report, and a python -m bencher.render CLI for out-of-process report generation.
- Provide an example script demonstrating the collect/render workflow for benchmarks.

Tests:
- Add test_render.py to validate collect behavior, serialization round trips, render_report functionality, and the bencher.render CLI.