### PR TITLE
A2 Phase S2: selection decision table — registry.explain() + BenchResult.explain_selection()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`BenchResult.explain_selection()` / `PluginRegistry.explain()`** (A2 Phase S2): the full plot-selection decision table — one row per registered plugin, chosen entries first, each rejected entry carrying the first gate that dropped it (named-only, not in `plot_list`, excluded, missing capability, shape-filter mismatch, superseded backend resolution). `select()` is now exactly the chosen subset of `explain()`, so the table is the authoritative record of why a plot did or did not appear.
+
 ## [1.114.0] - 2026-07-06
 
 ### Added

--- a/bencher/plugins/__init__.py
+++ b/bencher/plugins/__init__.py
@@ -18,7 +18,9 @@ from bencher.plugins.bench_data import BenchData, CacheHandle, RunMeta
 from bencher.plugins.plugin import PlotPlugin, plot_plugin
 from bencher.plugins.registry import (
     ENTRY_POINT_GROUP,
+    PluginDecision,
     PluginRegistry,
+    decisions_to_table,
     get_registry,
     register_plugin,
     unregister_plugin,
@@ -30,7 +32,9 @@ __all__ = [
     "ENTRY_POINT_GROUP",
     "PlotFilter",
     "PlotPlugin",
+    "PluginDecision",
     "PluginRegistry",
+    "decisions_to_table",
     "RunMeta",
     "VarRange",
     "get_registry",

--- a/bencher/plugins/registry.py
+++ b/bencher/plugins/registry.py
@@ -33,12 +33,12 @@ def decisions_to_table(decisions: Iterable[PluginDecision]) -> str:
     text table, chosen rows first."""
     rows = [("chart type", "backend", "chosen", "reason")]
     rows += [(d.name, d.backend, "yes" if d.chosen else "no", d.reason) for d in decisions]
-    widths = [max(len(r[i]) for r in rows) for i in range(3)]
+    widths = [max(len(r[i]) for r in rows) for i in range(4)]
     lines = [
-        f"| {r[0]:<{widths[0]}} | {r[1]:<{widths[1]}} | {r[2]:<{widths[2]}} | {r[3]} |"
+        f"| {r[0]:<{widths[0]}} | {r[1]:<{widths[1]}} | {r[2]:<{widths[2]}} | {r[3]:<{widths[3]}} |"
         for r in rows
     ]
-    lines.insert(1, "|" + "|".join("-" * (w + 2) for w in widths) + "|" + "-" * 8 + "|")
+    lines.insert(1, "|" + "|".join("-" * (w + 2) for w in widths) + "|")
     return "\n".join(lines)
 
 
@@ -265,13 +265,16 @@ class PluginRegistry:
             winner = max(pool, key=lambda p: (p.priority, p.backend))
             picked_plugins.append(winner)
             for plugin in impls:
-                if plugin is not winner:
+                if plugin is winner:
+                    continue
+                if backend and winner.backend == backend and plugin.backend != backend:
+                    why = f"backend {backend!r} preferred over {plugin.backend!r}"
+                else:
                     why = (
-                        f"backend {winner.backend!r} preferred"
-                        if backend == winner.backend and plugin.backend != backend
-                        else f"lower priority than {winner.backend!r} implementation"
+                        f"lower priority ({plugin.priority}) than {winner.backend!r} "
+                        f"implementation (priority={winner.priority})"
                     )
-                    reject(plugin, f"superseded for chart type {plugin.name!r}: {why}")
+                reject(plugin, f"superseded for chart type {plugin.name!r}: {why}")
 
         picked_plugins.sort(key=lambda p: (-p.priority, p.name))
         chosen = [

--- a/bencher/plugins/registry.py
+++ b/bencher/plugins/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import traceback
+from dataclasses import dataclass, field
 from importlib import metadata
 from typing import Iterable, Optional
 
@@ -13,6 +14,32 @@ from bencher.plugins.plugin import PlotPlugin
 ENTRY_POINT_GROUP = "bencher.plot_plugins"
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PluginDecision:
+    """One row of a selection decision table: whether a plugin was chosen for a
+    given BenchData, and the first gate that rejected it when it wasn't."""
+
+    name: str
+    backend: str
+    chosen: bool
+    reason: str
+    plugin: PlotPlugin = field(repr=False)
+
+
+def decisions_to_table(decisions: Iterable[PluginDecision]) -> str:
+    """Render a decision table (from ``PluginRegistry.explain``) as a markdown-ish
+    text table, chosen rows first."""
+    rows = [("chart type", "backend", "chosen", "reason")]
+    rows += [(d.name, d.backend, "yes" if d.chosen else "no", d.reason) for d in decisions]
+    widths = [max(len(r[i]) for r in rows) for i in range(3)]
+    lines = [
+        f"| {r[0]:<{widths[0]}} | {r[1]:<{widths[1]}} | {r[2]:<{widths[2]}} | {r[3]} |"
+        for r in rows
+    ]
+    lines.insert(1, "|" + "|".join("-" * (w + 2) for w in widths) + "|" + "-" * 8 + "|")
+    return "\n".join(lines)
 
 
 def _render_error_pane(plugin_name: str, exc: BaseException) -> pn.viewable.Viewable:
@@ -152,42 +179,106 @@ class PluginRegistry:
           best other implementation. This is what lets a config flag swap the
           rendering library under the same set of plotters.
         """
+        return tuple(
+            d.plugin
+            for d in self.explain(
+                data, include=include, exclude=exclude, backend=backend, only=only
+            )
+            if d.chosen
+        )
+
+    def explain(
+        self,
+        data: BenchData,
+        *,
+        include: Optional[Iterable[str]] = None,
+        exclude: Optional[Iterable[str]] = None,
+        backend: Optional[str] = None,
+        only: Optional[str] = None,
+    ) -> tuple[PluginDecision, ...]:
+        """The full selection decision table: one entry per registered plugin, chosen
+        entries first (in `select()` order — descending priority, then name), each
+        rejected entry carrying the first gate that dropped it. `select()` is exactly
+        the chosen subset, so this is the authoritative record of why a plot did or
+        did not appear (A2 Phase S2)."""
+        chosen: list[PluginDecision] = []
+        rejected: list[PluginDecision] = []
+
+        def reject(plugin: PlotPlugin, reason: str) -> None:
+            rejected.append(PluginDecision(plugin.name, plugin.backend, False, reason, plugin))
+
         if only is not None:
             picked = self.get(only, backend) or self.get(only)
-            return (picked,) if picked is not None else ()
+            for plugin in self.all():
+                if plugin is picked:
+                    chosen.append(
+                        PluginDecision(
+                            plugin.name,
+                            plugin.backend,
+                            True,
+                            f"explicitly requested (only={only!r}; filters bypassed)",
+                            plugin,
+                        )
+                    )
+                else:
+                    reject(plugin, f"not requested (only={only!r})")
+            return tuple(chosen + rejected)
 
-        candidates = list(self.all())
-        if include is not None:
-            inc = set(include)
-            candidates = [p for p in candidates if p.name in inc]
-        else:
-            candidates = [p for p in candidates if getattr(p, "auto", True)]
-        if exclude is not None:
-            exc = set(exclude)
-            candidates = [p for p in candidates if p.name not in exc]
+        inc = set(include) if include is not None else None
+        exc = set(exclude) if exclude is not None else set()
 
         matched: list[PlotPlugin] = []
-        for plugin in candidates:
-            if not all(data.has(cap) for cap in plugin.requires):
+        for plugin in self.all():
+            if inc is not None and plugin.name not in inc:
+                reject(plugin, "not named in include/plot_list")
+                continue
+            if inc is None and not getattr(plugin, "auto", True):
+                reject(plugin, "named-only (auto=False): request explicitly by name")
+                continue
+            if plugin.name in exc:
+                reject(plugin, "excluded by name")
+                continue
+            missing = [cap for cap in plugin.requires if not data.has(cap)]
+            if missing:
+                reject(plugin, f"missing capability: {', '.join(sorted(missing))}")
                 continue
             if data.plt_cnt_cfg is None:
+                reject(plugin, "no plot signature (plt_cnt_cfg missing)")
                 continue
             result = plugin.match.matches_result(data.plt_cnt_cfg, plugin.name, override=False)
-            if result.overall:
-                matched.append(plugin)
+            if not result.overall:
+                failed = "; ".join(
+                    line.strip() for line in result.matches_info.splitlines()[1:]
+                ).replace("\t", " ")
+                reject(plugin, f"shape filter mismatch: {failed}")
+                continue
+            matched.append(plugin)
 
         # Resolve each chart type to one implementation.
         by_name: dict[str, list[PlotPlugin]] = {}
         for plugin in matched:
             by_name.setdefault(plugin.name, []).append(plugin)
-        chosen: list[PlotPlugin] = []
+        picked_plugins: list[PlotPlugin] = []
         for impls in by_name.values():
             preferred = [p for p in impls if p.backend == backend] if backend else []
             pool = preferred or impls
-            chosen.append(max(pool, key=lambda p: (p.priority, p.backend)))
+            winner = max(pool, key=lambda p: (p.priority, p.backend))
+            picked_plugins.append(winner)
+            for plugin in impls:
+                if plugin is not winner:
+                    why = (
+                        f"backend {winner.backend!r} preferred"
+                        if backend == winner.backend and plugin.backend != backend
+                        else f"lower priority than {winner.backend!r} implementation"
+                    )
+                    reject(plugin, f"superseded for chart type {plugin.name!r}: {why}")
 
-        chosen.sort(key=lambda p: (-p.priority, p.name))
-        return tuple(chosen)
+        picked_plugins.sort(key=lambda p: (-p.priority, p.name))
+        chosen = [
+            PluginDecision(p.name, p.backend, True, f"chosen (priority={p.priority})", p)
+            for p in picked_plugins
+        ]
+        return tuple(chosen + rejected)
 
     def render(
         self,

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -39,7 +39,7 @@ from bencher.results.histogram_result import HistogramResult
 from bencher.results.optuna_result import OptunaResult
 from bencher.results.dataset_result import DataSetResult
 from bencher.plugins.bench_data import BenchData, RunMeta
-from bencher.plugins.registry import get_registry
+from bencher.plugins.registry import get_registry, decisions_to_table
 from bencher.plugins.builtins import (
     CALLBACK_TO_PLUGIN,
     PANES_PLUGIN_NAME,
@@ -266,6 +266,33 @@ class BenchResult(
         if len(row.pane) == 0:
             row.append(pn.pane.Markdown("No Plotters are able to represent these results"))
         return row.pane
+
+    def explain_selection(
+        self,
+        plot_list: list[callable | str] | None = None,
+        remove_plots: list[callable | str] | None = None,
+        numeric_only: bool = False,
+        backend: str | None = None,
+    ) -> str:
+        """Why each registered plugin would or wouldn't render for this result.
+
+        Runs the same selection `to_auto` uses (same plot_list/remove_plots
+        normalization) and renders the full decision table — chosen plugins first,
+        each rejected one with the first gate that dropped it (named-only, missing
+        capability, shape-filter mismatch, superseded backend, ...).
+
+        Returns:
+            str: A text table, one row per registered plugin.
+        """
+        include_names, _ = self._normalize_plot_list(listify(plot_list))
+        exclude_names, _ = self._plot_exclusions(listify(remove_plots), [], numeric_only)
+        decisions = get_registry().explain(
+            self.to_bench_data(),
+            include=include_names,
+            exclude=exclude_names or None,
+            backend=backend,
+        )
+        return decisions_to_table(decisions)
 
     @staticmethod
     def _normalize_plot_list(

--- a/test/test_explain_selection.py
+++ b/test/test_explain_selection.py
@@ -1,0 +1,150 @@
+"""Tests for the selection decision table (A2 Phase S2): registry.explain() and
+BenchResult.explain_selection(). select() must be exactly the chosen subset."""
+
+import unittest
+
+import bencher as bn
+from bencher.plugins import (
+    PlotFilter,
+    VarRange,
+    get_registry,
+    plot_plugin,
+    unregister_plugin,
+)
+from bencher.results.bench_result import BenchResult
+
+
+class Linear(bn.ParametrizedSweep):
+    x = bn.FloatSweep(default=0, bounds=[0, 2], samples=3)
+    value = bn.ResultFloat(units="m")
+
+    def benchmark(self):
+        self.value = self.x * 2.0
+
+
+class Cat(bn.ParametrizedSweep):
+    kind = bn.StringSweep(["a", "b"])
+    value = bn.ResultFloat(units="m")
+
+    def benchmark(self):
+        self.value = 2.0 if self.kind == "a" else 3.0
+
+
+class TwoFloat(bn.ParametrizedSweep):
+    x = bn.FloatSweep(default=0, bounds=[0, 2], samples=3)
+    y = bn.FloatSweep(default=0, bounds=[0, 2], samples=3)
+    value = bn.ResultFloat(units="m")
+
+    def benchmark(self):
+        self.value = self.x * self.y
+
+
+def run_sweep(sweep_cls, input_vars, repeats=1) -> BenchResult:
+    bench = bn.Bench("test_explain_selection", sweep_cls())
+    return bench.plot_sweep(
+        "sweep",
+        input_vars=input_vars,
+        result_vars=[sweep_cls.param.value],
+        run_cfg=bn.BenchRunCfg(repeats=repeats, auto_plot=False),
+    )
+
+
+class TestExplainMatchesSelect(unittest.TestCase):
+    """The chosen subset of explain() must equal select(), for the three canonical
+    sweep shapes, with and without selection filters."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.results = {
+            "1_float": run_sweep(Linear, [Linear.param.x]),
+            "1_cat_repeats": run_sweep(Cat, [Cat.param.kind], repeats=2),
+            "2_float": run_sweep(TwoFloat, [TwoFloat.param.x, TwoFloat.param.y]),
+        }
+
+    def assert_explain_matches_select(self, data, **kwargs):
+        reg = get_registry()
+        selected = [(p.name, p.backend) for p in reg.select(data, **kwargs)]
+        chosen = [(d.name, d.backend) for d in reg.explain(data, **kwargs) if d.chosen]
+        self.assertEqual(chosen, selected)
+
+    def test_parity_across_shapes_and_filters(self):
+        for shape, res in self.results.items():
+            data = res.to_bench_data()
+            with self.subTest(shape=shape):
+                self.assert_explain_matches_select(data)
+                self.assert_explain_matches_select(data, include=["line", "violin"])
+                self.assert_explain_matches_select(data, exclude=["line"])
+                self.assert_explain_matches_select(data, only="table")
+                self.assert_explain_matches_select(data, backend="holoviews")
+
+    def test_every_plugin_gets_a_decision(self):
+        reg = get_registry()
+        data = self.results["1_float"].to_bench_data()
+        decisions = reg.explain(data)
+        self.assertEqual(len(decisions), len(list(reg.all())))
+        self.assertTrue(all(d.reason for d in decisions))
+
+    def test_rejection_reasons(self):
+        reg = get_registry()
+        data = self.results["1_float"].to_bench_data()
+        by_name = {d.name: d for d in reg.explain(data)}
+        violin = by_name["violin"]  # named-only builtin
+        self.assertFalse(violin.chosen)
+        self.assertIn("named-only", violin.reason)
+        line = by_name["line"]
+        self.assertTrue(line.chosen)
+
+    def test_shape_filter_rejection_reason(self):
+        """Built-ins register match_all (shape gating still lives inside to_plot),
+        so use a plugin with an honest filter to exercise the mismatch reason."""
+
+        @plot_plugin(
+            name="needs_two_floats",
+            backend="test",
+            match=PlotFilter(
+                float_range=VarRange(2, 2),
+                cat_range=VarRange(0, None),
+                repeats_range=VarRange(1, None),
+                input_range=VarRange(1, None),
+            ),
+        )
+        def _two_floats(_: object):
+            return None
+
+        try:
+            data = self.results["1_float"].to_bench_data()
+            by_name = {d.name: d for d in get_registry().explain(data)}
+            decision = by_name["needs_two_floats"]
+            self.assertFalse(decision.chosen)
+            self.assertIn("shape filter mismatch", decision.reason)
+            self.assertIn("float", decision.reason)
+            # and on a matching shape it is chosen
+            data2 = self.results["2_float"].to_bench_data()
+            by_name2 = {d.name: d for d in get_registry().explain(data2)}
+            self.assertTrue(by_name2["needs_two_floats"].chosen)
+        finally:
+            unregister_plugin("needs_two_floats")
+
+    def test_only_reasons(self):
+        reg = get_registry()
+        data = self.results["1_float"].to_bench_data()
+        decisions = reg.explain(data, only="table")
+        chosen = [d for d in decisions if d.chosen]
+        self.assertEqual([d.name for d in chosen], ["table"])
+        self.assertIn("only", chosen[0].reason)
+
+
+class TestExplainFacade(unittest.TestCase):
+    def test_explain_selection_table(self):
+        res = run_sweep(Linear, [Linear.param.x])
+        table = res.explain_selection()
+        self.assertIn("chart type", table)
+        self.assertIn("line", table)
+        self.assertIn("named-only", table)  # violin et al. appear with their reason
+        # plot_list entries go through the same normalization as to_auto
+        table_named = res.explain_selection(plot_list=["violin"])
+        self.assertIn("not named in include", table_named)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_explain_selection.py
+++ b/test/test_explain_selection.py
@@ -129,9 +129,20 @@ class TestExplainMatchesSelect(unittest.TestCase):
         reg = get_registry()
         data = self.results["1_float"].to_bench_data()
         decisions = reg.explain(data, only="table")
+
+        # chosen plugin still reports the "only" reason
         chosen = [d for d in decisions if d.chosen]
         self.assertEqual([d.name for d in chosen], ["table"])
         self.assertIn("only", chosen[0].reason)
+
+        # rejected plugins should report the "not requested (only=...)" message
+        rejected = [d for d in decisions if not d.chosen]
+        self.assertTrue(
+            rejected,
+            msg="Expected at least one rejected plugin when using only='table'",
+        )
+        for r in rejected:
+            self.assertIn("not requested (only=", r.reason)
 
 
 class TestExplainFacade(unittest.TestCase):


### PR DESCRIPTION
## Summary

Second phase of the A2 plot-selection redesign: make selection *explainable* without executing renderers, fixing P2 ("nothing can answer 'what would render for this sweep?'") and the selection half of P5 (silent drops).

- `PluginRegistry.explain(data, include/exclude/backend/only)` returns one `PluginDecision` per registered plugin — chosen entries first (identical order to `select()`), each rejected entry carrying the **first gate that dropped it**: not named in `plot_list`/include, named-only (`auto=False`), excluded, missing capability, no plot signature, shape-filter mismatch (with the failing ranges), or superseded during backend resolution.
- `select()` is reimplemented as exactly the chosen subset of `explain()` — one selection code path, so the table can never drift from reality. Existing selection tests all pass unchanged.
- `BenchResult.explain_selection(plot_list=..., remove_plots=..., numeric_only=..., backend=...)` renders the table as text through the **same** plot_list normalization `to_auto` uses.
- `PluginDecision` + `decisions_to_table` exported from `bencher.plugins`.

Example (1-float sweep):
```
| chart type | backend   | chosen | reason |
|------------|-----------|--------|--------|
| line       | holoviews | yes    | chosen (priority=85) |
| violin     | holoviews | no     | named-only (auto=False): request explicitly by name |
...
```

Note: the built-ins register `match_all` (their shape gating still lives inside `to_plot` — legacy), so today their rejections show up as named-only/exclusion gates only; the shape-mismatch reason becomes fully informative as A2 S3/S4 lift the internal filters into declarative registry signatures.

## Verification
- New `test/test_explain_selection.py`: explain↔select parity across 3 canonical sweep shapes × {no filter, include, exclude, only, backend}; every registered plugin gets a decision; named-only/shape-mismatch/only reasons asserted (shape mismatch via an honestly-filtered temp plugin)
- Plugin suites + split-render guards + full suite locally: unchanged vs main
- prek `--all-files` green

Builds on #973; changelog under `[Unreleased]` (no version bump yet, same as #983).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an explainable plot selection decision table and expose it via registry and bench results.

New Features:
- Add PluginRegistry.explain() to return a full selection decision table for all registered plugins.
- Add BenchResult.explain_selection() to surface the selection decision table for a given result using existing plot-list normalization.
- Expose PluginDecision and decisions_to_table from the plugins package for rendering decision tables.

Enhancements:
- Refactor PluginRegistry.select() to be defined as the chosen subset of explain(), ensuring selection behavior and explanations stay in sync.

Documentation:
- Document the new explainable selection APIs in the changelog under the Unreleased section.

Tests:
- Add tests verifying explain() and select() parity across sweep shapes and selection filters, decision coverage for all plugins, rejection reason correctness, and the BenchResult.explain_selection() facade.