### PR TITLE
fix: show units on curve, line and scatter axis labels

### DIFF
--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -13,6 +13,7 @@ from bencher.utils import (
     get_nearest_coords1D,
     hmap_canonical_input,
     get_nearest_coords,
+    label_with_units,
     listify,
 )
 from bencher.results.pane_result import PaneResult
@@ -254,6 +255,12 @@ class HoloviewResult(PaneResult):
             return None
         kdims = [d for d in ds_dims if d in float_names] or ds_dims[:1]
         groupby = [d for d in ds_dims if d not in kdims]
+
+        # Show units on both axes: x from the float input var, y from the result var
+        kwargs.setdefault("ylabel", label_with_units(result_var))
+        x_var = next((fv for fv in self.plt_cnt_cfg.float_vars if fv.name == kdims[0]), None)
+        if x_var is not None:
+            kwargs.setdefault("xlabel", label_with_units(x_var))
 
         vdims = [var, std_var] if has_spread else [var]
 

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 from bencher.results.bench_result_base import ReduceType
 from bencher.plotting.plot_filter import VarRange
+from bencher.utils import label_with_units
 from bencher.variables.results import SCALAR_RESULT_TYPES
 from bencher.results.holoview_results.holoview_result import HoloviewResult
 from bencher.results.holoview_results.holoview_result import use_tap as _USE_TAP
@@ -123,6 +124,7 @@ class LineResult(HoloviewResult):
             ):
                 return None
             title = self.title_from_ds(da_plot, result_var, **kwargs)
+            kwargs.setdefault("ylabel", label_with_units(result_var))
             plot = da_plot.hvplot.line(
                 x="over_time",
                 y=da_plot.name,
@@ -142,6 +144,9 @@ class LineResult(HoloviewResult):
         if self.plt_cnt_cfg.cat_cnt >= 1:
             by = self.plt_cnt_cfg.cat_vars[0].name
         title = self.title_from_ds(da_plot, result_var, **kwargs)
+        # Show units on both axes: x from the float input var, y from the result var
+        kwargs.setdefault("xlabel", label_with_units(self.plt_cnt_cfg.float_vars[0]))
+        kwargs.setdefault("ylabel", label_with_units(result_var))
 
         if self._use_holomap_for_time(dataset):
 
@@ -190,6 +195,9 @@ class LineResult(HoloviewResult):
         if self.plt_cnt_cfg.cat_cnt >= 1:
             by = self.plt_cnt_cfg.cat_vars[0].name
         title = self.title_from_ds(da_plot, result_var, **kwargs)
+        # Show units on both axes: x from the float input var, y from the result var
+        kwargs.setdefault("xlabel", label_with_units(self.plt_cnt_cfg.float_vars[0]))
+        kwargs.setdefault("ylabel", label_with_units(result_var))
         plot = da_plot.hvplot.line(x=x, by=by, title=title, **kwargs).opts(
             tools=["hover"], xrotation=30
         )

--- a/bencher/results/holoview_results/scatter_result.py
+++ b/bencher/results/holoview_results/scatter_result.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 from bencher.results.bench_result_base import ReduceType
 from bencher.plotting.plot_filter import VarRange
+from bencher.utils import label_with_units
 from bencher.variables.results import ResultVar
 from bencher.results.holoview_results.holoview_result import HoloviewResult
 
@@ -49,7 +50,7 @@ class ScatterResult(HoloviewResult):
             **kwargs,
         )
 
