### PR TITLE
A2 Phase S1: enrich PltCntCfg into a plot-selection signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Plot-selection signature enrichment** (A2 Phase S1): `PltCntCfg` gains additive, cheaply-computed facts alongside the existing counts — `has_time`/`time_steps` (temporal axis presence and length), `result_kinds` (result-variable name → coarse serializable kind), `cat_levels` (levels per categorical input), and `samples_per_point` (min non-NaN repeat count actually present, vs the configured `repeats`). `generate_plt_cnt_cfg` takes an optional dataset for the data-derived facts. No selection behavior changes.
+- **Plot-selection signature enrichment** (A2 Phase S1): `PltCntCfg` gains additive, cheaply-computed facts alongside the existing counts — `has_time`/`time_steps` (temporal axis presence and length), `result_kinds` (result-variable name → coarse serializable kind, via the new `result_kind` / `RESULT_KIND_ORDER` in `bencher.variables.results`), `cat_levels` (levels per categorical input), and `samples_per_point` (min repeat count actually present at the latest time step, missing-sentinel-aware per result type, vs the configured `repeats`). `generate_plt_cnt_cfg` takes an optional dataset for the data-derived facts, `PltCntCfg.__str__` includes the new fields, and the aggregation plotting path carries them through. No selection behavior changes.
 
 ## [1.116.0] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plot-selection signature enrichment** (A2 Phase S1): `PltCntCfg` gains additive, cheaply-computed facts alongside the existing counts — `has_time`/`time_steps` (temporal axis presence and length), `result_kinds` (result-variable name → coarse serializable kind), `cat_levels` (levels per categorical input), and `samples_per_point` (min non-NaN repeat count actually present, vs the configured `repeats`). `generate_plt_cnt_cfg` takes an optional dataset for the data-derived facts. No selection behavior changes.
+
 ## [1.113.1] - 2026-07-06
 
 ### Dependencies

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -158,19 +158,31 @@ class PltCntCfg(param.Parameterized):
         return plt_cnt_cfg
 
     def __str__(self):
