### PR TITLE
Apply default figure size to Histogram, Area, and ErrorBars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.102.1] - 2026-06-05
+
+### Fixed
+- Histograms rendered at hvplot's default 700×300 instead of the shared 600×600 used by every other plot type. `HoloviewResult.set_default_opts()` registered the default figure size for `Curve`, `Points`, `Bars`, `Scatter`, `BoxWhisker`, `Violin`, and `HeatMap`, but `Histogram` was missing so it escaped to hvplot's own default. Also registered `Area` and `ErrorBars` for consistency (`ErrorBars` would likewise escape when returned standalone from `to_error_bar()`; `Area` previously inherited the size only by virtue of being overlaid). Added `test_default_opts_cover_all_element_types` to guard against future omissions.
+
 ## [1.102.0] - 2026-06-02
 
 ### Added

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -49,6 +49,9 @@ class HoloviewResult(PaneResult):
             hv.opts.BoxWhisker(**width_height),
             hv.opts.Violin(**width_height),
             hv.opts.HeatMap(cmap="plasma", **width_height, colorbar=True),
+            hv.opts.Histogram(**width_height),
+            hv.opts.Area(**width_height),
+            hv.opts.ErrorBars(**width_height),
             # hv.opts.Surface(**width_heigh),
             hv.opts.GridSpace(plot_size=400),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.102.0"
+version = "1.102.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_holoview_result.py
+++ b/test/test_holoview_result.py
@@ -62,6 +62,21 @@ class TestHoloviewResult(unittest.TestCase):
         result = HoloviewResult.set_default_opts(width=800, height=400)
         self.assertEqual(result["width"], 800)
         self.assertEqual(result["height"], 400)
+        # Restore the standard defaults for subsequent tests/elements.
+        HoloviewResult.set_default_opts()
+
+    def test_default_opts_cover_all_element_types(self):
+        """Every element type bencher emits must carry the shared default size.
+
+        Histogram/Area/ErrorBars were previously absent from hv.opts.defaults, so a
+        histogram silently fell back to hvplot's 700x300 instead of 600x600.
+        """
+        HoloviewResult.set_default_opts()
+        for element in (hv.Histogram, hv.Area, hv.ErrorBars):
+            registered = hv.Store.options(backend="bokeh")[element.name]
+            opts = registered.groups["plot"].options
+            self.assertEqual(opts.get("width"), 600, element.name)
+            self.assertEqual(opts.get("height"), 600, element.name)
 
     def test_to_hv_type_curve(self):
         chart = self.res_1d.to_hv_type(hv.Curve)


### PR DESCRIPTION
## Problem

The histogram was rendering at **700×300** while every other plot type renders at **600×600**.

`HoloviewResult.set_default_opts()` registers the shared default figure size (`width=600, height=600`) via `hv.opts.defaults(...)`, but only for `Curve`, `Points`, `Bars`, `Scatter`, `BoxWhisker`, `Violin`, and `HeatMap`. `Histogram` was missing, so a histogram built through `HistogramResult` (`dataset.hvplot(kind="hist", ...)`) inherited hvplot's own 700×300 default instead — escaping the rest of the figure sizes.

## Review of other plot types

Auditing every element type the results code emits:

| Element | Was in defaults? | Notes |
|---|---|---|
| Curve, Points, Bars, Scatter, BoxWhisker, Violin, HeatMap | ✅ | 600×600 |
| **Histogram** | ❌ | Escaped to 700×300 via hvplot — the actual bug |
| **ErrorBars** | ❌ | `to_error_bar()` returns a standalone element that would escape |
| **Area** | ❌ | Only ever overlaid (band plots), so it inherited 600 — registered for consistency |

## Change

- Add `hv.opts.Histogram`, `hv.opts.Area`, and `hv.opts.ErrorBars` to `set_default_opts()` so all plot types share the same default figure size.
- Add `test_default_opts_cover_all_element_types` asserting these element types carry the 600×600 default, and restore the standard defaults in `test_set_default_opts_custom` so its 800×400 override doesn't leak into other tests.

Verified that registering the default overrides hvplot's explicit 700×300 (the default wins for histograms). Format, lint (ruff/ty/pylint 10.00), and the holoview/histogram/band/distribution test subset all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify default figure sizing across all HoloViews result element types and guard it with tests.

Bug Fixes:
- Ensure Histogram plots use the shared 600×600 default size instead of hvplot's 700×300 defaults.
- Ensure ErrorBars elements returned standalone also receive the shared 600×600 default size.

Enhancements:
- Centralize the list of default-sized HoloViews elements in HoloviewResult.DEFAULT_SIZED_ELEMENTS for reuse by configuration and tests.
- Add a test to verify all supported HoloViews element types are covered by the default size registration and to prevent future regressions.
- Reset HoloViews default options after each holoview_result test to avoid cross-test leakage of custom defaults.

Build:
- Bump project version from 1.103.0 to 1.103.1.

Documentation:
- Document the histogram sizing fix and related default-size behavior in the changelog.