### PR TITLE
Lazy-import plotly backend and optuna.visualization to speed up import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104.0] - 2026-06-08
+
+### Changed
+- Sped up `import bencher` (~19s → ~4s warm) by lazy-loading two heavy plotting dependencies that were imported eagerly at module load but only needed when a plot is rendered. `holoview_result.py` no longer registers the holoviews plotly backend (`hv.extension("bokeh", "plotly")` → `hv.extension("bokeh")`) — nothing in bencher renders through it, since `SurfaceResult`/`VolumeResult` build `plotly.graph_objs` figures directly and wrap them in `pn.pane.Plotly`. The `optuna.visualization` imports (which pull in sklearn's fANOVA evaluator) were moved into the functions that use them (`param_importance()`, `collect_optuna_plots()`). No public API changes.
+
 ## [1.103.1] - 2026-06-08
 
 ### Fixed

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -7,7 +7,7 @@ import panel as pn
 import param
 
 # NOTE: `optuna.visualization` pulls in sklearn's fANOVA evaluator (~3s at
-# import). It is only needed by collect_optuna_plots(), so import it lazily there.
+# import). It is only needed by param_importance(), so import it lazily there.
 
 from bencher.bench_cfg import BenchCfg
 

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -5,7 +5,9 @@ import logging
 import optuna
 import panel as pn
 import param
-from optuna.visualization import plot_param_importances
+
+# NOTE: `optuna.visualization` pulls in sklearn's fANOVA evaluator (~3s at
+# import). It is only needed by collect_optuna_plots(), so import it lazily there.
 
 from bencher.bench_cfg import BenchCfg
 
@@ -52,6 +54,8 @@ def optuna_grid_search(bench_cfg: BenchCfg, trial_vars: list | None = None) -> o
 def param_importance(
     bench_cfg: BenchCfg, study: optuna.Study, plot_width: int | None = None
 ) -> pn.Column:
+    from optuna.visualization import plot_param_importances
+
     col_importance = pn.Column()
     for idx, tgt in enumerate(bench_cfg.optuna_targets()):
 

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -20,7 +20,10 @@ from bencher.results.bench_result_base import ReduceType
 
 from bencher.variables.results import ResultFloat, ResultImage, ResultVideo
 
-hv.extension("bokeh", "plotly")
+# NOTE: plotly is intentionally NOT registered here. Nothing in bencher renders
+# through the holoviews plotly backend (Surface/Volume use plotly.graph_objs
+# directly via pn.pane.Plotly), and registering it eagerly costs ~6s at import.
+hv.extension("bokeh")
 
 # Flag to enable or disable tap tool functionality in visualizations
 use_tap = True

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -8,11 +8,8 @@ import optuna
 import panel as pn
 
 
-from optuna.visualization import (
-    plot_param_importances,
-    plot_pareto_front,
-    plot_optimization_history,
-)
+# NOTE: `optuna.visualization` pulls in sklearn's fANOVA evaluator (~3s at
+# import). It is only used inside collect_optuna_plots(), so import it lazily there.
 from bencher.utils import hmap_canonical_input
 from bencher.variables.time import TimeSnapshot, TimeEvent
 from bencher.variables.inputs import BoolSweep
@@ -245,6 +242,11 @@ class OptunaResult(BenchResultBase):
         Returns:
             pn.pane.panel: A panel with optuna visualisations.
         """
+        from optuna.visualization import (
+            plot_param_importances,
+            plot_pareto_front,
+            plot_optimization_history,
+        )
 
         try:
             self.studies = [self.bench_result_to_study(True)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.103.1"
+version = "1.104.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Problem

`import bencher` is slow because two heavy dependencies are imported eagerly at
module load, even though neither is needed until a plot is actually rendered:

1. **The holoviews plotly backend** — `holoview_result.py` calls
   `hv.extension("bokeh", "plotly")` at import. Registering the plotly backend
   alone costs ~6s, and it triggers `plotly.io._renderers`, whose import does
   environment scanning that is highly variable (12s+ on my machine).
   **Nothing in bencher actually renders through the holoviews plotly backend** —
   `SurfaceResult`/`VolumeResult` build `plotly.graph_objs` figures directly and
   wrap them in `pn.pane.Plotly`. So the registration is pure dead weight.

2. **`optuna.visualization`** — imported at the top of `optuna_conversions.py`
   and `optuna_result.py`. It pulls in sklearn's fANOVA evaluator (~3s) but is
   only used inside `param_importance()` / `collect_optuna_plots()`.

## Change

- `holoview_result.py`: `hv.extension("bokeh", "plotly")` → `hv.extension("bokeh")`.
- `optuna_conversions.py` / `optuna_result.py`: move the `optuna.visualization`
  imports into the functions that use them.

No public API changes; plotly/optuna are still imported, just lazily on first use.

## Impact

`import bencher`, measured warm (mean of 3):

| | import time |
|---|---|
| `main` | ~19s |
| this PR | ~4s |

The plotly portion is environment-dependent (the renderer scan varies a lot), but
the change removes the unused backend registration entirely, so the win holds
regardless of environment.

## Testing

All affected tests pass:

```
pytest test/test_surface_result.py test/test_optuna_result.py \
       test/test_optuna_conversions.py test/test_holoview_result.py
# 70 passed
```

`ruff check` clean on the changed files.

## Summary by Sourcery

Lazy-load heavy plotting dependencies to speed up module import.

Enhancements:
- Remove eager registration of the holoviews plotly backend and rely only on the bokeh backend during import.
- Defer importing optuna.visualization to the specific functions that render Optuna plots to avoid unnecessary import overhead.