-    def _to_scatter_ds(  # pylint: disable=unused-argument
+    def _to_scatter_ds(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs
     ) -> pn.panel | None:
         """Creates a scatter plot from the provided dataset.
@@ -65,6 +66,10 @@ class ScatterResult(HoloviewResult):
         by = None
         if self.plt_cnt_cfg.cat_cnt > 1:
             by = [v.name for v in self.bench_cfg.input_vars[1:]]
+        # Show units on both axes: x from the first input var, y from the result var
+        kwargs.setdefault("ylabel", label_with_units(result_var))
+        if self.bench_cfg.input_vars:
+            kwargs.setdefault("xlabel", label_with_units(self.bench_cfg.input_vars[0]))
         plot = dataset.hvplot.scatter(
             by=by,
             subplots=False,

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -457,6 +457,20 @@ def params_to_str(param_list: list[param.Parameter]) -> list[str]:
     return [get_name(i) for i in param_list]
 
 
+def label_with_units(var: Any) -> str:
+    """Axis label for a variable: ``name [units]``, or just ``name`` if it has no units.
+
+    Args:
+        var (Any): A parameter-like object with a ``name`` and optional ``units`` attribute
+
+    Returns:
+        str: The axis label, e.g. ``"throughput [ops/s]"`` or ``"throughput"``
+    """
+    units = getattr(var, "units", "") or ""
+    # "ul" is the sweep-variable convention for unitless (see sweep_base.describe_variable)
+    return f"{var.name} [{units}]" if units and units != "ul" else var.name
+
+
 def publish_file(filepath: str, remote: str, branch_name: str) -> str:  # pragma: no cover
     """Publish a file to an orphan git branch:
 

--- a/test/test_axis_units.py
+++ b/test/test_axis_units.py
@@ -1,0 +1,137 @@
+"""Tests that curve, line and scatter plots show result-var units on their axes.
+
+Follow-up to https://github.com/blooop/bencher/pull/960: histogram gained units
+there, and band/bar/heatmap/surface/distribution already showed them. These
+tests cover the remaining gaps (curve/line/scatter) plus the shared
+``label_with_units`` helper.
+"""
+
+import unittest
+import warnings
+
+import holoviews as hv
+
+import bencher as bn
+from bencher.utils import label_with_units
+
+
+def _unwrap_hv(obj):
+    """Unwrap a panel Row/HoloViews pane returned by filter() to the hv object inside."""
+    while True:
+        if hasattr(obj, "object"):
+            obj = obj.object
+        elif hasattr(obj, "objects"):
+            assert len(obj.objects) > 0
+            obj = obj.objects[0]
+        else:
+            return obj
+
+
+def _find_element(obj, element_type):
+    """Depth-first search for the first holoviews element of the given type."""
+    obj = _unwrap_hv(obj)
+    if isinstance(obj, element_type):
+        return obj
+    if hasattr(obj, "traverse"):
+        found = obj.traverse(lambda x: x, [element_type])
+        if found:
+            return found[0]
+    return None
+
+
+class FloatBench(bn.ParametrizedSweep):
+    """1-float sweep with units on both the input and the result."""
+
+    distance = bn.FloatSweep(default=0, bounds=[0, 10], units="m", samples=4)
+    throughput = bn.ResultFloat(units="ops/s")
+
+    def benchmark(self):
+        self.throughput = self.distance * 2.0 + 1.0
+
+
+with warnings.catch_warnings():
+    # ResultVar is deprecated, but to_scatter's result_types filter only accepts it.
+    warnings.simplefilter("ignore", DeprecationWarning)
+
+    class CatBench(bn.ParametrizedSweep):
+        """1-categorical sweep accepted by the scatter filter."""
+
+        method = bn.StringSweep(["alpha", "beta"])
+        score = bn.ResultVar(units="m")
+
+        def benchmark(self):
+            self.score = float(len(self.method))
+
+
+def _run_sweep(bench_class, name, input_vars, result_vars, repeats):
+    run_cfg = bn.BenchRunCfg(
+        repeats=repeats, cache_results=False, cache_samples=False, auto_plot=False
+    )
+    bench = bn.Bench(name, bench_class(), run_cfg=run_cfg)
+    return bench.plot_sweep(
+        name, input_vars=input_vars, result_vars=result_vars, plot_callbacks=False
+    )
+
+
+class _LabelBench(bn.ParametrizedSweep):
+    """Params must be class-bound for param to assign their names."""
+
+    with_units = bn.ResultFloat(units="ms")
+    no_units = bn.ResultFloat(units="")
+    unitless = bn.ResultFloat(units="ul")
+
+
+class TestLabelWithUnits(unittest.TestCase):
+    def test_name_and_units(self):
+        self.assertEqual(label_with_units(_LabelBench.param.with_units), "with_units [ms]")
+
+    def test_no_units(self):
+        self.assertEqual(label_with_units(_LabelBench.param.no_units), "no_units")
+
+    def test_unitless_convention(self):
+        """'ul' is the sweep-variable convention for unitless and must not be shown."""
+        self.assertEqual(label_with_units(_LabelBench.param.unitless), "unitless")
+
+
+class TestCurveAxisUnits(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_sweep(FloatBench, "units_curve", ["distance"], ["throughput"], repeats=2)
+
+    def test_curve_axis_labels_show_units(self):
+        curve = _find_element(self.res.to_curve(), hv.Curve)
+        self.assertIsNotNone(curve)
+        opts = curve.opts.get().kwargs
+        self.assertEqual(opts["xlabel"], "distance [m]")
+        self.assertEqual(opts["ylabel"], "throughput [ops/s]")
+
+
+class TestLineAxisUnits(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_sweep(FloatBench, "units_line", ["distance"], ["throughput"], repeats=1)
+
+    def test_line_axis_labels_show_units(self):
+        curve = _find_element(self.res.to_line(use_tap=False), hv.Curve)
+        self.assertIsNotNone(curve)
+        opts = curve.opts.get().kwargs
+        self.assertEqual(opts["xlabel"], "distance [m]")
+        self.assertEqual(opts["ylabel"], "throughput [ops/s]")
+
+
+class TestScatterAxisUnits(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _run_sweep(CatBench, "units_scatter", ["method"], ["score"], repeats=1)
+
+    def test_scatter_axis_labels_show_units(self):
+        scatter = _find_element(self.res.to_scatter(), hv.Scatter)
+        self.assertIsNotNone(scatter)
+        opts = scatter.opts.get().kwargs
+        self.assertEqual(opts["ylabel"], "score [m]")
+        # StringSweep defaults to unitless ("ul"), so the x label stays the bare name
+        self.assertEqual(opts["xlabel"], "method")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_axis_units.py
+++ b/test/test_axis_units.py
@@ -92,6 +92,23 @@ class TestLabelWithUnits(unittest.TestCase):
         """'ul' is the sweep-variable convention for unitless and must not be shown."""
         self.assertEqual(label_with_units(_LabelBench.param.unitless), "unitless")
 
+    def test_no_units_attribute(self):
+        """Objects without a ``units`` attribute fall back to just the name."""
+
+        class _NoUnits:
+            name = "bare"
+
+        self.assertEqual(label_with_units(_NoUnits()), "bare")
+
+    def test_units_none(self):
+        """``units=None`` is treated the same as no units."""
+
+        class _NoneUnits:
+            name = "nothing"
+            units = None
+
+        self.assertEqual(label_with_units(_NoneUnits()), "nothing")
+
 
 class TestCurveAxisUnits(unittest.TestCase):
     @classmethod
@@ -111,12 +128,19 @@ class TestLineAxisUnits(unittest.TestCase):
     def setUpClass(cls):
         cls.res = _run_sweep(FloatBench, "units_line", ["distance"], ["throughput"], repeats=1)
 
-    def test_line_axis_labels_show_units(self):
-        curve = _find_element(self.res.to_line(use_tap=False), hv.Curve)
+    def _assert_line_axis_labels(self, curve):
         self.assertIsNotNone(curve)
         opts = curve.opts.get().kwargs
         self.assertEqual(opts["xlabel"], "distance [m]")
         self.assertEqual(opts["ylabel"], "throughput [ops/s]")
+
+    def test_line_axis_labels_show_units(self):
+        # float-x path: LineResult.to_line_ds
+        self._assert_line_axis_labels(_find_element(self.res.to_line(use_tap=False), hv.Curve))
+
+    def test_line_tap_axis_labels_show_units(self):
+        # tap path: LineResult._to_line_tap_ds
+        self._assert_line_axis_labels(_find_element(self.res.to_line(use_tap=True), hv.Curve))
 
 
 class TestScatterAxisUnits(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to #960, as promised in [this comment](https://github.com/blooop/bencher/pull/960#issuecomment-4692463977): the audit found that `curve_result.py`, `line_result.py` and `scatter_result.py` were the remaining plots that didn't show units on their axes (they set no axis label at all).

- Adds a shared `label_with_units()` helper in `bencher.utils` producing `name [units]`, following the existing `'ul'` = unitless convention from `sweep_base.describe_variable`
- Applies it to:
  - `HoloviewResult._build_curve_overlay` — covers `to_curve` and the aggregated line/over-time path (x = float input var, y = result var)
  - `LineResult.to_line_ds` (float-x path and 0D over_time path) and `_to_line_tap_ds`
  - `ScatterResult._to_scatter_ds`
- Labels are applied with `kwargs.setdefault`, so explicit user `xlabel`/`ylabel` kwargs still take precedence

## Test plan

- New `test/test_axis_units.py`: asserts `distance [m]` / `throughput [ops/s]` on curve and line axes, `score [m]` on scatter, and unit tests for `label_with_units` (units / no units / `'ul'`)
- Full suite: 1485 passed, 5 skipped; ruff + pylint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add shared axis labeling helper and ensure curve, line, and scatter plots display variable units on their axes.

New Features:
- Introduce a reusable label_with_units helper to generate axis labels from parameter names and units.

Enhancements:
- Apply unit-aware axis labels to curve, line, and scatter Holoviews plots while preserving user-provided labels.

Tests:
- Add axis unit tests for curve, line, and scatter plots, along with unit tests for the label_with_units helper.