### PR TITLE
Implement plans 09+14: schema-evolving over_time history (retain+projection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.114.0] - 2026-07-06
+
+### Changed — cache-busting release (`CACHE_VERSION` 4 → 5)
+
+Every benchmark-level and `over_time` history cache key changes in this
+release: expect a one-time cache miss and a fresh history series per the
+standing cache policy (no migration of old entries). Implements plans 09 and
+14 (`plans/09-result-cache-invalidation.md`,
+`plans/14-history-schema-reconciliation.md`).
+
+- **`BenchCfg.hash_persistent` composition** (plan 09):
+  - `result_vars` and `const_vars` now contribute as an *unordered set* —
+    reordering either no longer resets caches or history (D1).
+  - Every per-variable identity (input, result, const) now includes the
+    variable's **name** — renaming a variable is a detected identity change
+    instead of a silent history split or phantom-dimension broadcast (D2).
+- **`over_time` history survives result-variable changes** (plan 14): the
+  history cache is keyed *without* result vars
+  (`hash_persistent(True, include_result_vars=False)`) and stores a superset
+  record of every column ever measured. At load time, columns are reconciled
+  per identity `(name, class, units, meaning_version)` — added columns are
+  NaN-backfilled and birth-stamped, removed columns go dormant (retained,
+  invisible, resumed on return), redefined columns are retired under a mangled
+  name and restart — and consumers receive a projection onto exactly the
+  current config's columns. The benchmark-level result cache stays strict.
+
+### Added
+
+- **`meaning_version`** on `ResultFloat`/`ResultBool` — bump it when a metric
+  keeps its name but changes meaning; that column's history and regression
+  baseline restart cleanly while every other column continues.
+- **`BenchRunCfg.on_history_reset`** (`"warn"` default / `"error"` /
+  `"ignore"`) — loss-y history events (full reset with a named diff and
+  orphaned-event count via a per-benchmark last-seen index, column dormant,
+  column retired, incompatible history discarded) are logged, raised
+  (`bencher.HistoryResetError`, before any state is persisted), or suppressed.
+- **`BenchRunCfg.regression_min_history`** (default 1 = previous behavior) —
+  regressions on a baseline younger than N points since the column's birth are
+  reported and exported (`young_baseline: true` in `result.json`,
+  `RegressionReport.has_blocking_regressions`) but never trigger
+  `regression_fail`; history-free `absolute` checks still gate. Per-variable
+  override via a `min_history` key in `regression_overrides`.
+
 ## [1.113.1] - 2026-07-06
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,18 @@ standing cache policy (no migration of old entries). Implements plans 09 and
   orphaned-event count via a per-benchmark last-seen index, column dormant,
   column retired, incompatible history discarded) are logged, raised
   (`bencher.HistoryResetError`, before any state is persisted), or suppressed.
+  Pre-record (bare-dataset) history entries participate in the same lifecycle:
+  a column they carry that leaves the config is reported dormant, and it
+  resumes rather than restarts when it returns.
 - **`BenchRunCfg.regression_min_history`** (default 1 = previous behavior) —
   regressions on a baseline younger than N points since the column's birth are
   reported and exported (`young_baseline: true` in `result.json`,
   `RegressionReport.has_blocking_regressions`) but never trigger
   `regression_fail`; history-free `absolute` checks still gate. Per-variable
-  override via a `min_history` key in `regression_overrides`.
+  override via a `min_history` key in `regression_overrides`. Young rows are
+  marked notify-only (†) in the rendered regression report, the scorecard
+  shows them as uncolored trend cells, and the exported report JSON carries a
+  top-level `has_blocking_regressions`.
 
 ## [1.115.0] - 2026-07-11
 

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -139,6 +139,7 @@ from .regression import (
     MethodCells,
     method_cells,
 )
+from .history import HistoryResetError, HistoryEvent
 from .perf_tracker import PerfTracker, PerfReport
 from .git_info import git_time_event
 from .plotting.plot_filter import VarRange, PlotFilter

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -347,6 +347,20 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     clear_history: bool = param.Boolean(False, doc="Clear historical results")
 
+    on_history_reset: str = param.Selector(
+        default="warn",
+        objects=["warn", "error", "ignore"],
+        doc="Policy for history-affecting schema changes detected at history-load "
+        "time (a result column removed or redefined, or the whole history "
+        "orphaned by an input/const change). 'warn' (default): log a WARNING "
+        "naming the change and continue. 'error': raise HistoryResetError so a "
+        "CI run can never silently lose a baseline; use 'warn'/'ignore' for one "
+        "run (or clear_history) to acknowledge a deliberate change. 'ignore': "
+        "log at DEBUG only. Retained data is never deleted by any policy — "
+        "removed columns stay dormant in the stored history and resume if the "
+        "variable returns with the same identity.",
+    )
+
     max_time_events: int | None = param.Integer(
         None,
         bounds=[1, None],
@@ -411,6 +425,19 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "'delta': absolute-unit change vs historical mean (uses regression_delta). "
         "'absolute': hard directional threshold, no history required (uses "
         "regression_absolute).",
+    )
+
+    regression_min_history: int = param.Integer(
+        default=1,
+        bounds=[1, None],
+        doc="Minimum number of historical over_time points a result variable "
+        "needs before its regressions can *fail* the run. A variable with a "
+        "younger baseline (freshly added, or restarted by a meaning_version "
+        "bump) still runs detection and reports regressions, but they are "
+        "marked young_baseline and never trigger regression_fail — warn-only "
+        "until the baseline matures. The default of 1 preserves the previous "
+        "behavior (any history gates). Override per variable with a "
+        "'min_history' key in regression_overrides.",
     )
 
     regression_mad: float = param.Number(
@@ -754,7 +781,7 @@ class BenchCfg(BenchRunCfg):
         self.hmap_kdims = None
         self.iv_repeat = None
 
-    def hash_persistent(self, include_repeats: bool) -> str:
+    def hash_persistent(self, include_repeats: bool, include_result_vars: bool = True) -> str:
         """Generate a persistent hash for the benchmark configuration.
 
         Overrides the default hash function because the default hash function does not
@@ -762,9 +789,22 @@ class BenchCfg(BenchRunCfg):
         variables that are consistent across instances of BenchCfg with the same
         configuration.
 
+        ``input_vars`` are folded in list order because their order determines the
+        dimension layout of the result arrays. ``result_vars`` and ``const_vars``
+        contribute as an *unordered set* (their per-var digests are sorted before
+        hashing): result vars become name-keyed xarray data variables and const
+        order only affects the title string, so reordering either is a
+        presentation change that must not move the cache key.
+
         Args:
             include_repeats (bool): Whether to include repeats as part of the hash
                                    (True by default except when using the sample cache)
+            include_result_vars (bool): Whether result variables contribute to the
+                hash. True for the benchmark-level result cache, where a cached
+                result must match the exact result-var set. False for the
+                over_time history key, so the history survives result-var
+                changes and per-column reconciliation can retain, retire, or
+                backfill individual columns (see ``bencher.history``).
 
         Returns:
             str: A persistent hash value for the benchmark configuration
@@ -793,14 +833,21 @@ class BenchCfg(BenchRunCfg):
                 hash_sha1(self.tag),
             )
         )
-        all_vars = (self.input_vars or []) + (self.result_vars or [])
-        for v in all_vars:
+        for v in self.input_vars or []:
             hash_val = hash_sha1((hash_val, v.hash_persistent()))
 
-        for v in self.const_vars or []:
-            hash_val = hash_sha1((hash_val, v[0].hash_persistent(), hash_sha1(v[1])))
+        if include_result_vars:
+            result_hashes = tuple(sorted(v.hash_persistent() for v in self.result_vars or []))
+        else:
+            result_hashes = ()
 
-        return hash_val
+        const_hashes = tuple(
+            sorted(
+                hash_sha1((v[0].hash_persistent(), hash_sha1(v[1]))) for v in self.const_vars or []
+            )
+        )
+
+        return hash_sha1((hash_val, result_hashes, const_hashes))
 
     def inputs_as_str(self) -> list[str]:
         """Get a list of input variable names.

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -38,6 +38,7 @@ from bencher.job import Job, FutureCache, JobFuture, Executors
 from bencher.utils import params_to_str, resolve_aggregate, AGG_FN_MAP
 from bencher.sample_order import SampleOrder
 from bencher.regression import detect_regressions, RegressionError
+from bencher.history import config_summary as history_config_summary
 from bencher.sweep_timings import SweepTimings, phase_timer
 
 # Import helper classes
@@ -678,6 +679,12 @@ class Bench(BenchPlotServer):
         bench_cfg_hash = bench_cfg.hash_persistent(True)
         bench_cfg.hash_value = bench_cfg_hash
 
+        # The over_time history is keyed WITHOUT result vars so metric-set
+        # changes reconcile per column instead of orphaning the whole history
+        # (see bencher.history). The benchmark-level result cache above stays
+        # strict: a cached single result must match the exact result-var set.
+        bench_cfg_history_hash = bench_cfg.hash_persistent(True, include_result_vars=False)
+
         # does not include repeats in hash as sample_hash already includes repeat as part of the per sample hash
         bench_cfg_sample_hash = bench_cfg.hash_persistent(False)
 
@@ -724,10 +731,14 @@ class Bench(BenchPlotServer):
                 with phase_timer() as elapsed:
                     bench_res.ds = self.load_history_cache(
                         bench_res.ds,
-                        bench_cfg_hash,
+                        bench_cfg_history_hash,
                         run_cfg.clear_history,
                         run_cfg.max_time_events,
                         bench_cfg.result_vars,
+                        on_history_reset=run_cfg.on_history_reset,
+                        bench_name=bench_cfg.bench_name,
+                        tag=bench_cfg.tag,
+                        config_summary=history_config_summary(bench_cfg),
                     )
                     # sync the over_time meta variable with the actual accumulated values
                     if bench_cfg.iv_time and "over_time" in bench_res.ds.coords:
@@ -743,7 +754,12 @@ class Bench(BenchPlotServer):
                 bench_res.regression_report = detect_regressions(bench_res.ds, bench_cfg, run_cfg)
                 if bench_res.regression_report.has_regressions:
                     logging.warning(bench_res.regression_report.summary())
-                    if run_cfg.regression_fail:
+                    # young_baseline regressions (fewer than regression_min_history
+                    # points since the column's birth) warn but never fail the run.
+                    if (
+                        run_cfg.regression_fail
+                        and bench_res.regression_report.has_blocking_regressions
+                    ):
                         raise RegressionError(bench_res.regression_report.summary())
 
             self.report_results(bench_res, run_cfg.print_xarray, run_cfg.print_pandas)
@@ -849,10 +865,23 @@ class Bench(BenchPlotServer):
         clear_history: bool,
         max_time_events: int | None = None,
         result_vars: list | None = None,
+        *,
+        on_history_reset: str = "warn",
+        bench_name: str | None = None,
+        tag: str | None = None,
+        config_summary: dict | None = None,
     ) -> xr.Dataset:
