### PR TITLE
feat: let ResultDataSet declare its own container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which 0.16 newly formats. Example generation now runs `ruff check --fix-only` alongside
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
+### Fixed
+- **A `ResultDataSet` renders on every run, not only the first.** With `over_time` and
+  more than one event in the history, a tabular result reached `ds_to_container` with
+  `over_time` still a live dimension: `_to_panes_da` drops `over_time` from the pane
+  recursion so hvplot can use groupby, and the branch that rebuilds it for pane-type
+  results only covered `ResultVideo`/`ResultImage`/`ResultRerun`. The render then died in
+  `zero_dim_da_to_val` with `ValueError: Dimension over_time already exists` (no input
+  vars) or, once another dimension was consumed first, in the `dataset_list` lookup with
+  `TypeError: only integer scalar arrays can be converted to a scalar index` — one cause,
+  two signatures, and via `to_auto` the traceback was swallowed and the plot silently
+  vanished from the report. A `ResultDataSet` now renders the current event: its cells
+  hold indices into `dataset_list`, which is rebuilt from the samples of the run doing the
+  rendering, so the indices merged in from history address *this* run's list and a slider
+  across the events would show the current table under every past run's label. Scalar
+  results keep their full `over_time` series. Two supporting hardenings: a length-1
+  dimension on a point now collapses to a value instead of a one-element array, and
+  `ds_to_container` names the result variable and the dimension that was not reduced
+  rather than indexing a list with an array several frames later.
+
 ### Added
 - **`ResultDataSet(container=...)`** — a `ResultDataSet` can now declare how it renders,
   the way `ResultReference` already could. The callback takes the stored object and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-argument callables are safe. Previously the only way to render a dataset as a
   plot was `bench.add(bn.DataSetResult, container=...)`, which appends to the end of the
   report and cannot sit among the other result variables. `container` is in
-  `_hash_exclude`, so declaring one does not change any cache key.
+  `_hash_exclude`, so declaring one does not change any cache key. A declared container
+  rides in `BenchCfg` into the result cache and the collect/render split, so it must be
+  picklable — a module-level function or a callable object, not a lambda.
 - **Plot-selection signature enrichment** (A2 Phase S1): `PltCntCfg` gains additive, cheaply-computed facts alongside the existing counts — `has_time`/`time_steps` (temporal axis presence and length), `result_kinds` (result-variable name → coarse serializable kind, via the new `result_kind` / `RESULT_KIND_ORDER` in `bencher.variables.results`), `cat_levels` (levels per categorical input), and `samples_per_point` (min repeat count actually present at the latest time step, missing-sentinel-aware per result type, vs the configured `repeats`). `generate_plt_cnt_cfg` takes an optional dataset for the data-derived facts, `PltCntCfg.__str__` includes the new fields, and the aggregation plotting path carries them through. No selection behavior changes.
 
 ## [1.116.0] - 2026-07-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
 ### Added
+- **`ResultDataSet(container=...)`** — a `ResultDataSet` can now declare how it renders,
+  the way `ResultReference` already could. The callback takes the stored object and
+  returns anything panel can display, so a measured table shows up as the plot it means
+  rather than as raw rows, *in `result_vars` order* with the rest of the results.
+  Precedence: a container passed to a renderer wins, then one attached to the stored
+  sample (`ResultDataSet(df, container=...)` inside `benchmark()`), then the one declared
+  on the class. The callback is invoked with the object alone (no plot kwargs), so
+  single-argument callables are safe. Previously the only way to render a dataset as a
+  plot was `bench.add(bn.DataSetResult, container=...)`, which appends to the end of the
+  report and cannot sit among the other result variables. `container` is in
+  `_hash_exclude`, so declaring one does not change any cache key.
 - **Plot-selection signature enrichment** (A2 Phase S1): `PltCntCfg` gains additive, cheaply-computed facts alongside the existing counts — `has_time`/`time_steps` (temporal axis presence and length), `result_kinds` (result-variable name → coarse serializable kind, via the new `result_kind` / `RESULT_KIND_ORDER` in `bencher.variables.results`), `cat_levels` (levels per categorical input), and `samples_per_point` (min repeat count actually present at the latest time step, missing-sentinel-aware per result type, vs the configured `repeats`). `generate_plt_cnt_cfg` takes an optional dataset for the data-derived facts, `PltCntCfg.__str__` includes the new fields, and the aggregation plotting path carries them through. No selection behavior changes.
 
 ## [1.116.0] - 2026-07-11

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -870,11 +870,19 @@ class BenchResultBase:
                 self.bench_cfg.over_time
                 and "over_time" in list(dataset.sizes)
                 and dataset.sizes["over_time"] > 1
