### PR TITLE
Pass const_vars through to the worker in Bench.optimize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.106.0] - 2026-06-12
+
+### Fixed
+- `Bench.optimize()` never passed `const_vars` to the worker: `_run_optuna_job` folded the constants into the **cache key** but submitted only the trial-suggested values as `job_args`, so every Optuna trial silently ran with the worker class's parameter *defaults* for all `const_vars`. Constants are now merged into the submitted `job_args` (mirroring the sweep path's `WorkerJob.setup_hashes`); trial-suggested values keep precedence since `_resolve_optimize_vars` already strips colliding const entries. Regression coverage in `test/test_optimize.py::TestConstVars` for both the plain and `aggregate`/`repeats>1` branches.
+- `CACHE_VERSION` bumped to `"4"`: because the old cache key already included the constants, any cached `optimize()` entries produced with non-default `const_vars` hold values actually computed with worker defaults — wrong data under a correct-looking key, indistinguishable on disk from good entries. The bump wipes the cache tree on first use of the new version so the fixed code can never warm-start from poisoned entries.
+
 ## [1.105.0] - 2026-06-11
 
 ### Changed

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1447,10 +1447,13 @@ class Bench(BenchPlotServer):
         full_input["repeat"] = repeat
 
         cache_key = self._build_cache_key(full_input, tag)
+        # Mirror the sweep path (WorkerJob.setup_hashes): constants must reach the
+        # worker, not just the cache key. Collisions with input_vars are already
+        # stripped in _resolve_optimize_vars, so suggested values are never clobbered.
         job = Job(
             job_id=f"optimize:trial_{trial.number}",
             function=self.worker,
-            job_args=job_args,
+            job_args=dict(job_args) | constant_inputs,
             job_key=cache_key,
             tag=tag,
         )

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1450,10 +1450,12 @@ class Bench(BenchPlotServer):
         # Mirror the sweep path (WorkerJob.setup_hashes): constants must reach the
         # worker, not just the cache key. Collisions with input_vars are already
         # stripped in _resolve_optimize_vars, so suggested values are never clobbered.
+        # deepcopy for the same mutation safety worker_kwargs_wrapper gives the sweep
+        # path: a worker mutating a mutable constant must not leak state across trials.
         job = Job(
             job_id=f"optimize:trial_{trial.number}",
             function=self.worker,
-            job_args=dict(job_args) | constant_inputs,
+            job_args=deepcopy(dict(job_args) | constant_inputs),
             job_key=cache_key,
             tag=tag,
         )

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # ``BenchCfg.hash_persistent``) so bumping here atomically invalidates every
 # benchmark-level and over_time history key in addition to wiping the on-disk
 # tree via ``ensure_cache_version()``.
-CACHE_VERSION = "3"
+CACHE_VERSION = "4"
 
 # Default cache size for benchmark results (100 GB).
 # Used by ResultCollector, SweepExecutor, and Bench.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.105.0"
+version = "1.106.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -736,8 +736,8 @@ class TestSweepSlotCoverage:
 # on-disk benchmark-level and over_time entry in the field.
 # ---------------------------------------------------------------------------
 
-GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS = "afbbadba143168305abeaab3e2e53ea9c429c2a5"
-GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "6093b4560b17af4dab2f14f5609b7b945499df63"
+GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS = "4fb6a177d55ff3ca67cbe851076f7606dbe3e364"
+GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "3b91a536f825054f4ec7712808699564014a023a"
 
 
 def _build_golden_bench_cfg():

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -238,6 +238,66 @@ class TestAggregateOptimize:
             bench.optimize(n_trials=5, aggregate=["seed"], agg_fn="bogus", plot=False)
 
 
