### PR TITLE
feat: add an xy_scatter chart type for tabular results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
 ### Added
+- **`xy_scatter` chart type** — scatters two *measured* columns of a `ResultDataSet`
+  against each other, for results whose rows are the measurement (landing points, hit
+  locations, a phase-space cloud). Distinct from the existing `scatter`, which puts an
+  input variable on x and a result variable on y; here both axes come from inside one
+  sample and the sweep dimensions separate one plot from the next. Available two ways
+  from one implementation: `bn.xy_scatter(x=..., y=..., color=..., data_aspect=1)`
+  returns a picklable spec usable as a `ResultDataSet(container=...)`, so the cloud
+  renders in `result_vars` order with the other results; and `XYScatterResult` is
+  registered as a **named-only** chart type (`bench.add(bn.XYScatterResult, x=..., y=...)`
+  or `to_auto(plot_list=["xy_scatter"], ...)`), so no existing report gains a plot it
+  did not ask for. Columns are validated against the frame — a typo names the available
+  columns instead of rendering nothing — x/y are inferred from the numeric columns when
+  omitted, `data_aspect=1` gives the equal-aspect scaling a position cloud needs, and
+  DataFrame / xarray / `hv.Dataset` objects are all accepted. Gallery example:
+  `example_plot_xy_scatter`.
 - **`ResultDataSet(container=...)`** — a `ResultDataSet` can now declare how it renders,
   the way `ResultReference` already could. The callback takes the stored object and
   returns anything panel can display, so a measured table shows up as the plot it means

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -19,6 +19,7 @@ from bencher.results.holoview_results.scatter_result import ScatterResult
 from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.holoview_results.table_result import TableResult
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
+from bencher.results.holoview_results.xy_scatter_result import XYScatterResult, xy_scatter
 from bencher.results.volume_result import VolumeResult
 
 from .bench_cfg import ShowMode