-                and isinstance(result_var, (ResultVideo, ResultImage, ResultRerun))
             ):
                 if isinstance(result_var, ResultRerun):
                     return self._pane_over_time_grid(dataset, result_var)
-                return self._pane_over_time_slider(dataset, result_var)
+                if isinstance(result_var, (ResultVideo, ResultImage)):
+                    return self._pane_over_time_slider(dataset, result_var)
+                if isinstance(result_var, ResultDataSet):
+                    # A ResultDataSet cell holds an index into dataset_list, which is
+                    # rebuilt from the samples of the run that is rendering.  Rows
+                    # merged in from history therefore address *this* run's list, so a
+                    # slider over them would show the current table under every past
+                    # run's label.  Render the event being reported instead; scalar
+                    # results keep their real history either way.
+                    dataset = dataset.isel(over_time=-1)
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
         return outer_container.render()
@@ -1009,16 +1017,41 @@ class BenchResultBase:
         else:
             da = da_ds
 
+        # Callers hand this a single point, so collapse any length-1 dimension it
+        # still carries; keep the coordinates, they are what expand_dims below uses.
+        if any(size == 1 for size in da.sizes.values()):
+            da = da.squeeze(drop=False)
+
+        # expand_dims needs a name that is not a dimension yet.  Picking one that is
+        # still live raises "Dimension <name> already exists", which points at the
+        # coordinate rather than at the caller that failed to reduce it.
         for k in da.coords:
-            dim = k
-            break
-        if dim is None:
-            return da_ds.values.squeeze().item()
+            if k not in da.dims:
+                dim = k
+                break
+        if dim is None or dim in da.dims:
+            return da.values.squeeze().item()
         return da.expand_dims(dim).values[0]
+
+    @staticmethod
+    def _unreduced_dims(da: xr.DataArray) -> dict[str, int]:
+        """Dimensions of a supposedly-single point that still hold several values."""
+        return {str(d): int(da.sizes[d]) for d in da.dims if da.sizes[d] > 1}
 
     def ds_to_container(  # pylint: disable=too-many-return-statements
         self, dataset: xr.Dataset, result_var: Parameter, container, **kwargs
     ) -> Any:
+        if isinstance(result_var, (ResultDataSet, ResultReference)):
+            # These two store an index into a side list, so a value that is still an
+            # array indexes that list with an array several frames from the cause.
+            # Name the dimension the caller did not reduce instead.
+            unreduced = self._unreduced_dims(dataset[result_var.name])
+            if unreduced:
+                raise ValueError(
+                    f"cannot render one {type(result_var).__name__} sample for "
+                    f"'{result_var.name}': dimension(s) {unreduced} were neither "
+                    "selected nor reduced, so there is no single value to look up"
+                )
         val = self.zero_dim_da_to_val(dataset[result_var.name])
         if isinstance(result_var, ResultDataSet):
             ref = self.dataset_list[val]
@@ -1028,13 +1061,13 @@ class BenchResultBase:
                 # object alone (no plot kwargs) so single-argument callables work.
                 # getattr, not attribute access: a result pickled before the slot
                 # existed unpickles without it, and reports of old runs still render.
-                dataset_container = (
-                    container
-                    or getattr(ref, "container", None)
-                    or getattr(result_var, "container", None)
-                )
-                if dataset_container is not None:
-                    return dataset_container(ref.obj)
+                for candidate in (
+                    container,
+                    getattr(ref, "container", None),
+                    getattr(result_var, "container", None),
+                ):
+                    if candidate is not None:
+                        return candidate(ref.obj)
                 return ref.obj
             return None
         if isinstance(result_var, ResultReference):

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1023,8 +1023,18 @@ class BenchResultBase:
         if isinstance(result_var, ResultDataSet):
             ref = self.dataset_list[val]
             if ref is not None:
