### PR TITLE
Save-perf test follow-up: alternate measurement order, name the retry constant

### DIFF
--- a/test/test_over_time_save_perf.py
+++ b/test/test_over_time_save_perf.py
@@ -51,22 +51,33 @@ def _run_and_save(show_agg: bool) -> float:
         return time.perf_counter() - t0
 
 
+# Retries before declaring a perf regression; see comment in the test body.
+PERF_COMPARE_ATTEMPTS = 3
+
+
 def test_save_faster_without_aggregated_tab():
     """report.save() should be meaningfully faster with show_aggregated_time_tab=False."""
     # Wall-clock comparison of two single runs is noisy on shared CI runners
     # (observed 1.94s vs 1.86s false failures); a real regression makes the
-    # no-agg save consistently slower, so retry before declaring one.
+    # no-agg save consistently slower, so retry before declaring one. The
+    # measurement order alternates between attempts so cache warmup or a
+    # transient load spike cannot consistently bias one side.
     attempts = []
-    for _ in range(3):
-        time_with_agg = _run_and_save(show_agg=True)
-        time_without_agg = _run_and_save(show_agg=False)
+    for i in range(PERF_COMPARE_ATTEMPTS):
+        if i % 2 == 0:
+            time_with_agg = _run_and_save(show_agg=True)
+            time_without_agg = _run_and_save(show_agg=False)
+        else:
+            time_without_agg = _run_and_save(show_agg=False)
+            time_with_agg = _run_and_save(show_agg=True)
         if time_without_agg < time_with_agg:
             return
         attempts.append(f"{time_without_agg:.2f}s vs {time_with_agg:.2f}s")
 
     raise AssertionError(
         "Expected save without aggregated tab to be faster than with aggregated tab "
-        f"in at least one of 3 attempts (without vs with): {', '.join(attempts)}"
+        f"in at least one of {PERF_COMPARE_ATTEMPTS} attempts (without vs with): "
+        f"{', '.join(attempts)}"
     )
 
 


### PR DESCRIPTION
Addresses the two Sourcery comments on #971, which auto-merged before they could be applied:

- Measurement order now alternates between attempts so cache warmup or transient runner load cannot consistently bias one side of the comparison.
- `PERF_COMPARE_ATTEMPTS = 3` makes the retry policy self-documenting.

Test-only change; no version bump. `pixi run pytest test/test_over_time_save_perf.py` — 2 passed; format/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the save performance comparison test to reduce bias and make its retry policy clearer.

Tests:
- Adjust the performance comparison test to alternate measurement order between attempts to avoid consistent bias.
- Introduce a named PERF_COMPARE_ATTEMPTS constant to document and control the number of retry attempts in the perf test.