+class OffsetSphere(bn.ParametrizedSweep):
+    """Sphere with a constant offset; records what the worker actually received."""
+
+    x = bn.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+    offset = bn.FloatSweep(default=0.0, bounds=[0, 100], samples=3)
+
+    loss = bn.ResultFloat("ul", bn.OptDir.minimize)
+
+    observed_offsets: list[float] = []
+    observed_x: list[float] = []
+
+    def benchmark(self):
+        type(self).observed_offsets.append(float(self.offset))
+        type(self).observed_x.append(float(self.x))
+        self.loss = float(self.x**2 + self.offset)
+
+
+class TestConstVars:
+    def setup_method(self):
+        OffsetSphere.observed_offsets.clear()
+        OffsetSphere.observed_x.clear()
+
+    def test_const_vars_reach_worker(self):
+        """const_vars must be passed to the worker, not just hashed into the cache key."""
+        cfg = OffsetSphere()
+        bench = bn.Bench("test_opt_const_vars", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(
+            input_vars=["x"],
+            const_vars=dict(offset=50.0),
+            n_trials=5,
+            warm_start=False,
+            plot=False,
+        )
+
+        # Every trial must see the non-default constant, not the class default of 0.0.
+        assert OffsetSphere.observed_offsets == [50.0] * 5
+        # loss = x**2 + offset, so with offset delivered the best value is >= 50.
+        assert result.best_value >= 50.0
+        # Constants must not override the trial-suggested values for optimized vars.
+        suggested_x = [t.params["x"] for t in result.study.trials]
+        assert sorted(OffsetSphere.observed_x) == sorted(suggested_x)
+
+    def test_const_vars_reach_worker_with_repeats(self):
+        """The aggregate/repeats branch must also deliver const_vars to the worker."""
+        cfg = OffsetSphere()
+        bench = bn.Bench("test_opt_const_vars_rep", cfg, run_cfg=_run_cfg())
+        result = bench.optimize(
+            input_vars=["x"],
+            const_vars=dict(offset=50.0),
+            n_trials=3,
+            repeats=2,
+            agg_fn="mean",
+            warm_start=False,
+            plot=False,
+        )
+
+        assert OffsetSphere.observed_offsets == [50.0] * 6
+        assert result.best_value >= 50.0
+
+
 class TestConvenience:
     def test_to_optimize(self):
         result = Sphere().to_optimize(n_trials=15, plot=False)

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -63,7 +63,7 @@ class CategoricalProblem(bn.ParametrizedSweep):
 
 
 def _run_cfg():
-    """Minimal run config with caching enabled."""
+    """Minimal run config (single repeat, default caching off)."""
     cfg = bn.BenchRunCfg()
     cfg.repeats = 1
     return cfg


### PR DESCRIPTION
## Bug

`Bench.optimize()` resolves `const_vars` correctly (`_resolve_optimize_vars` → `define_const_inputs` → `constant_inputs` dict), but `_run_optuna_job` only used the constants to build the **cache key** — it never passed them to the worker:

```python
full_input = dict(job_args)
full_input.update(constant_inputs)          # cache key sees the constants...
cache_key = self._build_cache_key(full_input, tag)
job = Job(..., job_args=job_args, ...)      # ...the worker does not
```

Since the worker is `ParametrizedSweep.__call__(**kwargs)` → `update_params_from_kwargs`, which only sets keys present in kwargs, every Optuna trial silently ran with the worker class's parameter **defaults** for all `const_vars`. Real-world impact: an `optimize()` call with `const_vars=dict(scene="shelf", planner="curobo_v2", headless=True)` ran all trials on the default scene/planner with a GUI window.

Both objective branches (plain, and `aggregate`/`repeats>1`) funnel through `_run_optuna_job`, so both were affected.

## Fix

Merge `constant_inputs` into the `job_args` actually submitted to the worker, mirroring the sweep path (`WorkerJob.setup_hashes()` does `function_input | constant_inputs`). Trial-suggested values keep precedence: `_resolve_optimize_vars` already strips const entries that collide with `input_vars`, and the regression test asserts the worker sees exactly the suggested values for optimized vars. The `repeat` meta key is still not forwarded, matching `worker_kwargs_wrapper`'s default (`pass_repeat=False`) behaviour on the sweep path.

Cache key construction is unchanged, so `_warm_start_from_cache` stays consistent.

## Cache poisoning note

Because the cache key already included the constants, any previously cached `optimize()` results produced with non-default `const_vars` are **invalid**: they are stored under a const-vars key but were actually computed with worker defaults, and are indistinguishable from good entries on disk. `CACHE_VERSION` is therefore bumped to `"4"`, which wipes the cache tree on first use of the new version (`ensure_cache_version()`), so the fixed code can never warm-start from poisoned entries — no manual cache clearing needed. Golden `BenchCfg` hashes regenerated and the break is documented in CHANGELOG.md (1.106.0).

## Regression test

`test/test_optimize.py::TestConstVars` — an `OffsetSphere` worker records the `offset` it actually receives (`loss = x**2 + offset`). With `const_vars=dict(offset=50.0)`:
- every trial must observe `offset == 50.0` (was `0.0` default before the fix),
- `best_value >= 50.0` (was ~0 before the fix),
- observed `x` values must equal the trial-suggested values (constants never clobber suggestions),
- a second test covers the `repeats>1` aggregation branch.

Both tests fail on `main` and pass with the fix.

## Verification

Run via pixi: `pixi run test` (1476 passed, 5 skipped), `pixi run ruff-lint`, `pixi run format`, `pixi run pylint` (10.00/10) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Bench.optimize forwards constant variables to worker jobs while adding regression coverage for const_vars handling in Optuna optimization.

Bug Fixes:
- Pass const_vars through to worker job arguments in Bench.optimize so Optuna trials respect non-default constant parameters.

Tests:
- Add OffsetSphere-based regression tests verifying const_vars are delivered to workers for both single and repeated trials and do not override suggested inputs.