-                if container is not None:
-                    return container(ref.obj)
+                # Renderer-supplied container wins, then the one the sample was
+                # stored with, then the one declared on the class. Called with the
+                # object alone (no plot kwargs) so single-argument callables work.
+                # getattr, not attribute access: a result pickled before the slot
+                # existed unpickles without it, and reports of old runs still render.
+                dataset_container = (
+                    container
+                    or getattr(ref, "container", None)
+                    or getattr(result_var, "container", None)
+                )
+                if dataset_container is not None:
+                    return dataset_container(ref.obj)
                 return ref.obj
             return None
         if isinstance(result_var, ResultReference):

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -424,12 +424,31 @@ class ResultReference(param.Parameter):
 
 
 class ResultDataSet(param.Parameter):
-    __slots__ = ["units", "obj", "max_time_events"]
-    _hash_exclude = ("obj", "max_time_events")
+    """A tabular result: one DataFrame (or Dataset) per sample.
+
+    ``container`` is an optional callback taking the stored object and returning
+    something panel can display, so a table can render as the plot it means
+    instead of as raw rows.  Declare it once on the class and every sample
+    renders through it, in ``result_vars`` order, alongside the other results::
+
+        cloud = ResultDataSet(container=my_scatter)   # my_scatter(df) -> plot
+
+        def benchmark(self):
+            self.cloud = ResultDataSet(build_frame())
+
+    Per-sample overrides are honoured too (``ResultDataSet(df, container=...)``
+    inside ``benchmark()``), and an explicit ``container=`` passed to a renderer
+    beats both.  The callback receives only the object — no plot kwargs — so
+    single-argument callables are safe.
+    """
+
+    __slots__ = ["units", "obj", "container", "max_time_events"]
+    _hash_exclude = ("obj", "container", "max_time_events")
 
     def __init__(
         self,
         obj: Any | None = None,
+        container: Callable[[Any], pn.pane.panel] | None = None,
         default: Any | None = None,
         units: str = "dataset",
         max_time_events=None,
@@ -438,6 +457,7 @@ class ResultDataSet(param.Parameter):
         super().__init__(default=default, **params)
         self.units = units
         self.obj = obj
+        self.container = container
         self.max_time_events = max_time_events
 
     def hash_persistent(self) -> str:

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -440,6 +440,10 @@ class ResultDataSet(param.Parameter):
     inside ``benchmark()``), and an explicit ``container=`` passed to a renderer
     beats both.  The callback receives only the object — no plot kwargs — so
     single-argument callables are safe.
