### PR TITLE
Add catch parameter to Bench.optimize() so one failed trial doesn't abort the study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.106.2] - 2026-06-12
+
+### Added
+- `catch` parameter on `Bench.optimize()`, forwarded to `optuna.Study.optimize()`: a trial whose worker raises one of the given exception types is recorded as `FAILED` and the study continues with the remaining trials, instead of one raising trial aborting the entire study. The default `()` mirrors Optuna's own default and preserves the existing fail-fast behaviour exactly. `ParametrizedSweep.to_optimize()` already forwards `**kwargs`, so it picks up `catch` with no change. A raising worker leaves no committed sample-cache entry (both the serial and parallel paths raise before `cache.set`), so `FAILED` trials cannot poison the cache. Coverage in `test/test_optimize.py::TestCatch`.
+
 ## [1.106.1] - 2026-06-12
 
 ### Changed

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1121,6 +1121,7 @@ class Bench(BenchPlotServer):
         tag: str = "",
         run_cfg: BenchRunCfg | None = None,
         plot: bool = True,
+        catch: tuple[type[Exception], ...] = (),
     ) -> OptimizeResult | None:
         """Run optuna optimization directly — no full grid sweep required.
 
@@ -1147,6 +1148,13 @@ class Bench(BenchPlotServer):
             tag: Cache tag (same semantics as ``plot_sweep``).
             run_cfg: Run configuration.  Defaults to ``BenchRunCfg()``.
             plot: If *True*, append visualisation to ``self.report``.
+            catch: Exception types that should not abort the study.  Forwarded
+                to ``optuna.Study.optimize``: a trial whose worker raises one
+                of these is recorded as FAILED and the study continues with the
+                remaining trials.  Use for flaky or expensive workers
+                (simulator cold starts, network calls).  The default ``()``
+                preserves fail-fast behaviour: any worker exception aborts the
+                whole study.
 
         Returns:
             OptimizeResult wrapping the completed ``optuna.Study``.
@@ -1234,7 +1242,7 @@ class Bench(BenchPlotServer):
             agg_callable=agg_callable,
             repeats=repeats,
         )
-        study.optimize(objective, n_trials=n_trials)
+        study.optimize(objective, n_trials=n_trials, catch=catch)
 
         # --- clean up cache -------------------------------------------------
         logging.info(self.sample_cache.stats())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.106.1"
+version = "1.106.2"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_optimize.py
+++ b/test/test_optimize.py
@@ -62,6 +62,26 @@ class CategoricalProblem(bn.ParametrizedSweep):
         self.score = lookup[self.color] + (0.0 if self.flag else 0.3)
 
 
+class FlakySphere(bn.ParametrizedSweep):
+    """Sphere whose worker raises on its first invocation, then succeeds.
+
+    Models a flaky expensive worker (e.g. a simulator cold-start failure).
+    Tests must reset ``FlakySphere.calls = 0`` before use.
+    """
+
+    calls = 0  # class-level so the counter survives however the worker is invoked
+
+    x = bn.FloatSweep(default=0, bounds=[-5, 5], samples=5)
+
+    loss = bn.ResultFloat("ul", bn.OptDir.minimize)
+
+    def benchmark(self):
+        FlakySphere.calls += 1
+        if FlakySphere.calls == 1:
+            raise RuntimeError("infra flake")
+        self.loss = float(self.x**2)
+
+
 def _run_cfg():
     """Minimal run config with caching enabled."""
     cfg = bn.BenchRunCfg()
@@ -244,6 +264,36 @@ class TestConvenience:
         assert result.best_params is not None
         assert result.best_value >= 0
         assert result.n_new_trials == 15
+
+
+class TestCatch:
+    def test_optimize_without_catch_aborts_study(self):
+        FlakySphere.calls = 0
+        bench = bn.Bench("test_opt_no_catch", FlakySphere(), run_cfg=_run_cfg())
+        with pytest.raises(RuntimeError, match="infra flake"):
+            bench.optimize(n_trials=5, plot=False, warm_start=False)
+
+    def test_optimize_with_catch_continues_after_failed_trial(self):
+        from optuna.trial import TrialState
+
+        FlakySphere.calls = 0
+        bench = bn.Bench("test_opt_catch", FlakySphere(), run_cfg=_run_cfg())
+        result = bench.optimize(n_trials=5, plot=False, warm_start=False, catch=(RuntimeError,))
+
+        assert result is not None
+        states = [t.state for t in result.study.trials]
+        assert len(states) == 5
+        assert states.count(TrialState.FAIL) == 1
+        assert states.count(TrialState.COMPLETE) == 4
+        assert result.best_value >= 0  # surviving trials still produce a best value
+
+    def test_to_optimize_forwards_catch(self):
+        FlakySphere.calls = 0
+        result = FlakySphere().to_optimize(
+            n_trials=3, plot=False, warm_start=False, catch=(RuntimeError,)
+        )
+        assert result is not None
+        assert len(result.study.trials) == 3
 
 
 class TestCategoricalInputs:


### PR DESCRIPTION
## The gap

`Bench.optimize()` ran its study as

```python
study.optimize(objective, n_trials=n_trials)
```

with no `catch=` and no per-trial exception handling in the objective (`_make_optuna_objective` / `_run_optuna_job` let worker exceptions propagate). One raising trial therefore aborts the **entire** study — all remaining trials are lost.

Real-world motivation: a 24-trial robotics optimization where each trial cold-starts a simulator died on trial 0 because of a one-off simulator startup flake (`RuntimeError("... infra flake")`); 0 of 24 trials ran.

## The fix

Optuna supports this natively, so the fix is a one-line forward plus the new parameter:

```python
def optimize(self, ..., catch: tuple[type[Exception], ...] = ()):
    ...
    study.optimize(objective, n_trials=n_trials, catch=catch)
```

- A trial whose worker raises one of the caught types is recorded as `FAILED` and the study continues with the remaining trials. This is the knob for flaky/expensive workers (simulator cold starts, network calls).
- The default `()` mirrors Optuna's own default and **preserves the existing fail-fast behaviour exactly** — any worker exception still aborts the whole study.
- `ParametrizedSweep.to_optimize()` already forwards `**kwargs` to `Bench.optimize()`, so it picks up `catch` with no change (covered by a test).

## Sample-cache safety (checked, no change needed)

A raised worker leaves no committed cache entry, so a `FAILED` trial cannot poison the sample cache:
- serial path: `run_job()` raises before the `JobFuture` is ever constructed, so `cache.set` is never reached;
- parallel path: `JobFuture.result()` re-raises from `self.future.result()` before the `cache.set` line.

## Tests (TDD)

New `TestCatch` class in `test/test_optimize.py` with a `FlakySphere` worker that raises `RuntimeError` on its first invocation and succeeds afterwards:

1. `test_optimize_without_catch_aborts_study` — locks in current behaviour: without `catch`, the study aborts (`pytest.raises(RuntimeError)`). Passed before and after the fix.
2. `test_optimize_with_catch_continues_after_failed_trial` — with `catch=(RuntimeError,)`, all 5 trials exist: exactly 1 `FAILED`, 4 `COMPLETE`, and a best value is still produced. Failed before the fix with `TypeError: Bench.optimize() got an unexpected keyword argument 'catch'`; passes after.
3. `test_to_optimize_forwards_catch` — `catch` flows through `ParametrizedSweep.to_optimize()`'s `**kwargs`. Same before/after behaviour as (2).

## Verification

- `pixi run pytest test/test_optimize.py -k TestCatch` — before fix: 2 failed (TypeError), 1 passed (abort lock-in); after fix: 3 passed.
- `pixi run test` — full suite: 1477 passed, 5 skipped.
- `pixi run format` (no changes), `pixi run ruff-lint` (clean), pylint 10.00/10, `pixi run ty` — same 18 pre-existing diagnostics as `main`, none in touched files.

Note: kept the diff minimal to the `optimize()` signature/docstring/forwarding + tests, since a sibling PR is touching `_run_optuna_job` const_vars handling in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow Bench.optimize to continue an Optuna study when selected exceptions are raised during trials by forwarding a new catch parameter, and add tests to cover the new behavior and its propagation from ParametrizedSweep.to_optimize.

New Features:
- Add a catch parameter to Bench.optimize to configure exception types that should not abort an Optuna study.

Tests:
- Add FlakySphere test sweep and TestCatch test cases to verify default fail-fast behavior, successful continuation with catch, and catch forwarding from ParametrizedSweep.to_optimize.