### PR TITLE
Add 'bencher' console-script entry point for the render/compare CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.108.0] - 2026-06-21
+
+### Added
+- `bencher` console-script entry point (`[project.scripts]` → `bencher.render:main`), so the render/compare CLI can be invoked as `bencher <result.pkl> <out_dir> [--json PATH]` and `bencher compare <a.pkl> <b.pkl> --json PATH` instead of only `python -m bencher.render …`. **Non-breaking**: the existing `python -m bencher.render` invocation is unchanged and keeps working; this is purely an additional way to reach the same `main()`. Usage/`--help` text is now invocation-aware via a small `_prog()` helper — it shows `bencher` under the console script and `python -m bencher.render` from a source checkout — so the displayed command always matches how the tool was run. Coverage in `test/test_render.py`.
+
 ## [1.107.0] - 2026-06-12
 
 ### Changed

--- a/bencher/render.py
+++ b/bencher/render.py
@@ -132,9 +132,20 @@ def render_report(
     )
 
 
+def _prog() -> str:
+    """Program name for ``--help``/usage text.
+
+    Resolves to ``bencher`` when invoked via the installed console script and
+    to the explicit ``python -m bencher.render`` form otherwise, so the usage
+    line always names a command the reader can actually run.
+    """
+    exe = Path(sys.argv[0]).name
+    return "bencher" if exe == "bencher" else "python -m bencher.render"
+
+
 def _render_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="python -m bencher.render",
+        prog=_prog(),
         description="Render a saved benchmark result to HTML (and optionally JSON).",
     )
     parser.add_argument("result_path", nargs="?", help="Path to a saved .pkl result")
@@ -150,7 +161,7 @@ def _render_parser() -> argparse.ArgumentParser:
 
 def _compare_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="python -m bencher.render compare",
+        prog=f"{_prog()} compare",
         description="Diff two saved results into a machine-readable comparison JSON.",
     )
     parser.add_argument("baseline", help="Path to the baseline .pkl result")
@@ -206,8 +217,11 @@ def _run_compare(argv: list[str]) -> int:
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint.
 
-    Render: ``python -m bencher.render <result.pkl> <output_dir> [--json PATH]``
-    Compare: ``python -m bencher.render compare <a.pkl> <b.pkl> --json PATH``
+    Invoke via the installed ``bencher`` console script, or equivalently with
+    ``python -m bencher.render`` when running from a source checkout.
+
+    Render: ``bencher <result.pkl> <output_dir> [--json PATH]``
+    Compare: ``bencher compare <a.pkl> <b.pkl> --json PATH``
     """
     argv = sys.argv[1:] if argv is None else argv
 
@@ -218,7 +232,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.result_path or not args.output_dir:
         print(
-            "Usage: python -m bencher.render <result_path> <output_dir> [--json PATH]",
+            f"Usage: {_prog()} <result_path> <output_dir> [--json PATH]",
             file=sys.stderr,
         )
         return 2

--- a/bencher/render.py
+++ b/bencher/render.py
@@ -138,9 +138,14 @@ def _prog() -> str:
     Resolves to ``bencher`` when invoked via the installed console script and
     to the explicit ``python -m bencher.render`` form otherwise, so the usage
     line always names a command the reader can actually run.
+
+    Matches a ``bencher`` prefix rather than an exact name so platform/packaging
+    variants of the launcher still resolve (``bencher.exe`` on Windows,
+    ``bencher-3.12`` for a versioned install); the module form's ``render.py``
+    never matches.
     """
     exe = Path(sys.argv[0]).name
-    return "bencher" if exe == "bencher" else "python -m bencher.render"
+    return "bencher" if exe.startswith("bencher") else "python -m bencher.render"
 
 
 def _render_parser() -> argparse.ArgumentParser:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.107.0"
+version = "1.108.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"
@@ -30,6 +30,9 @@ dependencies = [
 Repository = "https://github.com/blooop/bencher"
 Home = "https://github.com/blooop/bencher"
 Documentation = "https://bencher.readthedocs.io/en/latest/"
+
+[project.scripts]
+bencher = "bencher.render:main"
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "https://prefix.dev/blooop"]

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -321,8 +321,13 @@ class TestSaveLoadRender(unittest.TestCase):
     def test_prog_name_is_invocation_aware(self):
         """Usage/help shows ``bencher`` under the console script and the
         explicit module form otherwise, so the displayed command is runnable."""
