### PR TITLE
Flip ResultFloat/ResultVec/ResultBool default from 0 to NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.105.0] - 2026-06-11
+
+### Changed
+- The default value for `ResultFloat`, `ResultVec`, and `ResultBool` is now `NaN` instead of `0`. An *unrecorded* sample — a run that aborts before measuring, or a result var the worker never sets — is now treated as missing and dropped by the nan-aware regression/aggregation reductions, instead of masquerading as a real `0`/`False` measurement and dragging means toward zero. This matches the storage layer, which already initialises result arrays with `NaN`. Callers who want unrecorded samples to read as `0` can opt out with `default=0`.
+- For `ResultBool`, this means **missing ≠ failure**: an unrecorded repeat is dropped from the success proportion rather than counted as `False`. A worker that wants a crash/abort to count as a failure must explicitly record `False` on its failure path. The binomial standard error already divides by the per-cell count of valid (non-NaN) repeats (see 1.104.2), so missing repeats no longer understate the SE.
+- `CACHE_VERSION` is **not** bumped: the result-var `default` is not part of `BenchCfg.hash_persistent()`, so existing benchmark and `over_time` history caches are preserved. The new `NaN` default only applies to cache *misses* (newly computed cells); already-cached cells keep whatever sentinel they were stored with, so a benchmark with missing samples may transiently hold a mix of `0` (old) and `NaN` (new) until those cells are recomputed.
+
 ## [1.104.2] - 2026-06-10
 
 ### Fixed

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -111,16 +111,19 @@ class ResultFloat(Number):
         direction: OptDir = OptDir.minimize,
         share_axis=True,
         max_time_events=None,
-        default=0,
+        default=float("nan"),
         **params,
     ):
         Number.__init__(self, **params)
         assert isinstance(units, str)
         self.units = units
-        # Defaults to 0 because NaN is not JSON-serialisable; callers that want
-        # an unrecorded sample treated as "missing" (dropped before regression
-        # and aggregation, which use nan-aware reductions) can opt in with
-        # ``default=float("nan")``.
+        # Defaults to NaN so an *unrecorded* sample (a run that aborts before
+        # measuring, or a result var the worker never sets) is treated as
+        # missing and dropped by the nan-aware reductions used for regression
+        # and aggregation, rather than masquerading as a real 0 measurement.
+        # This matches the storage layer, which initialises result arrays with
+        # NaN. Callers that want unrecorded samples to read as 0 opt out with
+        # ``default=0``.
         self.default = default
         self.direction = direction
         self.share_axis = share_axis
@@ -141,8 +144,18 @@ class ResultBool(ResultFloat):
     For continuous scalar metrics (time, distance, score), use ``ResultFloat`` instead.
     """
 
-    def __init__(self, units="ratio", direction: OptDir = OptDir.minimize, default=0, **params):
+    def __init__(
+        self, units="ratio", direction: OptDir = OptDir.minimize, default=float("nan"), **params
+    ):
         super().__init__(units=units, direction=direction, allow_None=True, **params)
+        # Defaults to NaN like ResultFloat (see ResultFloat.__init__): an
+        # *unrecorded* repeat is "missing", not a recorded failure, so it is
+        # dropped from the success proportion rather than counted as False. The
+        # binomial-std calc in bench_result_base divides p*(1-p) by the per-cell
+        # count of valid (non-NaN) repeats, so missing repeats don't understate
+        # the SE. A worker that wants a crash/abort to count as a failure must
+        # record False on its failure path; callers wanting the old False-fill
+        # opt out with ``default=0``.
         self.default = default
         self.bounds = (0, 1)  # bools are always between 0 and 1
 
@@ -177,13 +190,13 @@ class ResultVec(param.List):
         units="ul",
         direction: OptDir = OptDir.minimize,
         max_time_events=None,
-        default=0,
+        default=float("nan"),
         **params,
     ):
         param.List.__init__(self, **params)
         self.units = units
-        # See ResultFloat.__init__ — defaults to 0 for JSON-safety; pass
-        # ``default=float("nan")`` to treat unrecorded samples as missing.
+        # See ResultFloat.__init__ — defaults to NaN so unrecorded samples are
+        # treated as missing; pass ``default=0`` to make them read as 0.
         self.default = default
         self.direction = direction
         self.size = size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.104.2"
+version = "1.105.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_result_bool.py
+++ b/test/test_result_bool.py
@@ -195,8 +195,8 @@ class TestDataIntegrity(unittest.TestCase):
         self.assertEqual(BoolBenchDeterministic.param.out.bounds, (0, 1))
 
     def test_result_bool_default(self):
-        """ResultBool.default should be 0."""
-        self.assertEqual(BoolBenchDeterministic.param.out.default, 0)
+        """ResultBool.default should be NaN (an unrecorded repeat is missing, not False)."""
+        self.assertTrue(np.isnan(BoolBenchDeterministic.param.out.default))
 
     def test_result_bool_units(self):
         """ResultBool.units should be 'ratio'."""

--- a/test/test_result_nan_default.py
+++ b/test/test_result_nan_default.py
@@ -1,10 +1,10 @@
-"""Tests for the opt-in NaN default on scalar result variables.
+"""Tests for the NaN default on scalar result variables.
 
-``ResultFloat``/``ResultVec`` default to 0 because NaN is not JSON-serialisable,
-but a 0 default means an *unrecorded* sample (e.g. a run that aborted before
-measuring) is indistinguishable from a real 0 measurement.  Callers can opt in
-to ``default=float("nan")`` so unrecorded samples are treated as missing and
-dropped by the nan-aware reductions used for regression/aggregation.
+``ResultFloat``/``ResultVec``/``ResultBool`` default to NaN so an *unrecorded*
+sample (e.g. a run that aborted before measuring) is treated as missing and
+dropped by the nan-aware reductions used for regression/aggregation, rather than
+being indistinguishable from a real 0/``False`` measurement.  Callers can opt
+out with ``default=0`` to make unrecorded samples read as 0.
 """
 
 import math
