### PR TITLE
scorecard: Add metric/benchmark orientation toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.115.0] - 2026-07-11
+
 ### Added
-- **Scorecard orientation toggle** — each category's table can now be read two ways, switched by a control in the page header (the choice persists via `localStorage`). The default *metric across benchmarks* view is unchanged (one column per metric, one row per benchmark); the new *metrics within benchmark* view transposes it (one column per benchmark, one row per metric) so a benchmark's metrics stack with their sparkline time axes aligned. Both orientations are rendered from a single benchmark-by-metric cell matrix through one shared cell macro; the switch is pure show/hide of the pre-rendered tables, so it needs no data round-trip.
+- **Scorecard orientation toggle** — each category's table can now be read two ways, switched by a control in the page header (the choice persists via `localStorage`). The default *metric across benchmarks* view is unchanged (one column per metric, one row per benchmark); the new *metrics within benchmark* view transposes it (one column per benchmark, one row per metric) so a benchmark's metrics stack with their sparkline time axes aligned. Both orientations are rendered from a single set of per-benchmark cells through one shared cell macro; the switch is pure show/hide of the pre-rendered tables, so it needs no data round-trip.
 
 ## [1.114.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Scorecard orientation toggle** — each category's table can now be read two ways, switched by a control in the page header (the choice persists via `localStorage`). The default *metric across benchmarks* view is unchanged (one column per metric, one row per benchmark); the new *metrics within benchmark* view transposes it (one column per benchmark, one row per metric) so a benchmark's metrics stack with their sparkline time axes aligned. Both orientations are rendered from a single benchmark-by-metric cell matrix through one shared cell macro; the switch is pure show/hide of the pre-rendered tables, so it needs no data round-trip.
+
 ## [1.114.0] - 2026-07-06
 
 ### Added

--- a/bencher/scorecard/render.py
+++ b/bencher/scorecard/render.py
@@ -1,13 +1,13 @@
 """Render the benchmark health scorecard to a single HTML page.
 
 Discovers every ``*.summary.json`` under the reports directory, groups them by
-category, and builds a benchmark-by-metric cell matrix per category, rendered by
-a bundled Jinja template. Each cell shows a verdict-colored value, a Δ, and a
-noise sparkline. The template lays the matrix out two ways — one column per
-metric (compare a metric across benchmarks) or one column per benchmark (stack a
-benchmark's metrics on a shared time axis) — and a client-side control toggles
-between them. Benchmarks with only image reports are listed as plain links so
-they stay reachable from this page.
+category, and builds one metric cell per (benchmark, metric) pair per category,
+rendered by a bundled Jinja template. Each cell shows a verdict-colored value, a
+Δ, and a noise sparkline. The template lays those cells out two ways — one column
+per metric (compare a metric across benchmarks) or one column per benchmark
+(stack a benchmark's metrics on a shared time axis) — and a client-side control
+toggles between them. Benchmarks with only image reports are listed as plain
+links so they stay reachable from this page.
 """
 
 from __future__ import annotations
@@ -78,9 +78,11 @@ def generate_scorecard(
     # metrics present in that category are shown. Categories render in the
     # registry's display order (records are already sorted that way).
     #
-    # Each section carries a benchmark-by-metric cell ``matrix`` plus the two
-    # label axes, so the template can lay the same cells out either way — one
-    # column per metric (compare a metric across benchmarks) or one column per
+    # Each section carries the two label axes (``metrics`` and ``benchmarks``),
+    # and every benchmark carries its ``cells`` in metric order. That single list
+    # feeds both orientations: the template reads a benchmark's ``cells`` straight
+    # across for one column per metric (compare a metric across benchmarks), or
+    # indexes ``bench.cells[metric_i]`` down a metric row for one column per
     # benchmark (stack a benchmark's metrics on a shared time axis). The view is
     # toggled client-side, so both orientations are rendered from this one model.
     sections: list[dict] = []
@@ -93,13 +95,11 @@ def generate_scorecard(
                 "tag": rec["tag"],
                 "link": rec["link"],
                 "time_event": rec["time_event"],
+                "cells": [build_cell(rec, var, config) for var in metrics],
             }
             for rec in cat_records
         ]