-        return f"float_cnt: {self.float_cnt}\ncat_cnt: {self.cat_cnt} \npanel_cnt: {self.panel_cnt}\nvector_len: {self.vector_len}"
+        return (
+            f"float_cnt: {self.float_cnt}\n"
+            f"cat_cnt: {self.cat_cnt}\n"
+            f"panel_cnt: {self.panel_cnt}\n"
+            f"vector_len: {self.vector_len}\n"
+            f"has_time: {self.has_time}\n"
+            f"time_steps: {self.time_steps}\n"
+            f"result_kinds: {self.result_kinds}\n"
+            f"cat_levels: {self.cat_levels}\n"
+            f"samples_per_point: {self.samples_per_point}"
+        )
 
 
 def _samples_per_point(ds: xr.Dataset) -> int:
     """The number of repeat samples actually present at the sparsest sweep point:
     the minimum non-NaN count along the repeat dimension over all result variables
     that carry it. Differs from the configured `repeats` when runs are missing
-    (missing values are stored as NaN)."""
-    if "repeat" not in ds.dims:
-        return 1 if len(ds.data_vars) else 0
+    (missing values are stored as NaN). Result variables that don't carry the
+    repeat dimension count as one sample each, whether or not the dimension exists
+    structurally; 0 means the dataset holds no result data at all."""
     counts = [
         int(da.notnull().sum(dim="repeat").min())
         for da in ds.data_vars.values()
         if "repeat" in da.dims
     ]
-    return min(counts) if counts else 0
+    if counts:
+        return min(counts)
+    return 1 if len(ds.data_vars) else 0

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Optional
 
 import param
@@ -8,18 +9,8 @@ import xarray as xr
 from bencher.bench_cfg import BenchCfg
 from bencher.variables.results import (
     PANEL_TYPES,
-    ResultBool,
-    ResultContainer,
-    ResultDataSet,
-    ResultFloat,
-    ResultHmap,
-    ResultImage,
-    ResultPath,
-    ResultReference,
-    ResultString,
-    ResultVec,
-    ResultVideo,
-    ResultVolume,
+    result_kind,
+    result_missing_fill,
 )
 
 from bencher.variables.inputs import (
@@ -32,31 +23,11 @@ from bencher.variables.inputs import (
 )
 from bencher.variables.time import TimeSnapshot, TimeEvent
 
-# Most-derived first: kind classification takes the first isinstance match
-# (ResultBool subclasses ResultFloat; ResultRerun subclasses ResultContainer).
-_RESULT_KIND_ORDER = (
-    (ResultBool, "bool"),
-    (ResultFloat, "float"),
-    (ResultVec, "vec"),
-    (ResultImage, "image"),
-    (ResultVideo, "video"),
-    (ResultPath, "path"),
-    (ResultString, "string"),
-    (ResultDataSet, "dataset"),
-    (ResultContainer, "container"),
-    (ResultHmap, "hmap"),
-    (ResultReference, "reference"),
-    (ResultVolume, "volume"),
-)
+__all__ = ["PltCntCfg", "result_kind"]
 
-
-def result_kind(result_var) -> str:
-    """Classify a result variable into a coarse, serializable kind name used by
-    plot-selection signatures (A2)."""
-    for cls, kind in _RESULT_KIND_ORDER:
-        if isinstance(result_var, cls):
-            return kind
-    return "unknown"
+# Time-like sweep inputs: drives both their classification as float axes and
+# has_time, so the two facts can't drift apart.
+TIME_TYPES = (TimeSnapshot, TimeEvent)
 
 
 class PltCntCfg(param.Parameterized):
@@ -88,8 +59,9 @@ class PltCntCfg(param.Parameterized):
     )
     samples_per_point = param.Integer(
         0,
-        doc="Repeat samples actually present in the data (min non-NaN count over the repeat "
-        "dim), as opposed to the configured `repeats`; 0 when no dataset was provided",
+        doc="Repeat samples actually present in the data (min non-missing count over the "
+        "repeat dim at the latest time step), as opposed to the configured `repeats`; "
+        "0 when no dataset was provided",
     )
 
     print_debug = param.Boolean(
@@ -124,7 +96,7 @@ class PltCntCfg(param.Parameterized):
 
         for iv in bench_cfg.input_vars:
             type_allocated = False
-            if isinstance(iv, (IntSweep, FloatSweep, TimeSnapshot, TimeEvent)):
+            if isinstance(iv, (IntSweep, FloatSweep, *TIME_TYPES)):
                 # if "IntSweep" in typestr or "FloatSweep" in typestr:
                 plt_cnt_cfg.float_vars.append(iv)
                 type_allocated = True
@@ -147,14 +119,14 @@ class PltCntCfg(param.Parameterized):
         plt_cnt_cfg.inputs_cnt = len(bench_cfg.input_vars)
 
         plt_cnt_cfg.has_time = bool(bench_cfg.over_time) or any(
-            isinstance(iv, (TimeSnapshot, TimeEvent)) for iv in bench_cfg.input_vars
+            isinstance(iv, TIME_TYPES) for iv in bench_cfg.input_vars
         )
         plt_cnt_cfg.result_kinds = {rv.name: result_kind(rv) for rv in bench_cfg.result_vars}
         plt_cnt_cfg.cat_levels = {v.name: len(v.values()) for v in plt_cnt_cfg.cat_vars}
         if ds is not None:
             if "over_time" in ds.dims:
                 plt_cnt_cfg.time_steps = int(ds.sizes["over_time"])
-            plt_cnt_cfg.samples_per_point = _samples_per_point(ds)
+            plt_cnt_cfg.samples_per_point = _samples_per_point(ds, bench_cfg.result_vars)
         return plt_cnt_cfg
 
     def __str__(self):
@@ -171,18 +143,39 @@ class PltCntCfg(param.Parameterized):
         )
 
 
-def _samples_per_point(ds: xr.Dataset) -> int:
+def _missing_mask(da: xr.DataArray, rv) -> xr.DataArray:
+    """True where an entry holds *rv*'s missing-value sentinel (see
+    ``result_missing_fill``); plain NaN when the variable is unknown."""
+    if rv is not None:
+        fill, _ = result_missing_fill(rv)
+        if not (isinstance(fill, float) and math.isnan(fill)):
+            return da == fill
+    return da.isnull()
+
+
+def _samples_per_point(ds: xr.Dataset, result_vars=None) -> int:
     """The number of repeat samples actually present at the sparsest sweep point:
