### PR TITLE
Allow NaN default/value on ResultBool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `ResultBool` rejected NaN as a default or value even though NaN is the documented "missing"/unrecorded sentinel for result variables (see `ResultFloat.__init__`). `ResultBool` locks its bounds to `[0, 1]`, and param validates a Parameter's default against its bounds whenever a subclass *overrides* it (and validates every value assignment). So `ResultBool(default=float("nan"))` raised `must be at most 1, not nan` the moment a subclass overrode the inherited Parameter, and assigning `float("nan")` at runtime to mark a sample missing raised the same — making the NaN "missing" sentinel that already works for `ResultFloat` unusable for `ResultBool`. `ResultBool._validate_bounds` now treats NaN as in-bounds, so result bools can use the same missing sentinel as `ResultFloat` while genuinely out-of-range values (e.g. `2.0`) are still rejected. Added coverage in `test/test_result_nan_default.py`.
+
 ## [1.104.1] - 2026-06-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.104.2] - 2026-06-10
 
 ### Fixed
 - `ResultBool` rejected NaN as a default or value even though NaN is the documented "missing"/unrecorded sentinel for result variables (see `ResultFloat.__init__`). `ResultBool` locks its bounds to `[0, 1]`, and param validates a Parameter's default against its bounds whenever a subclass *overrides* it (and validates every value assignment). So `ResultBool(default=float("nan"))` raised `must be at most 1, not nan` the moment a subclass overrode the inherited Parameter, and assigning `float("nan")` at runtime to mark a sample missing raised the same — making the NaN "missing" sentinel that already works for `ResultFloat` unusable for `ResultBool`. `ResultBool._validate_bounds` now treats NaN as in-bounds, so result bools can use the same missing sentinel as `ResultFloat` while genuinely out-of-range values (e.g. `2.0`) are still rejected. Added coverage in `test/test_result_nan_default.py`.
+- The `ResultBool` binomial standard error (`REDUCE` path in `bench_result_base.py`) divided `p*(1-p)` by the full repeat-dimension size while computing `p` with a `skipna=True` mean. Now that NaN is a valid "missing" repeat for `ResultBool`, those diverged and the SE was understated whenever a repeat was missing. The SE now divides by the per-cell count of valid (non-NaN) repeats. Added coverage in `test/test_result_bool.py`.
 
 ## [1.104.1] - 2026-06-09
 

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -301,12 +301,16 @@ class BenchResultBase:
             case ReduceType.REDUCE:
                 ds_reduce_mean = ds_out.mean(dim="repeat", skipna=True, keep_attrs=True)
                 ds_reduce_std = ds_out.std(dim="repeat", skipna=True, keep_attrs=False)
-                # For ResultBool: use binomial SE sqrt(p*(1-p)/n) instead of sample std
-                n_repeats = ds_out.sizes["repeat"]
+                # For ResultBool: use binomial SE sqrt(p*(1-p)/n) instead of sample std.
+                # n is the per-cell count of *valid* (non-NaN) repeats, not the full
+                # repeat dim size: NaN is the "missing" sentinel (see ResultBool /
+                # ResultFloat.__init__) and p above is a skipna mean, so dividing by the
+                # full dim size would understate the SE when any repeat is missing.
                 for rv in self.bench_cfg.result_vars:
                     if isinstance(rv, ResultBool) and rv.name in ds_reduce_std.data_vars:
                         p = ds_reduce_mean[rv.name]
-                        ds_reduce_std[rv.name] = np.sqrt(p * (1 - p) / n_repeats)
+                        n_valid = ds_out[rv.name].notnull().sum(dim="repeat")
+                        ds_reduce_std[rv.name] = np.sqrt(p * (1 - p) / n_valid)
                 # Assign std vars directly onto mean dataset (avoids xr.merge copy)
                 for var in ds_reduce_std.data_vars:
                     ds_reduce_mean[f"{var}_std"] = ds_reduce_std[var]

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -28,6 +28,7 @@ IMPORTANT — hash_persistent() contract:
 
 from __future__ import annotations
 
+import math
 import warnings
 from enum import auto
 from typing import Callable, Any
@@ -144,6 +145,18 @@ class ResultBool(ResultFloat):
         super().__init__(units=units, direction=direction, allow_None=True, **params)
         self.default = default
         self.bounds = (0, 1)  # bools are always between 0 and 1
+
+    def _validate_bounds(self, val, bounds, inclusive_bounds):
+        # NaN is the sentinel for an unrecorded ("missing") sample — see
+        # ResultFloat.__init__.  It lies outside the [0, 1] bounds, so param's
+        # bounds check would reject both ``default=float("nan")`` (re-validated
+        # whenever a subclass overrides the Parameter) and any NaN *value* set
+        # at runtime to mark a sample missing.  Treat NaN as always valid so a
+        # result bool can use the same missing sentinel as ResultFloat, while
+        # still rejecting genuinely out-of-range values.
+        if isinstance(val, float) and math.isnan(val):
+            return
+        super()._validate_bounds(val, bounds, inclusive_bounds)
 
 
 class ResultVec(param.List):

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -153,9 +153,15 @@ class ResultBool(ResultFloat):
         # whenever a subclass overrides the Parameter) and any NaN *value* set
         # at runtime to mark a sample missing.  Treat NaN as always valid so a
         # result bool can use the same missing sentinel as ResultFloat, while