@@ -26,10 +26,10 @@ class _Cat(StrEnum):
 
 
 class UnrecordedZeroBench(bn.ParametrizedSweep):
-    """Result var with the default 0 default; benchmark never records it."""
+    """Result var that opts out to a 0 default; benchmark never records it."""
 
     cat = bn.EnumSweep(_Cat)
-    out = bn.ResultFloat(doc="never recorded")
+    out = bn.ResultFloat(doc="never recorded", default=0)
 
     def benchmark(self):
         return self.get_results_values_as_dict()
@@ -57,21 +57,24 @@ def _run_sweep(bench_cls):
 
 
 class TestNanDefaultConstruction(unittest.TestCase):
-    def test_default_is_zero_for_backward_compat(self):
-        self.assertEqual(ResultFloat().default, 0)
-        self.assertEqual(ResultVec(size=2).default, 0)
+    def test_default_is_nan(self):
+        self.assertTrue(math.isnan(ResultFloat().default))
+        self.assertTrue(math.isnan(ResultVec(size=2).default))
+        self.assertTrue(math.isnan(ResultBool().default))
 
     def test_default_can_be_nan(self):
         self.assertTrue(math.isnan(ResultFloat(default=float("nan")).default))
         self.assertTrue(math.isnan(ResultVec(size=2, default=float("nan")).default))
 
-    def test_bool_default_is_zero_for_backward_compat(self):
-        self.assertEqual(ResultBool().default, 0)
-
     def test_bool_default_can_be_nan(self):
         # ResultBool locks bounds to [0, 1]; NaN must still be accepted as the
         # "missing" sentinel rather than rejected as out-of-bounds.
         self.assertTrue(math.isnan(ResultBool(default=float("nan")).default))
+
+    def test_explicit_zero_default_opt_out(self):
+        self.assertEqual(ResultFloat(default=0).default, 0)
+        self.assertEqual(ResultVec(size=2, default=0).default, 0)
+        self.assertEqual(ResultBool(default=0).default, 0)
 
     def test_explicit_numeric_default_still_honoured(self):
         self.assertEqual(ResultFloat(default=5).default, 5)


### PR DESCRIPTION
## What

Flip the default value of `ResultFloat`, `ResultVec`, **and `ResultBool`** from `0` to `NaN`.

## Why

A `0`/`False` default makes an **unrecorded** sample — a run that aborts before measuring, or a result var the worker never sets — indistinguishable from a real `0`/`False` measurement, dragging nan-aware regression/aggregation means toward zero. The storage layer (`result_collector.setup_dataset`) already initialises result arrays with `np.nan`; the `0` param default was the value that *overwrote* that "unwritten" sentinel.

After this change, unrecorded samples stay `NaN` and are dropped by the existing nan-aware reductions (`skipna=True` xarray reductions, `_clean_1d` in `regression.py`, `np.nanmean`/`nansum` in the agg registry, `df.dropna()` in the Optuna path).

## Scope / decisions

- **`ResultBool` is now included.** An earlier draft kept it at `0`/`False`, justified by the binomial-std calc treating bool means as proportions over a fixed repeat count. That rationale is now obsolete: the binomial SE was fixed on `main` to divide `p*(1-p)` by the per-cell count of valid (non-NaN) repeats, so missing repeats no longer understate it. The semantics are **missing ≠ failure**: an unrecorded repeat is dropped from the success proportion rather than counted as `False`. A worker that wants a crash/abort to count as a failure must explicitly record `False` on its failure path.
- Callers wanting the old zero/False-fill behaviour opt out with `default=0`.
- **`CACHE_VERSION` is deliberately NOT bumped.** The result-var `default` is not part of `BenchCfg.hash_persistent()`, so existing benchmark and `over_time` history caches are preserved (no forced global wipe). The trade-off: the new `NaN` default only applies to cache *misses*; already-cached cells keep whatever sentinel they were stored with, so a benchmark with missing samples may transiently hold a mix of `0` (old) and `NaN` (new) until those cells are recomputed. For rolling `over_time` history this self-heals as old samples age out of the window.

## Verification

`pixi run ci` green (1474 passed, 5 skipped); format/lint clean (pylint 10.00/10). No `allow_nan=False` JSON sinks exist; the report-export contract coerces non-finite floats to `null` via `_finite_or_none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