--- a/bencher/example/generated/plot_types/example_plot_xy_scatter.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_scatter.py
@@ -1,0 +1,44 @@
+"""Auto-generated example: Plot Type: Xy Scatter."""
+
+import random
+
+import pandas as pd
+
+import bencher as bn
+from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
+
+
+class TouchCloud(bn.ParametrizedSweep):
+    """Where a repeated motion lands: one row per touch, both axes measured."""
+
+    spread = bn.FloatSweep(default=0.5, bounds=[0.1, 1.0], doc="Positioning noise")
+
+    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+
+    def benchmark(self):
+        rng = random.Random(0)
+        self.touches = bn.ResultDataSet(
+            pd.DataFrame(
+                [
+                    {
+                        "touch": i,
+                        "dx_mm": rng.gauss(0.0, self.spread),
+                        "dy_mm": rng.gauss(0.0, self.spread),
+                    }
+                    for i in range(60)
+                ]
+            )
+        )
+
+
+def example_plot_xy_scatter(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Plot Type: Xy Scatter."""
+    bench = TouchCloud().to_bench(run_cfg)
+    res = bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
+    bench.report.append(res.to(XYScatterResult, x="dx_mm", y="dy_mm", color="touch", data_aspect=1))
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_plot_xy_scatter, subsampling_divisions=3)

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -73,6 +73,34 @@ class ThroughputCompare(bn.ParametrizedSweep):
         lookup = {"redis": 5.4, "memcached": 4.1, "local": 8.7}
         self.distance = lookup[self.backend]"""
 
+_TOUCH_CLOUD_CODE = """\
+import random
+
+import pandas as pd
+
+
+class TouchCloud(bn.ParametrizedSweep):
+    \"\"\"Where a repeated motion lands: one row per touch, both axes measured.\"\"\"
+
+    spread = bn.FloatSweep(default=0.5, bounds=[0.1, 1.0], doc="Positioning noise")
+
+    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+
+    def benchmark(self):
+        rng = random.Random(0)
+        self.touches = bn.ResultDataSet(
+            pd.DataFrame(
+                [
+                    {
+                        "touch": i,
+                        "dx_mm": rng.gauss(0.0, self.spread),
+                        "dy_mm": rng.gauss(0.0, self.spread),
+                    }
+                    for i in range(60)
+                ]
+            )
+        )"""
+
 _HEATMAP_DEMO_CODE = """\
 import math
 
@@ -250,6 +278,21 @@ PLOT_CONFIGS = {
         "input_vars": '["backend"]',
         "benchable_class": "ScatterJitterDemo",
         "class_code": _SCATTER_JITTER_DEMO_CODE,
+    },
+    # Both axes measured *within* one sample, unlike every other scatter here, so the
+    # result is a table per sample and the sweep input separates the clouds.
+    "xy_scatter": {
+        "float_dims": 1,
+        "cat_dims": 0,
+        "repeats": 1,
+        "plot_call": 'res.to(XYScatterResult, x="dx_mm", y="dy_mm", color="touch", data_aspect=1)',
+        "extra_import": (
+            "from bencher.results.holoview_results.xy_scatter_result import XYScatterResult"
+        ),
+        "input_vars": '["spread"]',
+        "result_vars": '["touches"]',
+        "benchable_class": "TouchCloud",
+        "class_code": _TOUCH_CLOUD_CODE,
     },
 }
 

--- a/bencher/plugins/builtins.py
+++ b/bencher/plugins/builtins.py
@@ -106,9 +106,13 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
     from bencher.results.holoview_results.surface_result import SurfaceResult
     from bencher.results.holoview_results.table_result import TableResult
     from bencher.results.holoview_results.tabulator_result import TabulatorResult
+    from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
     from bencher.results.rerun_result import RerunResult
     from bencher.results.video_summary import VideoSummaryResult
 
+    # Appended rather than grouped next to "dataset" so existing priorities keep their
+    # numbers; priority is inert for named-only plugins, which are only ever selected
+    # by name (it decides between backends implementing the *same* chart type).
     return [
         ("violin", "holoviews", ViolinResult.to_plot),
         ("scatter_jitter", "holoviews", ScatterJitterResult.to_plot),
@@ -120,6 +124,7 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
         ("dataset", "panel", DataSetResult.to_plot),
         ("video_summary", "panel", VideoSummaryResult.to_video_summary),
         ("rerun", "rerun", RerunResult.to_rerun),
+        ("xy_scatter", "holoviews", XYScatterResult.to_plot),
     ]
 
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -43,6 +43,7 @@ from bencher.results.holoview_results.scatter_result import ScatterResult
 from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.holoview_results.table_result import TableResult
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
+from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
 from bencher.results.optuna_result import OptunaResult
 from bencher.results.pane_result import PaneResult
 from bencher.results.video_summary import VideoSummaryResult
@@ -75,6 +76,7 @@ class BenchResult(
     # unbound on a BenchResult.
     TableResult,
     TabulatorResult,
+    XYScatterResult,
     HoloviewResult,
     VideoSummaryResult,
     DataSetResult,

--- a/bencher/results/holoview_results/xy_scatter_result.py
+++ b/bencher/results/holoview_results/xy_scatter_result.py
@@ -1,0 +1,297 @@
+"""Scatter two *measured* columns of a tabular result against each other.
+
+Every other scatter in bencher puts an input variable on x and a result variable on
+y: one point per sample. This one plots inside a single sample — a ``ResultDataSet``
+whose rows are the measurement (landing points, hit locations, a phase-space cloud),
+where both axes are things the benchmark measured and the sweep dimensions are what
+separate one plot from the next.
+
+Two ways in, same renderer:
+
+* declaratively, so the cloud renders with the other results in ``result_vars`` order::
+
+      cloud = bn.ResultDataSet(container=bn.xy_scatter(x="dx_mm", y="dy_mm"))
+
+* explicitly, for a report-level plot::
+
+      bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm", color="index")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import partial
+from typing import Any
+
+import holoviews as hv
+import pandas as pd
+import panel as pn
+import xarray as xr
+from param import Parameter
+
+from bencher.results.bench_result_base import ReduceType
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.variables.results import ResultDataSet
+
+
+def _to_dataframe(obj: Any) -> pd.DataFrame:
+    """Coerce a stored dataset object to a DataFrame with plottable columns."""
+    if isinstance(obj, pd.DataFrame):
+        return obj
+    if isinstance(obj, (xr.Dataset, xr.DataArray)):
+        # reset_index so dimension coordinates become columns and can be plotted.
+        return obj.to_dataframe().reset_index()
+    if isinstance(obj, hv.Dataset):
+        return obj.dframe()
+    raise TypeError(
+        f"xy_scatter needs a DataFrame, xarray Dataset/DataArray or hv.Dataset, "
+        f"got {type(obj).__name__}"
+    )
+
+
+def _check_column(df: pd.DataFrame, name: str, role: str) -> str:
+    if name not in df.columns:
+        raise ValueError(
+            f"xy_scatter {role}={name!r} is not a column of the result; "
+            f"available columns: {list(df.columns)}"
+        )
+    return name
+
+
+def _resolve_axes(df: pd.DataFrame, x: str | None, y: str | None) -> tuple[str, str]:
+    """The x and y columns, inferring unspecified ones from the numeric columns.
+
+    Inference takes the first two numeric columns in frame order, which is only
+    meaningful for a frame that holds exactly the pair being plotted — name the
+    columns whenever the frame carries anything else (an index, a z coordinate).
+    """
+    if x is not None and y is not None:
+        return _check_column(df, x, "x"), _check_column(df, y, "y")
+    numeric = [str(c) for c in df.select_dtypes("number").columns]
+    if len(numeric) < 2:
+        raise ValueError(
+            "xy_scatter needs two numeric columns to infer x and y, found "
+            f"{numeric}; pass x= and y= explicitly"
+        )
+    if x is None and y is None:
+        return numeric[0], numeric[1]
+    if x is None:
+        x_inferred = next((c for c in numeric if c != y), None)
+        if x_inferred is None:
+            raise ValueError(f"xy_scatter found no numeric column for x besides {y!r}")
+        return x_inferred, _check_column(df, y, "y")
+    y_inferred = next((c for c in numeric if c != x), None)
+    if y_inferred is None:
+        raise ValueError(f"xy_scatter found no numeric column for y besides {x!r}")
+    return _check_column(df, x, "x"), y_inferred
+
+
+@dataclass(frozen=True)
+class XYScatter:
+    """A column spec that renders a table as an XY scatter when called.
+
+    A class rather than a closure so it survives pickling: a result var declaring
+    ``container=`` is part of ``BenchCfg``, which goes into the result cache and
+    through the collect/render split, and a local function cannot be pickled. Build
+    one with :func:`xy_scatter`.
+    """
+
+    x: str | None = None
+    y: str | None = None
+    color: str | None = None
+    vdims: tuple[str, ...] = ()
+    size: int = 7
+    cmap: str = "viridis"
+    marker: str = "circle"
+    data_aspect: float | None = None
+    hover: bool = True
+    title: str | None = None
+    xlabel: str | None = None
+    ylabel: str | None = None
+    opts: tuple[tuple[str, Any], ...] = ()
+
+    def __call__(self, obj: Any) -> hv.Points:
+        df = _to_dataframe(obj)
+        x_col, y_col = _resolve_axes(df, self.x, self.y)
+        value_dims = [str(c) for c in self.vdims]
+        for name in value_dims:
+            _check_column(df, name, "vdims entry")
+        if self.color is not None:
+            _check_column(df, self.color, "color")
+            if self.color not in value_dims:
+                value_dims.append(self.color)
+
+        point_opts: dict[str, Any] = {
+            "size": self.size,
+            "marker": self.marker,
+            "xlabel": self.xlabel if self.xlabel is not None else x_col,
+            "ylabel": self.ylabel if self.ylabel is not None else y_col,
+        }
+        if self.color is not None:
+            point_opts.update(color=self.color, cmap=self.cmap, colorbar=True)
+        if self.data_aspect is not None:
+            point_opts["data_aspect"] = self.data_aspect
+        if self.hover:
+            point_opts["tools"] = ["hover"]
+        if self.title is not None:
+            point_opts["title"] = self.title
+        point_opts.update(self.opts)
+
+        return hv.Points(df, kdims=[x_col, y_col], vdims=value_dims).opts(**point_opts)
+
+
+def xy_scatter(
+    x: str | None = None,
+    y: str | None = None,
+    *,
+    color: str | None = None,
+    vdims: Sequence[str] | None = None,
+    size: int = 7,
+    cmap: str = "viridis",
+    marker: str = "circle",
+    data_aspect: float | None = None,
+    hover: bool = True,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    **opts: Any,
+) -> XYScatter:
+    """Build a container callback that scatters two columns of a table.
+
+    The result takes the stored object alone, which is exactly what
+    ``ResultDataSet(container=...)`` and ``ds_to_container`` hand it, so one spec
+    works declaratively and through :class:`XYScatterResult`.
+
+    Args:
+        x: Column on the x axis. Inferred from the numeric columns when omitted.
+        y: Column on the y axis. Inferred from the numeric columns when omitted.
+        color: Column to colour points by (adds a colourbar).
+        vdims: Extra columns to carry into the plot, so hover can show them.
+        size: Point size.
+        cmap: Colourmap used when *color* is set.
+        marker: Point marker.
+        data_aspect: Set to 1 to force equal x/y scaling — the honest choice for a
+            cloud of positions, where an auto-scaled aspect makes an elongated cloud
+            look round. Left unset otherwise, so a plot of unrelated quantities is
+            not forced square.
+        hover: Enable the hover tool.
+        title: Plot title.
+        xlabel: X axis label. Defaults to the column name.
+        ylabel: Y axis label. Defaults to the column name.
+        **opts: Passed through to ``hv.Points.opts``, so anything holoviews accepts
+            (``alpha``, ``line_color``, ``width``, ...) works without a wrapper.
+
+    Returns:
+        An :class:`XYScatter` mapping the stored object to an ``hv.Points`` element.
+
+    Raises:
+        ValueError: at call time, if a named column is absent or x/y cannot be inferred.
+        TypeError: at call time, if the stored object is not a table.
+    """
+    return XYScatter(
+        x=x,
+        y=y,
+        color=color,
+        vdims=tuple(str(v) for v in (vdims or ())),
+        size=size,
+        cmap=cmap,
+        marker=marker,
+        data_aspect=data_aspect,
+        hover=hover,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        opts=tuple(opts.items()),
+    )
+
+
+class XYScatterResult(HoloviewResult):
+    """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns.
+
+    One plot per sample rather than one plot for the sweep: the rows of a sample are
+    the cloud, so averaging them across samples would destroy the thing being
+    measured. Other result types are skipped — a scatter of two columns is only
+    defined for a tabular result.
+    """
+
+    def to_plot(
+        self,
+        result_var: Parameter | None = None,
+        x: str | None = None,
+        y: str | None = None,
+        *,
+        color: str | None = None,
+        vdims: Sequence[str] | None = None,
+        size: int = 7,
+        cmap: str = "viridis",
+        marker: str = "circle",
+        data_aspect: float | None = None,
+        hover: bool = True,
+        title: str | None = None,
+        xlabel: str | None = None,
+        ylabel: str | None = None,
+        opts: dict[str, Any] | None = None,
+        hv_dataset=None,
+        target_dimension: int = 0,
+        subsampling_divisions: int | None = None,
+        **kwargs: Any,
+    ) -> pn.panel | None:
+        """Scatter columns *x* against *y* for each tabular result sample.
+
+        Args:
+            result_var: Restrict to one result variable. Defaults to every
+                ``ResultDataSet`` in the sweep.
+            x: Column on the x axis (see :func:`xy_scatter` for x/y inference and
+                every option from *color* to *ylabel*, which are passed straight on).
+            y: Column on the y axis.
+            color: Column to colour points by.
+            vdims: Extra columns to carry into the plot for hover.
+            size: Point size.
+            cmap: Colourmap used when *color* is set.
+            marker: Point marker.
+            data_aspect: Set to 1 to force equal x/y scaling.
+            hover: Enable the hover tool.
+            title: Plot title.
+            xlabel: X axis label.
+            ylabel: Y axis label.
+            opts: Extra ``hv.Points.opts`` keywords.
+            hv_dataset: Pre-built dataset to render instead of this result's own.
+            target_dimension: Dimension depth to recurse the panes down to.
+            subsampling_divisions: Level to subsample the dataset at.
+            **kwargs: Forwarded to ``map_plot_panes`` (layout and the plot-size
+                keywords every ``to_auto`` render call carries).
+
+        Returns:
+            A panel of scatter plots, or None when the sweep has no tabular result.
+        """
+        container = xy_scatter(
+            x=x,
+            y=y,
+            color=color,
+            vdims=vdims,
+            size=size,
+            cmap=cmap,
+            marker=marker,
+            data_aspect=data_aspect,
+            hover=hover,
+            title=title,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            **(opts or {}),
+        )
+
+        if hv_dataset is None:
+            hv_dataset = self.to_hv_dataset(
+                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
+            )
+        elif not isinstance(hv_dataset, hv.Dataset):
+            hv_dataset = hv.Dataset(hv_dataset)
+        return self.map_plot_panes(
+            partial(self.ds_to_container, container=container),
+            hv_dataset=hv_dataset,
+            target_dimension=target_dimension,
+            result_var=result_var,
+            result_types=(ResultDataSet,),
+            **kwargs,
+        )

--- a/bencher/results/holoview_results/xy_scatter_result.py
+++ b/bencher/results/holoview_results/xy_scatter_result.py
@@ -19,8 +19,8 @@ Two ways in, same renderer:
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any
 
@@ -50,7 +50,7 @@ def _to_dataframe(obj: Any) -> pd.DataFrame:
     )
 
 