-        # still rejecting genuinely out-of-range values.
-        if isinstance(val, float) and math.isnan(val):
-            return
+        # still rejecting genuinely out-of-range values.  Use math.isnan rather
+        # than ``isinstance(val, float)`` so numpy NaN scalars (e.g. np.float32)
+        # are also recognised; non-numeric values (None, str) raise here and
+        # fall through to the normal bounds check.
+        try:
+            if math.isnan(val):
+                return
+        except (TypeError, ValueError):
+            pass
         super()._validate_bounds(val, bounds, inclusive_bounds)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.104.1"
+version = "1.104.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_result_bool.py
+++ b/test/test_result_bool.py
@@ -426,6 +426,33 @@ class TestNoneHandling(unittest.TestCase):
             self.assertTrue(np.isnan(val))
 
 
+class TestBinomialSEWithMissingRepeats(unittest.TestCase):
+    """Binomial SE must divide by the count of valid (non-NaN) repeats.
+
+    NaN is the "missing" sentinel for result variables, and REDUCE computes the
+    mean with skipna=True.  The ResultBool binomial SE must therefore use the
+    per-cell valid repeat count rather than the full repeat-dimension size,
+    otherwise a missing repeat understates the error.
+    """
+
+    def test_se_uses_valid_repeat_count(self):
+        res = _run_sweep(BoolBenchAlternating, ["cat"], repeats=4)
+        # Inject a known pattern with one missing (NaN) repeat into a cell so the
+        # valid count (3) differs from the repeat-dim size (4).
+        res.ds["out"][dict(cat=0)] = np.array([1.0, 0.0, 1.0, np.nan])
+        res._to_dataset_cache.clear()  # pylint: disable=protected-access
+
+        ds = res.to_dataset(reduce=bn.ReduceType.REDUCE)
+        p = float(ds["out"][dict(cat=0)])
+        se = float(ds["out_std"][dict(cat=0)])
+
+        self.assertAlmostEqual(p, 2.0 / 3.0)  # skipna mean over 3 valid samples
+        n_valid = 3
+        self.assertAlmostEqual(se, float(np.sqrt(p * (1 - p) / n_valid)))
+        # The full-dim-size SE would be measurably smaller; ensure we didn't use it.
+        self.assertNotAlmostEqual(se, float(np.sqrt(p * (1 - p) / 4)))
+
+
 # ===========================================================================
 # Category 12: ResultBool Class Properties
 # ===========================================================================

--- a/test/test_result_nan_default.py
+++ b/test/test_result_nan_default.py
@@ -113,6 +113,16 @@ class TestResultBoolNanBounds(unittest.TestCase):
         obj.flag = float("nan")  # mark missing at runtime
         self.assertTrue(math.isnan(obj.flag))
 
+    def test_numpy_nan_scalar_accepted(self):
+        # The NaN check uses math.isnan rather than isinstance(val, float) so
+        # numpy NaN scalars (not subclasses of built-in float) are recognised too.
+        class B(bn.ParametrizedSweep):
+            flag = ResultBool(default=float("nan"), doc="x")
+
+        obj = B()
+        obj.flag = np.float32("nan")
+        self.assertTrue(math.isnan(obj.flag))
+
     def test_real_outcomes_still_coerce_in_bounds(self):
         class B(bn.ParametrizedSweep):
             flag = ResultBool(default=float("nan"), doc="x")
@@ -129,7 +139,9 @@ class TestResultBoolNanBounds(unittest.TestCase):
 
         obj = B()
         with self.assertRaises(ValueError):
-            obj.flag = 2.0
+            obj.flag = 2.0  # above upper bound
+        with self.assertRaises(ValueError):
+            obj.flag = -1.0  # below lower bound
 
 
 class TestNanDefaultEndToEnd(unittest.TestCase):

--- a/test/test_result_nan_default.py
+++ b/test/test_result_nan_default.py
@@ -17,7 +17,7 @@ import numpy as np
 from strenum import StrEnum
 
 import bencher as bn
-from bencher.variables.results import ResultFloat, ResultVec
+from bencher.variables.results import ResultBool, ResultFloat, ResultVec
 
 
 class _Cat(StrEnum):
@@ -65,6 +65,14 @@ class TestNanDefaultConstruction(unittest.TestCase):
         self.assertTrue(math.isnan(ResultFloat(default=float("nan")).default))
         self.assertTrue(math.isnan(ResultVec(size=2, default=float("nan")).default))
 