-        matrix = [[build_cell(rec, var, config) for var in metrics] for rec in cat_records]
-        sections.append(
-            {"category": category, "metrics": metrics, "benchmarks": benchmarks, "matrix": matrix}
-        )
+        sections.append({"category": category, "metrics": metrics, "benchmarks": benchmarks})
 
     link_sections = discover_report_links(reports_dir, config, {r["tag"] for r in records})
 

--- a/bencher/scorecard/render.py
+++ b/bencher/scorecard/render.py
@@ -1,10 +1,13 @@
 """Render the benchmark health scorecard to a single HTML page.
 
 Discovers every ``*.summary.json`` under the reports directory, groups them by
-category, builds one row per benchmark and one column per (aliased) scalar
-metric, and renders a bundled Jinja template. Each cell shows a verdict-colored
-value, a Δ, and a noise sparkline; benchmarks with only image reports are listed
-as plain links so they stay reachable from this page.
+category, and builds a benchmark-by-metric cell matrix per category, rendered by
+a bundled Jinja template. Each cell shows a verdict-colored value, a Δ, and a
+noise sparkline. The template lays the matrix out two ways — one column per
+metric (compare a metric across benchmarks) or one column per benchmark (stack a
+benchmark's metrics on a shared time axis) — and a client-side control toggles
+between them. Benchmarks with only image reports are listed as plain links so
+they stay reachable from this page.
 """
 
 from __future__ import annotations
