### PR TITLE
Allow opting in to a NaN default on scalar result variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.102.0] - 2026-06-02
+
+### Added
+- Optional `default=` argument on `ResultFloat` and `ResultVec` (defaults to `0`, so no behaviour change). The hardcoded `0` default meant an *unrecorded* sample — a run that aborts before measuring, or a result var the worker never sets — was indistinguishable from a real `0` measurement, dragging nan-aware regression/aggregation means toward zero. Callers can now opt in with `default=float("nan")` so unrecorded samples are treated as missing and dropped by the existing `np.nanmean`/`np.nansum` reductions. `default` is not a hashed slot, so opting in does not invalidate `over_time` history for an otherwise-identical result var.
+- `test/test_result_nan_default.py`: backward-compat (default still `0`), NaN/explicit-default opt-in, hash stability, end-to-end unrecorded-sample handling, plus serialization coverage — a pickle `save_result`/`load_result` round-trip and a HoloViews→bokeh `render_report` HTML render both preserve/handle the NaN default.
+
 ## [1.101.1] - 2026-06-01
 
 ### Fixed

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -110,12 +110,17 @@ class ResultFloat(Number):
         direction: OptDir = OptDir.minimize,
         share_axis=True,
         max_time_events=None,
+        default=0,
         **params,
     ):
         Number.__init__(self, **params)
         assert isinstance(units, str)
         self.units = units
-        self.default = 0  # json is terrible and does not support nan values
+        # Defaults to 0 because NaN is not JSON-serialisable; callers that want
+        # an unrecorded sample treated as "missing" (dropped before regression
+        # and aggregation, which use nan-aware reductions) can opt in with
+        # ``default=float("nan")``.
+        self.default = default
         self.direction = direction
         self.share_axis = share_axis
         self.max_time_events = max_time_events
@@ -148,11 +153,19 @@ class ResultVec(param.List):
     _hash_exclude = ("max_time_events",)
 
     def __init__(
-        self, size, units="ul", direction: OptDir = OptDir.minimize, max_time_events=None, **params
+        self,
+        size,
+        units="ul",
+        direction: OptDir = OptDir.minimize,
+        max_time_events=None,
+        default=0,
+        **params,
     ):
         param.List.__init__(self, **params)
         self.units = units
-        self.default = 0  # json is terrible and does not support nan values
+        # See ResultFloat.__init__ — defaults to 0 for JSON-safety; pass
+        # ``default=float("nan")`` to treat unrecorded samples as missing.
+        self.default = default
         self.direction = direction
         self.size = size
         self.max_time_events = max_time_events

--- a/pixi.lock
+++ b/pixi.lock
@@ -1341,7 +1341,7 @@ packages:
   - numpy>=1.0,<=2.4.6
   - param>=2.0,<=2.4.0
   - hvplot>=0.12.0,<=0.12.2
-  - panel>=1.9.0,<=1.9.2
+  - panel>=1.9.0,<=1.9.3
   - diskcache>=5.6,<=5.6.3
   - optuna>=3.2,<=4.9.0
   - xarray>=2023.7,<=2026.4.0
@@ -1364,7 +1364,7 @@ packages:
   - sphinxcontrib-mermaid>=1.0,<3.0 ; extra == 'test'
   - coverage>=7.5.4,<=7.14.1 ; extra == 'test'
   - prek>=0.2.28,<0.5.0 ; extra == 'test'
-  - ty>=0.0.13,<=0.0.40 ; extra == 'test'
+  - ty>=0.0.13,<=0.0.42 ; extra == 'test'
   - rerun-sdk>=0.32.0,<=0.33.0 ; extra == 'rerun'
   - rerun-notebook>=0.32.0,<=0.33.0 ; extra == 'rerun'
   requires_python: '>=3.10,<3.14'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.101.1"