-    the minimum non-NaN count along the repeat dimension over all result variables
-    that carry it. Differs from the configured `repeats` when runs are missing
-    (missing values are stored as NaN). Result variables that don't carry the
-    repeat dimension count as one sample each, whether or not the dimension exists
-    structurally; 0 means the dataset holds no result data at all."""
-    counts = [
-        int(da.notnull().sum(dim="repeat").min())
-        for da in ds.data_vars.values()
-        if "repeat" in da.dims
-    ]
+    the minimum non-missing count along the repeat dimension over the result
+    variables that carry it. Differs from the configured `repeats` when runs are
+    missing. Missingness is each variable's storage sentinel (NaN / -1 / "NAN",
+    matched to `result_vars` by name) so object- and reference-backed misses
+    count too. Only the latest `over_time` step is inspected — older steps carry
+    structural padding when repeats or levels grew between runs. Variables
+    without the repeat dimension are ignored when another variable carries it
+    (a lone panel var must not mask real repeats); if none carries it, each
+    point holds one sample, or none at all for a dataset with no result data."""
+    rv_by_name = {rv.name: rv for rv in result_vars} if result_vars else {}
+    counts = []
+    for name, da in ds.data_vars.items():
+        if "repeat" not in da.dims:
+            continue
+        if "over_time" in da.dims:
+            if da.sizes["over_time"] == 0:
+                counts.append(0)
+                continue
+            da = da.isel(over_time=-1)
+        per_point = (~_missing_mask(da, rv_by_name.get(name))).sum(dim="repeat")
+        counts.append(int(per_point.min()) if per_point.size else 0)
     if counts:
         return min(counts)
     return 1 if len(ds.data_vars) else 0

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -1,7 +1,26 @@
 from __future__ import annotations
+
+from typing import Optional
+
 import param
+import xarray as xr
+
 from bencher.bench_cfg import BenchCfg