-        with mock.patch("bencher.render.sys.argv", ["/usr/local/bin/bencher", "--help"]):
-            self.assertEqual(_prog(), "bencher")
+        for argv0 in (
+            "/usr/local/bin/bencher",
+            "/venv/Scripts/bencher.exe",
+            "/venv/bin/bencher-3.12",
+        ):
+            with mock.patch("bencher.render.sys.argv", [argv0, "--help"]):
+                self.assertEqual(_prog(), "bencher")
         with mock.patch("bencher.render.sys.argv", ["/path/to/render.py"]):
             self.assertEqual(_prog(), "python -m bencher.render")
 

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 from bencher import Bench, BenchRunCfg, render_report, save_result, load_result
-from bencher.render import main as render_main
+from bencher.render import main as render_main, _prog
 from bencher.example.benchmark_data import ExampleBenchCfg
 
 
@@ -317,6 +317,14 @@ class TestSaveLoadRender(unittest.TestCase):
                 rc = render_main(["compare", str(a), str(b), "--json", str(Path(tmp) / "c.json")])
             self.assertEqual(rc, 1)
             self.assertIn("no comparable scalar result variables", stderr.getvalue())
+
+    def test_prog_name_is_invocation_aware(self):
+        """Usage/help shows ``bencher`` under the console script and the
+        explicit module form otherwise, so the displayed command is runnable."""
+        with mock.patch("bencher.render.sys.argv", ["/usr/local/bin/bencher", "--help"]):
+            self.assertEqual(_prog(), "bencher")
+        with mock.patch("bencher.render.sys.argv", ["/path/to/render.py"]):
+            self.assertEqual(_prog(), "python -m bencher.render")
 
     def test_save_emit_json_opt_in(self):
         """BenchReport.save(emit_json=...) writes result.json next to the HTML."""


### PR DESCRIPTION
## What

Register a `bencher` **console-script entry point** so the render/compare CLI is a real command instead of only `python -m bencher.render`.

```toml
[project.scripts]
bencher = "bencher.render:main"
```

After install:

```
bencher <result.pkl> <out_dir> [--json result.json]   # render (+ optional JSON export)
bencher compare <a.pkl> <b.pkl> --json comparison.json # machine-readable diff
```

## Why

`python -m bencher.render` is non-obvious and easy to mistype — the module name `render` doesn't hint that it also does JSON export and result comparison. A first-time user (or an agent told to "use the bencher CLI") has to go discover the module path. A named command matches the mental model and makes `bencher --help` self-documenting.

## Non-breaking

This is **purely additive**:
- `python -m bencher.render …` is unchanged and keeps working — same `main()`.
- No argument names, subcommand structure, or exit codes changed.
- The only behaviour change is **help/usage text**, which is now invocation-aware via a small `_prog()` helper: it reads `bencher` under the console script and `python -m bencher.render` from a source checkout, so the displayed command always matches how the tool was run.

## Verification

- `test/test_render.py` — added `test_prog_name_is_invocation_aware`; full module green (22 passed). Existing CLI tests drive `render.main([...])` directly and are unaffected.
- Built + installed the wheel in an isolated venv and confirmed the `bencher` script resolves and dispatches:
  - `bencher --help` → `usage: bencher …`
  - `bencher compare --help` → `usage: bencher compare …`
  - no-arg → `Usage: bencher <result_path> <output_dir> [--json PATH]`, exit 2
- `ruff check` / `ruff format` / `prek run` all clean.

Version bumped `1.107.0 → 1.108.0` (minor — new feature) with a CHANGELOG entry, per the auto-publish-on-version-bump convention.

## Summary by Sourcery

Introduce a named bencher CLI entry point while keeping the existing python -m bencher.render invocation working unchanged.

New Features:
- Add a bencher console-script entry point that invokes the existing render/compare CLI main entry.

Enhancements:
- Make CLI usage and help text invocation-aware so it reflects whether the tool is run via the bencher script or python -m bencher.render.

Build:
- Register the bencher console script in pyproject.toml and bump the project version to 1.108.0.

Documentation:
- Document the new bencher CLI entry and behavior in the changelog.

Tests:
- Add a test ensuring the computed program name matches the actual invocation for usage/help output.