+version = "1.102.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_result_nan_default.py
+++ b/test/test_result_nan_default.py
@@ -1,0 +1,93 @@
+"""Tests for the opt-in NaN default on scalar result variables.
+
+``ResultFloat``/``ResultVec`` default to 0 because NaN is not JSON-serialisable,
+but a 0 default means an *unrecorded* sample (e.g. a run that aborted before
+measuring) is indistinguishable from a real 0 measurement.  Callers can opt in
+to ``default=float("nan")`` so unrecorded samples are treated as missing and
+dropped by the nan-aware reductions used for regression/aggregation.
+"""
+
+import math
+import unittest
+from enum import auto
+
+import numpy as np
+from strenum import StrEnum
+
+import bencher as bn
+from bencher.variables.results import ResultFloat, ResultVec
+
+
+class _Cat(StrEnum):
+    A = auto()
+    B = auto()
+
+
+class UnrecordedZeroBench(bn.ParametrizedSweep):
+    """Result var with the default 0 default; benchmark never records it."""
+
+    cat = bn.EnumSweep(_Cat)
+    out = bn.ResultFloat(doc="never recorded")
+
+    def benchmark(self):
+        return self.get_results_values_as_dict()
+
+
+class UnrecordedNanBench(bn.ParametrizedSweep):
+    """Result var that opts in to a NaN default; benchmark never records it."""
+
+    cat = bn.EnumSweep(_Cat)
+    out = bn.ResultFloat(doc="never recorded", default=float("nan"))
+
+    def benchmark(self):
+        return self.get_results_values_as_dict()
+
+
+def _run_sweep(bench_cls):
+    run_cfg = bn.BenchRunCfg(repeats=1)
+    bench = bench_cls().to_bench(run_cfg)
+    return bench.plot_sweep(
+        input_vars=["cat"],
+        result_vars=["out"],
+        title="test",
+        plot_callbacks=False,
+    )
+
+
+class TestNanDefaultConstruction(unittest.TestCase):
+    def test_default_is_zero_for_backward_compat(self):
+        self.assertEqual(ResultFloat().default, 0)
+        self.assertEqual(ResultVec(size=2).default, 0)
+
+    def test_default_can_be_nan(self):
+        self.assertTrue(math.isnan(ResultFloat(default=float("nan")).default))
+        self.assertTrue(math.isnan(ResultVec(size=2, default=float("nan")).default))
+
+    def test_explicit_numeric_default_still_honoured(self):
+        self.assertEqual(ResultFloat(default=5).default, 5)
+
+    def test_nan_default_does_not_change_hash(self):
+        # ``default`` is not a hashed slot, so opting in to NaN must not wipe
+        # over_time history for an otherwise-identical result var.
+        self.assertEqual(
+            ResultFloat(units="s").hash_persistent(),
+            ResultFloat(units="s", default=float("nan")).hash_persistent(),
+        )
+
+
+class TestNanDefaultEndToEnd(unittest.TestCase):
+    """An unrecorded metric should land as NaN (nan default) or 0 (default)."""
+
+    def test_unrecorded_zero_default_stores_zero(self):
+        ds = _run_sweep(UnrecordedZeroBench).to_dataset()
+        for val in ds["out"].values.flat:
+            self.assertEqual(float(val), 0.0)
+
+    def test_unrecorded_nan_default_stores_nan(self):
+        ds = _run_sweep(UnrecordedNanBench).to_dataset()
+        for val in ds["out"].values.flat:
+            self.assertTrue(np.isnan(val))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_result_nan_default.py
+++ b/test/test_result_nan_default.py
@@ -8,6 +8,8 @@ dropped by the nan-aware reductions used for regression/aggregation.
 """
 
 import math
+import os
+import tempfile
 import unittest
 from enum import auto
 
@@ -87,6 +89,45 @@ class TestNanDefaultEndToEnd(unittest.TestCase):
         ds = _run_sweep(UnrecordedNanBench).to_dataset()
         for val in ds["out"].values.flat:
             self.assertTrue(np.isnan(val))
+
+
+class TestNanDefaultSerialization(unittest.TestCase):
+    """Opting into a NaN default must not break the serialization/render paths.
+
+    The hardcoded ``0`` default was historically justified with the comment
+    "json is terrible and does not support nan values".  The package no longer
+    uses ``json`` directly: collected results are pickled
+    (``save_result``/``load_result``) and plots are serialised to the browser by
+    bokeh, which encodes NaN as ``null``.  A NaN default must therefore survive
+    both the pickle cache path and the HoloViews -> bokeh render-to-HTML path
+    without raising or silently corrupting the data.
+    """
+
+    @staticmethod
+    def _collect_nan():
+        bench = UnrecordedNanBench().to_bench(bn.BenchRunCfg(repeats=1))
+        return bench.collect(
+            input_vars=["cat"],
+            result_vars=["out"],
+            title="nan-serialise",
+        )
+
+    def test_save_load_pickle_roundtrip_preserves_nan(self):
+        res = self._collect_nan()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = bn.save_result(res, os.path.join(tmp, "res.pkl"))
+            loaded = bn.load_result(path)
+        for val in loaded.to_dataset()["out"].values.flat:
+            self.assertTrue(np.isnan(val))
+
+    def test_render_report_with_nan_default_succeeds(self):
+        # render_report is the only step that builds holoviews/panel/bokeh
+        # objects and serialises them to HTML (bokeh JSON-encodes the data).
+        # A NaN default must not break that path.
+        res = self._collect_nan()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = bn.render_report(res, tmp)
+            self.assertTrue(os.path.exists(out))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`ResultFloat`/`ResultVec` hardcode `default = 0` (with the comment *"json is terrible and does not support nan values"*). A `0` default means an **unrecorded** sample — a run that aborts before measuring, or a result var the worker never sets — is indistinguishable from a real `0` measurement. That phantom `0` is recorded as a genuine sample and can drag a regression/aggregation mean down.

The rest of the pipeline is already NaN-aware:
- the result dataset is pre-filled with `np.nan` (`result_collector.py`),
- regression uses `np.nanmean` / nan-dropping `_clean_1d`,
- aggregation uses `np.nanmean`/`np.nansum`/etc.

So a NaN sample is naturally treated as "missing". The only thing forcing a phantom `0` is the hardcoded default.

## Change

Add an optional `default=` argument to `ResultFloat` and `ResultVec`. It still defaults to `0`, so **this is not a breaking change**. Callers that want unrecorded samples excluded can opt in:

```python
out = bn.ResultFloat(units="s", default=float("nan"))
```

`ResultBool` already accepted a `default` param; `ResultVar` (deprecated) inherits the new one via `ResultFloat`.

`default` is not a hashed slot (it's excluded from `__slots__` hashing), so opting in to NaN does **not** invalidate `over_time` history for an otherwise-identical result var.

## Tests

New `test/test_result_nan_default.py`:
- backward-compat: default is still `0` for both types
- `default=float("nan")` opt-in works for both types
- explicit numeric defaults still honoured
- NaN default does not change `hash_persistent` (history preserved)
- end-to-end: an unrecorded metric lands as NaN with the nan default, and as `0` with the existing default

Existing `test_result_bool.py` + `test_hash_persistent.py`: 157 passed, 1 skipped (no regressions). `ruff check`/`ruff format` clean.

## Summary by Sourcery

Allow result variables to opt in to a NaN default so unrecorded samples are treated as missing while preserving backward compatibility.

New Features:
- Add an optional default parameter to ResultFloat and ResultVec that allows callers to use NaN or other values instead of the hardcoded 0 default.

Tests:
- Add unit tests verifying the new NaN-capable default behaviour for ResultFloat and ResultVec, including backward compatibility, hashing stability, and end-to-end handling of unrecorded metrics.