-def _check_column(df: pd.DataFrame, name: str, role: str) -> str:
+def _check_column(df: pd.DataFrame, name: Hashable, role: str) -> Hashable:
     if name not in df.columns:
         raise ValueError(
             f"xy_scatter {role}={name!r} is not a column of the result; "
@@ -59,16 +59,22 @@ def _check_column(df: pd.DataFrame, name: str, role: str) -> str:
     return name
 
 
-def _resolve_axes(df: pd.DataFrame, x: str | None, y: str | None) -> tuple[str, str]:
+def _resolve_axes(
+    df: pd.DataFrame, x: Hashable | None, y: Hashable | None
+) -> tuple[Hashable, Hashable]:
     """The x and y columns, inferring unspecified ones from the numeric columns.
 
     Inference takes the first two numeric columns in frame order, which is only
     meaningful for a frame that holds exactly the pair being plotted — name the
     columns whenever the frame carries anything else (an index, a z coordinate).
+
+    Labels come back exactly as the frame holds them: a column label is only a
+    string by convention, and an xarray-derived frame can hand back integers or
+    timestamps, which must still be usable to look the column back up.
     """
     if x is not None and y is not None:
         return _check_column(df, x, "x"), _check_column(df, y, "y")
-    numeric = [str(c) for c in df.select_dtypes("number").columns]
+    numeric = list(df.select_dtypes("number").columns)
     if len(numeric) < 2:
         raise ValueError(
             "xy_scatter needs two numeric columns to infer x and y, found "
@@ -87,6 +93,30 @@ def _resolve_axes(df: pd.DataFrame, x: str | None, y: str | None) -> tuple[str, 
     return _check_column(df, x, "x"), y_inferred
 
 
+def _plot_frame(
+    df: pd.DataFrame, columns: Sequence[Hashable]
+) -> tuple[pd.DataFrame, dict[Hashable, str]]:
+    """The plotted columns alone, renamed so every dimension name is a string.
+
+    A holoviews ``Dimension`` name has to be a string, but a column label does not,
+    so every lookup above works with the frame's own labels and the conversion
+    happens here, at the holoviews boundary, on a copy of the columns being plotted.
+
+    Returns the frame to plot and the label -> dimension name mapping.
+    """
+    # dict keys dedupe (x may also be a vdim) while keeping the requested order.
+    names = {col: str(col) for col in columns}
+    if len(set(names.values())) != len(names):
+        raise ValueError(
+            "xy_scatter cannot plot columns whose labels collide once converted to "
+            f"strings: {sorted(names.values())}"
+        )
+    plot_df = df[list(names)]
+    if any(col != name for col, name in names.items()):
+        plot_df = plot_df.rename(columns=names)
+    return plot_df, names
+
+
 @dataclass(frozen=True)
 class XYScatter:
     """A column spec that renders a table as an XY scatter when called.
@@ -97,10 +127,10 @@ class XYScatter:
     one with :func:`xy_scatter`.
     """
 
-    x: str | None = None
-    y: str | None = None
-    color: str | None = None
-    vdims: tuple[str, ...] = ()
+    x: Hashable | None = None
+    y: Hashable | None = None
+    color: Hashable | None = None
+    vdims: tuple[Hashable, ...] = ()
     size: int = 7
     cmap: str = "viridis"
     marker: str = "circle"
@@ -109,27 +139,32 @@ class XYScatter:
     title: str | None = None
     xlabel: str | None = None
     ylabel: str | None = None
-    opts: tuple[tuple[str, Any], ...] = ()
+    # Read-only by contract: the frozen dataclass cannot rebind it and nothing here
+    # mutates it, so the shallow copy :func:`xy_scatter` takes is never written to.
+    opts: Mapping[str, Any] = field(default_factory=dict)
 
     def __call__(self, obj: Any) -> hv.Points:
         df = _to_dataframe(obj)
         x_col, y_col = _resolve_axes(df, self.x, self.y)
-        value_dims = [str(c) for c in self.vdims]
-        for name in value_dims:
-            _check_column(df, name, "vdims entry")
+        value_cols = list(self.vdims)
+        for col in value_cols:
+            _check_column(df, col, "vdims entry")
         if self.color is not None:
             _check_column(df, self.color, "color")
-            if self.color not in value_dims:
-                value_dims.append(self.color)
+            if self.color not in value_cols:
+                value_cols.append(self.color)
+
+        plot_df, names = _plot_frame(df, [x_col, y_col, *value_cols])
+        x_name, y_name = names[x_col], names[y_col]
 
         point_opts: dict[str, Any] = {
             "size": self.size,
             "marker": self.marker,
-            "xlabel": self.xlabel if self.xlabel is not None else x_col,
-            "ylabel": self.ylabel if self.ylabel is not None else y_col,
+            "xlabel": self.xlabel if self.xlabel is not None else x_name,
+            "ylabel": self.ylabel if self.ylabel is not None else y_name,
         }
         if self.color is not None:
-            point_opts.update(color=self.color, cmap=self.cmap, colorbar=True)
+            point_opts.update(color=names[self.color], cmap=self.cmap, colorbar=True)
         if self.data_aspect is not None:
             point_opts["data_aspect"] = self.data_aspect
         if self.hover:
@@ -138,15 +173,17 @@ class XYScatter:
             point_opts["title"] = self.title
         point_opts.update(self.opts)
 
-        return hv.Points(df, kdims=[x_col, y_col], vdims=value_dims).opts(**point_opts)
+        return hv.Points(
+            plot_df, kdims=[x_name, y_name], vdims=[names[col] for col in value_cols]
+        ).opts(**point_opts)
 
 
 def xy_scatter(
-    x: str | None = None,
-    y: str | None = None,
+    x: Hashable | None = None,
+    y: Hashable | None = None,
     *,
-    color: str | None = None,
-    vdims: Sequence[str] | None = None,
+    color: Hashable | None = None,
+    vdims: Sequence[Hashable] | None = None,
     size: int = 7,
     cmap: str = "viridis",
     marker: str = "circle",
@@ -164,8 +201,10 @@ def xy_scatter(
     works declaratively and through :class:`XYScatterResult`.
 
     Args:
-        x: Column on the x axis. Inferred from the numeric columns when omitted.
-        y: Column on the y axis. Inferred from the numeric columns when omitted.
+        x: Column label for the x axis, as the frame holds it (a string for most
+            frames, but an integer or timestamp label works too). Inferred from the
+            numeric columns when omitted.
+        y: Column label for the y axis. Inferred from the numeric columns when omitted.
         color: Column to colour points by (adds a colourbar).
         vdims: Extra columns to carry into the plot, so hover can show them.
         size: Point size.
@@ -193,7 +232,7 @@ def xy_scatter(
         x=x,
         y=y,
         color=color,
-        vdims=tuple(str(v) for v in (vdims or ())),
+        vdims=tuple(vdims or ()),
         size=size,
         cmap=cmap,
         marker=marker,
@@ -202,7 +241,7 @@ def xy_scatter(
         title=title,
         xlabel=xlabel,
         ylabel=ylabel,
-        opts=tuple(opts.items()),
+        opts=dict(opts),
     )
 
 
@@ -218,11 +257,11 @@ class XYScatterResult(HoloviewResult):
     def to_plot(
         self,
         result_var: Parameter | None = None,
-        x: str | None = None,
-        y: str | None = None,
+        x: Hashable | None = None,
+        y: Hashable | None = None,
         *,
-        color: str | None = None,
-        vdims: Sequence[str] | None = None,
+        color: Hashable | None = None,
+        vdims: Sequence[Hashable] | None = None,
         size: int = 7,
         cmap: str = "viridis",
         marker: str = "circle",
@@ -238,6 +277,13 @@ class XYScatterResult(HoloviewResult):
         **kwargs: Any,
     ) -> pn.panel | None:
         """Scatter columns *x* against *y* for each tabular result sample.
+
+        The scatter options are named rather than swept up into ``**kwargs``, because
+        ``**kwargs`` belongs to ``map_plot_panes``: every render path adds keywords of
+        its own (``to()`` always passes ``override``/``agg_over_dims``/``agg_fn``,
+        ``to_auto`` adds the plot-size and ``pane_layout`` keywords), and those must
+        not end up in ``hv.Points.opts``. Naming the scatter options is what keeps the
+        two sets apart; :func:`xy_scatter` documents what each one does.
 
         Args:
             result_var: Restrict to one result variable. Defaults to every

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -156,6 +156,24 @@ Without it, the alternative is `bench.add(bn.DataSetResult, container=scatter, .
 which appends the plot to the end of the report instead of placing it with the results
 it belongs to.
 
+**XY scatter of two measured columns:** for the common case of that container —
+scattering two columns of the table against each other — `bn.xy_scatter` builds it for
+you, so no plotting code is needed:
+
+```python
+cloud = bn.ResultDataSet(
+    container=bn.xy_scatter(x="dx_mm", y="dy_mm", color="touch", data_aspect=1)
+)
+```
+
+`data_aspect=1` forces equal x/y scaling, which a cloud of positions wants: an
+auto-scaled aspect makes an elongated cloud look round. Columns are validated, and x/y
+are inferred from the numeric columns when the frame holds only the pair being plotted.
+What it returns is a picklable spec object, so it is safe as a declared container. The
+same spec is available as a chart type for a report-level plot —
+`bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")`, or by name via
+`to_auto(plot_list=["xy_scatter"], x=..., y=...)`.
+
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
 See the [ResultImage gallery](reference/meta/result_types/result_image/index) and

--- a/test/test_xy_scatter_result.py
+++ b/test/test_xy_scatter_result.py
@@ -1,0 +1,262 @@
+"""Tests for XYScatterResult / xy_scatter (bencher/results/holoview_results/xy_scatter_result.py)."""
+
+import pickle
+import unittest
+
+import holoviews as hv
+import pandas as pd
+import panel as pn
+import xarray as xr
+
+import bencher as bn
+from bencher.plugins import get_registry
+from bencher.results.holoview_results.xy_scatter_result import XYScatterResult, xy_scatter
+from test.helpers import run_cfg_with
+
+SPREADS = [1.0, 2.0]
+POINTS_PER_SAMPLE = 5
+
+
+def cloud_frame(spread: float) -> pd.DataFrame:
+    """A deterministic cloud: rows are the measurement, columns are the axes."""
+    return pd.DataFrame(
+        {
+            "index": list(range(POINTS_PER_SAMPLE)),
+            "dx_mm": [spread * i for i in range(POINTS_PER_SAMPLE)],
+            "dy_mm": [-spread * i for i in range(POINTS_PER_SAMPLE)],
+        }
+    )
+
+
+class CloudSweep(bn.ParametrizedSweep):
+    """Each sample measures a cloud of points, plus one scalar."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+
+    cloud = bn.ResultDataSet(doc="measured points, one row each")
+    peak = bn.ResultFloat(units="mm", doc="a scalar that is not a scatter")
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(cloud_frame(self.spread))
+        self.peak = self.spread * POINTS_PER_SAMPLE
+
+
+class DeclaredScatterSweep(bn.ParametrizedSweep):
+    """The spec lives on the result var, so the cloud renders with the other results."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    cloud = bn.ResultDataSet(container=xy_scatter(x="dx_mm", y="dy_mm", data_aspect=1))
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(cloud_frame(self.spread))
+
+
+def run_sweep(worker: bn.ParametrizedSweep, name: str, result_vars: list[str]):
+    bench = bn.Bench(name, worker, run_cfg=run_cfg_with(1))
+    return bench.plot_sweep(
+        name, input_vars=["spread"], result_vars=result_vars, plot_callbacks=False
+    )
+
+
+def all_points(viewable: pn.viewable.Viewable) -> list[hv.Points]:
+    """Every hv.Points element in a rendered pane tree."""
+    return [
+        pane.object
+        for pane in viewable.select(pn.pane.HoloViews)
+        if isinstance(pane.object, hv.Points)
+    ]
+
+
+def plot_opts(points: hv.Points) -> dict:
+    return hv.Store.lookup_options("bokeh", points, "plot").kwargs
+
+
+def style_opts(points: hv.Points) -> dict:
+    return hv.Store.lookup_options("bokeh", points, "style").kwargs
+
+
+class TestXYScatterFactory(unittest.TestCase):
+    """The container callback: a table in, an hv.Points out."""
+
+    def setUp(self):
+        self.df = cloud_frame(1.0)
+
+    def test_named_columns_become_the_axes(self):
+        points = xy_scatter(x="dx_mm", y="dy_mm")(self.df)
+        self.assertIsInstance(points, hv.Points)
+        self.assertEqual([d.name for d in points.kdims], ["dx_mm", "dy_mm"])
+        self.assertEqual(len(points), POINTS_PER_SAMPLE)
+
+    def test_takes_the_object_alone(self):
+        """No plot kwargs: the callback must be usable as a ResultDataSet container."""
+        self.assertIsInstance(xy_scatter(x="dx_mm", y="dy_mm")(self.df), hv.Points)
+
+    def test_color_column_becomes_a_value_dim(self):
+        points = xy_scatter(x="dx_mm", y="dy_mm", color="index")(self.df)
+        self.assertEqual([d.name for d in points.vdims], ["index"])
+        self.assertEqual(style_opts(points)["color"], "index")
+        self.assertTrue(plot_opts(points)["colorbar"])
+
+    def test_vdims_carried_for_hover(self):
+        points = xy_scatter(x="dx_mm", y="dy_mm", vdims=["index"])(self.df)
+        self.assertEqual([d.name for d in points.vdims], ["index"])
+
+    def test_data_aspect_is_opt_in(self):
+        self.assertNotIn("data_aspect", plot_opts(xy_scatter(x="dx_mm", y="dy_mm")(self.df)))
+        squared = xy_scatter(x="dx_mm", y="dy_mm", data_aspect=1)(self.df)
+        self.assertEqual(plot_opts(squared)["data_aspect"], 1)
+
+    def test_axis_labels_default_to_column_names(self):
+        opts = plot_opts(xy_scatter(x="dx_mm", y="dy_mm")(self.df))
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("dx_mm", "dy_mm"))
+        labelled = xy_scatter(x="dx_mm", y="dy_mm", xlabel="dx [mm]", ylabel="dy [mm]")(self.df)
+        self.assertEqual(plot_opts(labelled)["xlabel"], "dx [mm]")
+
+    def test_extra_opts_reach_holoviews(self):
+        points = xy_scatter(x="dx_mm", y="dy_mm", alpha=0.25)(self.df)
+        self.assertEqual(style_opts(points)["alpha"], 0.25)
+
+    def test_missing_column_names_what_is_available(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_scatter(x="dx_mm", y="nope")(self.df)
+        message = str(ctx.exception)
+        self.assertIn("nope", message)
+        self.assertIn("dy_mm", message, "the error should list the available columns")
+
+    def test_missing_color_column_raises(self):
+        with self.assertRaises(ValueError):
+            xy_scatter(x="dx_mm", y="dy_mm", color="nope")(self.df)
+
+    def test_axes_inferred_from_numeric_columns(self):
+        points = xy_scatter()(pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]}))
+        self.assertEqual([d.name for d in points.kdims], ["a", "b"])
+
+    def test_one_named_axis_infers_the_other(self):
+        points = xy_scatter(y="dy_mm")(self.df)
+        self.assertEqual([d.name for d in points.kdims], ["index", "dy_mm"])
+
+    def test_inference_needs_two_numeric_columns(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_scatter()(pd.DataFrame({"a": [1.0], "label": ["x"]}))
+        self.assertIn("x= and y=", str(ctx.exception))
+
+    def test_empty_frame_with_the_columns_renders(self):
+        """A run that measured nothing is an empty plot, not an exception."""
+        points = xy_scatter(x="dx_mm", y="dy_mm")(self.df.iloc[:0])
+        self.assertEqual(len(points), 0)
+
+    def test_xarray_dataset_accepted(self):
+        ds = xr.Dataset({"dy_mm": ("dx_mm", [1.0, 2.0, 3.0])}, coords={"dx_mm": [0.0, 1.0, 2.0]})
+        points = xy_scatter(x="dx_mm", y="dy_mm")(ds)
+        self.assertEqual(len(points), 3)
+
+    def test_non_table_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            xy_scatter(x="a", y="b")([1, 2, 3])
+        self.assertIn("list", str(ctx.exception))
+
+
+class TestXYScatterResult(unittest.TestCase):
+    """The chart type: one scatter per sample, tabular results only."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(CloudSweep(), "test_xy_scatter", ["cloud", "peak"])
+
+    def test_one_plot_per_sample(self):
+        points = all_points(self.res.to(XYScatterResult, x="dx_mm", y="dy_mm"))
+        self.assertEqual(len(points), len(SPREADS))
+        for element, spread in zip(points, SPREADS):
+            self.assertEqual(len(element), POINTS_PER_SAMPLE)
+            self.assertEqual(element["dx_mm"].max(), spread * (POINTS_PER_SAMPLE - 1))
+
+    def test_scalar_results_are_skipped(self):
+        """`peak` is in the sweep; a scatter of two columns is undefined for it."""
+        rendered = self.res.to(XYScatterResult, x="dx_mm", y="dy_mm")
+        self.assertEqual(len(all_points(rendered)), len(SPREADS))
+
+    def test_options_reach_the_elements(self):
+        points = all_points(
+            self.res.to(XYScatterResult, x="dx_mm", y="dy_mm", color="index", data_aspect=1)
+        )
+        self.assertEqual(plot_opts(points[0])["data_aspect"], 1)
+        self.assertEqual(style_opts(points[0])["color"], "index")
+
+    def test_result_var_restriction(self):
+        points = all_points(
+            self.res.to(
+                XYScatterResult,
+                result_var=CloudSweep.param.cloud,
+                x="dx_mm",
+                y="dy_mm",
+            )
+        )
+        self.assertEqual(len(points), len(SPREADS))
+
+    def test_bad_column_raises_rather_than_plotting_nothing(self):
+        with self.assertRaises(ValueError):
+            self.res.to(XYScatterResult, x="dx_mm", y="nope")
+
+    def test_no_tabular_result_renders_nothing(self):
+        self.assertIsNone(self.res.to(XYScatterResult, result_var=CloudSweep.param.peak))
+
+
+class TestXYScatterPlugin(unittest.TestCase):
+    """Registered as a named-only chart type, like dataset/table/rerun."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(CloudSweep(), "test_xy_scatter_plugin", ["cloud", "peak"])
+
+    def test_registered_under_its_chart_type_name(self):
+        plugin = get_registry().get("xy_scatter")
+        self.assertIsNotNone(plugin)
+        self.assertEqual(plugin.backend, "holoviews")
+        self.assertFalse(plugin.auto, "xy_scatter must not be selected automatically")
+
+    def test_absent_from_automatic_selection(self):
+        data = self.res.to_bench_data()
+        auto = [p.name for p in get_registry().select(data)]
+        self.assertIn("panes", auto, "guard: automatic selection is non-empty here")
+        self.assertNotIn("xy_scatter", auto)
+
+    def test_selected_by_name(self):
+        data = self.res.to_bench_data()
+        chosen = [p.name for p in get_registry().select(data, include=["xy_scatter"])]
+        self.assertEqual(chosen, ["xy_scatter"])
+
+    def test_renders_through_to_auto_by_name(self):
+        res = run_sweep(CloudSweep(), "test_xy_scatter_auto", ["cloud", "peak"])
+        rendered = res.to_auto(plot_list=["xy_scatter"], x="dx_mm", y="dy_mm")
+        self.assertEqual(len(all_points(pn.Column(*rendered))), len(SPREADS))
+
+
+class TestSpecIsPicklable(unittest.TestCase):
+    """Why XYScatter is a class and not a closure."""
+
+    def test_spec_round_trips_through_pickle(self):
+        spec = xy_scatter(x="dx_mm", y="dy_mm", color="index", data_aspect=1, alpha=0.5)
+        restored = pickle.loads(pickle.dumps(spec))
+        self.assertEqual(restored, spec)
+        points = restored(cloud_frame(1.0))
+        self.assertEqual([d.name for d in points.kdims], ["dx_mm", "dy_mm"])
+
+    def test_result_var_declaring_a_spec_pickles(self):
+        """A declared container rides in BenchCfg, which the result cache pickles."""
+        rv = pickle.loads(pickle.dumps(DeclaredScatterSweep.param.cloud))
+        self.assertEqual(rv.container, DeclaredScatterSweep.param.cloud.container)
+
+
+class TestDeclaredOnResultVar(unittest.TestCase):
+    """The declarative route: the spec on the result var, rendered in place."""
+
+    def test_panes_pass_renders_the_scatter(self):
+        res = run_sweep(DeclaredScatterSweep(), "test_xy_scatter_declared", ["cloud"])
+        points = all_points(res.to_auto(plot_list=["panes"]))
+        self.assertEqual(len(points), len(SPREADS))
+        self.assertEqual([d.name for d in points[0].kdims], ["dx_mm", "dy_mm"])
+        self.assertEqual(plot_opts(points[0])["data_aspect"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_xy_scatter_result.py
+++ b/test/test_xy_scatter_result.py
@@ -156,6 +156,49 @@ class TestXYScatterFactory(unittest.TestCase):
         self.assertIn("list", str(ctx.exception))
 
 
+class TestNonStringColumnLabels(unittest.TestCase):
+    """A column label is only a string by convention; lookups must use the real label."""
+
+    def setUp(self):
+        self.df = pd.DataFrame({0: [1.0, 2.0], 1: [3.0, 4.0], 2: [5.0, 6.0]})
+
+    def test_integer_labels_inferred(self):
+        points = xy_scatter()(self.df)
+        self.assertEqual([d.name for d in points.kdims], ["0", "1"])
+        self.assertEqual(len(points), 2)
+
+    def test_integer_labels_named_explicitly(self):
+        points = xy_scatter(x=2, y=0)(self.df)
+        self.assertEqual([d.name for d in points.kdims], ["2", "0"])
+        self.assertEqual(list(points["2"]), [5.0, 6.0])
+
+    def test_integer_label_as_colour_and_vdim(self):
+        points = xy_scatter(x=0, y=1, color=2)(self.df)
+        self.assertEqual([d.name for d in points.vdims], ["2"])
+        self.assertEqual(style_opts(points)["color"], "2")
+
+    def test_one_named_integer_axis_infers_the_other(self):
+        points = xy_scatter(y=1)(self.df)
+        self.assertEqual([d.name for d in points.kdims], ["0", "1"])
+
+    def test_missing_integer_label_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_scatter(x=0, y=9)(self.df)
+        self.assertIn("9", str(ctx.exception))
+
+    def test_timestamp_labels_are_usable(self):
+        stamps = pd.to_datetime(["2024-01-01", "2024-01-02"])
+        df = pd.DataFrame({stamps[0]: [1.0, 2.0], stamps[1]: [3.0, 4.0]})
+        points = xy_scatter(x=stamps[0], y=stamps[1])(df)
+        self.assertEqual([d.name for d in points.kdims], [str(stamps[0]), str(stamps[1])])
+
+    def test_labels_colliding_once_stringified_raise(self):
+        df = pd.DataFrame({0: [1.0, 2.0], "0": [3.0, 4.0]})
+        with self.assertRaises(ValueError) as ctx:
+            xy_scatter(x=0, y="0")(df)
+        self.assertIn("collide", str(ctx.exception))
+
+
 class TestXYScatterResult(unittest.TestCase):
     """The chart type: one scatter per sample, tabular results only."""
 

--- a/test/test_xy_scatter_result.py
+++ b/test/test_xy_scatter_result.py
@@ -2,6 +2,7 @@
 
 import pickle
 import unittest
+from datetime import datetime, timedelta
 
 import holoviews as hv
 import pandas as pd
@@ -56,6 +57,61 @@ def run_sweep(worker: bn.ParametrizedSweep, name: str, result_vars: list[str]):
     return bench.plot_sweep(
         name, input_vars=["spread"], result_vars=result_vars, plot_callbacks=False
     )
+
+
+def run_tagged_cloud(spread: float, run_id: int) -> pd.DataFrame:
+    """A cloud offset by its run, so a rendered plot names the run it came from."""
+    return pd.DataFrame(
+        {
+            "dx_mm": [spread * i + RUN_OFFSET * run_id for i in range(POINTS_PER_SAMPLE)],
+            "dy_mm": [-spread * i for i in range(POINTS_PER_SAMPLE)],
+        }
+    )
+
+
+RUN_OFFSET = 100.0
+OVER_TIME_RUNS = 3
+
+
+class OverTimeCloudSweep(bn.ParametrizedSweep):
+    """A declared scatter, to be run repeatedly against one history."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    cloud = bn.ResultDataSet(container=xy_scatter(x="dx_mm", y="dy_mm"))
+    peak = bn.ResultFloat(units="mm", doc="a scalar, which does keep history")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(run_tagged_cloud(self.spread, self.run_id))
+        self.peak = self.spread + self.run_id
+
+
+def run_sweep_over_time(worker: bn.ParametrizedSweep, name: str) -> bn.BenchResult:
+    """Run one sweep repeatedly against a single history, as a nightly rig does.
+
+    Only the first run clears the history, so from the second run on the rendered
+    dataset carries the earlier events on its over_time dimension.
+    """
+    run_cfg = run_cfg_with(1)
+    run_cfg.over_time = True
+    run_cfg.auto_plot = False
+    bench = bn.Bench(name, worker)
+    base_time = datetime(2000, 1, 1)
+    res = None
+    for i in range(OVER_TIME_RUNS):
+        worker.run_id = i
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            name,
+            input_vars=["spread"],
+            result_vars=["cloud", "peak"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+            plot_callbacks=False,
+        )
+    return res
 
 
 def all_points(viewable: pn.viewable.Viewable) -> list[hv.Points]:
@@ -299,6 +355,56 @@ class TestDeclaredOnResultVar(unittest.TestCase):
         self.assertEqual(len(points), len(SPREADS))
         self.assertEqual([d.name for d in points[0].kdims], ["dx_mm", "dy_mm"])
         self.assertEqual(plot_opts(points[0])["data_aspect"], 1)
+
+
+class TestOverTimeHistory(unittest.TestCase):
+    """A cloud has to render on every run, not only the first one.
+
+    A ResultDataSet cell holds an index into dataset_list, which is rebuilt from the
+    samples of whichever run is rendering, so the indices merged in from history point
+    at *this* run's list. The render therefore stays on the current event; before
+    _to_panes_da handled ResultDataSet it raised out of expand_dims instead, and via
+    to_auto the traceback was swallowed and the plot silently vanished.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep_over_time(OverTimeCloudSweep(), "test_xy_scatter_over_time")
+        cls.current_run = OVER_TIME_RUNS - 1
+
+    def assert_current_run(self, points: list[hv.Points]) -> None:
+        self.assertEqual(len(points), len(SPREADS))
+        for element, spread in zip(points, SPREADS):
+            self.assertEqual(len(element), POINTS_PER_SAMPLE)
+            self.assertAlmostEqual(element["dx_mm"].min(), RUN_OFFSET * self.current_run, places=6)
+            self.assertAlmostEqual(
+                element["dx_mm"].max(),
+                spread * (POINTS_PER_SAMPLE - 1) + RUN_OFFSET * self.current_run,
+                places=6,
+            )
+
+    def test_history_accumulated(self):
+        """Guard on the fixture: with a single event there is no regression to catch."""
+        self.assertEqual(self.res.to_dataset().sizes["over_time"], OVER_TIME_RUNS)
+
+    def test_declared_spec_renders_the_current_run(self):
+        self.assert_current_run(all_points(self.res.to_auto(plot_list=["panes"])))
+
+    def test_chart_type_renders_the_current_run(self):
+        rendered = self.res.to(XYScatterResult, x="dx_mm", y="dy_mm")
+        self.assert_current_run(all_points(rendered))
+
+    def test_named_chart_type_renders_the_current_run(self):
+        rendered = self.res.to_auto(plot_list=["xy_scatter"], x="dx_mm", y="dy_mm")
+        self.assert_current_run(all_points(pn.Column(*rendered)))
+
+    def test_scalar_results_keep_their_history(self):
+        """Rendering the current cloud must not cost the metrics their over_time series."""
+        peak = self.res.to_dataset()["peak"]
+        self.assertEqual(peak.sizes["over_time"], OVER_TIME_RUNS)
+        for run in range(OVER_TIME_RUNS):
+            observed = peak.isel(over_time=run).sel(spread=SPREADS[0]).values.squeeze()
+            self.assertAlmostEqual(float(observed), SPREADS[0] + run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Stacked on #989** (`ResultDataSet(container=...)`) — base branch is
`feature/dataset-result-container`, retarget to `main` once that merges. The declarative
half of this PR is what #989's hook is for.

## Problem

Every scatter bencher has puts an *input* variable on x and a *result* variable on y:
one point per sample. `ScatterResult` even encodes that shape in its filter
(`float_range=VarRange(0, 0)`, `result_types=(ResultVar,)`).

Nothing plots *inside* a sample. When the measurement is a cloud — landing points of a
repeated motion, hit locations, a phase-space slice — the result is a `ResultDataSet`
whose rows are the data, both axes are measured columns, and the sweep dimensions are
what separate one cloud from the next. Today that means hand-writing holoviews in a
container callback for what is a two-column scatter.

## Change

One renderer, reachable two ways:

```python
# declaratively (needs #989): renders in result_vars order with the other results
cloud = bn.ResultDataSet(container=bn.xy_scatter(x="dx_mm", y="dy_mm", color="touch", data_aspect=1))

# or as a chart type, for a report-level plot
bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm", color="touch", data_aspect=1)
res.to_auto(plot_list=["xy_scatter"], x="dx_mm", y="dy_mm")
```

Design points worth reviewing:

- **`xy_scatter()` returns a frozen dataclass (`XYScatter`), not a closure.** A declared
  container rides in `BenchCfg`, which the result cache and the collect/render split
  both pickle — a local function fails there (`AttributeError: Can't get local object`).
  Found by the declarative test, hence the class. Locked in by
  `TestSpecIsPicklable`.
- **Registered named-only** (`auto=False`), like `dataset`/`table`/`rerun`: no existing
  report gains a plot it did not ask for. Appended to `_named_only_specs` so no
  existing priority number moves (priority is inert for named-only entries — it only
  resolves competing backends for one chart type).
- **`XYScatterResult` joins `BenchResult`'s bases**, next to `TableResult`/
  `TabulatorResult` and before `HoloviewResult`, because named-only plugin callbacks are
  unbound methods invoked on the live `BenchResult`. `test_plugins_builtins.py`'s MRO
  guard caught this — worth noting that the guard works.
- **`result_types=(ResultDataSet,)`**, narrower than `DataSetResult`'s `PANEL_TYPES`: a
  scatter of two columns is undefined for a float or an image, so those are skipped
  rather than fed to the renderer.
- **Columns are validated**, and the error names what the frame actually has — a typo
  should not silently render an empty plot. x/y fall back to the first two numeric
  columns, which is only meaningful when the frame holds exactly the pair being plotted
  (documented as such).
- **`data_aspect` stays opt-in.** Equal scaling is right for a position cloud (an
  auto-scaled aspect makes an elongated cloud look round, hiding exactly the anisotropy
  you are measuring) and wrong for two unrelated quantities, so it is not defaulted.
- DataFrame, `xr.Dataset`/`DataArray` and `hv.Dataset` inputs all accepted; anything
  else raises `TypeError` naming the type.

## Tests / docs

`test/test_xy_scatter_result.py` (28 cases): axis/colour/vdims/opts plumbing, label
defaults, column validation and inference, empty frame, xarray input, non-table
rejection, one plot per sample with the right rows, scalar results skipped, `result_var`
restriction, registry registration + named-only + selection by name, pickle round-trip,
and the declarative path rendering through the auto `panes` pass.

Gallery example `example_plot_xy_scatter` via a new `PLOT_CONFIGS` entry (generated
tree regenerated — one new file, no churn elsewhere), plus `docs/how_to_use_bencher.md`.

Full suite green (1941 passed), `pixi run test-split` green (the pickle path),
`ruff`/`ty`/`pylint` clean (10.00/10), `prek run -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an xy_scatter chart type for plotting two measured columns from tabular results and expose it both declaratively and as a named-only chart plugin.

New Features:
- Add XYScatterResult holoviews chart type and xy_scatter factory for plotting two measured columns from ResultDataSet samples.
- Register xy_scatter as a named-only chart type and wire it into BenchResult and the public bencher API.
- Add a TouchCloud example benchmark and gallery plot configuration demonstrating xy_scatter usage.

Enhancements:
- Extend automatic pane rendering to support ResultDataSet containers built with xy_scatter.
- Improve bench documentation with guidance and examples for using xy_scatter for measured-column scatters.

Documentation:
- Document xy_scatter usage, options, and behavior in the how_to_use_bencher guide.
- Add a gallery/example entry for the xy_scatter plot type.

Tests:
- Add comprehensive tests for xy_scatter and XYScatterResult covering data coercion, column validation, rendering behavior, plugin registration, and pickling.