@@ -71,24 +74,32 @@ def generate_scorecard(
 
     records = discover_summaries(reports_dir, config)
 
-    # Group by category; each category gets its own union of columns so only the
+    # Group by category; each category gets its own union of metrics so only the
     # metrics present in that category are shown. Categories render in the
     # registry's display order (records are already sorted that way).
+    #
+    # Each section carries a benchmark-by-metric cell ``matrix`` plus the two
+    # label axes, so the template can lay the same cells out either way — one
+    # column per metric (compare a metric across benchmarks) or one column per
+    # benchmark (stack a benchmark's metrics on a shared time axis). The view is
+    # toggled client-side, so both orientations are rendered from this one model.
     sections: list[dict] = []
     for category in dict.fromkeys(r["category"] for r in records):
         cat_records = [r for r in records if r["category"] == category]
-        columns = metric_columns(cat_records)
-        rows = [
+        metrics = metric_columns(cat_records)
+        benchmarks = [
             {
                 "name": rec["name"],
                 "tag": rec["tag"],
                 "link": rec["link"],
                 "time_event": rec["time_event"],
-                "cells": [build_cell(rec, var, config) for var in columns],
             }
             for rec in cat_records
         ]
-        sections.append({"category": category, "columns": columns, "rows": rows})
+        matrix = [[build_cell(rec, var, config) for var in metrics] for rec in cat_records]
+        sections.append(
+            {"category": category, "metrics": metrics, "benchmarks": benchmarks, "matrix": matrix}
+        )
 
     link_sections = discover_report_links(reports_dir, config, {r["tag"] for r in records})
 

--- a/bencher/scorecard/templates/scorecard.html
+++ b/bencher/scorecard/templates/scorecard.html
@@ -27,6 +27,13 @@
   .badge-branch { background: #264653; color: #8ecae6; }
   .badge-pr { background: #2a6f3b; color: #a7f3d0; }
   .badge-count { background: #3a3a5c; color: #c4b5fd; }
+  .orient-switch { display: inline-flex; border: 1px solid #3a3a5c; border-radius: 6px; overflow: hidden; }
+  .orient-btn {
+    background: transparent; color: #c4b5fd; border: none; padding: 4px 10px;
+    font: inherit; font-size: 0.78rem; line-height: 1.2; cursor: pointer;
+  }
+  .orient-btn + .orient-btn { border-left: 1px solid #3a3a5c; }
+  .orient-btn[aria-pressed="true"] { background: #6366f1; color: #fff; }
   main { width: 100%; margin: 0; padding: 16px 20px; }
   .legend { display: flex; gap: 16px; font-size: 0.8rem; color: #6b7280; margin-bottom: 12px; flex-wrap: wrap; }
   .legend span { display: inline-flex; align-items: center; gap: 6px; }
@@ -41,25 +48,39 @@
     color: #6b7280; margin-bottom: 8px; padding-bottom: 5px; border-bottom: 2px solid #e5e7eb;
   }
   .table-wrap { overflow-x: auto; background: #fff; border: 1px solid #e5e7eb; border-radius: 10px; }
-  /* Fixed layout + width:100% spreads metric columns evenly across the full
+  /* Fixed layout + width:100% spreads the data columns evenly across the full
      viewport width; min-width keeps them readable (and lets .table-wrap scroll)
-     when a category has many metrics on a narrow screen. */
+     when a category has many columns on a narrow screen. Fixed columns also give
+     every sparkline in a benchmark column the same width, so their time axes line
+     up when comparing a benchmark's metrics in the transposed view. */
   table { border-collapse: collapse; width: 100%; table-layout: fixed; min-width: 640px; font-size: 0.8rem; }
   th, td { padding: 6px 8px; text-align: center; border-bottom: 1px solid #f0f0f0; }
-  thead th {
+  /* Header/label styling is keyed to position in the grid (top row = .colhead,
+     left column = .rowhead, .corner is both) rather than to what the axis holds,
+     so the same cells read correctly in either orientation. */
+  .colhead {
     position: sticky; top: 0; background: #f9fafb; color: #374151; font-weight: 600;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.72rem;
-    vertical-align: bottom; z-index: 1; overflow: hidden; text-overflow: ellipsis;
+    font-size: 0.72rem; vertical-align: bottom; z-index: 1; overflow: hidden; text-overflow: ellipsis;
   }
-  th.bench-col, td.bench-col {
-    position: sticky; left: 0; background: #fff; text-align: left; z-index: 2;
+  .rowhead, .corner {
+    position: sticky; left: 0; background: #fff; text-align: left;
     border-right: 1px solid #e5e7eb; width: 200px;
   }
-  thead th.bench-col { background: #f9fafb; z-index: 3; }
-  td.bench-col a { color: #1f2937; text-decoration: none; font-weight: 600; }
-  td.bench-col a:hover { color: #6366f1; text-decoration: underline; }
-  td.bench-col .when { display: block; font-size: 0.7rem; color: #9ca3af; font-weight: 400; }
+  .rowhead { z-index: 2; }
+  .corner { top: 0; z-index: 3; background: #f9fafb; color: #374151; font-weight: 600; }
+  /* Metric names are monospace wherever they sit; benchmark names carry a link
+     and a timestamp and read as prose. */
+  .metric-head { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .bench-head { font-weight: 600; }
+  .rowhead a, .colhead a { color: #1f2937; text-decoration: none; font-weight: 600; }
+  .rowhead a:hover, .colhead a:hover { color: #6366f1; text-decoration: underline; }
+  .when { display: block; font-size: 0.7rem; color: #9ca3af; font-weight: 400; }
   td.cell { vertical-align: middle; }
+  /* Only one orientation is shown at a time; the header switch flips the body
+     class. Default (no class) shows metrics-as-columns, matching the prior page. */
+  .table-wrap.orient-metric { display: none; }
+  body.show-metric .table-wrap.orient-benchmark { display: none; }
+  body.show-metric .table-wrap.orient-metric { display: block; }
   .spark { line-height: 0; }
   .spark svg { display: block; width: 100%; height: 30px; }
   .cval { font-weight: 600; color: #1f2937; }
@@ -128,6 +149,14 @@
     <a href="{{ stable_url }}">Stable Latest</a>
     {% endif %}
     <span class="badge badge-count">{{ bench_count }} benchmark{{ "s" if bench_count != 1 }}</span>
+    {% if sections %}
+    <div class="orient-switch" role="group" aria-label="Table orientation">
+      <button type="button" class="orient-btn" data-mode="benchmark"
+              title="One column per metric — compare a metric across benchmarks">metric across benchmarks</button>
+      <button type="button" class="orient-btn" data-mode="metric"
+              title="One column per benchmark — stack a benchmark's metrics on a shared time axis">metrics within benchmark</button>
+    </div>
+    {% endif %}
     <span style="font-size:0.78rem;color:#9ca3af;">{{ generated_at }}</span>
   </div>
 </header>
@@ -140,47 +169,73 @@
     <span><span class="swatch sw-none"></span> trend only (no regression check yet)</span>
     <span>sparkline = mean-over-time line + ±std band with a node per run; right-edge dots = per-run distribution; μ = mean</span>
   </div>
+  {% macro data_cell(cell) %}
+    {% if cell %}
+    <td class="cell v-{{ cell.verdict }}"{% if cell.tooltip %} title="{{ cell.tooltip }}"{% endif %}>
+      <div class="spark">{{ cell.svg|safe }}</div>
+      <div class="cfoot">
+        <div class="cstat">
+          <div class="cval">{{ cell.latest_str }}</div>
+          {% if cell.change_str %}<div class="cdelta">{{ cell.change_str }}</div>{% endif %}
+        </div>
+        {% if cell.mean_str and cell.mean_str != "—" %}
+        <div class="cdist" title="mean ± std of {{ cell.n_events }} runs">
+          <div class="cmean">μ {{ cell.mean_str }}</div>
+          {% if cell.std_str and cell.std_str != "—" %}<div class="csigma">σ {{ cell.std_str }}</div>{% endif %}
+        </div>
+        {% endif %}
+      </div>
+    </td>
+    {% else %}
+    <td class="cell v-none"><span class="cempty">—</span></td>
+    {% endif %}
+  {% endmacro %}
+  {% macro bench_label(bench) %}
+    <a href="{{ bench.link }}">{{ bench.name }}</a>
+    {% if bench.time_event %}<span class="when">{{ bench.time_event }}</span>{% endif %}
+  {% endmacro %}
   {% for section in sections %}
   <section class="category">
     <h2 class="category-title">{{ section.category }}</h2>
-    <div class="table-wrap">
-      <table>
+    {# One column per metric: read down a column to compare that metric across benchmarks. #}
+    <div class="table-wrap orient-benchmark">
+      <table data-orient="benchmark">
         <thead>
           <tr>
-            <th class="bench-col">Benchmark</th>
-            {% for col in section.columns %}
-            <th title="{{ col }}">{{ col }}</th>
+            <th class="corner">Benchmark</th>
+            {% for metric in section.metrics %}
+            <th class="colhead metric-head" title="{{ metric }}">{{ metric }}</th>
             {% endfor %}
           </tr>
         </thead>
         <tbody>
-          {% for row in section.rows %}
+          {% for bench in section.benchmarks %}
           <tr>
-            <td class="bench-col">
-              <a href="{{ row.link }}">{{ row.name }}</a>
-              {% if row.time_event %}<span class="when">{{ row.time_event }}</span>{% endif %}
-            </td>
-            {% for cell in row.cells %}
-            {% if cell %}
-            <td class="cell v-{{ cell.verdict }}"{% if cell.tooltip %} title="{{ cell.tooltip }}"{% endif %}>
-              <div class="spark">{{ cell.svg|safe }}</div>
-              <div class="cfoot">
-                <div class="cstat">
-                  <div class="cval">{{ cell.latest_str }}</div>
-                  {% if cell.change_str %}<div class="cdelta">{{ cell.change_str }}</div>{% endif %}
-                </div>
-                {% if cell.mean_str and cell.mean_str != "—" %}
-                <div class="cdist" title="mean ± std of {{ cell.n_events }} runs">
-                  <div class="cmean">μ {{ cell.mean_str }}</div>
-                  {% if cell.std_str and cell.std_str != "—" %}<div class="csigma">σ {{ cell.std_str }}</div>{% endif %}
-                </div>
-                {% endif %}
-              </div>
-            </td>
-            {% else %}
-            <td class="cell v-none"><span class="cempty">—</span></td>
-            {% endif %}
+            <td class="rowhead bench-head">{{ bench_label(bench) }}</td>
+            {% for cell in section.matrix[loop.index0] %}{{ data_cell(cell) }}{% endfor %}
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {# One column per benchmark: read down a column to compare a benchmark's
+       metrics against each other on a shared (aligned) time axis. #}
+    <div class="table-wrap orient-metric">
+      <table data-orient="metric">
+        <thead>
+          <tr>
+            <th class="corner">Metric</th>
+            {% for bench in section.benchmarks %}
+            <th class="colhead bench-head">{{ bench_label(bench) }}</th>
             {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for metric in section.metrics %}
+          {% set mi = loop.index0 %}
+          <tr>
+            <td class="rowhead metric-head" title="{{ metric }}">{{ metric }}</td>
+            {% for bench in section.benchmarks %}{{ data_cell(section.matrix[loop.index0][mi]) }}{% endfor %}
           </tr>
           {% endfor %}
         </tbody>
@@ -206,5 +261,32 @@
   </section>
   {% endif %}
 </main>
+<script>
+  // Orientation switch: flip the whole page between one-column-per-metric and
+  // one-column-per-benchmark. Pure show/hide of pre-rendered tables (no data is
+  // rebuilt), and the choice is remembered so it persists across the CI links.
+  (function () {
+    "use strict";
+    var KEY = "bencher-scorecard-orient";
+    var buttons = Array.prototype.slice.call(document.querySelectorAll(".orient-btn"));
+    if (!buttons.length) return;
+    function apply(mode) {
+      document.body.classList.toggle("show-metric", mode === "metric");
+      buttons.forEach(function (b) {
+        b.setAttribute("aria-pressed", b.getAttribute("data-mode") === mode ? "true" : "false");
+      });
+    }
+    var saved = "benchmark";
+    try { saved = window.localStorage.getItem(KEY) || saved; } catch (e) { /* storage unavailable */ }
+    apply(saved === "metric" ? "metric" : "benchmark");
+    buttons.forEach(function (b) {
+      b.addEventListener("click", function () {
+        var mode = b.getAttribute("data-mode");
+        apply(mode);
+        try { window.localStorage.setItem(KEY, mode); } catch (e) { /* storage unavailable */ }
+      });
+    });
+  })();
+</script>
 </body>
 </html>

--- a/bencher/scorecard/templates/scorecard.html
+++ b/bencher/scorecard/templates/scorecard.html
@@ -212,7 +212,7 @@
           {% for bench in section.benchmarks %}
           <tr>
             <td class="rowhead bench-head">{{ bench_label(bench) }}</td>
-            {% for cell in section.matrix[loop.index0] %}{{ data_cell(cell) }}{% endfor %}
+            {% for cell in bench.cells %}{{ data_cell(cell) }}{% endfor %}
           </tr>
           {% endfor %}
         </tbody>
@@ -232,10 +232,10 @@
         </thead>
         <tbody>
           {% for metric in section.metrics %}
-          {% set mi = loop.index0 %}
+          {% set metric_i = loop.index0 %}
           <tr>
             <td class="rowhead metric-head" title="{{ metric }}">{{ metric }}</td>
-            {% for bench in section.benchmarks %}{{ data_cell(section.matrix[loop.index0][mi]) }}{% endfor %}
+            {% for bench in section.benchmarks %}{{ data_cell(bench.cells[metric_i]) }}{% endfor %}
           </tr>
           {% endfor %}
         </tbody>

--- a/docs/scorecard.md
+++ b/docs/scorecard.md
@@ -15,6 +15,16 @@ It reads the machine-readable `*.summary.json` written by
 {func}`bencher.result_to_json` (with `include_series=True`) for every benchmark
 under a reports directory and groups them by category.
 
+Within each category the same cells can be read two ways, switched by a control
+in the page header (the choice is remembered across visits):
+
+- **metric across benchmarks** (default) — one column per metric, one row per
+  benchmark. Read down a column to compare a single metric across benchmarks.
+- **metrics within benchmark** — the transpose: one column per benchmark, one
+  row per metric. Read down a column to compare a benchmark's metrics against
+  each other. Because every column is the same fixed width, the sparklines stack
+  with their time axes aligned.
+
 ## Producing the input
 
 Each benchmark writes its summary with the over-time series attached:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.114.0"
+version = "1.115.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"

--- a/test/test_scorecard.py
+++ b/test/test_scorecard.py
@@ -490,7 +490,11 @@ class TestGenerateScorecard:
     def test_charted_bench_not_duplicated_as_link(self, mock_reports: Path):
         generate_scorecard(mock_reports, CONFIG)
         html = (mock_reports / "index.html").read_text()
-        assert html.count("benchmarks/test_bench_startup/Startup.html") == 1
+        # The charted bench appears in the metric tables (once per rendered
+        # orientation) but must NOT also be listed in the metric-less
+        # "Reports without metrics" links.
+        _before, _sep, links_section = html.partition("Reports without metrics")
+        assert "benchmarks/test_bench_startup/Startup.html" not in links_section
 
     def test_zero_config_default_still_renders(self, mock_reports: Path):
         # No config: benchmarks auto-name and fall into "Other"; still a page.
@@ -498,3 +502,43 @@ class TestGenerateScorecard:
         # Default layout root is "" so the "benchmarks/" tree is not discovered.
         assert out.exists()
         assert "No benchmark summaries found." in out.read_text()
+
+
+class TestOrientationToggle:
+    """The scorecard renders both orientations and a client-side switch."""
+
+    def test_both_orientation_tables_rendered(self, mock_reports: Path):
+        generate_scorecard(mock_reports, CONFIG)
+        html = (mock_reports / "index.html").read_text()
+        # Every category renders both a metric-per-column and a benchmark-per-column table.
+        n_categories = 3  # Performance, Startup, Other
+        assert html.count('data-orient="benchmark"') == n_categories
+        assert html.count('data-orient="metric"') == n_categories
+
+    def test_orientation_switch_present(self, mock_reports: Path):
+        generate_scorecard(mock_reports, CONFIG)
+        html = (mock_reports / "index.html").read_text()
+        assert 'class="orient-switch"' in html
+        assert 'data-mode="benchmark"' in html
+        assert 'data-mode="metric"' in html
+
+    def test_metric_is_a_row_header_in_transposed_table(self, mock_reports: Path):
+        generate_scorecard(mock_reports, CONFIG)
+        html = (mock_reports / "index.html").read_text()
+        # In the transposed view a metric name is a left-column row header.
+        _before, _sep, metric_table = html.partition('data-orient="metric"')
+        after_table = metric_table[: metric_table.index("</table>")]
+        assert '<td class="rowhead metric-head" title="success">success</td>' in after_table
+
+    def test_default_shows_metric_columns(self, mock_reports: Path):
+        # The metric-per-column table is the default; the transposed wrapper is
+        # hidden until the switch flips the body class.
+        generate_scorecard(mock_reports, CONFIG)
+        html = (mock_reports / "index.html").read_text()
+        assert ".table-wrap.orient-metric { display: none; }" in html
+        assert "body.show-metric .table-wrap.orient-benchmark { display: none; }" in html
+
+    def test_switch_absent_when_no_benchmarks(self, tmp_path: Path):
+        generate_scorecard(tmp_path, CONFIG)
+        html = (tmp_path / "index.html").read_text()
+        assert 'class="orient-switch"' not in html

--- a/test/test_scorecard.py
+++ b/test/test_scorecard.py
@@ -494,6 +494,7 @@ class TestGenerateScorecard:
         # orientation) but must NOT also be listed in the metric-less
         # "Reports without metrics" links.
         _before, _sep, links_section = html.partition("Reports without metrics")
+        assert "benchmarks/test_bench_startup/Startup.html" in _before
         assert "benchmarks/test_bench_startup/Startup.html" not in links_section
 
     def test_zero_config_default_still_renders(self, mock_reports: Path):


### PR DESCRIPTION
## What

Adds a **toggle to transpose the scorecard tables** so each category can be read two ways:

- **metric across benchmarks** (default, unchanged) — one column per metric, one row per benchmark. Read down a column to compare a single metric across benchmarks.
- **metrics within benchmark** (new) — the transpose: one column per benchmark, one row per metric. Read down a column to compare a benchmark's metrics against each other. Because every column is the same fixed width, the sparklines stack with their **time axes aligned**.

A small segmented control in the page header switches the view, and the choice persists in `localStorage` so it survives across the CI report links.

## Why

The existing layout is great for asking "how does *latency* compare across all benchmarks?" but can't answer "within *this* benchmark, how do its metrics move together over time?" — for that you want the metrics stacked with a shared time axis. Both questions matter; this makes the same data readable either way without regenerating anything.

## How

- `render.py` now builds a per-category **benchmark-by-metric cell matrix** plus the two label axes, instead of pre-baking benchmark rows. Both orientations render from that one model.
- The template renders both tables through a single shared `data_cell` macro (no cell-rendering logic is duplicated). Header/label styling is keyed to **grid position** — top row `.colhead`, left column `.rowhead`, `.corner` is both — rather than to what each axis holds, so the same cells read correctly in either orientation.
- The switch is pure CSS show/hide of the pre-rendered tables driven by a `body.show-metric` class; a ~20-line vanilla-JS handler flips it and remembers the choice. No external deps, consistent with the page's inline-only CSS/JS.

Trade-off: both orientations are emitted into the page, so the sparkline markup appears twice. For a static health report this is cheap (small numeric SVGs) and buys a fully client-side, robust toggle with no data round-trip. Noted in the CHANGELOG.

## Testing

- `test/test_scorecard.py` — new `TestOrientationToggle` (both tables rendered per category, switch present, metric-as-row-header in the transposed table, default view = metric columns, switch absent when there are no benchmarks). Updated `test_charted_bench_not_duplicated_as_link` to assert its real intent (charted bench not listed in the metric-less links) now that a bench link legitimately appears once per orientation.
- Verified against the fabricated `example_scorecard` output that the transposed table is a **faithful transpose** — for every category, the `(benchmark, metric) → cell` map is identical between the two orientations (incl. the 10-metric × 3-benchmark "many-column" case).
- `bm`-equivalent: `pytest test/test_scorecard.py test/test_example_scorecard.py` → 55 passed; `ruff check`, `ruff format`, and `prek` on the changed files all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a benchmark/metric orientation toggle for scorecard tables driven by a header control and a shared benchmark-by-metric data model.

New Features:
- Add a scorecard orientation switch that lets users view metrics across benchmarks or metrics within a benchmark, with the choice persisted in localStorage.

Enhancements:
- Refactor scorecard rendering to build a benchmark-by-metric cell matrix and reuse a single Jinja macro for data cells across both table orientations.
- Adjust table header and label styling to be position-based so the same markup works in both orientations.

Documentation:
- Document the two scorecard table orientations and the new header switch in the scorecard documentation.

Tests:
- Add tests verifying both orientation tables are rendered, the toggle control behavior, default orientation, and its absence when there are no benchmarks.
- Update existing tests to assert the charted benchmark is not duplicated in the metric-less links section despite appearing in the metric tables.