### PR TITLE
Fix dropped x-axis rotation on over_time plots with widget layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104.1] - 2026-06-09
+
+### Fixed
+- 30° x-axis label rotation (and `title`/`ylabel`) were silently dropped on plots that hvplot returns as a panel layout — specifically over_time time-series lines that pair `widget_location="bottom"` with an extra categorical `by` widget, which come back as a `pn.Column([HoloViews pane, WidgetBox])`. `HoloviewResult._apply_opts` only handled bare HoloViews elements (`.opts`) and `pn.pane.HoloViews` wrappers (`.object`); the layout container has neither, so the options never reached the nested pane and long x-axis labels (e.g. `over_time` datetime/`TimeEvent` ticks) rendered horizontally and unreadable. `_apply_opts` now recurses into panel layout containers to apply options to the nested pane. hv elements never expose `.objects`, so the new branch only catches panel layouts. Added unit coverage in `test/test_holoview_result.py` for all three input shapes (bare element, pane wrapper, layout container).
+
 ## [1.104.0] - 2026-06-08
 
 ### Changed

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -154,15 +154,32 @@ class HoloviewResult(PaneResult):
 
     @staticmethod
     def _apply_opts(plot, **opts_kwargs):
-        """Apply .opts() to a plot, handling panel.pane.HoloViews wrappers.
+        """Apply .opts() to a plot, handling panel wrappers and layout containers.
 
-        When hvplot is called with widget_location, it returns a panel pane
-        whose underlying .object is the actual holoviews element.
+        hvplot may return any of:
+          (a) a bare HoloViews element/DynamicMap/Overlay (has ``.opts``),
+          (b) a ``pn.pane.HoloViews`` wrapper whose underlying ``.object`` is the
+              actual holoviews element, or
+          (c) a panel layout container (``Row``/``Column``/``WidgetBox``) — this
+              happens when ``widget_location`` splits the plot from its widgets,
+              e.g. an over_time time-series line with a categorical ``by`` widget.
+              The HoloViews pane is then nested inside ``.objects``.
+
+        Without the container case, options such as ``xrotation``, ``title`` and
+        ``ylabel`` were silently dropped for those split plots (the over_time
+        x-axis kept its default horizontal labels). Recurse into containers so
+        the options reach the nested pane.
         """
-        if hasattr(plot, "opts"):
-            return plot.opts(**opts_kwargs)
+        # Panel layout containers expose .objects (panes/elements never do).
+        if hasattr(plot, "objects") and not hasattr(plot, "object"):
+            for child in plot.objects:
+                HoloviewResult._apply_opts(child, **opts_kwargs)
+            return plot
         if hasattr(plot, "object") and hasattr(plot.object, "opts"):
             plot.object = plot.object.opts(**opts_kwargs)
+            return plot
+        if hasattr(plot, "opts"):
+            return plot.opts(**opts_kwargs)
         return plot
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.104.0"
+version = "1.104.1"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_holoview_result.py
+++ b/test/test_holoview_result.py
@@ -10,6 +10,8 @@ from bencher.results.holoview_results.holoview_result import HoloviewResult
 from bencher.results.bench_result_base import ReduceType
 from bencher.variables.results import ResultFloat, ResultImage, ResultVideo
 
+# pylint: disable=protected-access
+
 
 class TestHoloviewResult(unittest.TestCase):
     @classmethod
@@ -173,3 +175,34 @@ class TestHoloviewResult(unittest.TestCase):
     def test_to_points_reduce(self):
         result = self.res_2d_r2.to_points(reduce=ReduceType.REDUCE)
         self.assertIsInstance(result, hv.Element)
+
+    def test_apply_opts_bare_element(self):
+        """A bare HoloViews element gets opts applied directly."""
+        curve = hv.Curve([(0, 0), (1, 1)])
+        result = HoloviewResult._apply_opts(curve, xrotation=30)
+        self.assertEqual(
+            hv.Store.lookup_options("bokeh", result, "plot").options.get("xrotation"), 30
+        )
+
+    def test_apply_opts_pane_wrapper(self):
+        """A pn.pane.HoloViews wrapper gets opts applied to its .object."""
+        pane = pn.pane.HoloViews(hv.Curve([(0, 0), (1, 1)]))
+        HoloviewResult._apply_opts(pane, xrotation=30)
+        self.assertEqual(
+            hv.Store.lookup_options("bokeh", pane.object, "plot").options.get("xrotation"), 30
+        )
+
+    def test_apply_opts_layout_container(self):
+        """A panel layout container (e.g. from widget_location='bottom') must
+        have opts recursed into its nested HoloViews pane.
+
+        Regression: over_time time-series lines with a categorical `by` widget
+        return a Column(pane, widget_box); previously _apply_opts dropped
+        xrotation/title/ylabel entirely, leaving long x-axis labels unreadable.
+        """
+        pane = pn.pane.HoloViews(hv.Curve([(0, 0), (1, 1)]))
+        column = pn.Column(pane, pn.widgets.Select(options=["a", "b"]))
+        HoloviewResult._apply_opts(column, xrotation=30)
+        self.assertEqual(
+            hv.Store.lookup_options("bokeh", pane.object, "plot").options.get("xrotation"), 30
+        )

--- a/test/test_holoview_result.py
+++ b/test/test_holoview_result.py
@@ -202,7 +202,11 @@ class TestHoloviewResult(unittest.TestCase):
         """
         pane = pn.pane.HoloViews(hv.Curve([(0, 0), (1, 1)]))
         column = pn.Column(pane, pn.widgets.Select(options=["a", "b"]))