+    def test_bool_default_is_zero_for_backward_compat(self):
+        self.assertEqual(ResultBool().default, 0)
+
+    def test_bool_default_can_be_nan(self):
+        # ResultBool locks bounds to [0, 1]; NaN must still be accepted as the
+        # "missing" sentinel rather than rejected as out-of-bounds.
+        self.assertTrue(math.isnan(ResultBool(default=float("nan")).default))
+
     def test_explicit_numeric_default_still_honoured(self):
         self.assertEqual(ResultFloat(default=5).default, 5)
 
@@ -75,6 +83,53 @@ class TestNanDefaultConstruction(unittest.TestCase):
             ResultFloat(units="s").hash_persistent(),
             ResultFloat(units="s", default=float("nan")).hash_persistent(),
         )
+
+
+class TestResultBoolNanBounds(unittest.TestCase):
+    """``ResultBool`` locks bounds to [0, 1], but NaN is the missing sentinel.
+
+    param validates a Parameter's default against its bounds when a *subclass*
+    overrides it, and validates every value assignment.  Without NaN being
+    treated as in-bounds, an overridden NaN default (or a NaN assigned at
+    runtime to mark a sample missing) would raise "must be at most 1, not nan".
+    """
+
+    def test_override_inherited_resultbool_with_nan_default(self):
+        class Base(bn.ParametrizedSweep):
+            flag = ResultBool(default=float("nan"), doc="base")
+
+        # Overriding the inherited Parameter triggers param's bounds
+        # re-validation of the default; NaN must be accepted.
+        class Child(Base):
+            flag = ResultBool(default=float("nan"), doc="child override")
+
+        self.assertTrue(math.isnan(Child.param.flag.default))
+
+    def test_nan_value_assignment_accepted(self):
+        class B(bn.ParametrizedSweep):
+            flag = ResultBool(default=float("nan"), doc="x")
+
+        obj = B()
+        obj.flag = float("nan")  # mark missing at runtime
+        self.assertTrue(math.isnan(obj.flag))
+
+    def test_real_outcomes_still_coerce_in_bounds(self):
+        class B(bn.ParametrizedSweep):
+            flag = ResultBool(default=float("nan"), doc="x")
+
+        obj = B()
+        obj.flag = True
+        self.assertEqual(obj.flag, 1)
+        obj.flag = False
+        self.assertEqual(obj.flag, 0)
+
+    def test_out_of_bounds_value_still_rejected(self):
+        class B(bn.ParametrizedSweep):
+            flag = ResultBool(doc="x")
+
+        obj = B()
+        with self.assertRaises(ValueError):
+            obj.flag = 2.0
 
 
 class TestNanDefaultEndToEnd(unittest.TestCase):


### PR DESCRIPTION
## What

`ResultBool` rejected `NaN` as a default or value, even though `NaN` is the documented "missing"/unrecorded sentinel for result variables (see `ResultFloat.__init__`).

## Why

`ResultBool` locks its bounds to `[0, 1]`. param validates a Parameter's default against its bounds whenever a **subclass overrides** it, and validates **every value assignment**. So two things broke:

- `ResultBool(default=float("nan"))` raised `must be at most 1, not nan` as soon as a subclass overrode the inherited Parameter (a base-class declaration happens to skip this validation, so the failure only showed up on override — surprising and hard to diagnose).
- Assigning `float("nan")` at runtime to mark a sample missing raised the same.

Net effect: the NaN "missing" sentinel that already works for `ResultFloat`/`ResultVec` was unusable for `ResultBool`. (Concretely, this bit a downstream benchmark that hoisted a `ResultBool` success metric onto a shared base class and overrode it in one subclass.)

## How

Override `ResultBool._validate_bounds` to treat `NaN` as in-bounds, then delegate to the normal bounds check. NaN becomes a valid default and value; genuinely out-of-range values (e.g. `2.0`) are still rejected.

## Tests

Added to `test/test_result_nan_default.py`:
- `ResultBool` default can be NaN; default stays `0` for backward compat.
- A subclass overriding an inherited NaN-default `ResultBool` no longer raises (the regression).
- Assigning `float("nan")` at runtime is accepted; `True`/`False` still coerce to `1`/`0`.
- Out-of-range value assignment (`2.0`) is still rejected.

`pytest test/test_result_nan_default.py test/test_result_bool.py` → 57 passed. `ruff check`/`ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow boolean result parameters to use NaN as the standard "missing" sentinel while preserving existing bounds and behavior.

Bug Fixes:
- Permit ResultBool to accept NaN as a default and assigned value without triggering bounds validation errors, while still rejecting truly out-of-range values.

Documentation:
- Document the ResultBool NaN handling fix in the unreleased changelog section.

Tests:
- Extend result NaN default tests to cover ResultBool defaults, subclass overrides, runtime NaN assignments, boolean coercion, and out-of-bounds rejection.