-from bencher.variables.results import PANEL_TYPES
+from bencher.variables.results import (
+    PANEL_TYPES,
+    ResultBool,
+    ResultContainer,
+    ResultDataSet,
+    ResultFloat,
+    ResultHmap,
+    ResultImage,
+    ResultPath,
+    ResultReference,
+    ResultString,
+    ResultVec,
+    ResultVideo,
+    ResultVolume,
+)
 
 from bencher.variables.inputs import (
     IntSweep,
@@ -12,6 +31,32 @@ from bencher.variables.inputs import (
     YamlSweep,
 )
 from bencher.variables.time import TimeSnapshot, TimeEvent
+
+# Most-derived first: kind classification takes the first isinstance match
+# (ResultBool subclasses ResultFloat; ResultRerun subclasses ResultContainer).
+_RESULT_KIND_ORDER = (
+    (ResultBool, "bool"),
+    (ResultFloat, "float"),
+    (ResultVec, "vec"),
+    (ResultImage, "image"),
+    (ResultVideo, "video"),
+    (ResultPath, "path"),
+    (ResultString, "string"),
+    (ResultDataSet, "dataset"),
+    (ResultContainer, "container"),
+    (ResultHmap, "hmap"),
+    (ResultReference, "reference"),
+    (ResultVolume, "volume"),
+)
+
+
+def result_kind(result_var) -> str:
+    """Classify a result variable into a coarse, serializable kind name used by
+    plot-selection signatures (A2)."""
+    for cls, kind in _RESULT_KIND_ORDER:
+        if isinstance(result_var, cls):
+            return kind
+    return "unknown"
 
 
 class PltCntCfg(param.Parameterized):
@@ -28,6 +73,25 @@ class PltCntCfg(param.Parameterized):
     repeats = param.Integer(0, doc="The number of repeat samples")
     inputs_cnt = param.Integer(0, doc="The number of repeat samples")
 
+    # Richer signature facts (A2 Phase S1) — additive alongside the counts above.
+    has_time = param.Boolean(
+        False, doc="True when the sweep has a temporal axis (over_time or a time input var)"
+    )
+    time_steps = param.Integer(
+        0, doc="Number of time points present in the dataset's over_time axis (0 = no axis)"
+    )
+    result_kinds = param.Dict(
+        default={}, doc="result variable name -> coarse kind (float, bool, vec, image, video, ...)"
+    )
+    cat_levels = param.Dict(
+        default={}, doc="categorical input variable name -> number of levels swept"
+    )
+    samples_per_point = param.Integer(
+        0,
+        doc="Repeat samples actually present in the data (min non-NaN count over the repeat "
+        "dim), as opposed to the configured `repeats`; 0 when no dataset was provided",
+    )
+
     print_debug = param.Boolean(
         True,
         doc="Print debug information about why a filter matches this config or not",
@@ -36,11 +100,15 @@ class PltCntCfg(param.Parameterized):
     @staticmethod
     def generate_plt_cnt_cfg(
         bench_cfg: BenchCfg,
+        ds: Optional[xr.Dataset] = None,
     ) -> PltCntCfg:
         """Given a BenchCfg work out how many float and cat variables there are and store in a PltCntCfg class
 
         Args:
             bench_cfg (BenchCfg): See BenchCfg definition
+            ds (xr.Dataset, optional): The collected result dataset. When provided, the
+                data-derived signature facts (time_steps, samples_per_point) are
+                computed from it; without it they stay at their defaults.
 
         Raises:
             ValueError: If no plotting procedure could be automatically detected
@@ -77,7 +145,32 @@ class PltCntCfg(param.Parameterized):
         plt_cnt_cfg.panel_cnt = len(plt_cnt_cfg.panel_vars)
         plt_cnt_cfg.repeats = bench_cfg.repeats
         plt_cnt_cfg.inputs_cnt = len(bench_cfg.input_vars)
+
+        plt_cnt_cfg.has_time = bool(bench_cfg.over_time) or any(
+            isinstance(iv, (TimeSnapshot, TimeEvent)) for iv in bench_cfg.input_vars
+        )
+        plt_cnt_cfg.result_kinds = {rv.name: result_kind(rv) for rv in bench_cfg.result_vars}
+        plt_cnt_cfg.cat_levels = {v.name: len(v.values()) for v in plt_cnt_cfg.cat_vars}
+        if ds is not None:
+            if "over_time" in ds.dims:
+                plt_cnt_cfg.time_steps = int(ds.sizes["over_time"])
+            plt_cnt_cfg.samples_per_point = _samples_per_point(ds)
         return plt_cnt_cfg
 
     def __str__(self):
         return f"float_cnt: {self.float_cnt}\ncat_cnt: {self.cat_cnt} \npanel_cnt: {self.panel_cnt}\nvector_len: {self.vector_len}"
+
+
+def _samples_per_point(ds: xr.Dataset) -> int:
+    """The number of repeat samples actually present at the sparsest sweep point:
+    the minimum non-NaN count along the repeat dimension over all result variables
+    that carry it. Differs from the configured `repeats` when runs are missing
+    (missing values are stored as NaN)."""
+    if "repeat" not in ds.dims:
+        return 1 if len(ds.data_vars) else 0
+    counts = [
+        int(da.notnull().sum(dim="repeat").min())
+        for da in ds.data_vars.values()
+        if "repeat" in da.dims
+    ]
+    return min(counts) if counts else 0

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -169,7 +169,7 @@ class BenchResultBase:
         return bench_cfg
 
     def post_setup(self):
-        self.plt_cnt_cfg = PltCntCfg.generate_plt_cnt_cfg(self.bench_cfg)
+        self.plt_cnt_cfg = PltCntCfg.generate_plt_cnt_cfg(self.bench_cfg, self.ds)
         self.bench_cfg = self.wrap_long_time_labels(self.bench_cfg)
         self.ds = convert_dataset_bool_dims_to_str(self.ds)
         self._to_dataset_cache.clear()

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -707,6 +707,17 @@ class BenchResultBase:
                 panel_cnt=self.plt_cnt_cfg.panel_cnt,
                 repeats=self.plt_cnt_cfg.repeats,
                 inputs_cnt=len(adj_float) + len(adj_cat),
+                # signature facts carry over; cat_levels drops the collapsed dims
+                # to stay consistent with adj_cat
+                has_time=self.plt_cnt_cfg.has_time,
+                time_steps=self.plt_cnt_cfg.time_steps,
+                result_kinds=dict(self.plt_cnt_cfg.result_kinds),
+                cat_levels={
+                    name: levels
+                    for name, levels in self.plt_cnt_cfg.cat_levels.items()
+                    if name not in agg_set
+                },
+                samples_per_point=self.plt_cnt_cfg.samples_per_point,
                 print_debug=self.plt_cnt_cfg.print_debug,
             )
         matches_res = plot_filter.matches_result(check_cfg, callable_name(plot_callback), override)

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -498,6 +498,33 @@ ALL_RESULT_TYPES = (
     ResultVolume,
 )
 
+# Most-derived first: kind classification takes the first isinstance match
+# (ResultBool subclasses ResultFloat; ResultRerun subclasses ResultContainer).
+RESULT_KIND_ORDER = (
+    (ResultBool, "bool"),
+    (ResultFloat, "float"),
+    (ResultVec, "vec"),
+    (ResultImage, "image"),
+    (ResultVideo, "video"),
+    (ResultPath, "path"),
+    (ResultString, "string"),
+    (ResultDataSet, "dataset"),
+    (ResultRerun, "rerun"),
+    (ResultContainer, "container"),
+    (ResultHmap, "hmap"),
+    (ResultReference, "reference"),
+    (ResultVolume, "volume"),
+)
+
+
+def result_kind(result_var) -> str:
+    """Classify a result variable into a coarse, serializable kind name used by
+    plot-selection signatures (A2)."""
+    for cls, kind in RESULT_KIND_ORDER:
+        if isinstance(result_var, cls):
+            return kind
+    return "unknown"
+
 
 # --- Missing / unrecorded-sample representation ----------------------------
 #

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -29,10 +29,10 @@ def inner_element(overlay):
     return items[0]
 
 
-def run_cfg_with(repeats: int) -> bn.BenchRunCfg:
+def run_cfg_with(repeats: int, **kwargs) -> bn.BenchRunCfg:
     """A BenchRunCfg with caching and auto-plot disabled for the given repeat count."""
     return bn.BenchRunCfg(
-        repeats=repeats, cache_results=False, cache_samples=False, auto_plot=False
+        repeats=repeats, cache_results=False, cache_samples=False, auto_plot=False, **kwargs
     )
 
 

--- a/test/test_plt_cnt_cfg_signature.py
+++ b/test/test_plt_cnt_cfg_signature.py
@@ -1,0 +1,115 @@
+"""Tests for the enriched plot-selection signature fields on PltCntCfg (A2 Phase S1).
+
+Each new field (has_time, time_steps, result_kinds, cat_levels, samples_per_point)
+is asserted on small synthetic sweeps; the existing counts must be unchanged.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+
+import bencher as bn
+from bencher.plotting.plt_cnt_cfg import PltCntCfg, result_kind, _samples_per_point
+
+
+class CatFloat(bn.ParametrizedSweep):
+    kind = bn.StringSweep(["a", "b", "c"])
+    x = bn.FloatSweep(default=0, bounds=[0, 2], samples=3)
+    value = bn.ResultFloat(units="m")
+    ok = bn.ResultBool()
+
+    def benchmark(self):
+        self.value = self.x * (2.0 if self.kind == "a" else 3.0)
+        self.ok = self.value > 1.0
+
+
+def run_sweep(repeats: int = 1, over_time: bool = False, run_cfg_kwargs=None):
+    bench = bn.Bench("test_plt_cnt_cfg_signature", CatFloat())
+    return bench.plot_sweep(
+        "sweep",
+        input_vars=[CatFloat.param.kind, CatFloat.param.x],
+        result_vars=[CatFloat.param.value, CatFloat.param.ok],
+        run_cfg=bn.BenchRunCfg(
+            repeats=repeats, over_time=over_time, auto_plot=False, **(run_cfg_kwargs or {})
+        ),
+    )
+
+
+class TestSignatureFields(unittest.TestCase):
+    def test_counts_unchanged(self):
+        cfg = run_sweep().plt_cnt_cfg
+        self.assertEqual(cfg.float_cnt, 1)
+        self.assertEqual(cfg.cat_cnt, 1)
+        self.assertEqual(cfg.panel_cnt, 0)
+        self.assertEqual(cfg.inputs_cnt, 2)
+
+    def test_result_kinds(self):
+        cfg = run_sweep().plt_cnt_cfg
+        self.assertEqual(cfg.result_kinds, {"value": "float", "ok": "bool"})
+
+    def test_cat_levels(self):
+        cfg = run_sweep().plt_cnt_cfg
+        self.assertEqual(cfg.cat_levels, {"kind": 3})
+
+    def test_no_time(self):
+        cfg = run_sweep().plt_cnt_cfg
+        self.assertFalse(cfg.has_time)
+        self.assertEqual(cfg.time_steps, 0)
+
+    def test_over_time(self):
+        res = run_sweep(over_time=True)
+        cfg = res.plt_cnt_cfg
+        self.assertTrue(cfg.has_time)
+        # over_time accumulates history across (cached) runs, so assert consistency
+        # with the dataset rather than an absolute count.
+        self.assertEqual(cfg.time_steps, res.ds.sizes["over_time"])
+        self.assertGreaterEqual(cfg.time_steps, 1)
+
+    def test_samples_per_point_full(self):
+        cfg = run_sweep(repeats=2).plt_cnt_cfg
+        self.assertEqual(cfg.samples_per_point, 2)
+        self.assertEqual(cfg.repeats, 2)
+
+    def test_no_dataset_defaults(self):
+        res = run_sweep()
+        cfg = PltCntCfg.generate_plt_cnt_cfg(res.bench_cfg)
+        self.assertEqual(cfg.time_steps, 0)
+        self.assertEqual(cfg.samples_per_point, 0)
+        # config-derived fields are still populated without a dataset
+        self.assertEqual(cfg.cat_levels, {"kind": 3})
+        self.assertEqual(cfg.result_kinds, {"value": "float", "ok": "bool"})
+
+
+class TestSamplesPerPoint(unittest.TestCase):
+    def test_nan_holes_reduce_count(self):
+        data = np.ones((2, 3))
+        data[0, 1] = np.nan  # one missing repeat at one sweep point
+        ds = xr.Dataset({"value": (("x", "repeat"), data)})
+        self.assertEqual(_samples_per_point(ds), 2)
+        data[1, 1] = np.nan
+        data[1, 2] = np.nan
+        ds = xr.Dataset({"value": (("x", "repeat"), data)})
+        self.assertEqual(_samples_per_point(ds), 1)
+
+    def test_no_repeat_dim(self):
+        ds = xr.Dataset({"value": (("x",), np.ones(3))})
+        self.assertEqual(_samples_per_point(ds), 1)
+
+    def test_empty_dataset(self):
+        self.assertEqual(_samples_per_point(xr.Dataset()), 0)
+
+
+class TestResultKind(unittest.TestCase):
+    def test_kind_order(self):
+        self.assertEqual(result_kind(bn.ResultBool()), "bool")
+        self.assertEqual(result_kind(bn.ResultFloat()), "float")
+        self.assertEqual(result_kind(bn.ResultImage()), "image")
+        self.assertEqual(result_kind(bn.ResultVideo()), "video")
+        self.assertEqual(result_kind(bn.ResultString()), "string")
+        self.assertEqual(result_kind(bn.ResultContainer()), "container")
+        self.assertEqual(result_kind(object()), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_plt_cnt_cfg_signature.py
+++ b/test/test_plt_cnt_cfg_signature.py
@@ -14,6 +14,7 @@ import bencher as bn
 from bencher.bench_cfg import BenchCfg
 from bencher.plotting.plt_cnt_cfg import PltCntCfg, result_kind, _samples_per_point
 from bencher.variables.time import TimeEvent, TimeSnapshot
+from test.helpers import run_cfg_with
 
 
 class CatFloat(bn.ParametrizedSweep):
@@ -27,15 +28,14 @@ class CatFloat(bn.ParametrizedSweep):
         self.ok = self.value > 1.0
 
 
-def run_sweep(repeats: int = 1, over_time: bool = False, run_cfg_kwargs=None):
+def run_sweep(repeats: int = 1, over_time: bool = False):
     bench = bn.Bench("test_plt_cnt_cfg_signature", CatFloat())
+    # clear_history keeps over_time runs hermetic: exactly one snapshot per test run
     return bench.plot_sweep(
         "sweep",
         input_vars=[CatFloat.param.kind, CatFloat.param.x],
         result_vars=[CatFloat.param.value, CatFloat.param.ok],
-        run_cfg=bn.BenchRunCfg(
-            repeats=repeats, over_time=over_time, auto_plot=False, **(run_cfg_kwargs or {})
-        ),
+        run_cfg=run_cfg_with(repeats, over_time=over_time, clear_history=over_time),
     )
 
 
@@ -64,10 +64,9 @@ class TestSignatureFields(unittest.TestCase):
         res = run_sweep(over_time=True)
         cfg = res.plt_cnt_cfg
         self.assertTrue(cfg.has_time)
-        # over_time accumulates history across (cached) runs, so assert consistency
-        # with the dataset rather than an absolute count.
+        # clear_history=True makes this the first snapshot: exactly one time step
+        self.assertEqual(cfg.time_steps, 1)
         self.assertEqual(cfg.time_steps, res.ds.sizes["over_time"])
-        self.assertGreaterEqual(cfg.time_steps, 1)
 
     def test_samples_per_point_full(self):
         cfg = run_sweep(repeats=2).plt_cnt_cfg
@@ -124,6 +123,32 @@ class TestSamplesPerPoint(unittest.TestCase):
         self.assertIn("repeat", ds.dims)
         self.assertEqual(_samples_per_point(ds), 1)
 
+    def test_zero_size_dim(self):
+        # a zero-size sweep dim leaves no points to count: 0, not a ValueError
+        # from reducing an empty array
+        ds = xr.Dataset({"value": (("x", "repeat"), np.ones((0, 3)))})
+        self.assertEqual(_samples_per_point(ds), 0)
+
+    def test_sentinel_missing_counted(self):
+        # object-backed result types store misses as the "NAN" sentinel, which
+        # notnull() would count as present; the per-variable sentinel must not
+        img = bn.ResultImage()
+        img.name = "img"
+        data = np.array([["a.png", "b.png", "NAN"]], dtype=object)
+        ds = xr.Dataset({"img": (("x", "repeat"), data)})
+        self.assertEqual(_samples_per_point(ds, [img]), 2)
+        # without the result var to identify the sentinel, NaN is all we can test
+        self.assertEqual(_samples_per_point(ds), 3)
+
+    def test_over_time_history_padding_ignored(self):
+        # when repeats grow between over_time runs, historical steps are NaN-padded;
+        # only the latest step reflects the current run's samples
+        data = np.full((2, 2, 3), np.nan)
+        data[1] = 1.0  # latest step: full repeat coverage
+        data[0, :, 0] = 1.0  # historical step recorded with repeats=1
+        ds = xr.Dataset({"value": (("over_time", "x", "repeat"), data)})
+        self.assertEqual(_samples_per_point(ds), 3)
+
     def test_empty_dataset(self):
         self.assertEqual(_samples_per_point(xr.Dataset()), 0)
 
@@ -137,6 +162,11 @@ class TestResultKind(unittest.TestCase):
         self.assertEqual(result_kind(bn.ResultString()), "string")
         self.assertEqual(result_kind(bn.ResultContainer()), "container")
         self.assertEqual(result_kind(object()), "unknown")
+
+    def test_rerun_kind_before_container(self):
+        from bencher.variables.results import ResultRerun
+
+        self.assertEqual(result_kind(ResultRerun()), "rerun")
 
 
 if __name__ == "__main__":

--- a/test/test_plt_cnt_cfg_signature.py
+++ b/test/test_plt_cnt_cfg_signature.py
@@ -5,12 +5,15 @@ is asserted on small synthetic sweeps; the existing counts must be unchanged.
 """
 
 import unittest
+from datetime import datetime
 
 import numpy as np
 import xarray as xr
 
 import bencher as bn
+from bencher.bench_cfg import BenchCfg
 from bencher.plotting.plt_cnt_cfg import PltCntCfg, result_kind, _samples_per_point
+from bencher.variables.time import TimeEvent, TimeSnapshot
 
 
 class CatFloat(bn.ParametrizedSweep):
@@ -74,11 +77,29 @@ class TestSignatureFields(unittest.TestCase):
     def test_no_dataset_defaults(self):
         res = run_sweep()
         cfg = PltCntCfg.generate_plt_cnt_cfg(res.bench_cfg)
+        self.assertFalse(cfg.has_time)
         self.assertEqual(cfg.time_steps, 0)
         self.assertEqual(cfg.samples_per_point, 0)
         # config-derived fields are still populated without a dataset
         self.assertEqual(cfg.cat_levels, {"kind": 3})
         self.assertEqual(cfg.result_kinds, {"value": "float", "ok": "bool"})
+
+    def test_time_inputs_without_over_time(self):
+        # TimeSnapshot/TimeEvent inputs are injected by the framework when over_time
+        # is set, so build the config directly to isolate the input-var path:
+        # has_time derives purely from the config, and time_steps stays 0 because
+        # there is no over_time axis (no dataset at all here).
+        for time_var in (TimeSnapshot(datetime(2026, 1, 1)), TimeEvent("v1.0")):
+            time_var.name = "time"
+            bench_cfg = BenchCfg(
+                input_vars=[time_var],
+                result_vars=[CatFloat.param.value],
+                over_time=False,
+            )
+            cfg = PltCntCfg.generate_plt_cnt_cfg(bench_cfg)
+            self.assertTrue(cfg.has_time)
+            self.assertEqual(cfg.time_steps, 0)
+            self.assertEqual(cfg.result_kinds, {"value": "float"})
 
 
 class TestSamplesPerPoint(unittest.TestCase):
@@ -94,6 +115,13 @@ class TestSamplesPerPoint(unittest.TestCase):
 
     def test_no_repeat_dim(self):
         ds = xr.Dataset({"value": (("x",), np.ones(3))})
+        self.assertEqual(_samples_per_point(ds), 1)
+
+    def test_repeat_dim_without_repeat_vars(self):
+        # a structural repeat axis whose data vars don't carry it behaves the same
+        # as no repeat axis at all: one sample per point, not "no samples"
+        ds = xr.Dataset({"value": (("x",), np.ones(3))}, coords={"repeat": [1, 2]})
+        self.assertIn("repeat", ds.dims)
         self.assertEqual(_samples_per_point(ds), 1)
 
     def test_empty_dataset(self):


### PR DESCRIPTION
## Summary

First phase of the A2 plot-selection redesign (`plans/architecture/A2-plot-selection-redesign.md`): extend `PltCntCfg` with richer, cheaply-computable signature facts, **additive only** — the existing counts and all `PlotFilter` matching are unchanged.

New fields:

| Field | Meaning | Source |
|---|---|---|
| `has_time` | sweep has a temporal axis | `over_time` flag or a `TimeSnapshot`/`TimeEvent` input var |
| `time_steps` | time points present in the data | `ds.sizes["over_time"]` (0 = no axis) |
| `result_kinds` | result var name → coarse kind (`float`, `bool`, `vec`, `image`, `video`, `path`, `string`, `dataset`, `container`, ...) | most-derived-first isinstance classification (`result_kind()`) |
| `cat_levels` | categorical input name → number of levels | `len(var.values())` |
| `samples_per_point` | repeats **actually present** (min non-NaN count over the `repeat` dim) | dataset; differs from configured `repeats` when runs are missing |

`generate_plt_cnt_cfg` gains an optional `ds` parameter for the data-derived facts; `post_setup` now passes the collected dataset. Without a dataset the fields stay at their defaults, so all existing construction sites keep working.

These are the hooks A2 S2–S4 build on (kills the hand-wired `over_time` branch, lets heatmap demote itself on 50-level categoricals, etc.).

## Verification

- 11 new unit tests (`test/test_plt_cnt_cfg_signature.py`) asserting each field on small synthetic sweeps, NaN-hole handling for `samples_per_point`, and kind-classification order (ResultBool before ResultFloat, etc.)
- Full suite locally: unchanged vs main (same pass set; the 2 `test_result_collector` dtype failures reproduce on origin/main in my env)
- prek `--all-files` green; pylint errors-only 10.00

Note: no version bump yet — changelog entry sits under `[Unreleased]`; will re-version once #973 (1.114.0) lands to avoid churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enrich PltCntCfg with additional plot-selection signature metadata derived from bench configuration and datasets while preserving existing count-based behavior.

New Features:
- Add new PltCntCfg fields for temporal presence and length, result variable kinds, categorical level counts, and actual samples per sweep point.
- Expose a coarse result-kind classification helper for use in plot-selection signatures.

Enhancements:
- Allow generate_plt_cnt_cfg to accept an optional result dataset to compute data-derived signature facts.
- Extend bench_result_base post-setup to propagate the collected dataset into PltCntCfg generation.

Documentation:
- Update the changelog under Unreleased to describe the new plot-selection signature enrichment.

Tests:
- Add unit tests covering the new PltCntCfg signature fields, result-kind classification ordering, and samples-per-point computation including NaN handling.