### PR TITLE
De-flake test_save_faster_without_aggregated_tab

### DIFF
--- a/test/test_over_time_save_perf.py
+++ b/test/test_over_time_save_perf.py
@@ -53,14 +53,20 @@ def _run_and_save(show_agg: bool) -> float:
 
 def test_save_faster_without_aggregated_tab():
     """report.save() should be meaningfully faster with show_aggregated_time_tab=False."""
-    time_with_agg = _run_and_save(show_agg=True)
-    time_without_agg = _run_and_save(show_agg=False)
+    # Wall-clock comparison of two single runs is noisy on shared CI runners
+    # (observed 1.94s vs 1.86s false failures); a real regression makes the
+    # no-agg save consistently slower, so retry before declaring one.
+    attempts = []
+    for _ in range(3):
+        time_with_agg = _run_and_save(show_agg=True)
+        time_without_agg = _run_and_save(show_agg=False)
+        if time_without_agg < time_with_agg:
+            return
+        attempts.append(f"{time_without_agg:.2f}s vs {time_with_agg:.2f}s")
 
-    # The aggregated tab roughly doubles the embed cost.  Assert at least
-    # 20% improvement to allow for noise while still catching regressions.
-    assert time_without_agg < time_with_agg, (
-        f"Expected save without aggregated tab ({time_without_agg:.2f}s) to be faster "
-        f"than with aggregated tab ({time_with_agg:.2f}s)"
+    raise AssertionError(
+        "Expected save without aggregated tab to be faster than with aggregated tab "
+        f"in at least one of 3 attempts (without vs with): {', '.join(attempts)}"
     )
 
 


### PR DESCRIPTION
## Summary

`test_save_faster_without_aggregated_tab` compares two single wall-clock measurements; on shared CI runners the noise exceeds the signal, producing false failures (observed `1.94s` vs `1.86s` on a ci-split run of #932, unrelated to that PR's changes). A genuine regression makes the no-agg save *consistently* slower, so the comparison now retries up to 3 times and fails only if it loses every attempt, reporting all three timings.

Test-only change; no version bump.

## Verification

- `pixi run pytest test/test_over_time_save_perf.py` — 2 passed
- `pixi run format` / `ruff-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Make the performance test for saving without the aggregated tab more robust by retrying the timing comparison up to three times and only failing if all attempts are slower.