-        """Load and concatenate historical benchmark data from cache."""
+        """Load, reconcile, and persist historical benchmark data from cache."""
         return self._collector.load_history_cache(
-            dataset, bench_cfg_hash, clear_history, max_time_events, result_vars
+            dataset,
+            bench_cfg_hash,
+            clear_history,
+            max_time_events,
+            result_vars,
+            on_history_reset=on_history_reset,
+            bench_name=bench_name,
+            tag=tag,
+            config_summary=config_summary,
         )
 
     def setup_dataset(

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -35,7 +35,10 @@ logger = logging.getLogger(__name__)
 # ``BenchCfg.hash_persistent``) so bumping here atomically invalidates every
 # benchmark-level and over_time history key in addition to wiping the on-disk
 # tree via ``ensure_cache_version()``.
-CACHE_VERSION = "4"
+# v5: hash composition changed (variable names in per-var identity, unordered
+# result/const var sets) and the history cache switched to schema-evolving
+# records (see bencher/history.py).
+CACHE_VERSION = "5"
 
 # Default cache size for benchmark results (100 GB).
 # Used by ResultCollector, SweepExecutor, and Bench.

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -1,0 +1,382 @@
+"""Schema-evolving over_time history: column identity, reconciliation, projection.
+
+The over_time history cache is keyed by the benchmark identity *excluding*
+result variables (``BenchCfg.hash_persistent(True, include_result_vars=False)``),
+so changing the set of measured metrics does not orphan the whole history.
+Result-variable differences are instead reconciled per column at load time
+under a retain + projection model:
+
+- The stored record keeps a **superset** dataset holding every column ever
+  measured. Columns are never deleted: a column whose variable left the config
+  goes *dormant* (retained, excluded from what consumers see) and resumes if
+  the variable returns with the same identity; a column whose identity changed
+  (units, class, or ``meaning_version``) is *retired* under a mangled name and
+  a fresh column starts.
+- Consumers are served a **projection** onto exactly the current config's
+  columns, so every downstream reader (plots, regression detection, export)
+  sees a dataset congruent with the current benchmark definition — the same
+  invariant a destructive prune would give, without the ability to lose data
+  to a typo'd variable name or a partial run.
+- A column's identity is ``(name, class, units, meaning_version)``. The
+  explicit ``meaning_version`` field on result variables is the sanctioned way
+  to declare "same name, new semantics"; bumping it restarts just that
+  column's history instead of silently splicing two different quantities into
+  one trend line.
+- Newly added columns are NaN-backfilled by the merge; each live column
+  carries its birth ``over_time`` coordinate (the ``history_birth`` DataArray
+  attr on the served dataset) so consumers can tell "did not exist yet" from
+  "sample failed" and regression gating can hold fire while a baseline is
+  young.
+
+Input variables and constants stay in the history key: changing the input
+space is a different experiment and yields a clean, *reported* full reset
+(never a cross-dimension merge). The ``on_history_reset`` policy on
+``BenchRunCfg`` controls how loss-y events (full reset, dormant, retired,
+discarded) surface: warn (default), error, or ignore.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from bencher.utils import hash_sha1
+from bencher.variables.results import (
+    DATA_VAR_RESULT_TYPES,
+    ResultVec,
+    result_missing_fill,
+)
+
+logger = logging.getLogger(__name__)
+
+# Version of the on-disk history record layout (independent of CACHE_VERSION,
+# which invalidates keys; this describes the value stored under a key).
+HISTORY_FORMAT = 1
+
+# DataArray attr on served datasets: the over_time coordinate value at which
+# this column first appeared (or was last restarted by an identity change).
+# Absent for columns as old as the history itself.
+BIRTH_ATTR = "history_birth"
+
+_LOSSY_KINDS = frozenset({"full_reset", "column_dormant", "column_retired", "history_discarded"})
+
+
+class HistoryResetError(Exception):
+    """Raised when history is reset or loses a column and on_history_reset='error'."""
+
+
+@dataclass
+class HistoryEvent:
+    """One schema-affecting event detected while loading over_time history."""
+
+    kind: str  # full_reset | column_born | column_dormant | column_retired |
+    #            column_resumed | history_discarded
+    detail: str
+    column: str | None = None
+
+    @property
+    def lossy(self) -> bool:
+        """True when the event removes data from what consumers will see."""
+        return self.kind in _LOSSY_KINDS
+
+
+def data_var_columns(result_vars: list | None) -> dict[str, Any]:
+    """Map history column name -> owning result variable.
+
+    Mirrors ``ResultCollector.setup_dataset``: ``ResultVec`` expands to one
+    column per element; only ``DATA_VAR_RESULT_TYPES`` get a data variable.
+    Result types stored out-of-band (hmaps, volumes) have no history column.
+    """
+    cols: dict[str, Any] = {}
+    for rv in result_vars or []:
+        if type(rv) is ResultVec:
+            for i in range(rv.size):
+                cols[rv.index_name(i)] = rv
+        elif isinstance(rv, DATA_VAR_RESULT_TYPES):
+            cols[rv.name] = rv
+    return cols
+
+
+def column_identity(rv: Any, col_name: str) -> str:
+    """Persistent identity of one history column.
+
+    ``(name, class, units, meaning_version)`` — a change to any of these means
+    the column is a different measurement and must not continue the old trend.
+    ``meaning_version`` is read with getattr so result types that do not carry
+    the field participate with None.
+    """
+    return hash_sha1(
+        (
+            col_name,
+            type(rv).__name__,
+            getattr(rv, "units", None),
+            getattr(rv, "meaning_version", None),
+        )
+    )
+
+
+def column_meta(rv: Any, col_name: str, birth: Any) -> dict:
+    """Metadata stored per live column in the history record."""
+    return {
+        "identity": column_identity(rv, col_name),
+        "class": type(rv).__name__,
+        "units": getattr(rv, "units", None),
+        "meaning_version": getattr(rv, "meaning_version", None),
+        "birth": birth,
+        "dormant": False,
+    }
+
+
+def config_summary(bench_cfg: Any) -> dict:
+    """Compact identity summary of a BenchCfg, stored in the last-seen index.
+
+    Diffed against the current config when the history key moves, so the reset
+    warning can name what changed instead of just reporting a missing key.
+    """
+
+    def row(v: Any) -> tuple:
+        return (str(v.name), type(v).__name__, str(getattr(v, "units", None)))
+
+    return {
+        "inputs": [row(v) for v in bench_cfg.input_vars or []],
+        "consts": sorted((*row(v), str(hash_sha1(val))) for v, val in bench_cfg.const_vars or []),
+        "results": sorted(
+            (*row(v), str(getattr(v, "meaning_version", None))) for v in bench_cfg.result_vars or []
+        ),
+        "repeats": int(bench_cfg.repeats),
+    }
+
+
+def diff_summaries(old: dict | None, new: dict | None) -> list[str]:
+    """Human-readable lines describing how *new* differs from *old*."""
+    if not old or not new:
+        return []
+    lines = []
+    for kind in ("inputs", "consts", "results"):
+        o = [tuple(t) for t in old.get(kind, [])]
+        n = [tuple(t) for t in new.get(kind, [])]
+        if o == n:
+            continue
+        added = [t[0] for t in n if t not in o]
+        removed = [t[0] for t in o if t not in n]
+        parts = []
+        if added:
+            parts.append(f"added {added}")
+        if removed:
+            parts.append(f"removed {removed}")
+        if not parts:
+            parts.append("reordered")
+        lines.append(f"{kind} changed: " + ", ".join(parts))
+    if old.get("repeats") != new.get("repeats"):
+        lines.append(f"repeats changed: {old.get('repeats')} -> {new.get('repeats')}")
+    return lines
+
+
+def last_seen_key(bench_name: str, tag: str | None) -> str:
+    """History-cache key of the last-seen index entry for one benchmark."""
+    return f"__history_last_seen__:{bench_name}:{tag}"
+
+
+def current_time_value(dataset: xr.Dataset) -> Any:
+    """The over_time coordinate value of the (single) current run, or None.
+
+    Only real coordinate values are usable as birth markers — a bare over_time
+    dimension exposes an implicit positional index that shifts when history is
+    trimmed, so no birth is recorded for coordinate-less datasets.
+    """
+    if "over_time" in dataset.coords and dataset.sizes.get("over_time"):
+        return dataset["over_time"].values[-1]
+    return None
+
+
+def incompatible_reason(ds_old: xr.Dataset, fresh: xr.Dataset) -> str | None:
+    """Why stored history cannot be merged with the fresh dataset, or None.
+
+    Mismatched non-over_time dimension layouts must never reach ``xr.concat``:
+    an outer join across different dims broadcasts both, fabricating points at
+    coordinate combinations that were never measured (with no NaNs to betray
+    it). The history key makes this unreachable in normal operation; this is
+    the defense in depth for hand-seeded or corrupted records.
+    """
+    if "over_time" in ds_old.dims and "over_time" in fresh.dims:
+        try:
+            if ds_old["over_time"].dtype != fresh["over_time"].dtype:
+                return (
+                    "over_time dtype changed: "
+                    f"{ds_old['over_time'].dtype} -> {fresh['over_time'].dtype}"
+                )
+        except KeyError:
+            pass
+    old_dims = {d: s for d, s in ds_old.sizes.items() if d != "over_time"}
+    new_dims = {d: s for d, s in fresh.sizes.items() if d != "over_time"}
+    if old_dims != new_dims:
+        return f"dimension layout changed: {old_dims} -> {new_dims}"
+    return None
+
+
+def _mangled_name(name: str, meta: dict, taken: set[str]) -> str:
+    """Stable, collision-free storage name for a retired column."""
+    base = f"{name}__retired_{str(meta.get('identity'))[:8]}"
+    candidate = base
+    suffix = 1
+    while candidate in taken:
+        suffix += 1
+        candidate = f"{base}_{suffix}"
+    return candidate
+
+
+def reconcile(
+    record: dict, fresh: xr.Dataset, current_cols: dict[str, Any]
+) -> tuple[xr.Dataset, dict, dict, list[HistoryEvent]]:
+    """Merge stored history with the fresh run, classifying column mutations.
+
+    Returns ``(merged_superset, columns_meta, retired, events)``. Never raises
+    on schema differences — the caller applies the on_history_reset policy to
+    the returned events *before* persisting anything.
+    """
+    ds_old = record["dataset"]
+    columns: dict = {k: dict(v) for k, v in (record.get("columns") or {}).items()}
+    retired: dict = dict(record.get("retired") or {})
+    events: list[HistoryEvent] = []
+    birth_val = current_time_value(fresh)
+    n_history = int(ds_old.sizes.get("over_time", 0))
+
+    renames: dict[str, str] = {}
+    for name, rv in current_cols.items():
+        ident = column_identity(rv, name)
+        meta = columns.get(name)
+        if meta is None:
+            columns[name] = column_meta(rv, name, birth_val)
+            if name in ds_old.data_vars:
+                # Data exists under this name but carries no metadata (record
+                # predates column tracking): adopt it as the same column
+                # rather than fabricating a birth mid-history.
+                columns[name]["birth"] = None
+            else:
+                events.append(
+                    HistoryEvent(
+                        "column_born",
+                        f"result column '{name}' added; earlier history is backfilled "
+                        f"as missing and its regression baseline starts now",
+                        column=name,
+                    )
+                )
+        elif meta.get("identity") != ident:
+            taken = set(ds_old.data_vars) | set(retired)
+            mangled = _mangled_name(name, meta, taken)
+            if name in ds_old.data_vars:
+                renames[name] = mangled
+            retired[mangled] = {**meta, "retired_from": name}
+            columns[name] = column_meta(rv, name, birth_val)
+            events.append(
+                HistoryEvent(
+                    "column_retired",
+                    f"result column '{name}' changed identity "
+                    f"(class/units/meaning_version); {n_history} historical events "
+                    f"retired to '{mangled}' and the column restarts",
+                    column=name,
+                )
+            )
+        elif meta.get("dormant"):
+            meta["dormant"] = False
+            events.append(
+                HistoryEvent(
+                    "column_resumed",
+                    f"result column '{name}' returned with the same identity; "
+                    f"its earlier history resumes",
+                    column=name,
+                )
+            )
+
+    for name, meta in columns.items():
+        if name not in current_cols and not meta.get("dormant"):
+            meta["dormant"] = True
+            events.append(
+                HistoryEvent(
+                    "column_dormant",
+                    f"result column '{name}' removed from the config; {n_history} "
+                    f"historical events retained (dormant) and will resume if it "
+                    f"returns with the same identity",
+                    column=name,
+                )
+            )
+
+    if renames:
+        ds_old = ds_old.rename(renames)
+
+    merged = xr.concat([ds_old, fresh], "over_time")
+    _restore_sentinel_fill(merged, current_cols)
+    return merged, columns, retired, events
+
+
+def _restore_sentinel_fill(merged: xr.Dataset, current_cols: dict[str, Any]) -> None:
+    """Repair concat's NaN fill for columns whose missing sentinel is not NaN.
+
+    ``xr.concat`` fills variables absent from one side with float NaN. For
+    NaN-sentinel (numeric) columns that IS the missing marker; for object
+    columns ("NAN" sentinel) and index-backed reference columns (-1 sentinel,
+    int dtype promoted to float by the fill) the gap cells must be rewritten
+    so ``result_is_missing`` still recognises them.
+    """
+    for name, rv in current_cols.items():
+        if name not in merged.data_vars:
+            continue
+        fill, dtype = result_missing_fill(rv)
+        if isinstance(fill, float) and math.isnan(fill):
+            continue
+        da = merged[name]
+        if da.dtype == object:
+            arr = da.values
+            mask = np.array(
+                [val is None or (isinstance(val, float) and math.isnan(val)) for val in arr.flat],
+                dtype=bool,
+            ).reshape(arr.shape)
+            if mask.any():
+                arr[mask] = fill
+        elif np.issubdtype(da.dtype, np.floating):
+            merged[name] = da.fillna(fill).astype(dtype)
+
+
+def project(merged: xr.Dataset, current_cols: dict[str, Any], columns_meta: dict) -> xr.Dataset:
+    """Serve exactly the current config's columns, with birth annotations.
+
+    The returned dataset shares variables with *merged*; only the set of data
+    variables narrows. Dormant and retired columns stay in the stored record
+    but are invisible to every consumer.
+    """
+    keep = [n for n in current_cols if n in merged.data_vars]
+    served = merged if len(keep) == len(merged.data_vars) else merged[keep]
+    for name in keep:
+        birth = (columns_meta.get(name) or {}).get("birth")
+        if birth is not None:
+            served[name].attrs[BIRTH_ATTR] = birth
+        else:
+            served[name].attrs.pop(BIRTH_ATTR, None)
+    return served
+
+
+def apply_policy(events: list[HistoryEvent], policy: str) -> None:
+    """Surface history events according to on_history_reset.
+
+    Informational events (born, resumed) always log at INFO. Lossy events
+    (full reset, dormant, retired, discarded) warn by default; with
+    policy='error' they raise HistoryResetError — callers must apply the
+    policy *before* persisting the merged record so an erroring CI run does
+    not advance history state; policy='ignore' logs at DEBUG.
+    """
+    for event in events:
+        if not event.lossy:
+            logger.info("history: %s", event.detail)
+    lossy = [e for e in events if e.lossy]
+    if not lossy:
+        return
+    if policy == "error":
+        raise HistoryResetError("; ".join(e.detail for e in lossy))
+    log = logger.warning if policy == "warn" else logger.debug
+    for event in lossy:
+        log("history: %s", event.detail)

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -266,6 +266,22 @@ def reconcile(
                         column=name,
                     )
                 )
+        elif meta.get("identity") is None:
+            # Stub meta for a column from a record predating column tracking:
+            # its identity was never recorded, so adopt it in place rather than
+            # retiring (a retire would mangle real continuous history under a
+            # dormant stub identity). Birth stays None: data as old as tracking.
+            was_dormant = meta.get("dormant")
+            columns[name] = column_meta(rv, name, birth=None)
+            if was_dormant:
+                events.append(
+                    HistoryEvent(
+                        "column_resumed",
+                        f"result column '{name}' returned with the same identity; "
+                        f"its earlier history resumes",
+                        column=name,
+                    )
+                )
         elif meta.get("identity") != ident:
             taken = set(ds_old.data_vars) | set(retired)
             mangled = _mangled_name(name, meta, taken)
@@ -292,6 +308,32 @@ def reconcile(
                     column=name,
                 )
             )
+
+    # Data variables from a record predating column tracking carry no metadata.
+    # Any such column absent from the current config must still go dormant, so
+    # on_history_reset='error' fires and a later return resumes (via the
+    # identity-None branch above) instead of silently re-adopting. Retired
+    # mangled names are data_vars too and are skipped.
+    for name in ds_old.data_vars:
+        if name in columns or name in current_cols or name in retired:
+            continue
+        columns[name] = {
+            "identity": None,
+            "class": None,
+            "units": None,
+            "meaning_version": None,
+            "birth": None,
+            "dormant": True,
+        }
+        events.append(
+            HistoryEvent(
+                "column_dormant",
+                f"result column '{name}' from a record predating column tracking is "
+                f"absent from the config; {n_history} historical events retained "
+                f"(dormant) and will resume if it returns",
+                column=name,
+            )
+        )
 
     for name, meta in columns.items():
         if name not in current_cols and not meta.get("dormant"):

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -18,6 +18,7 @@ import numpy as np
 import xarray as xr
 
 from bencher.variables.results import OptDir, SCALAR_RESULT_TYPES
+from bencher.history import BIRTH_ATTR
 
 # Default thresholds per method — used when the user hasn't explicitly set a threshold.
 _METHOD_DEFAULTS = {
@@ -70,6 +71,10 @@ class RegressionResult:
     # ``over_time`` datetimes). Optional: falls back to integer indices.
     historical_x: np.ndarray | None = None
     current_x: np.ndarray | None = None
+    # True when the variable's baseline is younger than regression_min_history
+    # (freshly added column, or restarted by a meaning_version bump). Young
+    # regressions are reported but never trigger regression_fail.
+    young_baseline: bool = False
 
     def render_png(
         self,
@@ -115,6 +120,9 @@ class RegressionResult:
             value = getattr(self, band)
             if value is not None:
                 out[band] = _finite_or_none(value)
+        # Emitted only when set so the base JSON contract stays byte-stable.
+        if self.young_baseline:
+            out["young_baseline"] = True
         return out
 
 
@@ -129,6 +137,15 @@ class RegressionReport:
         return any(r.regressed for r in self.results)
 
     @property
+    def has_blocking_regressions(self) -> bool:
+        """True when any regression has a mature baseline and may fail the run.
+
+        Regressions on young baselines (see ``regression_min_history``) are
+        notify-only: reported in the summary/export but never blocking.
+        """
+        return any(r.regressed and not r.young_baseline for r in self.results)
+
+    @property
     def regressed_variables(self) -> list[RegressionResult]:
         return [r for r in self.results if r.regressed]
 
@@ -140,7 +157,10 @@ class RegressionReport:
         else:
             lines.append(f"Regressions detected in {len(regressed)} variable(s):")
             for r in regressed:
-                lines.append(_format_summary_line(r))
+                line = _format_summary_line(r)
+                if r.young_baseline:
+                    line += " [young baseline - notify only]"
+                lines.append(line)
         return "\n".join(lines)
 
     def to_markdown(self) -> str:
@@ -1345,7 +1365,7 @@ def _valid_threshold(value) -> float | None:
     return value if math.isfinite(value) else None
 
 
-def _normalize_overrides(overrides) -> dict:
+def _normalize_overrides(overrides) -> tuple[dict, dict]:
     """Validate ``run_cfg.regression_overrides`` into ``{var: {method: threshold}}``.
 
     A bare number is shorthand for ``{"absolute": value}``. Malformed entries
@@ -1354,17 +1374,38 @@ def _normalize_overrides(overrides) -> dict:
     falls back to the benchmark-wide method (so a typo'd key can't silently
     disable detection). Only a literal empty spec opts the variable out of
     detection — the variable was explicitly listed with no checks.
+
+    A ``min_history`` key inside a spec is not a check: it is the per-variable
+    override of ``regression_min_history`` and is returned separately as the
+    second element ``{var: min_history}``. A spec containing only
+    ``min_history`` keeps the benchmark-wide method.
     """
     normalized: dict = {}
+    min_history: dict = {}
     if not overrides:
-        return normalized
+        return normalized, min_history
     for var_name, spec in overrides.items():
         shorthand = _valid_threshold(spec)
         if shorthand is not None:
             normalized[var_name] = {"absolute": shorthand}
         elif isinstance(spec, dict):
             valid = {}
+            has_min_history = False
             for method, threshold in spec.items():
+                if method == "min_history":
+                    if (
+                        isinstance(threshold, int)
+                        and not isinstance(threshold, bool)
+                        and (threshold >= 1)
+                    ):
+                        min_history[var_name] = threshold
+                        has_min_history = True
+                    else:
+                        logging.warning(
+                            f"regression_overrides['{var_name}']: 'min_history' must be "
+                            f"an int >= 1, got {threshold!r}; ignored"
+                        )
+                    continue
                 if method not in _METHOD_THRESHOLD_ATTR:
                     logging.warning(
                         f"regression_overrides['{var_name}']: unknown method '{method}' ignored"
@@ -1378,9 +1419,9 @@ def _normalize_overrides(overrides) -> dict:
                     )
                     continue
                 valid[method] = valid_threshold
-            if valid or not spec:
+            if valid or (not spec and not has_min_history):
                 normalized[var_name] = valid
-            else:
+            elif not has_min_history:
                 logging.warning(
                     f"regression_overrides['{var_name}']: no valid checks in spec; "
                     "keeping the benchmark-wide method"
@@ -1390,7 +1431,7 @@ def _normalize_overrides(overrides) -> dict:
                 f"regression_overrides['{var_name}']: expected a finite number or "
                 f"{{method: threshold}} dict, got {spec!r}; ignored"
             )
-    return normalized
+    return normalized, min_history
 
 
 def _run_check(
@@ -1441,6 +1482,26 @@ def _run_check(
     raise ValueError(f"Unknown regression check method '{check_method}'")
 
 
+def _history_points_since_birth(dataset: xr.Dataset, da: xr.DataArray) -> int:
+    """Historical over_time points available for *da*, excluding the current run.
+
+    Counts from the column's birth coordinate (stamped by history
+    reconciliation on freshly added or meaning_version-restarted columns) so
+    NaN backfill before the column existed does not inflate its baseline age.
+    Columns without a birth marker — as old as the history itself, or a
+    dataset without over_time coordinates — count the full window. A birth
+    value no longer present in the coordinates means the birth has aged out
+    past max_time_events, so the whole (trimmed) window is real history.
+    """
+    n_time = int(dataset.sizes.get("over_time", 0))
+    birth = da.attrs.get(BIRTH_ATTR)
+    if birth is None or "over_time" not in dataset.coords:
+        return max(n_time - 1, 0)
+    matches = np.nonzero(dataset["over_time"].values == birth)[0]
+    start = int(matches[0]) if len(matches) else 0
+    return max(n_time - start - 1, 0)
+
+
 def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionReport:
     """Run regression detection on a dataset with over_time dimension.
 
