### PR TITLE
plans: result cache & history invalidation correctness (research + fix prompt)

### DIFF
--- a/plans/09-result-cache-invalidation.md
+++ b/plans/09-result-cache-invalidation.md
@@ -1,23 +1,36 @@
 # Plan 09 — Result Cache & History Invalidation Correctness
 
-**Goal:** Fix two correctness defects in how the benchmark-config hash
+**Goal:** Fix three correctness defects in how the benchmark-config hash
 (`BenchCfg.hash_persistent`) invalidates the result cache (Layer B) and the
 `over_time` history cache (Layer C):
 
-1. It is **sensitive to the order** of `result_vars`, so reordering the result
-   columns — a change that alters nothing about *what* is measured — silently
-   discards a benchmark's entire accumulated history and regression baselines.
-2. The per-variable hash **excludes the variable name**, so *renaming* a result
-   variable does not change the key, yet the stored history is keyed internally by
-   name. The result is a silent, partial history split rather than a clean reset.
+1. It is **sensitive to list order** — for `result_vars` *and* `const_vars` — so
+   reordering the result columns, or reordering a dict of constants, silently
+   discards a benchmark's entire accumulated history and regression baselines,
+   though nothing about *what* is measured changed.
+2. The per-variable hash **excludes the variable name** — for result vars *and*
+   input/sweep vars — so *renaming* a variable does not change the key, yet the
+   stored history is keyed internally by name: silent, partial history
+   corruption (a different flavor per variable kind — see D2).
+3. Invalidation is **silent**: when the key moves, history vanishes with only an
+   info-level log. D3 proposes a last-seen-key index and an `on_history_reset`
+   policy knob to make resets observable.
+
+These semantics demonstrably violate user expectations: large downstream
+benchmark suites document the key in their own contributor docs as "a hash of
+the *set* of input/result/const vars" (it is not — it is an ordered fold), and
+invent conventions such as routing every result-var list through one shared
+constant purely to protect against resets they cannot see. When users build
+folklore defenses around a cache key, the key should change, not the users.
 
 **⚠️ Read first:** This plan deliberately revisits `hash_persistent()` *semantics*,
 which `plans/architecture/A4-caching-architecture.md` §5 says NOT to change. A4's
 "don't touch it" refers to the intentional exclusion of display-only fields (e.g.
-`title`) — that guidance stands. The ordering/naming behavior described here is a
-*different* thing: a genuine defect, not an intentional exclusion. Coordinate with
-A4: if A4 Phase C2 (the `bencher/caching/keys.py` key module) has already landed,
-implement this fix there instead of in `bench_cfg.py`.
+`title`) — that guidance stands; the ordering/naming behavior here is a genuine
+defect, not an intentional exclusion. Coordinate with A4: if A4 Phase C2 (the
+`bencher/caching/keys.py` key module) has landed, implement this fix there
+instead of in `bench_cfg.py`. Note also that A4's §2 W5 row says "Layer C key
+excludes repeats" — stale against current source (see §1); do not inherit it.
 
 **Rules:**
 - Always use the pixi environment (`pixi run ...`, e.g. `pixi run pytest`). Never
@@ -26,9 +39,10 @@ implement this fix there instead of in `bench_cfg.py`.
   auto-publishes to PyPI — see plans/01).
 - The `hash_persistent()` determinism contract (the auto-discovering determinism
   tests) must still hold: identical configs → identical hash across processes.
-- Any change to a cache key is cache-busting. Bump `CACHE_VERSION` in the same PR
-  and add a headline CHANGELOG entry. Do not attempt to migrate pickled legacy
-  entries — a one-time miss is the accepted recovery path.
+- Any change to a cache key is cache-busting. Bump `CACHE_VERSION`
+  (`bencher/cache_management.py:38`) in the same PR and add a headline CHANGELOG
+  entry; do not migrate pickled legacy entries — a one-time miss is the accepted
+  recovery path.
 - If a step fails in a way this plan does not cover, stop and report rather than
   improvising.
 
@@ -37,44 +51,62 @@ implement this fix there instead of in `bench_cfg.py`.
 ## 1. Background — where the key is used
 
 `BenchCfg.hash_persistent(include_repeats)` (`bencher/bench_cfg.py:757`) is the
-persistent identity of a benchmark run. Two on-disk caches key on it:
+persistent identity of a benchmark run. Both on-disk caches key on the **same**
+hash, computed once as `bench_cfg.hash_persistent(True)` (`bencher/bencher.py:678`):
 