+
+    A declared container travels with ``BenchCfg`` into the result cache and through
+    the collect/render split, so it has to be picklable: a module-level function or a
+    callable object, not a lambda or a local function.
     """
 
     __slots__ = ["units", "obj", "container", "max_time_events"]

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -452,7 +452,7 @@ class ResultDataSet(param.Parameter):
     def __init__(
         self,
         obj: Any | None = None,
-        container: Callable[[Any], pn.pane.panel] | None = None,
+        container: Callable[[Any], Any] | None = None,
         default: Any | None = None,
         units: str = "dataset",
         max_time_events=None,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -237,7 +237,8 @@ Result types declare what a benchmark function returns:
 - `ResultVideo` — a file path to a video
 - `ResultPath` — an arbitrary file path
 - `ResultString` — a string result
-- `ResultDataSet` — an xarray Dataset
+- `ResultDataSet` — a table (DataFrame or xarray Dataset) per sample, optionally with a
+  `container=` callback that renders it as a plot instead of raw rows
 - `ResultVolume` — volume data
 
 Bencher distinguishes inputs from results by type: anything that is a subclass of a result type

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -129,11 +129,32 @@ demo.
 | `bn.ResultPath()` | Downloadable file outputs | `self.artifact = "/path/to/file"` |
 | `bn.ResultContainer()` | Embeddable HTML/panel content | `self.widget = pane` |
 | `bn.ResultVec(size=3)` | Fixed-size vector results (x, y, z) | `self.position = [1.0, 2.0, 3.0]` |
+| `bn.ResultDataSet()` | A table per sample (many rows measured at one point) | `self.cloud = bn.ResultDataSet(df)` |
 
 **Choosing between ResultFloat and ResultBool:** If a result is binary (success/failure,
 reachable/unreachable, pass/fail), always use `ResultBool` — it locks bounds to [0, 1]
 and produces correct boolean-style plots. Only use `ResultFloat` for continuous metrics.
 See the [Result Types gallery](reference/meta/result_types/index) for examples of each type.
+
+**Rendering a table as a plot:** `ResultDataSet` shows raw rows by default. Pass
+`container=` a callable taking the stored object and returning anything panel can
+display, and every sample renders through it, in `result_vars` order alongside the
+other results:
+
+```python
+def scatter(df):                       # -> a holoviews / panel object
+    return hv.Points(df, kdims=["x", "y"])
+
+class MySweep(bn.ParametrizedSweep):
+    cloud = bn.ResultDataSet(container=scatter)
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(measure())     # per-sample container= also works
+```
+
+Without it, the alternative is `bench.add(bn.DataSetResult, container=scatter, ...)`,
+which appends the plot to the end of the report instead of placing it with the results
+it belongs to.
 
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -156,6 +156,10 @@ Without it, the alternative is `bench.add(bn.DataSetResult, container=scatter, .
 which appends the plot to the end of the report instead of placing it with the results
 it belongs to.
 
+A declared container is part of the benchmark config, which the result cache and the
+collect/render split both pickle, so it must be picklable: a module-level function (as
+above) or a callable object, not a lambda or a local function.
+
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
 See the [ResultImage gallery](reference/meta/result_types/result_image/index) and

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -160,6 +160,11 @@ A declared container is part of the benchmark config, which the result cache and
 collect/render split both pickle, so it must be picklable: a module-level function (as
 above) or a callable object, not a lambda or a local function.
 
+Under `over_time`, a `ResultDataSet` renders the run being reported rather than a slider
+over the history: a cell holds an index into a list of tables rebuilt on every run, so
+the indices carried in from earlier runs address the current list and a slider would show
+today's table under yesterday's label. Scalar results keep their full history.
+
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
 See the [ResultImage gallery](reference/meta/result_types/result_image/index) and

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,12 +1,6 @@
 version: 7
 platforms:
-- name: p1
-  subdir: linux-64
-  virtual-packages:
-  - __glibc=2.31
-  - __unix=0=0
-  - __linux=4.18
-  - __archspec=0=x86_64
+- name: linux-64
 environments:
   default:
     channels:
@@ -15,7 +9,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -46,7 +40,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -187,7 +181,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -218,7 +212,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -368,7 +362,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -399,7 +393,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
@@ -542,7 +536,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -574,7 +568,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
@@ -715,7 +709,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -747,7 +741,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -888,7 +882,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      p1:
+      linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -919,7 +913,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
+      - pypi: .
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -1613,7 +1607,7 @@ packages:
   run_exports: {}
   size: 27468597
   timestamp: 1767671008593
-- pypi: ./
+- pypi: .
   name: holobench
   requires_dist:
   - holoviews>=1.15,<=1.23.1

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -2,10 +2,12 @@
 
 import pickle
 import unittest
+from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
 import panel as pn
+import xarray as xr
 
 import bencher as bn
 from bencher.results.dataset_result import DataSetResult
@@ -65,6 +67,67 @@ class LegacyPickleSweep(bn.ParametrizedSweep):
 
     def benchmark(self):
         self.table = bn.ResultDataSet(expected_frame(self.scale))
+
+
+def tagged_frame(scale: float, run_id: int) -> pd.DataFrame:
+    """A frame that says which run produced it, so a render can be traced to its run."""
+    return pd.DataFrame({"y": [scale * 1.0, scale * 2.0], "run": [run_id, run_id]})
+
+
+def run_tagging_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"declared run={df['run'].iloc[0]} scale={df['y'].iloc[0]:g}")
+
+
+class OverTimeSweep(bn.ParametrizedSweep):
+    """A tabular result and a scalar one, to be run repeatedly against one history."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=run_tagging_container, doc="run-tagged dataframe")
+    magnitude = bn.ResultFloat(units="m", doc="scalar result, which does keep history")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(tagged_frame(self.scale, self.run_id))
+        self.magnitude = self.scale + self.run_id
+
+
+class PlainOverTimeSweep(OverTimeSweep):
+    """The same shape with no declared container: the defect predates that feature."""
+
+    table = bn.ResultDataSet(doc="run-tagged dataframe, rendered as rows")
+
+
+OVER_TIME_RUNS = 3
+
+
+def run_sweep_over_time(
+    worker: bn.ParametrizedSweep, name: str, runs: int = OVER_TIME_RUNS
+) -> bn.BenchResult:
+    """Run one sweep `runs` times against a single history, as a nightly rig does.
+
+    Only the first run clears the history, so from the second run on the rendered
+    dataset carries the earlier events on its over_time dimension.
+    """
+    run_cfg = bn.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 1
+    run_cfg.auto_plot = False
+    bench = bn.Bench(name, worker)
+    base_time = datetime(2000, 1, 1)
+    res = None
+    for i in range(runs):
+        worker.run_id = i
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "over_time_dataset_sweep",
+            input_vars=["scale"],
+            result_vars=["table", "magnitude"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+    return res
 
 
 def run_sweep(worker: bn.ParametrizedSweep | None = None, name: str = "test_dataset_result"):
@@ -200,6 +263,90 @@ class TestContainerIsNotData(unittest.TestCase):
         del res.dataset_list[0].container
         frame = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
         pd.testing.assert_frame_equal(frame, expected_frame(SCALES[0]))
+
+
+class TestOverTimeHistory(unittest.TestCase):
+    """A ResultDataSet has to render on every run, not only the first one.
+
+    dataset_list is rebuilt from the samples of whichever run is rendering, so the
+    indices merged in from history address *this* run's list.  Rendering therefore
+    stays on the current event: a slider across the events would show the current
+    table under every past run's label, and before the over_time branch knew about
+    ResultDataSet the render raised out of expand_dims instead.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep_over_time(OverTimeSweep(), "test_dataset_over_time")
+        cls.current_run = OVER_TIME_RUNS - 1
+
+    def expected_panes(self) -> list[str]:
+        return [f"declared run={self.current_run} scale={scale:g}" for scale in SCALES]
+
+    def test_history_accumulated(self):
+        """Guard on the fixture: with a single event there is no regression to catch."""
+        self.assertEqual(self.res.to_dataset().sizes["over_time"], OVER_TIME_RUNS)
+
+    def test_panes_pass_renders_the_current_run(self):
+        self.assertEqual(
+            container_output(self.res.to_auto(plot_list=["panes"])), self.expected_panes()
+        )
+
+    def test_dataset_view_renders_the_current_run(self):
+        self.assertEqual(container_output(self.res.to(DataSetResult)), self.expected_panes())
+
+    def test_one_pane_per_sample_not_per_event(self):
+        """History must not multiply the panes, since the tables are not comparable."""
+        self.assertEqual(len(container_output(self.res.to(DataSetResult))), len(SCALES))
+
+    def test_scalar_results_keep_their_history(self):
+        """Slicing the tables must not cost the metrics their over_time series."""
+        magnitude = self.res.to_dataset()["magnitude"]
+        self.assertEqual(magnitude.sizes["over_time"], OVER_TIME_RUNS)
+        for run in range(OVER_TIME_RUNS):
+            observed = magnitude.isel(over_time=run).sel(scale=SCALES[0]).values.squeeze()
+            self.assertAlmostEqual(float(observed), SCALES[0] + run)
+
+
+class TestOverTimeWithoutContainer(unittest.TestCase):
+    def test_raw_frame_renders_after_the_first_run(self):
+        res = run_sweep_over_time(PlainOverTimeSweep(), "test_dataset_over_time_plain", runs=2)
+        rv = res.bench_cfg.result_vars[0]
+        point = res.to_dataset().isel(over_time=-1).sel(scale=SCALES[0])
+        frame = res.ds_to_container(point, rv, container=None)
+        self.assertEqual(frame["run"].tolist(), [1, 1])
+        self.assertIsInstance(res.to(DataSetResult), pn.viewable.Viewable)
+
+
+class TestSinglePointGuard(unittest.TestCase):
+    """ds_to_container renders one sample, and names the dimension when it cannot."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(DeclaredContainerSweep(), "test_dataset_single_point_guard")
+
+    def test_unreduced_dimension_is_named(self):
+        """A whole dataset is not a point: the error says what was not reduced.
+
+        Indexing dataset_list with an array otherwise fails several frames away,
+        naming neither the result variable nor the dimension.
+        """
+        rv = self.res.bench_cfg.result_vars[0]
+        with self.assertRaises(ValueError) as raised:
+            self.res.ds_to_container(self.res.to_dataset(), rv, container=None)
+        self.assertIn("scale", str(raised.exception))
+        self.assertIn("table", str(raised.exception))
+
+    def test_length_one_dimensions_collapse_to_a_value(self):
+        """A point that kept its length-1 dimensions is one value, not an array."""
+        da = xr.DataArray(
+            [[4.0]],
+            dims=["over_time", "repeat"],
+            coords={"over_time": [0], "repeat": [0]},
+        )
+        value = self.res.zero_dim_da_to_val(da)
+        self.assertNotIsInstance(value, np.ndarray)
+        self.assertEqual(float(value), 4.0)
 
 
 if __name__ == "__main__":

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -1,5 +1,6 @@
 """Tests for DataSetResult (bencher/results/dataset_result.py)."""
 
+import pickle
 import unittest
 
 import numpy as np
@@ -181,6 +182,11 @@ class TestContainerIsNotData(unittest.TestCase):
         other_container = bn.ResultDataSet(container=explicit_container, doc="d")
         self.assertEqual(plain.hash_persistent(), with_container.hash_persistent())
         self.assertEqual(with_container.hash_persistent(), other_container.hash_persistent())
+
+    def test_declared_container_survives_pickling(self):
+        """It rides in BenchCfg, which the result cache and split render both pickle."""
+        rv = pickle.loads(pickle.dumps(DeclaredContainerSweep.param.table))
+        self.assertIs(rv.container, declared_container)
 
     def test_unset_slot_falls_back_to_raw_frame(self):
         """A result pickled before the slot existed unpickles with it unset, and still renders.

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -26,8 +26,49 @@ class DataFrameSweep(bn.ParametrizedSweep):
         self.table = bn.ResultDataSet(expected_frame(self.scale))
 
 
-def run_sweep():
-    bench = bn.Bench("test_dataset_result", DataFrameSweep())
+def declared_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    """Stand-in for a real plot: takes the frame alone, returns something viewable."""
+    return pn.pane.Markdown(f"declared rows={len(df)} sum={df['y'].sum():g}")
+
+
+def per_sample_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"per-sample rows={len(df)}")
+
+
+def explicit_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"explicit rows={len(df)}")
+
+
+class DeclaredContainerSweep(bn.ParametrizedSweep):
+    """Container declared once on the class, applied to every sample."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=declared_container, doc="rendered dataframe result")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale))
+
+
+class PerSampleContainerSweep(DeclaredContainerSweep):
+    """Worker overrides the declared container on the sample it stores."""
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale), container=per_sample_container)
+
+
+class LegacyPickleSweep(bn.ParametrizedSweep):
+    """Owned by the unset-slot test, which mutates its params."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(doc="frame stored without a container")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale))
+
+
+def run_sweep(worker: bn.ParametrizedSweep | None = None, name: str = "test_dataset_result"):
+    worker = DataFrameSweep() if worker is None else worker
+    bench = bn.Bench(name, worker)
     return bench.plot_sweep(
         "dataset_sweep",
         input_vars=["scale"],
@@ -35,6 +76,19 @@ def run_sweep():
         run_cfg=bn.BenchRunCfg(repeats=1, cache_results=False, cache_samples=False),
         auto_plot=False,
     )
+
+
+def container_output(viewable: pn.viewable.Viewable) -> list[str]:
+    """Container-produced Markdown in a rendered pane tree, in render order.
+
+    Filtered by prefix because the surrounding panes carry their own labels
+    (the sample's input values), which is not what these tests are about.
+    """
+    return [
+        pane.object
+        for pane in viewable.select(pn.pane.Markdown)
+        if str(pane.object).startswith(("declared", "per-sample", "explicit"))
+    ]
 
 
 class TestDataSetResult(unittest.TestCase):
@@ -70,6 +124,76 @@ class TestDataSetResult(unittest.TestCase):
         frame = self.res.ds_to_container(point, rv, container=None)
         pd.testing.assert_frame_equal(frame, expected_frame(SCALES[1]))
         np.testing.assert_allclose(frame["y"].to_numpy(), [2.0, 4.0, 6.0])
+
+
+class TestDeclaredContainer(unittest.TestCase):
+    """A container declared on the ResultDataSet renders every sample through it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(DeclaredContainerSweep(), "test_dataset_declared_container")
+
+    def _point(self, scale: float):
+        return self.res.to_dataset().sel(scale=scale)
+
+    def test_declared_container_replaces_raw_frame(self):
+        rv = self.res.bench_cfg.result_vars[0]
+        pane = self.res.ds_to_container(self._point(SCALES[1]), rv, container=None)
+        self.assertIsInstance(pane, pn.pane.Markdown)
+        self.assertEqual(pane.object, "declared rows=3 sum=12")
+
+    def test_explicit_container_beats_declared(self):
+        """A renderer that is given a container keeps using it."""
+        rv = self.res.bench_cfg.result_vars[0]
+        pane = self.res.ds_to_container(self._point(SCALES[0]), rv, container=explicit_container)
+        self.assertEqual(pane.object, "explicit rows=3")
+
+    def test_dataset_view_renders_through_container(self):
+        """The dataset viewer shows the container output, not the raw table."""
+        rendered = container_output(self.res.to(DataSetResult))
+        self.assertEqual(rendered, ["declared rows=3 sum=6", "declared rows=3 sum=12"])
+
+    def test_panes_view_renders_through_container(self):
+        """ResultDataSet is a panel type, so the auto panes pass picks it up too."""
+        rendered = container_output(self.res.to_auto(plot_list=["panes"]))
+        self.assertEqual(rendered, ["declared rows=3 sum=6", "declared rows=3 sum=12"])
+
+    def test_stored_frame_is_untouched(self):
+        """Rendering is a view: the container never rewrites what was measured."""
+        for ref, scale in zip(self.res.dataset_list, SCALES):
+            pd.testing.assert_frame_equal(ref.obj, expected_frame(scale))
+
+
+class TestPerSampleContainer(unittest.TestCase):
+    def test_sample_container_beats_declared(self):
+        res = run_sweep(PerSampleContainerSweep(), "test_dataset_per_sample_container")
+        rv = res.bench_cfg.result_vars[0]
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        self.assertEqual(pane.object, "per-sample rows=3")
+
+
+class TestContainerIsNotData(unittest.TestCase):
+    """The container is a renderer, so it must not participate in cache identity."""
+
+    def test_container_excluded_from_hash(self):
+        plain = bn.ResultDataSet(doc="d")
+        with_container = bn.ResultDataSet(container=declared_container, doc="d")
+        other_container = bn.ResultDataSet(container=explicit_container, doc="d")
+        self.assertEqual(plain.hash_persistent(), with_container.hash_persistent())
+        self.assertEqual(with_container.hash_persistent(), other_container.hash_persistent())
+
+    def test_unset_slot_falls_back_to_raw_frame(self):
+        """A result pickled before the slot existed unpickles with it unset, and still renders.
+
+        Unsetting the slot is the only way to reproduce that state in-process, hence
+        the dedicated sweep class: the deletions mutate params this test alone owns.
+        """
+        res = run_sweep(LegacyPickleSweep(), "test_dataset_legacy_pickle")
+        rv = res.bench_cfg.result_vars[0]
+        del rv.container
+        del res.dataset_list[0].container
+        frame = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        pd.testing.assert_frame_equal(frame, expected_frame(SCALES[0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`ResultDataSet` renders as raw rows. To draw a measured table as the plot it means, the
only route is

```python
bench.add(bn.DataSetResult, container=my_scatter, result_var=cls.param.cloud, reduce=bn.ReduceType.NONE)
```

which goes through `BenchReport.append` → `self.pane[-1].append(pane)`, i.e. the end of the
tab — after the sweep summary, after every auto plot, after the rerun panes. A cloud
measured in a run therefore cannot sit next to the metrics reduced from it, wherever
`cloud` appears in `result_vars`. The list order is honoured *within* the auto pass; a
report-level `add()` simply isn't part of it.

`ResultReference` already solves this for arbitrary objects: it carries a `container`
callback, and `ds_to_container` honours it (`bench_result_base.py:1030-1035`). The
`ResultDataSet` branch three lines above only uses a container handed down by the
renderer. That asymmetry looks like an oversight rather than a decision.

## Change

- `ResultDataSet` gains a `container` slot, same position and spelling as
  `ResultReference`'s (no existing call site passes a second positional argument).
- `ds_to_container` resolves it with a stated precedence: renderer-supplied →
  attached to the stored sample (`ResultDataSet(df, container=...)` in `benchmark()`) →
  declared on the class.
- The callback is invoked with the object alone, no plot kwargs — unlike the
  `ResultReference` path, which forwards `**kwargs` and so requires containers to accept
  them. Keeping the existing `container(ref.obj)` call shape means plain
  single-argument callables work.
- `getattr`, not attribute access: a result pickled before the slot existed unpickles
  with it unset, so old cached/serialized runs still render.

Because `ResultDataSet` is in `PANEL_TYPES`, the auto `panes` pass then renders every
sample through the declared container, in `result_vars` order, with no `bench.add` call
and no separate report entry.

```python
def scatter(df):
    return hv.Points(df, kdims=["x", "y"])

class MySweep(bn.ParametrizedSweep):
    cloud = bn.ResultDataSet(container=scatter)

    def benchmark(self):
        self.cloud = bn.ResultDataSet(measure())
```

## Cache safety

`container` is in `_hash_exclude`, so `hash_persistent()` is unchanged for every existing
`ResultDataSet` — no cache key moves, no history series resets. `_hash_slots` hashes slot
*values*, not the slot list, so the `__slots__` insertion is inert too. Asserted directly
in `TestContainerIsNotData`.

## Tests

`test/test_dataset_result.py`: declared container replaces the raw frame; explicit
container beats declared; per-sample beats declared; the `DataSetResult` viewer and the
auto `panes` pass both render through it in order; the stored frame is untouched;
container excluded from the hash; unset slot falls back to the raw frame.

Full suite green (1912 passed), `ruff`/`ty`/`pylint` clean (10.00/10), `prek run -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow ResultDataSet to declare how its tabular data is rendered and ensure it integrates cleanly into existing plotting and caching flows.

New Features:
- Add an optional container callback to ResultDataSet so each sample can render as a custom plot instead of raw rows, with precedence between renderer-supplied, per-sample, and class-level containers.

Enhancements:
- Update ds_to_container to respect ResultDataSet-level containers while preserving backward compatibility for previously pickled results.
- Exclude the ResultDataSet container from persistent hashing to keep cache identities stable.

Documentation:
- Document ResultDataSet as a table-per-sample result type and describe how to use the container callback to render tables as plots in the user guide and concepts documentation.
- Describe the new ResultDataSet(container=...) capability in the changelog.

Tests:
- Add test sweeps and unit tests covering declared, per-sample, and explicit containers for ResultDataSet, including rendering order and storage integrity.
- Add tests ensuring the container is excluded from cache hashes and that results with unset container slots fall back to raw frame rendering.