@@ -1475,7 +1536,10 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
     if "over_time" not in dataset.dims:
         return report
 
-    overrides = _normalize_overrides(getattr(run_cfg, "regression_overrides", None))
+    overrides, min_history_overrides = _normalize_overrides(
+        getattr(run_cfg, "regression_overrides", None)
+    )
+    default_min_history = getattr(run_cfg, "regression_min_history", 1) or 1
     method = run_cfg.regression_method
 
     regression_percentage = getattr(run_cfg, "regression_percentage", None)
@@ -1528,6 +1592,13 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
         da = dataset[var_name]
         direction = rv.direction if hasattr(rv, "direction") else OptDir.none
 
+        # Points since the column's birth (history reconciliation stamps the
+        # birth coordinate on freshly added / meaning_version-restarted
+        # columns). A baseline younger than min_history downgrades this
+        # variable's history-based regressions to notify-only.
+        min_history = min_history_overrides.get(var_name, default_min_history)
+        history_points = _history_points_since_birth(dataset, da)
+
         # Split: historical = all but last, current = last
         current_clean = _clean_1d(da.isel(over_time=-1).values)
         if len(current_clean) == 0:
@@ -1564,6 +1635,8 @@ def detect_regressions(dataset: xr.Dataset, bench_cfg, run_cfg) -> RegressionRep
             )
             if result is None:
                 continue