-- **Layer B — result cache** (`bencher/result_collector.py`, `cachedir/benchmark_inputs`):
-  keyed by `hash_persistent(include_repeats=True)`.
-- **Layer C — `over_time` history** (`bencher/result_collector.py:399`
-  `load_history_cache`, `cachedir/history`): keyed by
-  `hash_persistent(include_repeats=False)`. Each run loads `ds_old = cache[cfg_hash]`
-  and does `xr.concat([ds_old, dataset], "over_time")`. A missing key means "no
-  history" → the series starts fresh.
+- **Layer B — result cache** (`cachedir/benchmark_inputs`): lookup at
+  `bencher.py:701-703`, write via `cache_results` (`result_collector.py:391`).
+- **Layer C — `over_time` history** (`cachedir/history`): the same hash is passed
+  to `load_history_cache` (`bencher.py:725-731`; `result_collector.py:399`), which
+  loads `ds_old = c[bench_cfg_hash]` and does `xr.concat([ds_old, dataset],
+  "over_time")` (`result_collector.py:465`, xarray's default `join="outer"`).
+  A missing key means "no history" → fresh series.
 
-Crucially, the history dataset's *data variables* are named by each result var's
-`.name` (`add_metadata_to_dataset`: `bench_res.ds[rv.name]`). So a metric's identity
-*inside the history* is its **name**, while its identity *in the cache key* is its
-**type/units/direction** (see §2). Those two notions of identity disagree — that
-mismatch is the root of defect D2.
+(The `include_repeats=False` variant at `bencher.py:682` keys only the *sample*
+cache; repeats are intentionally in the history key so historical arrays have
+the same shape — see the comment at `bench_cfg.py:773-775`.)
+
+Crucially, identity *inside* the stored dataset is by **name**: data variables
+are created under each result var's `.name` (`result_collector.py:229`), and
+dims/coords are named by each input var's `.name` in `input_vars` list order
+(`DimsCfg`, `bench_cfg.py:1075`). Identity *in the cache key* is type/units/shape
+— never the name (see §2). That disagreement is the root of defect D2.
 
 ## 2. The defects
 
-### D1 — `result_vars` order changes the key (it should be a no-op)
+### D1 — `result_vars` and `const_vars` order changes the key (it should be a no-op)
 
 `hash_persistent` folds each variable into a running accumulator **in list order**
-(`bench_cfg.py:796-798`):
+(`bench_cfg.py:796-801`):
 
 ```python
 all_vars = (self.input_vars or []) + (self.result_vars or [])
 for v in all_vars:
     hash_val = hash_sha1((hash_val, v.hash_persistent()))
+
+for v in self.const_vars or []:
+    hash_val = hash_sha1((hash_val, v[0].hash_persistent(), hash_sha1(v[1])))
 ```
 
-The fold is a non-commutative chained hash, so permuting `result_vars` changes the
-final hash whenever the permuted vars have distinct `hash_persistent()` values
-(i.e. distinct class/units/direction — see D2). The *set* of measured quantities is
-unchanged, yet both Layer B and Layer C miss, and the benchmark's entire history
-and regression baselines are silently dropped.
+The fold is a non-commutative chained hash: permuting `result_vars` changes the
+final hash whenever the permuted vars have distinct `hash_persistent()` values —
+distinct class or units (`direction` is deliberately excluded via `_hash_exclude`,
+`bencher/variables/results.py:107`). The *set* of measured quantities is
+unchanged, yet both layers miss and the entire history is silently dropped.
 
-The intuitive mental model is that a benchmark's result vars are a *set* and their
-order is a presentation detail (column order). Nothing documents that reordering is
-a full invalidation event, and the determinism tests only assert *same input → same
+The same applies to `const_vars`, where order is even less meaningful: a
+user-supplied dict becomes `list(dict.items())` (`bencher.py:436-437`), and when
+`const_vars` is omitted it is auto-derived from `get_input_defaults()` in class
+*declaration* order (`bencher.py:376`, `variables/parametrised_sweep.py:126-138`).
+Reordering a kwargs dict or the param declarations in a sweep class resets
+history, yet const order affects nothing but the title string (`bencher.py:448-452`).
+The const *value* being folded (`hash_sha1(v[1])`) is intentional and correct —
+a different constant is a different experiment — only the *order* sensitivity is
+the defect.
+
+The intuitive mental model is that result vars and constants form a *set* whose
+order is a presentation detail. Nothing documents reordering as a full
+invalidation event, and the determinism tests only assert *same input → same
 hash*, never *reordered-but-equivalent input → same hash*.
 
 **Reproduction** (add as a failing test, then make it pass):
@@ -82,100 +114,142 @@ hash*, never *reordered-but-equivalent input → same hash*.
 ```python
 import bencher as bn
 from bencher.bench_cfg import BenchCfg
-from bencher.variables.results import OptDir
 
-def key(result_vars):
-    c = BenchCfg()
-    c.bench_name = "demo"
-    c.tag = "demo"
-    c.over_time = True
-    c.input_vars = []
-    c.result_vars = result_vars
+def key(result_vars, const_vars=()):
+    c = BenchCfg(bench_name="demo", tag="demo", over_time=True, input_vars=[],
+                 result_vars=list(result_vars), const_vars=list(const_vars))
     return c.hash_persistent(include_repeats=False)
 
-a = bn.ResultBool(units="ratio", direction=OptDir.maximize)
-b = bn.ResultFloat(units="s", direction=OptDir.minimize)
+a = bn.ResultBool(units="ratio")
+b = bn.ResultFloat(units="s")
+w = bn.FloatSweep(units="m", bounds=[0, 1]);    w.name = "width"
+g = bn.FloatSweep(units="deg", bounds=[0, 90]); g.name = "angle"
 
-assert key([a, b]) == key([b, a])   # FAILS today: reordering invalidates history
+assert key([a, b]) == key([b, a])  # FAILS: result reorder resets history
+assert key([a], [(w, 0.5), (g, 30.0)]) == key([a], [(g, 30.0), (w, 0.5)])  # FAILS: const reorder
 ```
 
-### D2 — the per-variable hash ignores the variable name
+### D2 — the per-variable hash ignores the variable name (result *and* input vars)
 
-`_hash_slots` (`bencher/variables/results.py:50`) hashes the concrete class name
-plus the values of every `__slots__` declared on bencher's own Result classes
-(units, direction, bounds, …), and stops walking the MRO at the param framework —
-so the Parameter's `name` is never hashed. Two result vars with the same
-class/units/direction but different names produce identical `hash_persistent()`.
+- **Result vars**: `_hash_slots` (`bencher/variables/results.py:50`) hashes the
+  concrete class name plus every non-excluded `__slots__` entry, stopping the
+  MRO walk at the param framework — so the Parameter's `name` is never hashed.
+  With `direction`/`share_axis`/`max_time_events` excluded (`results.py:102-107`),
+  a `ResultFloat`'s identity is effectively *(class, units)*.
+- **Input/sweep vars**: `SweepBase._sweep_identity` (`bencher/variables/sweep_base.py:111-130`)
+  returns `(type(self).__name__, self.units, self.samples)` plus subclass
+  extensions — `objects` (`variables/inputs.py:64`), bounds + `sample_values`
+  (`inputs.py:538-541`), `step` (`inputs.py:628-631`) — and never `self.name`.
 
-Consequences:
+Consequences (each verified against xarray 2025.6.1; re-verify in the pixi env):
 
-- **Renaming a result var does not change the benchmark key.** Layer C still finds
-  `ds_old`, but `ds_old` holds a data variable under the *old* name while the fresh
-  run produces the *new* name. `xr.concat([ds_old, dataset], "over_time")`
-  outer-joins them: the renamed metric appears as a new column holding only the
-  latest point (looks reset), while the old-named column persists as a dead column
-  that never receives new data. This is a silent partial corruption — worse than a
-  clean reset.
+- **Renaming a result var → dead-column split.** Layer C still finds `ds_old`,
+  but it holds a data variable under the *old* name while the fresh run produces
+  the *new* name. The outer-join concat yields both columns: the renamed metric
+  holds only the latest point (looks reset), while the old-named column persists
+  as a dead column that never receives new data — and its NaN fill is
+  indistinguishable from genuinely missing samples (`result_collector.py:228`).
+- **Renaming an input var → phantom-dimension broadcast.** The key is unchanged
+  but the history's *dimension* name differs from the fresh dataset's. Here
+  `xr.concat` does **not** NaN-split — it broadcasts: the combined dataset gains
+  *both* dims, every data variable is duplicated across the phantom dimension,
+  and there are **zero NaNs** to betray it — history silently gains points at
+  coordinate combinations never measured, and regression statistics then
+  aggregate the duplicates. Verify with:
+
+  ```python
+  import numpy as np, xarray as xr
+  old = xr.Dataset({"m": (("speed", "over_time"), np.ones((2, 3)))},
+                   coords={"speed": [0.1, 0.2], "over_time": [0, 1, 2]})
+  new = xr.Dataset({"m": (("velocity", "over_time"), 2 * np.ones((2, 1)))},
+                   coords={"velocity": [0.1, 0.2], "over_time": [3]})
+  out = xr.concat([old, new], "over_time")   # dims: speed × velocity × over_time
+  assert not np.isnan(out["m"]).any()        # fabricated points, no NaN tell
+  ```
+
+- **Const identity collisions.** Consts are input-type params, so holding
+  `width=0.5` vs `depth=0.5` constant (same class/units/bounds) yields the *same*
+  key — Layer B can serve cached results for a different experiment.
 - Conversely, this is *why* D1's fix is safe for same-type vars: they are already
-  indistinguishable to the key, so only reorders of *distinct-type* vars move it.
+  indistinguishable to the key, so only reorders of distinct-identity vars move it.
 
-**Reproduction** (names are normally bound via class-attribute declaration; set
-directly here to isolate the hash behavior):
+**Reproduction** (names set directly to isolate the hash behavior; they are
+normally bound via class-attribute declaration):
 
 ```python
 import bencher as bn
-from bencher.variables.results import OptDir
 
-x = bn.ResultFloat(units="s", direction=OptDir.minimize); x.name = "duration"
-y = bn.ResultFloat(units="s", direction=OptDir.minimize); y.name = "latency"
-
-assert x.hash_persistent() != y.hash_persistent()  # FAILS today: rename is invisible to the key
+x = bn.ResultFloat(units="s"); x.name = "duration"
+y = bn.ResultFloat(units="s"); y.name = "latency"
+p = bn.FloatSweep(units="m", bounds=[0, 1]); p.name = "speed"
+q = bn.FloatSweep(units="m", bounds=[0, 1]); q.name = "velocity"
+assert x.hash_persistent() != y.hash_persistent()  # FAILS: result rename invisible
+assert p.hash_persistent() != q.hash_persistent()  # FAILS: input rename invisible
 ```
 
 ### D3 — invalidation is silent
 
-When the key changes (D1) or the concat mismatches (D2), history vanishes or splits
-with only a debug/`info`-level log. A user cannot distinguish an intended reset from
-an accidental one. (A4 §3.5 / W5 already argue for *reporting* history
-incompatibilities; D2 is a concrete case that should surface to the user.)
+When the key changes (D1) or the concat mismatches (D2), history vanishes or
+corrupts with only info-level logs (`result_collector.py:431,435`) — a user
+cannot distinguish an intended reset from an accidental one. (A4 §3.5 / W5
+already argue for *reporting* history incompatibilities; D2 is a concrete case.)
+
+**Concrete remediation:** maintain a small per-`(bench_name, tag)` index in the
+history cache holding the last-seen `hash_persistent` key plus a compact identity
+summary — ordered `(kind, name, class, units)` tuples for input/result/const
+vars. (Prior art: Layer B stores a `bench_name`-keyed hash list alongside its
+hash-keyed entries, `result_collector.py:396-397`.) On a key mismatch where
+prior history exists, emit a prominent **WARNING** naming what likely changed
+(var added/removed/renamed/reordered/re-unitted, diffed from the summary) and
+how many historical `over_time` events are orphaned under the old key. Add an
+escape hatch on `BenchRunCfg` (`bench_cfg.py:98`, next to `clear_history` at
+`:348`): `on_history_reset = "warn" | "error" | "ignore"`, default `"warn"` —
+silent invalidation becomes observable without blocking legitimate resets.
 
 ## 3. Research questions (resolve before implementing)
 
 1. **Can the `result_vars` contribution be made order-independent safely?** Result
-   vars become xarray *data variables*, which are keyed by name and inherently
-   unordered, so in principle yes. Confirm nothing downstream depends on
-   `result_vars` list order for *correctness* — only for display ordering, which
-   should read the config list directly, not the cache key. Grep for places that
-   iterate `result_vars` and assume positional meaning.
-2. **Must `input_vars` stay ordered?** Input vars become xarray *dimensions*, and
-   dimension order can matter (coordinate layout, some reductions/reshapes). Decide
-   whether input order is part of identity (likely yes) or can also be
-   canonicalized. Default recommendation: make only the `result_vars` contribution
-   order-independent; keep `input_vars` ordered unless research proves order is
-   irrelevant.
-3. **Should the variable name be part of identity?** Including the name in the
-   per-var hash turns a rename into a *clean, detected* full invalidation (one-time
-   reset) instead of a silent split. Weigh against users who rename a column purely
-   for display and want history kept — but note the current behavior does not keep
-   it correctly (it produces a dead column). Recommendation: include the name, and
-   add the load-time reconciliation from A4 §3.5 so the reset is reported.
-4. **Interaction with A4.** If A4 Phase C2 has introduced `bencher/caching/keys.py`,
-   this fix belongs there. Otherwise implement in `bench_cfg.py` and leave a pointer
-   for A4 to absorb.
+   vars become xarray *data variables*, keyed by name and inherently unordered, so
+   in principle yes. Confirm nothing depends on `result_vars` list order for
+   *correctness* (display ordering should read the config list, not the cache
+   key); grep for positional iteration over `result_vars`.
+2. **Same for `const_vars`** — likely easier: constants create no dims and their
+   order only feeds the title string (`bencher.py:448-452`). Canonicalize by name.
+3. **Must `input_vars` stay ordered?** Input order determines the history array's
+   dim order (`bench_cfg.py:1075`), and although xarray aligns by dim *name* (a
+   transposed history may concat fine), positional code exists — `da.values[..., t_idx]`
+   assumes `over_time` is the last axis (`result_collector.py:86-93`). Default:
+   keep `input_vars` ordered; scope order-independence to `result_vars` + `const_vars`.
+4. **Should the variable name be part of identity?** Including it turns a rename
+   into a *clean, detected* full invalidation instead of a silent split (result
+   vars) or broadcast corruption (input vars). Weigh against users who rename
+   purely for display and want history kept — the current behavior does not keep
+   it correctly anyway. Recommendation: include the name for input, result, and
+   const vars, plus load-time reconciliation so the reset is reported.
+5. **What must the D3 index store to produce a useful diagnosis?** Enough to
+   classify rename vs reorder vs re-unit vs add/remove; decide its format and
+   where it lives (history cache vs alongside `CACHE_VERSION`).
+6. **Interaction with A4.** If A4 Phase C2 has introduced `bencher/caching/keys.py`,
+   this fix belongs there. Otherwise implement in `bench_cfg.py` and leave a
+   pointer for A4 to absorb (and flag A4's stale W5 wording to its owner).
 
 ## 4. Proposed direction (subject to the research above)
 
-Treat the benchmark identity as an unordered set of *named* result variables:
+Treat the benchmark identity as an unordered set of *named* variables:
 
 - Compute each result var's identity as `hash_sha1((rv.name, rv.hash_persistent()))`
-  (name included → fixes D2).
-- Combine the result-var identities **order-independently** — e.g. fold the
-  *sorted* tuple of per-var identity hashes, or use a commutative combiner — so any
-  permutation collapses to one key (fixes D1).
-- Keep `input_vars` folded in order (pending research question 2).
-- On history load, compare the stored dataset's data-variable set against the
-  current result-var names; if they differ, discard-and-report instead of
-  outer-joining into a corrupt dataset (fixes D2's split and D3's silence).
+  and each const's as `hash_sha1((cv.name, cv.hash_persistent(), hash_sha1(value)))`
+  — name included fixes D2; value retained (a different constant is a different
+  experiment).
+- Combine result-var and const-var identities **order-independently** — e.g. fold
+  the *sorted* tuple of per-var identity hashes — so any permutation collapses to
+  one key (fixes D1).
+- Keep `input_vars` folded in order, but include each var's name (pending
+  research question 3).
+- On history load, compare the stored dataset's data-variable *and dim* name sets
+  against the current config; on mismatch, discard-and-report instead of
+  outer-joining/broadcasting into a corrupt dataset (fixes D2's split and blow-up).
+- Add the last-seen-key index + `on_history_reset` policy from D3.
 
 This is a **cache-busting** change: bump `CACHE_VERSION` and headline it in the
 CHANGELOG (a one-time miss for everyone, same policy A4 uses for its `code_hash`).
@@ -184,21 +258,26 @@ CHANGELOG (a one-time miss for everyone, same policy A4 uses for its `code_hash`
 
 - New tests, all passing:
   - reordering `result_vars` yields an identical `hash_persistent` (D1);
-  - two same-type result vars with different names yield **different** per-var and
-    benchmark hashes (D2);
+  - reordering `const_vars` (including dict-sourced) yields an identical hash (D1);
+  - two same-type result vars — and two same-type input vars — with different
+    names yield **different** per-var and benchmark hashes (D2);
   - set-equal result-var collections in any order share one key;
-  - an end-to-end `over_time` test where a result var is renamed loads with a
-    *reported* history reset, not a phantom dead column (D2/D3).
-- The existing `hash_persistent` determinism-contract tests still pass (same config
-  → same hash across processes).
+  - end-to-end `over_time` tests where a result var (then an input var) is renamed
+    load with a *reported* history reset — no dead column, no phantom dim (D2/D3);
+  - `on_history_reset`: `"warn"` (default) emits a WARNING naming the change and
+    the orphaned-event count; `"error"` raises; `"ignore"` stays quiet (D3).
+- The existing `hash_persistent` determinism-contract tests still pass.
 - `CACHE_VERSION` bumped; CHANGELOG entry added.
 - `pixi run ci` (and `pixi run test-split` if present) green.
 
 ## 6. What NOT to do
 
-- Do not change the intentional exclusion of display-only fields (`title`) — that
-  part of A4 §5 stands.
+- Do not change the intentional exclusion of display-only fields (`title`) — A4 §5
+  stands — nor add `direction`/`share_axis`/`max_time_events` back into the per-var
+  hash: those `_hash_exclude` entries (`results.py:102-107`) are deliberate.
 - Do not attempt to migrate or preserve existing pickled history across the key
   change; a one-time reset is the accepted recovery path for a cache.
-- Do not make `input_vars` order-independent without first confirming
-  dimension-order independence.
+- Do not make `input_vars` order-independent without first confirming no code
+  relies on positional dim layout (research question 3).
+- Do not default `on_history_reset` to `"error"` — first runs and intentional
+  experiment changes are legitimate resets and must not hard-fail by default.

--- a/plans/09-result-cache-invalidation.md
+++ b/plans/09-result-cache-invalidation.md
@@ -199,12 +199,25 @@ history cache holding the last-seen `hash_persistent` key plus a compact identit
 summary — ordered `(kind, name, class, units)` tuples for input/result/const
 vars. (Prior art: Layer B stores a `bench_name`-keyed hash list alongside its
 hash-keyed entries, `result_collector.py:396-397`.) On a key mismatch where
-prior history exists, emit a prominent **WARNING** naming what likely changed
-(var added/removed/renamed/reordered/re-unitted, diffed from the summary) and
-how many historical `over_time` events are orphaned under the old key. Add an
-escape hatch on `BenchRunCfg` (`bench_cfg.py:98`, next to `clear_history` at
-`:348`): `on_history_reset = "warn" | "error" | "ignore"`, default `"warn"` —
-silent invalidation becomes observable without blocking legitimate resets.
+prior history exists, surface it — once per benchmark, at history-load time —
+through **all three** of these, so it is visible whether the user watches a
+console, a CI log, or only the rendered report:
+
+1. **A `logging.WARNING`** (module logger, not the current `INFO`/`DEBUG` at
+   `result_collector.py:431,435`) naming what likely changed (var
+   added/removed/renamed/reordered/re-unitted, diffed from the stored summary)
+   and how many historical `over_time` events are orphaned under the old key.
+2. **A note in the rendered report's over-time/history section** (the surfacing
+   A4 §3.5 / W5 already call for) so a reset is not invisible to someone who only
+   opens the HTML.
+3. **The `on_history_reset` policy knob** below, which decides whether the
+   mismatch is tolerated or fatal.
+
+Add the escape hatch on `BenchRunCfg` (`bench_cfg.py:98`, next to `clear_history`
+at `:348`): `on_history_reset = "warn" | "error" | "ignore"`, default `"warn"`
+(emit 1+2). `"error"` raises a `HistoryResetError` naming the diff — for CI that
+must never silently lose a baseline; `"ignore"` suppresses 1+2 for a deliberate
+reset. Silent invalidation becomes observable without blocking legitimate resets.
 
 ## 3. Research questions (resolve before implementing)
 
@@ -241,9 +254,21 @@ Treat the benchmark identity as an unordered set of *named* variables:
   and each const's as `hash_sha1((cv.name, cv.hash_persistent(), hash_sha1(value)))`
   — name included fixes D2; value retained (a different constant is a different
   experiment).
-- Combine result-var and const-var identities **order-independently** — e.g. fold
-  the *sorted* tuple of per-var identity hashes — so any permutation collapses to
-  one key (fixes D1).
+- Combine result-var and const-var identities **order-independently** (fixes D1).
+  Two candidate combiners, with the tradeoff spelled out so an implementer need
+  not re-derive it:
+  - **Sorted-tuple hash (recommended):** `hash_sha1(tuple(sorted(per_var_hashes)))`
+    — sort the per-variable digests, then hash the tuple. Deterministic, preserves
+    multiplicity (two vars sharing an identity stay two entries), trivially
+    auditable, and reuses the existing `hash_sha1` primitive.
+  - **Commutative/multiset hash:** an order-free operator (XOR or modular sum of
+    the per-var digests). No sort, but XOR *cancels* duplicates (two identical
+    identities collapse to 0) and additive sum is a weaker mixer with higher
+    collision risk.
+
+  Use the sorted-tuple hash: the sort cost is negligible (a handful of vars) and
+  it has no cancellation failure mode — important because same-type vars already
+  share an identity (§2), so a commutative combiner could silently zero them out.
 - Keep `input_vars` folded in order, but include each var's name (pending
   research question 3).
 - On history load, compare the stored dataset's data-variable *and dim* name sets

--- a/plans/09-result-cache-invalidation.md
+++ b/plans/09-result-cache-invalidation.md
@@ -1,0 +1,204 @@
+# Plan 09 — Result Cache & History Invalidation Correctness
+
+**Goal:** Fix two correctness defects in how the benchmark-config hash
+(`BenchCfg.hash_persistent`) invalidates the result cache (Layer B) and the
+`over_time` history cache (Layer C):
+
+1. It is **sensitive to the order** of `result_vars`, so reordering the result
+   columns — a change that alters nothing about *what* is measured — silently
+   discards a benchmark's entire accumulated history and regression baselines.
+2. The per-variable hash **excludes the variable name**, so *renaming* a result
+   variable does not change the key, yet the stored history is keyed internally by
+   name. The result is a silent, partial history split rather than a clean reset.
+
+**⚠️ Read first:** This plan deliberately revisits `hash_persistent()` *semantics*,
+which `plans/architecture/A4-caching-architecture.md` §5 says NOT to change. A4's
+"don't touch it" refers to the intentional exclusion of display-only fields (e.g.
+`title`) — that guidance stands. The ordering/naming behavior described here is a
+*different* thing: a genuine defect, not an intentional exclusion. Coordinate with
+A4: if A4 Phase C2 (the `bencher/caching/keys.py` key module) has already landed,
+implement this fix there instead of in `bench_cfg.py`.
+
+**Rules:**
+- Always use the pixi environment (`pixi run ...`, e.g. `pixi run pytest`). Never
+  run tools directly.
+- Work on a feature branch, never `main` (merging to `main` with a version bump
+  auto-publishes to PyPI — see plans/01).
+- The `hash_persistent()` determinism contract (the auto-discovering determinism
+  tests) must still hold: identical configs → identical hash across processes.
+- Any change to a cache key is cache-busting. Bump `CACHE_VERSION` in the same PR
+  and add a headline CHANGELOG entry. Do not attempt to migrate pickled legacy
+  entries — a one-time miss is the accepted recovery path.
+- If a step fails in a way this plan does not cover, stop and report rather than
+  improvising.
+
+---
+
+## 1. Background — where the key is used
+
+`BenchCfg.hash_persistent(include_repeats)` (`bencher/bench_cfg.py:757`) is the
+persistent identity of a benchmark run. Two on-disk caches key on it:
+
+- **Layer B — result cache** (`bencher/result_collector.py`, `cachedir/benchmark_inputs`):
+  keyed by `hash_persistent(include_repeats=True)`.
+- **Layer C — `over_time` history** (`bencher/result_collector.py:399`
+  `load_history_cache`, `cachedir/history`): keyed by
+  `hash_persistent(include_repeats=False)`. Each run loads `ds_old = cache[cfg_hash]`
+  and does `xr.concat([ds_old, dataset], "over_time")`. A missing key means "no
+  history" → the series starts fresh.
+
+Crucially, the history dataset's *data variables* are named by each result var's
+`.name` (`add_metadata_to_dataset`: `bench_res.ds[rv.name]`). So a metric's identity
+*inside the history* is its **name**, while its identity *in the cache key* is its
+**type/units/direction** (see §2). Those two notions of identity disagree — that
+mismatch is the root of defect D2.
+
+## 2. The defects
+
+### D1 — `result_vars` order changes the key (it should be a no-op)
+
+`hash_persistent` folds each variable into a running accumulator **in list order**
+(`bench_cfg.py:796-798`):
+
+```python
+all_vars = (self.input_vars or []) + (self.result_vars or [])
+for v in all_vars:
+    hash_val = hash_sha1((hash_val, v.hash_persistent()))
+```
+
+The fold is a non-commutative chained hash, so permuting `result_vars` changes the
+final hash whenever the permuted vars have distinct `hash_persistent()` values
+(i.e. distinct class/units/direction — see D2). The *set* of measured quantities is
+unchanged, yet both Layer B and Layer C miss, and the benchmark's entire history
+and regression baselines are silently dropped.
+
+The intuitive mental model is that a benchmark's result vars are a *set* and their
+order is a presentation detail (column order). Nothing documents that reordering is
+a full invalidation event, and the determinism tests only assert *same input → same
+hash*, never *reordered-but-equivalent input → same hash*.
+
+**Reproduction** (add as a failing test, then make it pass):
+
+```python
+import bencher as bn
+from bencher.bench_cfg import BenchCfg
+from bencher.variables.results import OptDir
+
+def key(result_vars):
+    c = BenchCfg()
+    c.bench_name = "demo"
+    c.tag = "demo"
+    c.over_time = True
+    c.input_vars = []
+    c.result_vars = result_vars
+    return c.hash_persistent(include_repeats=False)
+
+a = bn.ResultBool(units="ratio", direction=OptDir.maximize)
+b = bn.ResultFloat(units="s", direction=OptDir.minimize)
+
+assert key([a, b]) == key([b, a])   # FAILS today: reordering invalidates history
+```
+
+### D2 — the per-variable hash ignores the variable name
+
+`_hash_slots` (`bencher/variables/results.py:50`) hashes the concrete class name
+plus the values of every `__slots__` declared on bencher's own Result classes
+(units, direction, bounds, …), and stops walking the MRO at the param framework —
+so the Parameter's `name` is never hashed. Two result vars with the same
+class/units/direction but different names produce identical `hash_persistent()`.
+
+Consequences:
+
+- **Renaming a result var does not change the benchmark key.** Layer C still finds
+  `ds_old`, but `ds_old` holds a data variable under the *old* name while the fresh
+  run produces the *new* name. `xr.concat([ds_old, dataset], "over_time")`
+  outer-joins them: the renamed metric appears as a new column holding only the
+  latest point (looks reset), while the old-named column persists as a dead column
+  that never receives new data. This is a silent partial corruption — worse than a
+  clean reset.
+- Conversely, this is *why* D1's fix is safe for same-type vars: they are already
+  indistinguishable to the key, so only reorders of *distinct-type* vars move it.
+
+**Reproduction** (names are normally bound via class-attribute declaration; set
+directly here to isolate the hash behavior):
+
+```python
+import bencher as bn
+from bencher.variables.results import OptDir
+
+x = bn.ResultFloat(units="s", direction=OptDir.minimize); x.name = "duration"
+y = bn.ResultFloat(units="s", direction=OptDir.minimize); y.name = "latency"
+
+assert x.hash_persistent() != y.hash_persistent()  # FAILS today: rename is invisible to the key
+```
+
+### D3 — invalidation is silent
+
+When the key changes (D1) or the concat mismatches (D2), history vanishes or splits
+with only a debug/`info`-level log. A user cannot distinguish an intended reset from
+an accidental one. (A4 §3.5 / W5 already argue for *reporting* history
+incompatibilities; D2 is a concrete case that should surface to the user.)
+
+## 3. Research questions (resolve before implementing)
+
+1. **Can the `result_vars` contribution be made order-independent safely?** Result
+   vars become xarray *data variables*, which are keyed by name and inherently
+   unordered, so in principle yes. Confirm nothing downstream depends on
+   `result_vars` list order for *correctness* — only for display ordering, which
+   should read the config list directly, not the cache key. Grep for places that
+   iterate `result_vars` and assume positional meaning.
+2. **Must `input_vars` stay ordered?** Input vars become xarray *dimensions*, and
+   dimension order can matter (coordinate layout, some reductions/reshapes). Decide
+   whether input order is part of identity (likely yes) or can also be
+   canonicalized. Default recommendation: make only the `result_vars` contribution
+   order-independent; keep `input_vars` ordered unless research proves order is
+   irrelevant.
+3. **Should the variable name be part of identity?** Including the name in the
+   per-var hash turns a rename into a *clean, detected* full invalidation (one-time
+   reset) instead of a silent split. Weigh against users who rename a column purely
+   for display and want history kept — but note the current behavior does not keep
+   it correctly (it produces a dead column). Recommendation: include the name, and
+   add the load-time reconciliation from A4 §3.5 so the reset is reported.
+4. **Interaction with A4.** If A4 Phase C2 has introduced `bencher/caching/keys.py`,
+   this fix belongs there. Otherwise implement in `bench_cfg.py` and leave a pointer
+   for A4 to absorb.
+
+## 4. Proposed direction (subject to the research above)
+
+Treat the benchmark identity as an unordered set of *named* result variables:
+
+- Compute each result var's identity as `hash_sha1((rv.name, rv.hash_persistent()))`
+  (name included → fixes D2).
+- Combine the result-var identities **order-independently** — e.g. fold the
+  *sorted* tuple of per-var identity hashes, or use a commutative combiner — so any
+  permutation collapses to one key (fixes D1).
+- Keep `input_vars` folded in order (pending research question 2).
+- On history load, compare the stored dataset's data-variable set against the
+  current result-var names; if they differ, discard-and-report instead of
+  outer-joining into a corrupt dataset (fixes D2's split and D3's silence).
+
+This is a **cache-busting** change: bump `CACHE_VERSION` and headline it in the
+CHANGELOG (a one-time miss for everyone, same policy A4 uses for its `code_hash`).
+
+## 5. Acceptance criteria
+
+- New tests, all passing:
+  - reordering `result_vars` yields an identical `hash_persistent` (D1);
+  - two same-type result vars with different names yield **different** per-var and
+    benchmark hashes (D2);
+  - set-equal result-var collections in any order share one key;
+  - an end-to-end `over_time` test where a result var is renamed loads with a
+    *reported* history reset, not a phantom dead column (D2/D3).
+- The existing `hash_persistent` determinism-contract tests still pass (same config
+  → same hash across processes).
+- `CACHE_VERSION` bumped; CHANGELOG entry added.
+- `pixi run ci` (and `pixi run test-split` if present) green.
+
+## 6. What NOT to do
+
+- Do not change the intentional exclusion of display-only fields (`title`) — that
+  part of A4 §5 stands.
+- Do not attempt to migrate or preserve existing pickled history across the key
+  change; a one-time reset is the accepted recovery path for a cache.
+- Do not make `input_vars` order-independent without first confirming
+  dimension-order independence.

--- a/plans/README.md
+++ b/plans/README.md
@@ -29,6 +29,10 @@ without additional context. **Read the whole plan before starting it.**
 | 07 | [Low-risk core cleanup](07-core-cleanup.md) | Low | Small | Anytime |
 | 08 | [Larger core refactors](08-core-refactors.md) | Med–High | Large | Last — needs owner sign-off |
 | 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | After 02; coordinate with A4 |
+| 10 | [Regression policy on result vars & verdict export](10-regression-policy-and-verdict-export.md) | Low–Med | Medium | After 02; builds on #974 |
+| 11 | [Worker lifecycle & resource injection](11-worker-lifecycle-and-resource-injection.md) | Medium | Medium–Large | Coordinate with A3/A4 |
+| 12 | [Portable artifact paths & cache config](12-portable-artifact-paths-and-cache-config.md) | Low | Small–Medium | Precursor to A3/A4 |
+| 13 | [Benchmark declaration bundle & run defaults](13-benchmark-declaration-and-run-defaults.md) | Low | Medium | Coordinate with 09 |
 
 Plans 01–03 are quick wins. Plan 02 contains decisions only the repo owner can make
 (notably the Plotly-vs-plugin-system direction for PRs #830/#932); those steps are

--- a/plans/README.md
+++ b/plans/README.md
@@ -28,6 +28,7 @@ without additional context. **Read the whole plan before starting it.**
 | 06 | [Docs & onboarding](06-docs-onboarding.md) | Low | Medium | Anytime |
 | 07 | [Low-risk core cleanup](07-core-cleanup.md) | Low | Small | Anytime |
 | 08 | [Larger core refactors](08-core-refactors.md) | Med–High | Large | Last — needs owner sign-off |
+| 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | After 02; coordinate with A4 |
 
 Plans 01–03 are quick wins. Plan 02 contains decisions only the repo owner can make
 (notably the Plotly-vs-plugin-system direction for PRs #830/#932); those steps are


### PR DESCRIPTION
## What

Adds `plans/09-result-cache-invalidation.md` — a self-contained task prompt for a follow-up agent/developer to **research and fix** two correctness defects in how `BenchCfg.hash_persistent` invalidates the result cache (Layer B) and the `over_time` history cache (Layer C). No code change here; this is a plan doc in the existing `plans/` convention (+ one README index row).

## The two defects it documents

**D1 — `result_vars` *order* changes the key (should be a no-op).**
`hash_persistent` folds each var into a running accumulator *in list order* (`bench_cfg.py:796-798`). Permuting `result_vars` — which changes nothing about *what* is measured — changes the hash whenever the moved vars differ in class/units/direction, so both Layer B and Layer C miss and the benchmark's entire history + regression baselines are silently discarded. The mental model (and the determinism tests) treat the metric set as a *set*; nothing documents that reorder is a full invalidation.

```python
a = bn.ResultBool(units="ratio", direction=OptDir.maximize)
b = bn.ResultFloat(units="s", direction=OptDir.minimize)
assert key([a, b]) == key([b, a])   # fails today
```

**D2 — the per-variable hash ignores the variable *name*.**
`_hash_slots` (`variables/results.py:50`) hashes class + `__slots__` (units, direction, bounds) but stops at the param framework, so `name` is never hashed. Renaming a result var therefore does **not** change the key — but the history dataset's data variables are named by `rv.name`, so `xr.concat([ds_old, dataset], "over_time")` outer-joins old-name vs new-name into a phantom dead column + an apparently-reset series. A silent partial corruption, worse than a clean reset.

```python
x = bn.ResultFloat(units="s", direction=OptDir.minimize); x.name = "duration"
y = bn.ResultFloat(units="s", direction=OptDir.minimize); y.name = "latency"
assert x.hash_persistent() != y.hash_persistent()   # fails today
```

Plus **D3** — both invalidation paths are silent (info/debug log only), so an accidental reset is indistinguishable from an intended one.

## Scope / coordination

The doc includes reproductions, file refs, research questions (can `result_vars` be made order-independent while `input_vars` stays ordered? should name be part of identity?), a proposed order-independent + name-inclusive key with load-time reconciliation, and acceptance criteria (new invariant tests, determinism contract preserved, `CACHE_VERSION` bump + CHANGELOG).

It explicitly coordinates with `plans/architecture/A4-caching-architecture.md`, whose §5 declines to change `hash_persistent` semantics — A4's guidance targets the intentional `title` exclusion; this plan scopes the ordering/naming behavior as a separate, genuine defect (implement inside A4's `caching/keys.py` if that lands first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new planning document describing how to fix correctness issues in benchmark result and history cache invalidation, and index it in the plans README.

Documentation:
- Introduce Plan 09 documenting defects and proposed fixes for result cache and history invalidation semantics, including research questions and acceptance criteria.
- Update the plans index to reference the new cache and history invalidation correctness plan.