### PR TITLE
Remove stray .claude worktree gitlink that breaks git installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ docs/autoapi/*
 
 # Claude Code local settings (personal, not shared)
 .claude/settings.local.json
+.claude/worktrees/
 _tabs/*
 
 # Auto-generated docs (HTML reports, RST files) — examples are tracked


### PR DESCRIPTION
## Problem

`.claude/worktrees/agent-a7e7447280f6a5391` was accidentally committed as a **gitlink** (mode `160000`) with no entry in `.gitmodules` (the file doesn't exist). It's a leftover Claude Code worktree.

Any recursive clone of the repo then fails — most importantly, `uv` installing `holobench` from a `git+https://...` source:

```
× Failed to download and build `holobench @ git+https://github.com/blooop/bencher.git@<sha>`
├─▶ Git operation failed
    fatal: No url found for submodule path
```

This silently breaks every downstream consumer that pins bencher from git (rather than the PyPI wheel, which is unaffected because it ships no submodule).

## Fix

- `git rm --cached` the stray gitlink.
- Add `.claude/worktrees/` to `.gitignore` so it can't recur.

Verified: a `git clone --recurse-submodules` of the fixed tree succeeds with zero gitlinks (it failed with the submodule error before).

Found while pinning bencher from git in a downstream repo (the collect/render split, #943).

## Summary by Sourcery

Remove an accidentally committed Claude worktree gitlink to restore clean clones and installs.

Build:
- Ignore Claude worktree directories in .gitignore to prevent them from being re-committed.

Chores:
- Remove the stray .claude worktree gitlink from the repository history.