+            # History-free checks (hard limits) gate regardless of baseline age.
+            result.young_baseline = with_history and history_points < min_history
             _attach_plot_metadata(
                 result,
                 time_coord=time_coord,

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -35,6 +35,10 @@ _DRIFT_FRAC = 0.85
 # Hampel filter cutoff (in MAD units) used to drop outliers from the slope fit.
 _HAMPEL_K = 5.0
 
+# Marker appended to a young-baseline regression's Variable cell in the markdown
+# table (young regressions are reported but never block — see young_baseline).
+_YOUNG_MARKER = "†"
+
 
 class RegressionError(Exception):
     """Raised when regression detection finds regressions and regression_fail is True."""
@@ -175,6 +179,9 @@ class RegressionReport:
             lines.append("|----------|-------:|----------:|--------:|--------|----------:|")
             for r in regressed:
                 lines.append(_format_markdown_row(r))
+            if any(r.young_baseline for r in regressed):
+                lines.append("")
+                lines.append(f"*{_YOUNG_MARKER} young baseline — notify only, does not block*")
         else:
             lines.append("**No regressions detected**\n")
 
@@ -195,6 +202,7 @@ class RegressionReport:
         """
         return {
             "has_regressions": self.has_regressions,
+            "has_blocking_regressions": self.has_blocking_regressions,
             "results": [r.to_dict() for r in self.results],
         }
 
@@ -326,8 +334,9 @@ def _format_summary_line(r: RegressionResult) -> str:
 
 def _format_markdown_row(r: RegressionResult) -> str:
     cells = method_cells(r)
+    variable = f"{r.variable} {_YOUNG_MARKER}" if r.young_baseline else r.variable
     return (
-        f"| {r.variable} | {cells.change} | {cells.baseline} | "
+        f"| {variable} | {cells.change} | {cells.baseline} | "
         f"{r.current_value:.4g} | {r.method} | {cells.threshold} |"
     )
 
@@ -1492,13 +1501,19 @@ def _history_points_since_birth(dataset: xr.Dataset, da: xr.DataArray) -> int:
     dataset without over_time coordinates — count the full window. A birth
     value no longer present in the coordinates means the birth has aged out
     past max_time_events, so the whole (trimmed) window is real history.
+
+    When over_time labels are duplicated (a reused ``TimeEvent``), the birth
+    value can match more than one coordinate. We take the *last* occurrence:
+    if the column was truly born on the later duplicate this is exact, and if
+    it was born on an earlier one this undercounts history — erring toward
+    "younger", which is only ever notify-only and never a premature block.
     """
     n_time = int(dataset.sizes.get("over_time", 0))
     birth = da.attrs.get(BIRTH_ATTR)
     if birth is None or "over_time" not in dataset.coords:
         return max(n_time - 1, 0)
     matches = np.nonzero(dataset["over_time"].values == birth)[0]
-    start = int(matches[0]) if len(matches) else 0
+    start = int(matches[-1]) if len(matches) else 0
     return max(n_time - start - 1, 0)
 
 

--- a/bencher/report_export.py
+++ b/bencher/report_export.py
@@ -141,7 +141,7 @@ def result_to_dict(bench_res: BenchResult, *, include_series: bool = False) -> d
     regressions = (
         bench_res.regression_report.to_dict()
         if getattr(bench_res, "regression_report", None) is not None
-        else {"has_regressions": False, "results": []}
+        else {"has_regressions": False, "has_blocking_regressions": False, "results": []}
     )
 
     metrics = [_metric_entry(bench_res, rv) for rv in scalar_vars]

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -39,6 +39,19 @@ from bencher.worker_job import WorkerJob
 from bencher.job import JobFuture
 
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES
+from bencher.history import (
+    HISTORY_FORMAT,
+    HistoryEvent,
+    apply_policy,
+    column_meta,
+    current_time_value,
+    data_var_columns,
+    diff_summaries,
+    incompatible_reason,
+    last_seen_key,
+    project,
+    reconcile,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -396,6 +409,40 @@ class ResultCollector:
         logger.info(f"saving benchmark: {bench_res.bench_cfg.bench_name}")
         c[bench_res.bench_cfg.bench_name] = bench_cfg_hashes
 
+    def _load_history_record(self, cache: Cache, bench_cfg_hash: str) -> dict | None:
+        """Fetch and normalize one history record, or None when absent/unreadable.
+
+        Bare ``xr.Dataset`` values (hand-seeded or pre-record entries) are
+        wrapped into the record shape with no column metadata, which the
+        reconciler treats as adopt-in-place.
+        """
+        try:
+            record = cache[bench_cfg_hash]
+        except KeyError:
+            return None
+        except (AttributeError, TypeError, ModuleNotFoundError, ImportError) as exc:
+            logger.warning(
+                "Failed to deserialize cached history (%s: %s). "
+                "Discarding stale cache entry and continuing with fresh data.",
+                type(exc).__name__,
+                exc,
+            )
+            try:
+                del cache[bench_cfg_hash]
+            except (OSError, KeyError) as del_exc:
+                logger.debug("Could not remove stale cache entry: %s", del_exc)
+            return None
+        if isinstance(record, xr.Dataset):
+            return {"format": 0, "dataset": record, "columns": {}, "retired": {}}
+        if isinstance(record, dict) and isinstance(record.get("dataset"), xr.Dataset):
+            return record
+        logger.warning("Unrecognized history record shape; discarding stale entry")
+        try:
+            del cache[bench_cfg_hash]
+        except (OSError, KeyError) as del_exc:
+            logger.debug("Could not remove stale cache entry: %s", del_exc)
+        return None
+
     def load_history_cache(
         self,
         dataset: xr.Dataset,
@@ -403,83 +450,125 @@ class ResultCollector:
         clear_history: bool,
         max_time_events: int | None = None,
         result_vars: list | None = None,
+        *,
+        on_history_reset: str = "warn",
+        bench_name: str | None = None,
+        tag: str | None = None,
+        config_summary: dict | None = None,
     ) -> xr.Dataset:
-        """Load historical data from a cache if over_time is enabled.
+        """Load, reconcile, and persist historical benchmark data.
 
-        This method is used to retrieve and concatenate historical benchmark data from the cache
-        when tracking performance over time. If clear_history is True, it will clear any existing
-        historical data instead of loading it.
+        The history key excludes result variables, so the stored record is a
+        *superset* of every column ever measured under this benchmark's input
+        space; result-var differences are reconciled per column (retained,
+        retired, resumed, or born — see :mod:`bencher.history`) and consumers
+        receive a projection onto exactly the current ``result_vars`` columns.
+        If clear_history is True, existing history is ignored (a fresh series
+        starts and is written back).
 
         Args:
             dataset (xr.Dataset): Freshly calculated benchmark data for the current run
-            bench_cfg_hash (str): Hash of the input variables used to identify cached data
+            bench_cfg_hash (str): History key — the benchmark identity hash computed
+                with ``include_result_vars=False``
             clear_history (bool): If True, clears historical data instead of loading it
             max_time_events (int | None): Maximum number of over_time events to retain.
                 Oldest events are trimmed. None means unlimited.
-            result_vars (list | None): Result variable instances. When a variable has a
-                per-variable ``max_time_events`` smaller than the dataset's over_time
-                size, older entries are set to sentinel and media files are deleted.
+            result_vars (list | None): Result variable instances defining the served
+                columns. Also used for per-variable ``max_time_events`` aging. When
+                None, column reconciliation and projection are skipped entirely.
+            on_history_reset (str): Policy for loss-y schema events — "warn",
+                "error" (raise HistoryResetError before persisting), or "ignore".
+            bench_name (str | None): Benchmark name for the last-seen index; enables
+                full-reset detection when the history key moves.
+            tag (str | None): Benchmark tag for the last-seen index.
+            config_summary (dict | None): ``bencher.history.config_summary`` of the
+                current config, stored in the last-seen index and diffed on resets.
 
         Returns:
-            xr.Dataset: Combined dataset with both historical and current benchmark data,
-                or just the current data if no history exists or history is cleared
+            xr.Dataset: The current config's view of the accumulated history —
+                historical plus current data, projected onto the current columns.
         """
         c = self.get_history_cache()
+        current_cols = data_var_columns(result_vars)
+        events: list[HistoryEvent] = []
+        merged = dataset
+        birth_val = current_time_value(dataset)
+        columns_meta = {name: column_meta(rv, name, birth_val) for name, rv in current_cols.items()}
+        retired: dict = {}
+
         if clear_history:
             logger.info("clearing history")
         else:
             logger.info(f"checking historical key: {bench_cfg_hash}")
-            try:
-                ds_old = c[bench_cfg_hash]
-            except KeyError:
+            record = self._load_history_record(c, bench_cfg_hash)
+            if record is None:
                 logger.info("did not detect any historical data")
-            except (
-                AttributeError,
-                TypeError,
-                ModuleNotFoundError,
-                ImportError,
-            ) as exc:
-                logger.warning(
-                    "Failed to deserialize cached history (%s: %s). "
-                    "Discarding stale cache entry and continuing with fresh data.",
-                    type(exc).__name__,
-                    exc,
-                )
-                try:
-                    del c[bench_cfg_hash]
-                except (OSError, KeyError) as del_exc:
-                    logger.debug("Could not remove stale cache entry: %s", del_exc)
+                if bench_name is not None:
+                    last = c.get(last_seen_key(bench_name, tag))
+                    if last and last.get("key") != bench_cfg_hash:
+                        diff = diff_summaries(last.get("summary"), config_summary)
+                        detail = (
+                            f"over_time history reset for benchmark '{bench_name}' "
+                            f"(tag '{tag}'): the history key changed"
+                            + (": " + "; ".join(diff) if diff else "")
+                            + f"; {last.get('events', '?')} historical events are "
+                            f"orphaned under the old key"
+                        )
+                        events.append(HistoryEvent("full_reset", detail))
             else:
                 logger.info("loading historical data from cache")
-                if (
-                    "over_time" in ds_old.dims
-                    and "over_time" in dataset.dims
-                    and ds_old["over_time"].dtype != dataset["over_time"].dtype
-                ):
-                    logger.warning(
-                        "Discarding incompatible historical data "
-                        "(over_time dtype changed: "
-                        f"{ds_old['over_time'].dtype} -> {dataset['over_time'].dtype})"
+                ds_old = record["dataset"]
+                incompatible = incompatible_reason(ds_old, dataset)
+                if incompatible:
+                    events.append(
+                        HistoryEvent(
+                            "history_discarded",
+                            f"Discarding incompatible historical data ({incompatible})",
+                        )
                     )
+                elif current_cols:
+                    merged, columns_meta, retired, reconcile_events = reconcile(
+                        record, dataset, current_cols
+                    )
+                    events.extend(reconcile_events)
                 else:
-                    dataset = xr.concat([ds_old, dataset], "over_time")
+                    # No column information (result_vars not supplied): plain
+                    # append, preserving whatever metadata the record carries.
+                    merged = xr.concat([ds_old, dataset], "over_time")
+                    columns_meta = record.get("columns") or {}
+                    retired = record.get("retired") or {}
 
-        if max_time_events is not None and "over_time" in dataset.dims:
-            if dataset.sizes["over_time"] > max_time_events:
-                dataset = dataset.isel(over_time=slice(-max_time_events, None))
+        # Policy runs before anything is persisted so on_history_reset="error"
+        # leaves the stored history untouched for the next (acknowledged) run.
+        apply_policy(events, on_history_reset)
+
+        if max_time_events is not None and "over_time" in merged.dims:
+            if merged.sizes["over_time"] > max_time_events:
+                merged = merged.isel(over_time=slice(-max_time_events, None))
 
         # Per-variable max_time_events: null out older entries for variables
         # with a per-variable limit smaller than the dataset's over_time size.
         # File deletion is deferred until after the cache write succeeds.
         pending_deletes = []
-        if result_vars and "over_time" in dataset.dims:
+        if result_vars and "over_time" in merged.dims:
             for rv in result_vars:
                 var_limit = getattr(rv, "max_time_events", None)
                 if var_limit is not None:
-                    pending_deletes.extend(_null_old_entries(dataset, rv, var_limit))
+                    pending_deletes.extend(_null_old_entries(merged, rv, var_limit))
 
         logger.info("saving data to history cache")
-        c[bench_cfg_hash] = dataset
+        c[bench_cfg_hash] = {
+            "format": HISTORY_FORMAT,
+            "dataset": merged,
+            "columns": columns_meta,
+            "retired": retired,
+        }
+        if bench_name is not None:
+            c[last_seen_key(bench_name, tag)] = {
+                "key": bench_cfg_hash,
+                "summary": config_summary,
+                "events": int(merged.sizes.get("over_time", 0)),
+            }
 
         for fpath in pending_deletes:
             try:
@@ -488,7 +577,9 @@ class ResultCollector:
             except OSError as exc:
                 logger.warning("Failed to delete media file %s: %s", fpath, exc)
 
-        return dataset
+        if current_cols:
+            return project(merged, current_cols, columns_meta)
+        return merged
 
     def add_metadata_to_dataset(self, bench_res: BenchResult, input_var: Any) -> None:
         """Add variable metadata to the xarray dataset for improved visualization.

--- a/bencher/scorecard/model.py
+++ b/bencher/scorecard/model.py
@@ -62,11 +62,17 @@ def cell_verdict(reg: dict | None) -> str:
     """4-way display verdict for a cell.
 
     ``None`` — no regression gate on this metric (or too little history) — maps
-    to the uncolored ``"trend"`` fallback. Otherwise defer to bencher's 3-state
-    core verdict and render its ``"unchanged"`` as ``"passed"`` (the gate ran and
-    did not flag). A gate with no threshold can only have "passed".
+    to the uncolored ``"trend"`` fallback. A gate on a *young baseline* maps
+    there too: the baseline is younger than ``regression_min_history``, so
+    bencher reports the regression but never blocks on it — colouring it like a
+    real regression would overstate a verdict its own gate treats as advisory.
+    Otherwise defer to bencher's 3-state core verdict and render its
+    ``"unchanged"`` as ``"passed"`` (the gate ran and did not flag). A gate with
+    no threshold can only have "passed".
     """
     if reg is None:
+        return "trend"
+    if reg.get("young_baseline"):
         return "trend"
     if bool(reg.get("regressed")):
         return "regressed"

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -58,6 +58,11 @@ def _hash_slots(instance):
     The class name is always included in the hash to prevent collisions between different
     Result* classes that share the same slot layout and values (e.g. ResultPath,
     ResultVideo, and ResultImage all have __slots__ = ["units"] with default units="path").
+
+    The Parameter *name* is also included: history columns and regression baselines are
+    keyed by name, so two same-typed result vars with different names are different
+    measurements and must not share a cache identity. Unbound instances hash name=None,
+    which is deterministic.
     """
     cls = type(instance)
 
@@ -83,7 +88,7 @@ def _hash_slots(instance):
                 all_slots.append(slot)
 
     values = tuple(getattr(instance, slot) for slot in all_slots)
-    return hash_sha1((cls.__name__,) + values)
+    return hash_sha1((cls.__name__, instance.name) + values)
 
 
 class OptDir(StrEnum):
@@ -99,7 +104,7 @@ class ResultFloat(Number):
     bounds to [0, 1] and produces correct boolean-style plots.
     """
 
-    __slots__ = ["units", "direction", "share_axis", "max_time_events"]
+    __slots__ = ["units", "direction", "share_axis", "max_time_events", "meaning_version"]
     # ``direction`` is excluded because flipping minimize<->maximize does not
     # change the recorded numeric values, only their interpretation for
     # Pareto/optimizer plots.  Keeping it in the hash would needlessly wipe
@@ -113,11 +118,21 @@ class ResultFloat(Number):
         share_axis=True,
         max_time_events=None,
         default=float("nan"),
+        meaning_version=1,
         **params,
     ):
         Number.__init__(self, **params)
         assert isinstance(units, str)
         self.units = units
+        # The sanctioned way to declare "same name, new semantics": bump
+        # meaning_version when the quantity this metric measures changes
+        # (e.g. success redefined from reported to physically verified).
+        # It is part of the column identity, so the bump cleanly restarts
+        # this column's over_time history and regression baseline while
+        # every other column's history continues. Without a bump, a
+        # redefinition would silently splice two different quantities into
+        # one trend line.
+        self.meaning_version = meaning_version
         # Defaults to NaN so an *unrecorded* sample (a run that aborts before
         # measuring, or a result var the worker never sets) is treated as
         # missing and dropped by the nan-aware reductions used for regression

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -120,14 +120,19 @@ class SweepBase(param.Parameter):
         will silently serve stale data for a reshaped sweep.
 
         The class name is included so that different Sweep subclasses with
-        the same identity tuple do not collide.
+        the same identity tuple do not collide.  The variable *name* is also
+        included: the stored history keys its dims/coords by name, so two
+        same-shaped sweeps with different names are different experiments —
+        without the name in the key, renaming an input var would silently
+        concat a fresh dataset against history whose dimension no longer
+        exists, broadcasting both dims and fabricating never-measured points.
 
         Note: the sample cache is keyed solely by concrete input values
         (see :class:`bencher.worker_job.WorkerJob`) and is unaffected by
         this hash, so widening a sweep range still reuses per-sample cache
         entries for overlapping inputs.
         """
-        return (type(self).__name__, self.units, self.samples)  # pylint: disable=no-member
+        return (type(self).__name__, self.name, self.units, self.samples)  # pylint: disable=no-member
 
     def hash_persistent(self) -> str:
         """Deterministic hash based on :meth:`_sweep_identity`.

--- a/plans/09-result-cache-invalidation.md
+++ b/plans/09-result-cache-invalidation.md
@@ -1,5 +1,12 @@
 # Plan 09 — Result Cache & History Invalidation Correctness
 
+**Status: IMPLEMENTED** (v1.114.0, together with plan 14 — see
+`plans/14-history-schema-reconciliation.md` for the design record). D1 and D2
+landed as described (§4's sorted-tuple combiner, names in every per-var
+identity); D3's index + `on_history_reset` landed with plan 14's per-column
+events routed through the same policy. Kept for the analysis; line numbers
+reference the pre-fix source.
+
 **Goal:** Fix three correctness defects in how the benchmark-config hash
 (`BenchCfg.hash_persistent`) invalidates the result cache (Layer B) and the
 `over_time` history cache (Layer C):
@@ -62,9 +69,11 @@ hash, computed once as `bench_cfg.hash_persistent(True)` (`bencher/bencher.py:67
   "over_time")` (`result_collector.py:465`, xarray's default `join="outer"`).
   A missing key means "no history" → fresh series.
 
-(The `include_repeats=False` variant at `bencher.py:682` keys only the *sample*
-cache; repeats are intentionally in the history key so historical arrays have
-the same shape — see the comment at `bench_cfg.py:773-775`.)
+(The `include_repeats=False` variant at `bencher.py:682` is vestigial: it is
+threaded into `WorkerJob.bench_cfg_sample_hash` but never read — the sample
+cache keys on concrete function inputs + tag only (`worker_job.py`). Repeats
+are intentionally in the history key so historical arrays have the same
+shape — see the comment at `bench_cfg.py:773-775`.)
 
 Crucially, identity *inside* the stored dataset is by **name**: data variables
 are created under each result var's `.name` (`result_collector.py:229`), and

--- a/plans/09-result-cache-invalidation.md
+++ b/plans/09-result-cache-invalidation.md
@@ -1,6 +1,6 @@
 # Plan 09 — Result Cache & History Invalidation Correctness
 
-**Status: IMPLEMENTED** (v1.114.0, together with plan 14 — see
+**Status: IMPLEMENTED** (v1.116.0, together with plan 14 — see
 `plans/14-history-schema-reconciliation.md` for the design record). D1 and D2
 landed as described (§4's sorted-tuple combiner, names in every per-var
 identity); D3's index + `on_history_reset` landed with plan 14's per-column

--- a/plans/14-history-schema-reconciliation.md
+++ b/plans/14-history-schema-reconciliation.md
@@ -1,0 +1,129 @@
+# Plan 14 — Schema-Evolving over_time History (retain + projection)
+
+**Status: IMPLEMENTED** (same PR as the plan-09 fixes; one shared `CACHE_VERSION`
+bump). This document records the design and its rationale rather than
+prescribing future work — read it before touching `bencher/history.py`,
+`hash_persistent`, or `load_history_cache`.
+
+**Goal:** let the set of result variables evolve — add, remove, reorder, or
+deliberately redefine metrics — without orphaning a benchmark's accumulated
+`over_time` history and regression baselines, while keeping every dataset a
+consumer sees exactly congruent with the *current* benchmark definition.
+
+Plan 09 made history resets correct and observable; this plan makes most of
+them unnecessary. Downstream suites had grown folklore defenses against the
+old behavior (routing every `result_vars` list through one shared constant;
+documenting metrics as "deliberately omitted forever" because adding them
+would reset another metric's history). When users build conventions around a
+cache key, the key is wrong — plan 09 §"Read first" says the same.
+
+## 1. The core tension this resolves
+
+Two legitimate requirements pull the cache key in opposite directions:
+
+- **Single-result coherency** (Layer B, `cachedir/benchmark_inputs`): a cached
+  result must be exactly what the current definition would produce. Any
+  result-var change must force a recompute → the key must include result vars.
+- **History continuity** (Layer C, `cachedir/history`): `task_success`'s trend
+  does not logically depend on whether `shutdown_time` was added next to it →
+  the key must NOT include result vars.
+
+The pre-existing design used one hash for both layers, forcing one semantics
+onto both — the root cause of the tension. The fix is to split them:
+
+- Layer B keys on `hash_persistent(True)` — strict, includes result vars
+  (order-independently, per plan 09 D1).
+- Layer C keys on `hash_persistent(True, include_result_vars=False)` —
+  result-var differences are reconciled per column at load time.
+
+Input vars and constants stay in *both* keys: a change to the input space is a
+different experiment, and its history reset is clean and reported (plan 09 D3)
+rather than reconciled. This also structurally rules out the phantom-dimension
+broadcast corruption (plan 09 D2): datasets that reach `xr.concat` always have
+identical non-`over_time` dims, and a defensive layout check discards (with a
+report) rather than broadcasts if a hand-seeded record disagrees.
+
+## 2. Retain + projection
+
+`load_history_cache` stores a **record** `{format, dataset, columns, retired}`
+where `dataset` is a *superset* holding every column ever measured, and serves
+consumers a **projection** onto exactly the current config's columns
+(`bencher/history.py:project`). Consequences:
+
+- Every consumer — plotting (which iterates `dataset.data_vars`), regression
+  detection, export — sees only current columns: the same invariant a
+  destructive prune would give.
+- Removal is non-destructive. A column whose variable left the config goes
+  *dormant*: retained in the superset, invisible in the projection, resumed
+  (with a NaN gap) if the variable returns with the same identity. A typo'd
+  name in a shared result-var constant, a debug run with a reduced metric set,
+  or an unmapped rename can therefore never destroy shared history — the worst
+  case is a warning and a gap.
+- The one widening operation is NaN-backfill of a newly born column. NaN gaps
+  for non-NaN-sentinel column types (media "NAN", reference −1) are rewritten
+  to the proper sentinel after concat so `result_is_missing` semantics hold.
+
+## 3. Column identity and `meaning_version`
+
+A column's identity is `(name, class, units, meaning_version)`
+(`bencher/history.py:column_identity`). Name-keyed reconciliation cannot see a
+metric that keeps its name but changes *meaning* — the worst corruption,
+because splicing two different quantities into one trend defeats the point of
+history. `meaning_version` (a `ResultFloat` field, default 1, hashed) is the
+sanctioned way to declare that: bumping it *retires* the old column (kept in
+the superset under a mangled name) and restarts the trend, while every other
+column continues. Renames are remove+add by design; a rename that should keep
+history is expressed as… not renaming, or accepting the restart.
+
+Per-column birth coordinates are stamped on the served dataset
+(`history_birth` DataArray attr) so "did not exist yet" is distinguishable
+from "sample failed", and regression gating can hold fire while a baseline is
+young: below `BenchRunCfg.regression_min_history` points since birth
+(per-var override: a `min_history` key in `regression_overrides`), a
+regression is reported and exported (`young_baseline: true`) but never
+triggers `regression_fail`. History-free checks (`absolute` hard limits) gate
+regardless — they need no baseline. The default (`1`) reproduces the previous
+gating behavior exactly.
+
+## 4. Observability (plan 09 D3, extended to columns)
+
+All schema events route through `BenchRunCfg.on_history_reset`
+(`warn`/`error`/`ignore`, default `warn`) *before* the record is persisted, so
+an erroring CI run does not advance history state:
+
+- lossy events — whole-history reset (key moved; diagnosed via a per
+  `(bench_name, tag)` last-seen index storing the previous key and a config
+  summary, diffed to name what changed and how many events are orphaned),
+  column dormant, column retired, incompatible history discarded;
+- informational events (column born, column resumed) always log at INFO.
+
+## 5. What was deliberately NOT done
+
+- **No reconciliation across input/const changes** — different experiment,
+  clean reported reset. Do not "extend" reconciliation to dims; that path is
+  where fabricated-data corruption lives.
+- **No `renamed_from` continuity mapping** — renames restart the column;
+  retained data makes that cheap to reverse. Add only with a concrete need.
+- **No pruning / TTL of dormant columns** — they are NaN-cheap; deletion
+  reintroduces the accidental-loss class this design removes. `max_time_events`
+  still bounds the time axis for everything.
+- **No migration of pre-v5 cache entries** — `CACHE_VERSION` bump, one-time
+  miss, per the standing cache policy.
+- **`meaning_version` only on `ResultFloat`/`ResultBool`** (scalar metrics with
+  baselines). Other result types participate in identity with
+  `meaning_version=None`; versioning a media column is expressed by renaming.
+- **Report-page surfacing of history events** (plan 09 D3 item 2) — the
+  events are logged and the policy knob exists; embedding them in the rendered
+  report remains open (coordinate with A4 §3.5 / W5).
+
+## 6. Key files
+
+- `bencher/history.py` — identity, reconciliation, projection, policy.
+- `bencher/bench_cfg.py` — `hash_persistent(include_repeats,
+  include_result_vars)`; `on_history_reset`; `regression_min_history`.
+- `bencher/result_collector.py` — `load_history_cache` orchestration,
+  last-seen index, record persistence.
+- `bencher/regression.py` — `young_baseline` on `RegressionResult`,
+  `RegressionReport.has_blocking_regressions`, per-var `min_history`.
+- `test/test_history_reconciliation.py` — lifecycle, policy, and gating tests;
+  `test/test_hash_persistent.py` — golden hashes (updated for v5).

--- a/plans/README.md
+++ b/plans/README.md
@@ -28,11 +28,12 @@ without additional context. **Read the whole plan before starting it.**
 | 06 | [Docs & onboarding](06-docs-onboarding.md) | Low | Medium | Anytime |
 | 07 | [Low-risk core cleanup](07-core-cleanup.md) | Low | Small | Anytime |
 | 08 | [Larger core refactors](08-core-refactors.md) | Med–High | Large | Last — needs owner sign-off |
-| 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | After 02; coordinate with A4 |
+| 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | **Implemented** (with 14, v1.114.0) |
 | 10 | [Regression policy on result vars & verdict export](10-regression-policy-and-verdict-export.md) | Low–Med | Medium | After 02; builds on #974 |
 | 11 | [Worker lifecycle & resource injection](11-worker-lifecycle-and-resource-injection.md) | Medium | Medium–Large | Coordinate with A3/A4 |
 | 12 | [Portable artifact paths & cache config](12-portable-artifact-paths-and-cache-config.md) | Low | Small–Medium | Precursor to A3/A4 |
 | 13 | [Benchmark declaration bundle & run defaults](13-benchmark-declaration-and-run-defaults.md) | Low | Medium | Coordinate with 09 |
+| 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.114.0) |
 
 Plans 01–03 are quick wins. Plan 02 contains decisions only the repo owner can make
 (notably the Plotly-vs-plugin-system direction for PRs #830/#932); those steps are

--- a/plans/README.md
+++ b/plans/README.md
@@ -28,12 +28,12 @@ without additional context. **Read the whole plan before starting it.**
 | 06 | [Docs & onboarding](06-docs-onboarding.md) | Low | Medium | Anytime |
 | 07 | [Low-risk core cleanup](07-core-cleanup.md) | Low | Small | Anytime |
 | 08 | [Larger core refactors](08-core-refactors.md) | Med–High | Large | Last — needs owner sign-off |
-| 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | **Implemented** (with 14, v1.114.0) |
+| 09 | [Cache & history invalidation correctness](09-result-cache-invalidation.md) | Medium | Medium | **Implemented** (with 14, v1.116.0) |
 | 10 | [Regression policy on result vars & verdict export](10-regression-policy-and-verdict-export.md) | Low–Med | Medium | After 02; builds on #974 |
 | 11 | [Worker lifecycle & resource injection](11-worker-lifecycle-and-resource-injection.md) | Medium | Medium–Large | Coordinate with A3/A4 |
 | 12 | [Portable artifact paths & cache config](12-portable-artifact-paths-and-cache-config.md) | Low | Small–Medium | Precursor to A3/A4 |
 | 13 | [Benchmark declaration bundle & run defaults](13-benchmark-declaration-and-run-defaults.md) | Low | Medium | Coordinate with 09 |
-| 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.114.0) |
+| 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.116.0) |
 
 Plans 01–03 are quick wins. Plan 02 contains decisions only the repo owner can make
 (notably the Plotly-vs-plugin-system direction for PRs #830/#932); those steps are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.113.1"
+version = "1.114.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -736,8 +736,10 @@ class TestSweepSlotCoverage:
 # on-disk benchmark-level and over_time entry in the field.
 # ---------------------------------------------------------------------------
 
-GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS = "4fb6a177d55ff3ca67cbe851076f7606dbe3e364"
-GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "3b91a536f825054f4ec7712808699564014a023a"
+GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS = "6a2b022e6f72ac6c536a118c88065a30b788eca1"
+GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS = "5aa01b2f3c3ad8e1022c4c8cf027397a3204ba47"
+# The over_time history key: include_result_vars=False.
+GOLDEN_BENCH_CFG_HASH_HISTORY = "ec8e1d72fb6137e20156499c505547933e534ac0"
 
 
 def _build_golden_bench_cfg():
@@ -783,6 +785,13 @@ class TestGoldenBenchCfgHash:
         assert cfg.hash_persistent(include_repeats=False) == (
             GOLDEN_BENCH_CFG_HASH_EXCLUDING_REPEATS
         )
+
+    def test_golden_hash_history_key(self):
+        """The history key (include_result_vars=False) is a distinct golden value."""
+        cfg = _build_golden_bench_cfg()
+        history = cfg.hash_persistent(include_repeats=True, include_result_vars=False)
+        assert history == GOLDEN_BENCH_CFG_HASH_HISTORY
+        assert history != GOLDEN_BENCH_CFG_HASH_INCLUDING_REPEATS
 
     def test_title_change_does_not_affect_golden_hash(self):
         cfg = _build_golden_bench_cfg()

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -1,0 +1,367 @@
+"""Tests for schema-evolving over_time history (plans 09 + 14).
+
+Covers the three plan-09 defects (order-sensitive keys, nameless identity,
+silent invalidation) and the plan-14 retain+projection reconciliation model
+(column birth/dormant/resume/retire, meaning_version, young-baseline gating).
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+
+import numpy as np
+import xarray as xr
+
+import bencher as bn
+from bencher.bench_cfg import BenchCfg, BenchRunCfg
+from bencher.history import (
+    BIRTH_ATTR,
+    HistoryResetError,
+    column_identity,
+    data_var_columns,
+)
+from bencher.regression import detect_regressions
+from bencher.result_collector import ResultCollector
+
+
+def _result_float(name, units="s", meaning_version=1):
+    rv = bn.ResultFloat(units=units, meaning_version=meaning_version)
+    rv.name = name
+    return rv
+
+
+def _float_sweep(name, units="m", bounds=(0.0, 1.0)):
+    sweep = bn.FloatSweep(units=units, bounds=list(bounds))
+    sweep.name = name
+    return sweep
+
+
+def _bench_cfg(result_vars, const_vars=(), input_vars=()):
+    return BenchCfg(
+        bench_name="demo",
+        tag="demo",
+        over_time=True,
+        input_vars=list(input_vars),
+        result_vars=list(result_vars),
+        const_vars=list(const_vars),
+    )
+
+
+def _key(result_vars, const_vars=(), include_result_vars=True):
+    return _bench_cfg(result_vars, const_vars).hash_persistent(
+        True, include_result_vars=include_result_vars
+    )
+
+
+class TestOrderIndependentKeys(unittest.TestCase):
+    """Plan 09 D1: reordering result_vars or const_vars must not move the key."""
+
+    def test_result_var_reorder_is_noop(self):
+        a = bn.ResultBool(units="ratio")
+        b = bn.ResultFloat(units="s")
+        self.assertEqual(_key([a, b]), _key([b, a]))
+
+    def test_const_var_reorder_is_noop(self):
+        a = bn.ResultBool(units="ratio")
+        w = _float_sweep("width")
+        g = _float_sweep("angle", units="deg", bounds=(0, 90))
+        self.assertEqual(
+            _key([a], [(w, 0.5), (g, 30.0)]),
+            _key([a], [(g, 30.0), (w, 0.5)]),
+        )
+
+    def test_input_var_order_still_matters(self):
+        # Input order determines the dimension layout of the result arrays.
+        w = _float_sweep("width")
+        g = _float_sweep("angle", units="deg", bounds=(0, 90))
+        a = bn.ResultBool(units="ratio")
+        cfg_wg = _bench_cfg([a], input_vars=[w, g])
+        cfg_gw = _bench_cfg([a], input_vars=[g, w])
+        self.assertNotEqual(
+            cfg_wg.hash_persistent(True),
+            cfg_gw.hash_persistent(True),
+        )
+
+    def test_const_value_still_matters(self):
+        a = bn.ResultBool(units="ratio")
+        w = _float_sweep("width")
+        self.assertNotEqual(_key([a], [(w, 0.5)]), _key([a], [(w, 0.7)]))
+
+
+class TestNamedIdentity(unittest.TestCase):
+    """Plan 09 D2: the variable name is part of every per-var identity."""
+
+    def test_result_var_rename_moves_per_var_hash(self):
+        x = _result_float("duration")
+        y = _result_float("latency")
+        self.assertNotEqual(x.hash_persistent(), y.hash_persistent())
+
+    def test_input_var_rename_moves_per_var_hash(self):
+        p = _float_sweep("speed")
+        q = _float_sweep("velocity")
+        self.assertNotEqual(p.hash_persistent(), q.hash_persistent())
+
+    def test_result_var_rename_moves_strict_key(self):
+        self.assertNotEqual(_key([_result_float("duration")]), _key([_result_float("latency")]))
+
+    def test_const_rename_moves_key(self):
+        a = bn.ResultBool(units="ratio")
+        self.assertNotEqual(
+            _key([a], [(_float_sweep("width"), 0.5)]),
+            _key([a], [(_float_sweep("depth"), 0.5)]),
+        )
+
+    def test_meaning_version_moves_identity(self):
+        v1 = _result_float("m")
+        v2 = _result_float("m", meaning_version=2)
+        self.assertNotEqual(v1.hash_persistent(), v2.hash_persistent())
+        self.assertNotEqual(column_identity(v1, "m"), column_identity(v2, "m"))
+
+
+class TestHistoryKeyExcludesResultVars(unittest.TestCase):
+    """Plan 14: the history key ignores the result-var set entirely."""
+
+    def test_result_set_changes_share_history_key(self):
+        a = bn.ResultBool(units="ratio")
+        b = bn.ResultFloat(units="s")
+        x = _result_float("duration")
+        y = _result_float("latency")
+        self.assertEqual(
+            _key([a, b], include_result_vars=False),
+            _key([b], include_result_vars=False),
+        )
+        self.assertEqual(
+            _key([x], include_result_vars=False),
+            _key([y], include_result_vars=False),
+        )
+
+    def test_input_change_moves_history_key(self):
+        a = bn.ResultBool(units="ratio")
+        cfg_p = _bench_cfg([a], input_vars=[_float_sweep("speed")])
+        cfg_q = _bench_cfg([a], input_vars=[_float_sweep("velocity")])
+        self.assertNotEqual(
+            cfg_p.hash_persistent(True, include_result_vars=False),
+            cfg_q.hash_persistent(True, include_result_vars=False),
+        )
+
+
+def _day(t):
+    return np.datetime64("2026-01-01") + np.timedelta64(t, "D")
+
+
+def _run_ds(names, t):
+    data = {n: (("repeat", "over_time"), np.array([[float(t)]])) for n in names}
+    return xr.Dataset(data, coords={"repeat": [1], "over_time": [_day(t)]})
+
+
+class ReconcilerBase(unittest.TestCase):
+    """Runs the collector against a throwaway cachedir."""
+
+    def setUp(self):
+        self._old_cwd = os.getcwd()
+        self._tmp = tempfile.mkdtemp()
+        os.chdir(self._tmp)
+        self.collector = ResultCollector()
+        self.key = f"history-{uuid.uuid4()}"
+        self.kwargs = dict(
+            bench_name=f"bench-{uuid.uuid4()}",
+            tag="t",
+            config_summary={"inputs": [], "consts": [], "results": [], "repeats": 1},
+        )
+
+    def tearDown(self):
+        self.collector.close_caches()
+        os.chdir(self._old_cwd)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def load(self, names, t, result_vars, **overrides):
+        kwargs = {**self.kwargs, **overrides}
+        return self.collector.load_history_cache(
+            _run_ds(names, t), self.key, False, None, result_vars, **kwargs
+        )
+
+
+class TestReconcilerLifecycle(ReconcilerBase):
+    def test_added_column_backfills_and_records_birth(self):
+        self.load(["a"], 1, [_result_float("a")])
+        served = self.load(["a", "c"], 2, [_result_float("a"), _result_float("c")])
+        self.assertEqual(set(served.data_vars), {"a", "c"})
+        self.assertEqual(served.sizes["over_time"], 2)
+        self.assertTrue(np.isnan(served["c"].values[0, 0]))
+        self.assertEqual(served["c"].values[0, 1], 2.0)
+        self.assertEqual(served["c"].attrs[BIRTH_ATTR], _day(2))
+        # the untouched column's history continues
+        self.assertEqual(list(served["a"].values[0]), [1.0, 2.0])
+
+    def test_removed_column_goes_dormant_and_resumes(self):
+        rv_a, rv_b = _result_float("a"), _result_float("b")
+        self.load(["a", "b"], 1, [rv_a, rv_b])
+        served = self.load(["a"], 2, [rv_a])
+        # projection: consumers see exactly the current config's columns
+        self.assertEqual(set(served.data_vars), {"a"})
+        # storage: nothing deleted
+        record = self.collector.get_history_cache()[self.key]
+        self.assertIn("b", record["dataset"].data_vars)
+        # returning with the same identity resumes the old trend
+        served = self.load(["a", "b"], 3, [rv_a, rv_b])
+        b_vals = served["b"].values[0]
+        self.assertEqual(b_vals[0], 1.0)
+        self.assertTrue(np.isnan(b_vals[1]))
+        self.assertEqual(b_vals[2], 3.0)
+
+    def test_meaning_version_bump_retires_and_restarts_column(self):
+        self.load(["a"], 1, [_result_float("a")])
+        self.load(["a"], 2, [_result_float("a")])
+        served = self.load(["a"], 3, [_result_float("a", meaning_version=2)])
+        a_vals = served["a"].values[0]
+        self.assertTrue(np.isnan(a_vals[0]) and np.isnan(a_vals[1]))
+        self.assertEqual(a_vals[2], 3.0)
+        self.assertEqual(served["a"].attrs[BIRTH_ATTR], _day(3))
+        record = self.collector.get_history_cache()[self.key]
+        retired = [name for name in record["dataset"].data_vars if "__retired_" in name]
+        self.assertEqual(len(retired), 1)
+        self.assertEqual(list(record["dataset"][retired[0]].values[0][:2]), [1.0, 2.0])
+
+    def test_no_dead_columns_no_phantom_dims(self):
+        """The two plan-09 D2 corruption modes must be structurally impossible."""
+        rv_old, rv_new = _result_float("duration"), _result_float("latency")
+        self.load(["duration"], 1, [rv_old])
+        served = self.load(["latency"], 2, [rv_new])
+        # rename == remove+add: no dead 'duration' column in what consumers see
+        self.assertEqual(set(served.data_vars), {"latency"})
+        self.assertEqual(set(served.dims), {"repeat", "over_time"})
+
+    def test_incompatible_dims_discarded_not_broadcast(self):
+        cache = self.collector.get_history_cache()
+        alien = xr.Dataset(
+            {"a": (("speed", "over_time"), np.ones((2, 3)))},
+            coords={"speed": [0.1, 0.2], "over_time": [_day(0), _day(1), _day(2)]},
+        )
+        cache[self.key] = {"format": 1, "dataset": alien, "columns": {}, "retired": {}}
+        served = self.load(["a"], 3, [_result_float("a")])
+        self.assertNotIn("speed", served.dims)
+        self.assertEqual(served.sizes["over_time"], 1)
+
+    def test_plain_dataset_record_adopted(self):
+        cache = self.collector.get_history_cache()
+        cache[self.key] = _run_ds(["a"], 1)
+        served = self.load(["a"], 2, [_result_float("a")])
+        self.assertEqual(list(served["a"].values[0]), [1.0, 2.0])
+        # adopted columns have no fabricated birth
+        self.assertNotIn(BIRTH_ATTR, served["a"].attrs)
+
+
+class TestResetPolicy(ReconcilerBase):
+    def test_error_policy_raises_before_persisting(self):
+        rv_a, rv_b = _result_float("a"), _result_float("b")
+        self.load(["a", "b"], 1, [rv_a, rv_b])
+        record_before = self.collector.get_history_cache()[self.key]
+        with self.assertRaises(HistoryResetError):
+            self.load(["a"], 2, [rv_a], on_history_reset="error")
+        record_after = self.collector.get_history_cache()[self.key]
+        self.assertEqual(
+            record_before["dataset"].sizes["over_time"],
+            record_after["dataset"].sizes["over_time"],
+        )
+
+    def test_warn_policy_names_the_change(self):
+        rv_a, rv_b = _result_float("a"), _result_float("b")
+        self.load(["a", "b"], 1, [rv_a, rv_b])
+        with self.assertLogs("bencher.history", level=logging.WARNING) as logs:
+            self.load(["a"], 2, [rv_a])
+        self.assertTrue(any("'b' removed" in line for line in logs.output))
+
+    def test_ignore_policy_is_quiet(self):
+        rv_a, rv_b = _result_float("a"), _result_float("b")
+        self.load(["a", "b"], 1, [rv_a, rv_b])
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            self.load(["a"], 2, [rv_a], on_history_reset="ignore")
+
+    def test_full_reset_reported_via_last_seen_index(self):
+        self.load(["a"], 1, [_result_float("a")])
+        self.key = f"history-{uuid.uuid4()}"  # input/const change = new key
+        with self.assertLogs("bencher.history", level=logging.WARNING) as logs:
+            self.load(["a"], 2, [_result_float("a")])
+        self.assertTrue(any("orphaned under the old key" in line for line in logs.output))
+
+    def test_born_column_is_not_lossy(self):
+        self.load(["a"], 1, [_result_float("a")])
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            self.load(
+                ["a", "c"], 2, [_result_float("a"), _result_float("c")], on_history_reset="error"
+            )
+
+
+class TestYoungBaselineGating(unittest.TestCase):
+    def _dataset(self, values, birth_idx=None):
+        n = len(values)
+        coords = {"repeat": [1], "over_time": [_day(i) for i in range(n)]}
+        ds = xr.Dataset(
+            {"m": (("repeat", "over_time"), np.array(values, dtype=float).reshape(1, n))},
+            coords=coords,
+        )
+        if birth_idx is not None:
+            ds["m"].attrs[BIRTH_ATTR] = ds["over_time"].values[birth_idx]
+        return ds
+
+    def _detect(self, values, birth_idx=None, min_history=1, overrides=None):
+        rv = _result_float("m")
+        bench_cfg = _bench_cfg([rv])
+        run_cfg = BenchRunCfg(
+            over_time=True,
+            regression_detection=True,
+            regression_method="percentage",
+            regression_percentage=10.0,
+            regression_min_history=min_history,
+            regression_overrides=overrides,
+        )
+        return detect_regressions(self._dataset(values, birth_idx), bench_cfg, run_cfg)
+
+    def test_mature_baseline_blocks(self):
+        report = self._detect([1.0, 1.0, 10.0], min_history=2)
+        self.assertTrue(report.has_regressions)
+        self.assertTrue(report.has_blocking_regressions)
+
+    def test_young_baseline_notifies_but_does_not_block(self):
+        report = self._detect([1.0, 1.0, 10.0], birth_idx=1, min_history=2)
+        self.assertTrue(report.has_regressions)
+        self.assertFalse(report.has_blocking_regressions)
+        self.assertTrue(all(r.young_baseline for r in report.regressed_variables))
+        self.assertIn("young baseline", report.summary())
+
+    def test_default_min_history_preserves_existing_behavior(self):
+        report = self._detect([1.0, 1.0, 10.0], birth_idx=1, min_history=1)
+        self.assertTrue(report.has_blocking_regressions)
+
+    def test_per_var_min_history_override(self):
+        report = self._detect(
+            [1.0, 1.0, 10.0],
+            birth_idx=1,
+            min_history=1,
+            overrides={"m": {"min_history": 3}},
+        )
+        self.assertTrue(report.has_regressions)
+        self.assertFalse(report.has_blocking_regressions)
+
+    def test_young_baseline_in_dict_export(self):
+        report = self._detect([1.0, 1.0, 10.0], birth_idx=1, min_history=2)
+        exported = [r.to_dict() for r in report.regressed_variables]
+        self.assertTrue(all(entry.get("young_baseline") for entry in exported))
+        mature = self._detect([1.0, 1.0, 10.0], min_history=1)
+        exported = [r.to_dict() for r in mature.regressed_variables]
+        self.assertTrue(all("young_baseline" not in entry for entry in exported))
+
+
+class TestDataVarColumns(unittest.TestCase):
+    def test_result_vec_expands(self):
+        vec = bn.ResultVec(2, units="m")
+        vec.name = "pos"
+        cols = data_var_columns([vec, _result_float("a")])
+        self.assertEqual(set(cols), {"pos_x", "pos_y", "a"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -22,13 +22,29 @@ from bencher.history import (
     HistoryResetError,
     column_identity,
     data_var_columns,
+    last_seen_key,
 )
 from bencher.regression import detect_regressions
 from bencher.result_collector import ResultCollector
+from bencher.variables.results import result_is_missing
 
 
 def _result_float(name, units="s", meaning_version=1):
     rv = bn.ResultFloat(units=units, meaning_version=meaning_version)
+    rv.name = name
+    return rv
+
+
+def _result_string(name):
+    """An object-sentinel ('NAN') result column."""
+    rv = bn.ResultString()
+    rv.name = name
+    return rv
+
+
+def _result_reference(name):
+    """An index-backed reference-sentinel (-1) result column."""
+    rv = bn.ResultReference()
     rv.name = name
     return rv
 
@@ -157,6 +173,20 @@ def _run_ds(names, t):
     return xr.Dataset(data, coords={"repeat": [1], "over_time": [_day(t)]})
 
 
+def _run_ds_typed(values, t):
+    """A single (repeat=1, over_time=1) run with explicit per-column dtypes.
+
+    ``values`` maps column name -> (scalar, dtype), mirroring the typed backing
+    arrays ``ResultCollector.setup_dataset`` builds for object/reference result
+    types (object "NAN" sentinel, int -1 sentinel).
+    """
+    data = {
+        name: (("repeat", "over_time"), np.array([[val]], dtype=dtype))
+        for name, (val, dtype) in values.items()
+    }
+    return xr.Dataset(data, coords={"repeat": [1], "over_time": [_day(t)]})
+
+
 class ReconcilerBase(unittest.TestCase):
     """Runs the collector against a throwaway cachedir."""
 
@@ -177,11 +207,14 @@ class ReconcilerBase(unittest.TestCase):
         os.chdir(self._old_cwd)
         shutil.rmtree(self._tmp, ignore_errors=True)
 
-    def load(self, names, t, result_vars, **overrides):
+    def load_ds(self, dataset, result_vars, **overrides):
         kwargs = {**self.kwargs, **overrides}
         return self.collector.load_history_cache(
-            _run_ds(names, t), self.key, False, None, result_vars, **kwargs
+            dataset, self.key, False, None, result_vars, **kwargs
         )
+
+    def load(self, names, t, result_vars, **overrides):
+        return self.load_ds(_run_ds(names, t), result_vars, **overrides)
 
 
 class TestReconcilerLifecycle(ReconcilerBase):
@@ -254,18 +287,131 @@ class TestReconcilerLifecycle(ReconcilerBase):
         self.assertNotIn(BIRTH_ATTR, served["a"].attrs)
 
 
+class TestSentinelRestore(ReconcilerBase):
+    """_restore_sentinel_fill: object 'NAN' / reference -1 gaps survive concat."""
+
+    def test_object_and_reference_gap_holds_sentinel_after_resume(self):
+        rv_a, rv_s, rv_r = _result_float("a"), _result_string("s"), _result_reference("r")
+        # run 1: all present with real values
+        self.load_ds(
+            _run_ds_typed({"a": (1.0, float), "s": ("hello", object), "r": (3, int)}, 1),
+            [rv_a, rv_s, rv_r],
+        )
+        # run 2: object + reference columns go dormant (excluded from the run)
+        self.load_ds(_run_ds_typed({"a": (2.0, float)}, 2), [rv_a])
+        # run 3: they return
+        served = self.load_ds(
+            _run_ds_typed({"a": (3.0, float), "s": ("world", object), "r": (7, int)}, 3),
+            [rv_a, rv_s, rv_r],
+        )
+        s_vals, r_vals = served["s"].values[0], served["r"].values[0]
+        # pre-gap real values intact
+        self.assertEqual(s_vals[0], "hello")
+        self.assertEqual(r_vals[0], 3)
+        # the dormant-run gap holds exactly the proper sentinel
+        self.assertEqual(s_vals[1], "NAN")
+        self.assertEqual(r_vals[1], -1)
+        self.assertTrue(result_is_missing(rv_s, s_vals[1]))
+        self.assertTrue(result_is_missing(rv_r, r_vals[1]))
+        # returned real values
+        self.assertEqual(s_vals[2], "world")
+        self.assertEqual(r_vals[2], 7)
+        # dtype preserved: object stays object; reference round-trips to int -1
+        self.assertEqual(served["s"].dtype, object)
+        self.assertTrue(np.issubdtype(served["r"].dtype, np.integer))
+        self.assertEqual(served["r"].values[0, 1], -1)
+
+    def test_born_object_and_reference_columns_backfill_sentinel(self):
+        rv_a, rv_s, rv_r = _result_float("a"), _result_string("s"), _result_reference("r")
+        # run 1: only the float anchor exists
+        self.load_ds(_run_ds_typed({"a": (1.0, float)}, 1), [rv_a])
+        # run 2: object + reference columns are born after history exists
+        served = self.load_ds(
+            _run_ds_typed({"a": (2.0, float), "s": ("v", object), "r": (5, int)}, 2),
+            [rv_a, rv_s, rv_r],
+        )
+        # the pre-birth backfill is the sentinel, not raw NaN
+        self.assertEqual(served["s"].values[0, 0], "NAN")
+        self.assertEqual(served["r"].values[0, 0], -1)
+        self.assertTrue(result_is_missing(rv_s, served["s"].values[0, 0]))
+        self.assertTrue(result_is_missing(rv_r, served["r"].values[0, 0]))
+        self.assertEqual(served["s"].dtype, object)
+        self.assertTrue(np.issubdtype(served["r"].dtype, np.integer))
+        # the newly measured values are intact
+        self.assertEqual(served["s"].values[0, 1], "v")
+        self.assertEqual(served["r"].values[0, 1], 5)
+
+
+class TestLegacyRecordDormancy(ReconcilerBase):
+    """Format-0 (bare xr.Dataset) records must obey the dormant lifecycle."""
+
+    def _seed_legacy(self, t=1):
+        """Seed a bare (format-0) record with columns 'a' and 'b'."""
+        cache = self.collector.get_history_cache()
+        cache[self.key] = _run_ds_typed({"a": (1.0, float), "b": (10.0, float)}, t)
+
+    def test_legacy_missing_column_errors_before_persist(self):
+        self._seed_legacy()
+        cache = self.collector.get_history_cache()
+        record_before = cache[self.key]  # bare xr.Dataset (format 0)
+        with self.assertRaises(HistoryResetError):
+            self.load(["a"], 2, [_result_float("a")], on_history_reset="error")
+        record_after = cache[self.key]
+        # the raise happens before persist: the bare record is untouched
+        self.assertIsInstance(record_after, xr.Dataset)
+        xr.testing.assert_identical(record_before, record_after)
+
+    def test_legacy_missing_column_warn_records_dormant_stub(self):
+        self._seed_legacy()
+        with self.assertLogs("bencher.history", level=logging.WARNING) as logs:
+            served = self.load(["a"], 2, [_result_float("a")])
+        self.assertTrue(any("'b'" in line and "predat" in line for line in logs.output))
+        self.assertEqual(set(served.data_vars), {"a"})
+        record = self.collector.get_history_cache()[self.key]
+        stub = record["columns"]["b"]
+        self.assertTrue(stub["dormant"])
+        self.assertIsNone(stub["identity"])
+        # data retained, not deleted
+        self.assertIn("b", record["dataset"].data_vars)
+
+    def test_legacy_column_resumes_without_retire_or_duplicate(self):
+        self._seed_legacy()
+        self.load(["a"], 2, [_result_float("a")])  # b -> dormant (warns)
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            served = self.load(["a", "b"], 3, [_result_float("a"), _result_float("b")])
+        self.assertEqual(set(served.data_vars), {"a", "b"})
+        b_vals = served["b"].values[0]
+        self.assertEqual(b_vals[0], 10.0)  # legacy history served
+        self.assertTrue(np.isnan(b_vals[1]))  # gap while dormant
+        self.assertEqual(b_vals[2], 3.0)  # returned value
+        # adopt-in-place resume: no fabricated birth
+        self.assertNotIn(BIRTH_ATTR, served["b"].attrs)
+        # no retired mangled column and no phantom duplicate of 'b'
+        record = self.collector.get_history_cache()[self.key]
+        data_vars = list(record["dataset"].data_vars)
+        self.assertFalse(any("__retired_" in name for name in data_vars))
+        self.assertEqual(len(data_vars), 2)
+        self.assertEqual(record["retired"], {})
+
+
 class TestResetPolicy(ReconcilerBase):
     def test_error_policy_raises_before_persisting(self):
         rv_a, rv_b = _result_float("a"), _result_float("b")
         self.load(["a", "b"], 1, [rv_a, rv_b])
-        record_before = self.collector.get_history_cache()[self.key]
+        cache = self.collector.get_history_cache()
+        ls_key = last_seen_key(self.kwargs["bench_name"], self.kwargs["tag"])
+        record_before = cache[self.key]
+        last_before = cache.get(ls_key)
         with self.assertRaises(HistoryResetError):
             self.load(["a"], 2, [rv_a], on_history_reset="error")
-        record_after = self.collector.get_history_cache()[self.key]
-        self.assertEqual(
-            record_before["dataset"].sizes["over_time"],
-            record_after["dataset"].sizes["over_time"],
-        )
+        record_after = cache[self.key]
+        last_after = cache.get(ls_key)
+        # column + retire metadata, dataset values, and the last-seen index
+        # entry must all be byte-identical: an erroring run advances nothing.
+        self.assertEqual(record_before["columns"], record_after["columns"])
+        self.assertEqual(record_before["retired"], record_after["retired"])
+        xr.testing.assert_identical(record_before["dataset"], record_after["dataset"])
+        self.assertEqual(last_before, last_after)
 
     def test_warn_policy_names_the_change(self):
         rv_a, rv_b = _result_float("a"), _result_float("b")

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -8,10 +8,12 @@ import pytest
 import xarray as xr
 
 import bencher as bn
+from bencher.history import BIRTH_ATTR
 from bencher.regression import (
     RegressionError,
     RegressionReport,
     RegressionResult,
+    _history_points_since_birth,
     build_regression_overlay,
     detect_absolute,
     detect_adaptive,
@@ -639,6 +641,65 @@ class TestRegressionReport:
         assert "No regressions" in text
         assert "latency" in md
 
+    def test_markdown_marks_young_baseline_row_only(self):
+        """Young regressions are flagged in the table; mature rows are untouched."""
+        mature = RegressionResult(
+            "mature_var", "percentage", True, 110.0, 100.0, 10.0, 5.0, "minimize", ""
+        )
+        young = RegressionResult(
+            "young_var",
+            "percentage",
+            True,
+            110.0,
+            100.0,
+            10.0,
+            5.0,
+            "minimize",
+            "",
+            young_baseline=True,
+        )
+        md = RegressionReport(results=[mature, young]).to_markdown()
+        assert "| young_var † |" in md
+        assert "| mature_var |" in md
+        # The marker must not leak onto the mature row.
+        assert "| mature_var † |" not in md
+        # A legend explains the marker when any young regression is present.
+        assert "young baseline" in md
+
+    def test_markdown_has_no_young_legend_without_young_rows(self):
+        """No legend line when every regression has a mature baseline."""
+        mature = RegressionResult(
+            "mature_var", "percentage", True, 110.0, 100.0, 10.0, 5.0, "minimize", ""
+        )
+        md = RegressionReport(results=[mature]).to_markdown()
+        assert "young baseline" not in md
+        assert "†" not in md
+
+    def test_to_dict_exports_has_blocking_regressions(self):
+        """Report dict distinguishes blocking from notify-only regressions."""
+        young = RegressionResult(
+            "young_var",
+            "percentage",
+            True,
+            110.0,
+            100.0,
+            10.0,
+            5.0,
+            "minimize",
+            "",
+            young_baseline=True,
+        )
+        d = RegressionReport(results=[young]).to_dict()
+        assert d["has_regressions"] is True
+        assert d["has_blocking_regressions"] is False
+
+        mature = RegressionResult(
+            "mature_var", "percentage", True, 110.0, 100.0, 10.0, 5.0, "minimize", ""
+        )
+        d2 = RegressionReport(results=[mature]).to_dict()
+        assert d2["has_regressions"] is True
+        assert d2["has_blocking_regressions"] is True
+
 
 # ── method_cells public helper ────────────────────────────────────────────
 
@@ -756,6 +817,7 @@ def _make_cfg(
     regression_delta=None,
     regression_absolute=None,
     regression_overrides=None,
+    regression_min_history=None,
 ):
     """Create minimal bench_cfg and run_cfg mocks for detect_regressions tests."""
 
@@ -772,6 +834,7 @@ def _make_cfg(
             regression_delta,
             regression_absolute,
             regression_overrides,
+            regression_min_history,
         ):
             self.regression_method = method
             self.regression_mad = regression_mad
@@ -779,6 +842,7 @@ def _make_cfg(
             self.regression_delta = regression_delta
             self.regression_absolute = regression_absolute
             self.regression_overrides = regression_overrides
+            self.regression_min_history = regression_min_history
 
     return (
         FakeBenchCfg(result_vars),
@@ -789,6 +853,7 @@ def _make_cfg(
             regression_delta,
             regression_absolute,
             regression_overrides,
+            regression_min_history,
         ),
     )
 
@@ -1141,6 +1206,54 @@ class TestDetectRegressions:
         bench_cfg, run_cfg = _make_cfg([rv], method="delta", regression_delta=1.0)
         report = detect_regressions(ds, bench_cfg, run_cfg)
         assert report.results == []
+
+
+class TestHistoryPointsSinceBirth:
+    """Baseline-age counting from the birth coordinate (duplicate labels)."""
+
+    @staticmethod
+    def _dataset(labels, values, birth):
+        vals = np.asarray(values, dtype=float).reshape(len(labels), 1)
+        ds = xr.Dataset(
+            {"m": (["over_time", "repeat"], vals)},
+            coords={"over_time": list(labels), "repeat": [0]},
+        )
+        ds["m"].attrs[BIRTH_ATTR] = birth
+        return ds
+
+    def test_duplicate_birth_label_counts_from_last_occurrence(self):
+        """A duplicated birth label counts from its LAST occurrence.
+
+        The first occurrence would over-count history (undoing the young
+        gate); the last occurrence errs toward fewer points ("younger").
+        """
+        ds = self._dataset(
+            ["r0", "r1", "r1", "r2", "r3"], [100.0, 100.0, 100.0, 100.0, 200.0], birth="r1"
+        )
+        # 5 total points, birth at index 2 (last "r1"), current excluded -> 2.
+        assert _history_points_since_birth(ds, ds["m"]) == 2
+
+    def test_column_born_on_second_duplicate_stays_young(self):
+        """A column born on the second duplicate must remain notify-only.
+
+        With min_history=3 the last-occurrence count (2) is below the gate, so
+        the regression is young/non-blocking. The first-occurrence count (3)
+        would have crossed the gate and turned this into a blocking failure.
+        """
+        from bencher.variables.results import ResultFloat
+
+        ds = self._dataset(
+            ["r0", "r1", "r1", "r2", "r3"], [100.0, 100.0, 100.0, 100.0, 200.0], birth="r1"
+        )
+        rv = ResultFloat(units="s", direction=OptDir.minimize)
+        rv.name = "m"
+        bench_cfg, run_cfg = _make_cfg(
+            [rv], method="percentage", regression_percentage=10.0, regression_min_history=3
+        )
+        report = detect_regressions(ds, bench_cfg, run_cfg)
+        assert report.has_regressions
+        assert not report.has_blocking_regressions
+        assert all(r.young_baseline for r in report.regressed_variables)
 
 
 # ── RegressionError ────────────────────────────────────────────────────────

--- a/test/test_scorecard.py
+++ b/test/test_scorecard.py
@@ -173,6 +173,13 @@ class TestCellVerdict:
     def test_regressed_overrides(self):
         assert cell_verdict(_reg("v", "maximize", True, 1.0, 0.75, -25.0)) == "regressed"
 
+    def test_young_baseline_regression_is_trend(self):
+        """A regressed cell on a young baseline is notify-only -> uncolored trend."""
+        reg = _reg("v", "maximize", True, 1.0, 0.75, -25.0)
+        assert cell_verdict(reg) == "regressed"
+        reg["young_baseline"] = True
+        assert cell_verdict(reg) == "trend"
+
     def test_improved_when_beneficial_over_threshold(self):
         assert cell_verdict(_reg("v", "maximize", False, 1.0, 1.2, 20.0)) == "improved"
         assert cell_verdict(_reg("v", "minimize", False, 1.0, 0.8, -20.0)) == "improved"


### PR DESCRIPTION
Implements plans 09 and 14 together as one cache-busting change (`CACHE_VERSION` 4 → 5, version 1.116.0). Fixes the three plan-09 key-correctness defects and resolves the underlying tension that plan alone couldn't: evolving a benchmark's result variables no longer costs its accumulated `over_time` history.

## The design in one paragraph

The two caches want different keys, so they no longer share one. The **benchmark-level result cache stays strict** — result vars included (now order-independently, with names) — so a cached single result always matches the exact current definition. The **history cache keys without result vars** and stores a *superset* record of every column ever measured; at load time columns are reconciled per identity `(name, class, units, meaning_version)` and consumers receive a **projection onto exactly the current config's columns**. Nothing is ever deleted by reconciliation: removed columns go dormant and resume if they return; redefined columns are retired under a mangled name and restart. See `plans/14-history-schema-reconciliation.md` for the full design record and the deliberately-not-done list.

## Plan 09 (D1/D2/D3)

- **D1**: `result_vars`/`const_vars` contribute as an unordered set (sorted per-var digests) — reordering is a no-op. `input_vars` stay ordered (they define dim layout).
- **D2**: every per-var identity now includes the variable **name** — a rename is a detected identity change instead of a silent dead-column split (result vars) or a phantom-dimension broadcast that fabricates data (input vars). The dims-layout guard in `bencher.history.incompatible_reason` additionally makes the broadcast structurally unreachable even for hand-seeded records.
- **D3**: a per-`(bench_name, tag)` last-seen index stores the previous key + config summary; when the key moves, the reset is reported with a named diff (what was added/removed/changed) and the orphaned-event count, routed through the new **`BenchRunCfg.on_history_reset`** policy (`warn` default / `error` / `ignore`). `error` raises `HistoryResetError` *before* any state is persisted, so a CI run can never silently lose a baseline. Also corrected plan 09's stale `include_repeats=False` parenthetical (that hash is vestigial; the sample cache keys on inputs+tag).

## Plan 14 (new)

- **`meaning_version`** on `ResultFloat`/`ResultBool`: the sanctioned "same name, new semantics" declaration. Bumping it restarts that column's history and baseline cleanly while every other column continues — closing the silent-splice hole where a redefined metric's trend line mixes two different quantities.
- **Birth stamps + young-baseline gating**: freshly added / restarted columns carry their birth `over_time` coordinate (`history_birth` attr). Below **`regression_min_history`** points since birth (default 1 = previous behavior; per-var override via a `min_history` key in `regression_overrides`), regressions are reported and exported (`young_baseline: true`, `RegressionReport.has_blocking_regressions`) but never trigger `regression_fail`. History-free `absolute` checks still gate — they need no baseline.
- Non-NaN-sentinel columns (media `"NAN"`, reference `-1`) have concat's NaN fill rewritten back to their proper sentinel, so `result_is_missing` semantics hold across gaps.

## Why this shape (tradeoffs considered)

- **Retain + projection over prune**: pruning removed columns gives the same consumer-facing invariant but is irreversible — a typo'd name in a shared result-var constant or a partial run would permanently destroy shared history (in CI setups the history cache is a shared artifact). Retention makes the worst case a warning and a NaN gap. Plotting code iterates `dataset.data_vars`, so the projection (not raw retention) is what keeps ghost columns out of consumers.
- **No reconciliation across input/const changes**: a different input space is a different experiment; it gets a clean, *reported* full reset. Cross-dim merging is exactly where xarray fabricates data.
- **Rename = remove+add** (no `renamed_from` mapping): retained data makes a rename cheap to reverse; a continuity mapping can be added later if a concrete need appears.

## Validation

- `pixi run pytest`: **1851 passed, 3 skipped, 44 subtests passed** (includes 28 new tests in `test/test_history_reconciliation.py`: D1/D2 key semantics, full column lifecycle born→dormant→resumed→retired, error-before-persist, last-seen reset diffs, no-dead-column/no-phantom-dim invariants, young-baseline gating incl. per-var override and export shape).
- Golden hashes updated per the documented procedure (new history-key golden added); `CACHE_VERSION` bumped in the same change; headline CHANGELOG entry.
- `pixi run lint` (ruff, ty, pylint 10.00/10) and `prek run -a` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