-        HoloviewResult._apply_opts(column, xrotation=30)
-        self.assertEqual(
-            hv.Store.lookup_options("bokeh", pane.object, "plot").options.get("xrotation"), 30
+        HoloviewResult._apply_opts(
+            column, xrotation=30, title="A long title", ylabel="Custom Y Label"
         )
+        # title/ylabel are plot options for Curve in the bokeh backend, alongside xrotation.
+        plot_opts = hv.Store.lookup_options("bokeh", pane.object, "plot").options
+        self.assertEqual(plot_opts.get("xrotation"), 30)
+        self.assertEqual(plot_opts.get("title"), "A long title")
+        self.assertEqual(plot_opts.get("ylabel"), "Custom Y Label")


### PR DESCRIPTION
## Problem

On downstream projects, auto-generated over_time line plots render long x-axis labels (datetime / `TimeEvent` ticks) **horizontally and unreadable** — the 30° rotation that the bar chart and other plots get is missing. See the reported screenshot: the top bar chart is rotated correctly, but the bottom `startup_time vs launch_config vs over_time` line chart is not.

## Root cause

`xrotation=30` was already requested in `line_result.py`, `bar_result.py`, and `curve_result.py`, but it was being **silently dropped** for one class of plots.

`HoloviewResult._apply_opts` handled two shapes hvplot can return:
- a bare HoloViews element (`.opts`) — e.g. the bar chart, which is why *it* rotates
- a `pn.pane.HoloViews` wrapper (`.object`)

But when a plot uses `widget_location="bottom"` **and** has an extra widget dimension (e.g. the `launch_config` selector), hvplot returns a **`pn.Column([HoloViews pane, WidgetBox])`** layout. That container has neither `.opts` nor `.object`, so `_apply_opts` returned it untouched — dropping `xrotation`, **and also `title` and `ylabel`**.

Confirmed by rendering the scenario and inspecting the Bokeh model: the `DatetimeAxis` came out `orientation: horizontal` while the bar chart's categorical axis was correctly at 30° (0.5236 rad).

## Fix

`_apply_opts` now recurses into panel layout containers (`Row`/`Column`/`WidgetBox`) to reach the nested HoloViews pane. hv elements never expose `.objects`, so the new branch only catches panel layouts. This is a general fix — it restores rotation/title/ylabel for any result type that hits the split widget+plot layout.

## Tests

- Added unit coverage in `test/test_holoview_result.py` for all three `_apply_opts` input shapes (bare element, pane wrapper, layout container — the regression case).
- Full suite: 1466 passed, 5 skipped. Render-parity (`test_render.py`) and split-render (`test_split_render_examples.py`) suites pass. Lint clean.

Bumped version to `1.104.1` so downstream projects can pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure HoloViews plotting options propagate correctly through panel layout containers to fix dropped x-axis rotations and related metadata.

Bug Fixes:
- Restore x-axis label rotation, titles, and y-labels for over_time plots rendered via panel layout containers returned by hvplot.
- Handle panel layout containers (Row/Column/WidgetBox) in HoloviewResult._apply_opts so nested HoloViews panes receive plotting options instead of silently dropping them.

Build:
- Bump project version to 1.104.1 to publish the fix for downstream consumers.

Documentation:
- Document the fix and behavior change in the changelog for version 1.104.1.

Tests:
- Add unit tests covering _apply_opts behavior for bare HoloViews elements, pane wrappers, and layout containers to prevent regressions in option propagation.