### PR TITLE
refactor: extract a reusable base for intra-sample chart types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tools` is now set in both directions (`[]` when off). Passing `tools=` through `**opts`
   still wins, as it is applied last.
 - **A `ResultDataSet` renders on every run, not only the first.** With `over_time` and
-  more than one event in the history, a tabular result reached `ds_to_container` with
+  more than one event in the history, a stored payload reached `ds_to_container` with
   `over_time` still a live dimension: `_to_panes_da` drops `over_time` from the pane
   recursion so hvplot can use groupby, and the branch that rebuilds it for pane-type
   results only covered `ResultVideo`/`ResultImage`/`ResultRerun`. The render then died in
@@ -41,27 +41,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vanished from the report. A `ResultDataSet` now renders the current event: its cells
   hold indices into `dataset_list`, which is rebuilt from the samples of the run doing the
   rendering, so the indices merged in from history address *this* run's list and a slider
-  across the events would show the current table under every past run's label. Scalar
+  across the events would show the current payload under every past run's label. Scalar
   results keep their full `over_time` series. Two supporting hardenings: a length-1
   dimension on a point now collapses to a value instead of a one-element array, and
   `ds_to_container` names the result variable and the dimension that was not reduced
   rather than indexing a list with an array several frames later.
 
 ### Added
-- **Shared machinery for intra-sample chart types** (`holoview_results/tabular_spec.py`).
-  The parts of `xy_scatter` that are not specific to a scatter are now a reusable base:
-  `TabularSpec`, a frozen (therefore picklable) dataclass whose `__call__` coerces the
-  stored object to a DataFrame and delegates to a subclass's `build()`, carrying the
-  options every chart shares (`title`, `xlabel`, `ylabel`, `hover`, `data_aspect`, and
-  `**opts` passthrough) plus the column helpers (`to_dataframe`, `check_column`,
-  `resolve_axes`, `plot_frame`, `value_columns`); and `TabularSpecResult.render_spec`,
-  the `to_plot` body that maps a spec over every `ResultDataSet` sample. A new chart is
-  now a `build()`, a factory function, and a `to_plot` that names its own options.
-  Column-validation errors name the chart that rejected the column, via a `chart_name`
-  class var. Chart types keep naming their options explicitly rather than accepting
-  `**kwargs`: `**kwargs` belongs to `map_plot_panes`, and a signature-based split could
-  not tell a pane-sizing `width` from a holoviews style `width`. No behaviour change to
-  `xy_scatter`, which is the base's first user.
+- **Generic per-sample data rendering, with tabular handling kept at the edge.**
+  `render_data_samples` is the single operation that retrieves each
+  `ResultDataSet` payload and optionally maps a renderer over it; it neither checks nor
+  converts the payload type. `XYScatterResult` composes that generic operation instead
+  of introducing a parallel result hierarchy. The opt-in
+  `holoview_results/tabular_spec.py` module only contains renderer-side concerns:
+  `TabularSpec`, a frozen (therefore picklable) dataclass whose `__call__` coerces
+  supported table-like data to a DataFrame, shared HoloViews options, and column helpers
+  (`to_dataframe`, `check_column`, `resolve_axes`, `plot_frame`, `value_columns`).
+  Column-validation errors name the chart that rejected the column. Chart types keep
+  naming their options explicitly rather than accepting `**kwargs`: `**kwargs` belongs
+  to `map_plot_panes`, and a signature-based split could not tell a pane-sizing `width`
+  from a HoloViews style `width`.
 - **`xy_scatter` chart type** — scatters two *measured* columns of a `ResultDataSet`
   against each other, for results whose rows are the measurement (landing points, hit
   locations, a phase-space cloud). Distinct from the existing `scatter`, which puts an
@@ -75,18 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   did not ask for. Columns are validated against the frame — a typo names the available
   columns instead of rendering nothing — x/y are inferred from the numeric columns when
   omitted, `data_aspect=1` gives the equal-aspect scaling a position cloud needs, and
-  DataFrame / xarray / `hv.Dataset` objects are all accepted. Gallery example:
-  `example_plot_xy_scatter`.
-- **`ResultDataSet(container=...)`** — a `ResultDataSet` can now declare how it renders,
-  the way `ResultReference` already could. The callback takes the stored object and
-  returns anything panel can display, so a measured table shows up as the plot it means
-  rather than as raw rows, *in `result_vars` order* with the rest of the results.
+  DataFrame / xarray / `hv.Dataset` objects are all accepted. The
+  `example_plot_xy_scatter` gallery declares this renderer on its result, so the default
+  report contains the scatter in place of the raw table rather than appending both.
+- **`ResultDataSet(container=...)`** — `ResultDataSet` is a generic per-sample store for
+  any picklable Python payload, with no DataFrame/xarray requirement. It can declare how
+  the payload renders, the way `ResultReference` already could. The callback takes the
+  stored object and returns anything Panel can display, so domain data shows up as the
+  view it means, *in `result_vars` order* with the rest of the results.
   Precedence: a container passed to a renderer wins, then one attached to the stored
-  sample (`ResultDataSet(df, container=...)` inside `benchmark()`), then the one declared
+  sample (`ResultDataSet(data, container=...)` inside `benchmark()`), then the one declared
   on the class. The callback is invoked with the object alone (no plot kwargs), so
-  single-argument callables are safe. Previously the only way to render a dataset as a
-  plot was `bench.add(bn.DataSetResult, container=...)`, which appends to the end of the
-  report and cannot sit among the other result variables. `container` is in
+  single-argument callables are safe. An explicit
+  `bench.add(bn.DataSetResult, container=...)` view still appends to the end of the report
+  and cannot sit among the other result variables. `container` is in
   `_hash_exclude`, so declaring one does not change any cache key. A declared container
   rides in `BenchCfg` into the result cache and the collect/render split, so it must be
   picklable — a module-level function or a callable object, not a lambda.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
 ### Fixed
+- **`hover=False` on an intra-sample chart now actually disables hover.** `set_default_opts`
+  registers `tools=["hover"]` as a global holoviews default for most element types, so a
+  spec that merely omitted the key got hover back and the option was a silent no-op.
+  `tools` is now set in both directions (`[]` when off). Passing `tools=` through `**opts`
+  still wins, as it is applied last.
 - **A `ResultDataSet` renders on every run, not only the first.** With `over_time` and
   more than one event in the history, a tabular result reached `ds_to_container` with
   `over_time` still a live dimension: `_to_panes_da` drops `over_time` from the pane
@@ -43,6 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than indexing a list with an array several frames later.
 
 ### Added
+- **Shared machinery for intra-sample chart types** (`holoview_results/tabular_spec.py`).
+  The parts of `xy_scatter` that are not specific to a scatter are now a reusable base:
+  `TabularSpec`, a frozen (therefore picklable) dataclass whose `__call__` coerces the
+  stored object to a DataFrame and delegates to a subclass's `build()`, carrying the
+  options every chart shares (`title`, `xlabel`, `ylabel`, `hover`, `data_aspect`, and
+  `**opts` passthrough) plus the column helpers (`to_dataframe`, `check_column`,
+  `resolve_axes`, `plot_frame`, `value_columns`); and `TabularSpecResult.render_spec`,
+  the `to_plot` body that maps a spec over every `ResultDataSet` sample. A new chart is
+  now a `build()`, a factory function, and a `to_plot` that names its own options.
+  Column-validation errors name the chart that rejected the column, via a `chart_name`
+  class var. Chart types keep naming their options explicitly rather than accepting
+  `**kwargs`: `**kwargs` belongs to `map_plot_panes`, and a signature-based split could
+  not tell a pane-sizing `width` from a holoviews style `width`. No behaviour change to
+  `xy_scatter`, which is the base's first user.
 - **`xy_scatter` chart type** — scatters two *measured* columns of a `ResultDataSet`
   against each other, for results whose rows are the measurement (landing points, hit
   locations, a phase-space cloud). Distinct from the existing `scatter`, which puts an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`DataSetResult` now renders `ResultDataSet` results only.** It previously claimed every
+  pane-type result, which made `bench.add(bn.DataSetResult)` / `plot_list=["dataset"]` a
+  second name for the `panes` view on a sweep with no stored payload. Now that
+  `ResultDataSet` is a generic payload store, a `container=` written for a payload must not
+  be handed an unrelated result's value, so the view returns `None` for such a sweep instead
+  of falling back. Use the `panes` view (`res.to_panes()`, or the default report) for
+  image/video/string/reference results — it is unchanged, and both views share one render
+  path (`BenchResultBase.map_sample_panes`).
 - **Logging now goes through per-module loggers.** Every module logs via
   `logging.getLogger(__name__)` instead of calling `logging.info()` and friends on the
   root logger, so bencher's output can be configured and filtered per module (e.g.
@@ -49,15 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Generic per-sample data rendering, with tabular handling kept at the edge.**
-  `render_data_samples` is the single operation that retrieves each
-  `ResultDataSet` payload and optionally maps a renderer over it; it neither checks nor
-  converts the payload type. `XYScatterResult` composes that generic operation instead
-  of introducing a parallel result hierarchy. The opt-in
+  `BenchResultBase.map_sample_panes` is the single operation that retrieves each stored
+  sample and optionally maps a renderer over it; it neither checks nor converts the payload
+  type, and takes the result types it claims as a parameter. Both per-sample views now go
+  through it — `PaneResult.to_panes` (every pane type, and the path the default report
+  takes) and `render_data_samples` (`ResultDataSet` only) — so a fix to the render path
+  reaches the report and the chart types alike. `XYScatterResult` composes
+  `render_data_samples` instead of introducing a parallel result hierarchy. The opt-in
   `holoview_results/tabular_spec.py` module only contains renderer-side concerns:
   `TabularSpec`, a frozen (therefore picklable) dataclass whose `__call__` coerces
   supported table-like data to a DataFrame, shared HoloViews options, and column helpers
   (`to_dataframe`, `check_column`, `resolve_axes`, `plot_frame`, `value_columns`).
-  Column-validation errors name the chart that rejected the column. Chart types keep
+  `TabularSpec` is exported as `bn.TabularSpec`, since writing a new chart type is what it
+  is for. Column-validation errors name the chart that rejected the column, for every
+  column a chart plots — including the ones a chart *option* implies (`color=`), which
+  `value_columns` validates rather than letting them reach pandas as a bare `KeyError`.
+  Chart types keep
   naming their options explicitly rather than accepting `**kwargs`: `**kwargs` belongs
   to `map_plot_panes`, and a signature-based split could not tell a pane-sizing `width`
   from a HoloViews style `width`.

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -18,6 +18,7 @@ from bencher.results.holoview_results.line_result import LineResult
 from bencher.results.holoview_results.scatter_result import ScatterResult
 from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.holoview_results.table_result import TableResult
+from bencher.results.holoview_results.tabular_spec import TabularSpec
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
 from bencher.results.holoview_results.xy_scatter_result import XYScatterResult, xy_scatter
 from bencher.results.volume_result import VolumeResult

--- a/bencher/example/generated/plot_types/example_plot_xy_scatter.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_scatter.py
@@ -5,7 +5,6 @@ import random
 import pandas as pd
 
 import bencher as bn
-from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
 
 
 class TouchCloud(bn.ParametrizedSweep):
@@ -13,7 +12,15 @@ class TouchCloud(bn.ParametrizedSweep):
 
     spread = bn.FloatSweep(default=0.5, bounds=[0.1, 1.0], doc="Positioning noise")
 
-    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+    touches = bn.ResultDataSet(
+        container=bn.xy_scatter(
+            x="dx_mm",
+            y="dy_mm",
+            color="touch",
+            data_aspect=1,
+        ),
+        doc="Landing points, one row per touch",
+    )
 
     def benchmark(self):
         rng = random.Random(0)
@@ -34,8 +41,7 @@ class TouchCloud(bn.ParametrizedSweep):
 def example_plot_xy_scatter(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Plot Type: Xy Scatter."""
     bench = TouchCloud().to_bench(run_cfg)
-    res = bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
-    bench.report.append(res.to(XYScatterResult, x="dx_mm", y="dy_mm", color="touch", data_aspect=1))
+    bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
 
     return bench
 

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -84,7 +84,15 @@ class TouchCloud(bn.ParametrizedSweep):
 
     spread = bn.FloatSweep(default=0.5, bounds=[0.1, 1.0], doc="Positioning noise")
 
-    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+    touches = bn.ResultDataSet(
+        container=bn.xy_scatter(
+            x="dx_mm",
+            y="dy_mm",
+            color="touch",
+            data_aspect=1,
+        ),
+        doc="Landing points, one row per touch",
+    )
 
     def benchmark(self):
         rng = random.Random(0)
@@ -285,10 +293,9 @@ PLOT_CONFIGS = {
         "float_dims": 1,
         "cat_dims": 0,
         "repeats": 1,
-        "plot_call": 'res.to(XYScatterResult, x="dx_mm", y="dy_mm", color="touch", data_aspect=1)',
-        "extra_import": (
-            "from bencher.results.holoview_results.xy_scatter_result import XYScatterResult"
-        ),
+        # The declared renderer replaces the raw payload in the normal result
+        # position, so the example needs no second, appended report-level plot.
+        "plot_call": None,
         "input_vars": '["spread"]',
         "result_vars": '["touches"]',
         "benchable_class": "TouchCloud",

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -566,6 +566,40 @@ class BenchResultBase:
             return primary
         return panel_list
 
+    def map_sample_panes(
+        self,
+        result_types,
+        container: Callable | None = None,
+        result_var: Parameter | None = None,
+        hv_dataset=None,
+        target_dimension: int = 0,
+        subsampling_divisions: int | None = None,
+        **kwargs,
+    ) -> pn.pane.panel | None:
+        """One pane per sample of every result whose type is in *result_types*.
+
+        The single place the per-sample render path is spelled out: squeeze to one
+        value per sample, then map ``ds_to_container`` (which applies *container*,
+        the per-sample container, or the one declared on the result var) over each.
+        Callers differ only in which result types they claim — ``result_types`` is
+        the parameter rather than a subclass hook so a renderer can be a plain
+        function over any result object.
+        """
+        if hv_dataset is None:
+            hv_dataset = self.to_hv_dataset(
+                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
+            )
+        elif not isinstance(hv_dataset, hv.Dataset):
+            hv_dataset = hv.Dataset(hv_dataset)
+        return self.map_plot_panes(
+            partial(self.ds_to_container, container=container),
+            hv_dataset=hv_dataset,
+            target_dimension=target_dimension,
+            result_var=result_var,
+            result_types=result_types,
+            **kwargs,
+        )
+
     def map_plot_panes(
         self,
         plot_callback: Callable,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -879,7 +879,7 @@ class BenchResultBase:
                     # A ResultDataSet cell holds an index into dataset_list, which is
                     # rebuilt from the samples of the run that is rendering.  Rows
                     # merged in from history therefore address *this* run's list, so a
-                    # slider over them would show the current table under every past
+                    # slider over them would show the current payload under every past
                     # run's label.  Render the event being reported instead; scalar
                     # results keep their real history either way.
                     dataset = dataset.isel(over_time=-1)

--- a/bencher/results/dataset_result.py
+++ b/bencher/results/dataset_result.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from functools import partial
 from typing import Any
 
-import holoviews as hv
 import panel as pn
 from param import Parameter
 
-from bencher.results.bench_result_base import BenchResultBase, ReduceType
+from bencher.results.bench_result_base import BenchResultBase
 from bencher.variables.results import ResultDataSet
 
 
@@ -26,19 +24,19 @@ def render_data_samples(
     Storage is deliberately payload-agnostic. The renderer, when supplied, owns
     every interpretation of the object (tabular, image-like, domain specific,
     and so on); without one, the stored object is handed to Panel.
+
+    A thin naming of ``map_sample_panes`` restricted to ``ResultDataSet``: the
+    pane-type render path itself is shared with ``PaneResult.to_panes``, which is
+    what the default report actually goes through, so a chart type composing this
+    behaves identically to a declared ``container=``.
     """
-    if hv_dataset is None:
-        hv_dataset = result.to_hv_dataset(
-            ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
-        )
-    elif not isinstance(hv_dataset, hv.Dataset):
-        hv_dataset = hv.Dataset(hv_dataset)
-    return result.map_plot_panes(
-        partial(result.ds_to_container, container=renderer),
+    return result.map_sample_panes(
+        (ResultDataSet,),
+        container=renderer,
+        result_var=result_var,
         hv_dataset=hv_dataset,
         target_dimension=target_dimension,
-        result_var=result_var,
-        result_types=(ResultDataSet,),
+        subsampling_divisions=subsampling_divisions,
         **kwargs,
     )
 

--- a/bencher/results/dataset_result.py
+++ b/bencher/results/dataset_result.py
@@ -1,36 +1,67 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
+from typing import Any
 
 import holoviews as hv
 import panel as pn
 from param import Parameter
 
 from bencher.results.bench_result_base import BenchResultBase, ReduceType
-from bencher.variables.results import PANEL_TYPES
+from bencher.variables.results import ResultDataSet
+
+
+def render_data_samples(
+    result: BenchResultBase,
+    renderer: Callable[[Any], Any] | None = None,
+    result_var: Parameter | None = None,
+    hv_dataset=None,
+    target_dimension: int = 0,
+    subsampling_divisions: int | None = None,
+    **kwargs: Any,
+) -> pn.pane.panel | None:
+    """Map an optional renderer over each stored ``ResultDataSet`` payload.
+
+    Storage is deliberately payload-agnostic. The renderer, when supplied, owns
+    every interpretation of the object (tabular, image-like, domain specific,
+    and so on); without one, the stored object is handed to Panel.
+    """
+    if hv_dataset is None:
+        hv_dataset = result.to_hv_dataset(
+            ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
+        )
+    elif not isinstance(hv_dataset, hv.Dataset):
+        hv_dataset = hv.Dataset(hv_dataset)
+    return result.map_plot_panes(
+        partial(result.ds_to_container, container=renderer),
+        hv_dataset=hv_dataset,
+        target_dimension=target_dimension,
+        result_var=result_var,
+        result_types=(ResultDataSet,),
+        **kwargs,
+    )
 
 
 class DataSetResult(BenchResultBase):
+    """Render the arbitrary per-sample payloads stored by ``ResultDataSet``."""
+
     def to_plot(
         self,
         result_var: Parameter | None = None,
         hv_dataset=None,
         target_dimension: int = 0,
-        container=None,
+        container: Callable[[Any], Any] | None = None,
         subsampling_divisions: int | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> pn.pane.panel | None:
-        if hv_dataset is None:
-            hv_dataset = self.to_hv_dataset(
-                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
-            )
-        elif not isinstance(hv_dataset, hv.Dataset):
-            hv_dataset = hv.Dataset(hv_dataset)
-        return self.map_plot_panes(
-            partial(self.ds_to_container, container=container),
+        """Render stored payloads, preserving the public ``container=`` API."""
+        return render_data_samples(
+            self,
+            renderer=container,
+            result_var=result_var,
             hv_dataset=hv_dataset,
             target_dimension=target_dimension,
-            result_var=result_var,
-            result_types=PANEL_TYPES,
+            subsampling_divisions=subsampling_divisions,
             **kwargs,
         )

--- a/bencher/results/holoview_results/tabular_spec.py
+++ b/bencher/results/holoview_results/tabular_spec.py
@@ -1,0 +1,291 @@
+"""Shared machinery for chart types that plot *inside* one tabular sample.
+
+Every other chart in bencher plots across the sweep: an input variable on x, a
+result variable on y, one point per sample. The charts built on this module plot
+inside a single sample — a :class:`~bencher.variables.results.ResultDataSet` whose
+rows are the measurement (landing points, a collected timeseries, a phase-space
+cloud) — where the axes are columns the benchmark measured and the sweep
+dimensions are what separate one plot from the next.
+
+Each such chart is two objects with one implementation:
+
+* a :class:`TabularSpec` subclass, built by a small factory function, which is a
+  callable taking the stored object and returning a holoviews element. That makes
+  it usable directly as a declared renderer, so the plot appears in
+  ``result_vars`` order with the other results::
+
+      series = bn.ResultDataSet(container=bn.xy_curve(x="time", y="signal"))
+
+* a :class:`TabularSpecResult` subclass, so the same spec can be asked for as a
+  report-level chart type::
+
+      bench.add(bn.XYCurveResult, x="time", y="signal")
+
+This module holds the parts that do not depend on which chart it is: coercing the
+stored object to a DataFrame, validating and inferring columns, converting labels
+at the holoviews boundary, and mapping a spec over every tabular sample.
+
+A spec is a frozen dataclass rather than a closure because it has to survive
+pickling: a result var declaring ``container=`` is part of ``BenchCfg``, which
+goes into the result cache and through the collect/render split, and a local
+function cannot be pickled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any, ClassVar
+
+import holoviews as hv
+import pandas as pd
+import panel as pn
+import xarray as xr
+from param import Parameter
+
+from bencher.results.bench_result_base import ReduceType
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.variables.results import ResultDataSet
+
+
+def to_dataframe(obj: Any, chart: str) -> pd.DataFrame:
+    """Coerce a stored dataset object to a DataFrame with plottable columns."""
+    if isinstance(obj, pd.DataFrame):
+        return obj
+    if isinstance(obj, (xr.Dataset, xr.DataArray)):
+        # reset_index so dimension coordinates become columns and can be plotted.
+        return obj.to_dataframe().reset_index()
+    if isinstance(obj, hv.Dataset):
+        return obj.dframe()
+    raise TypeError(
+        f"{chart} needs a DataFrame, xarray Dataset/DataArray or hv.Dataset, "
+        f"got {type(obj).__name__}"
+    )
+
+
+def check_column(df: pd.DataFrame, name: Hashable, role: str, chart: str) -> Hashable:
+    if name not in df.columns:
+        raise ValueError(
+            f"{chart} {role}={name!r} is not a column of the result; "
+            f"available columns: {list(df.columns)}"
+        )
+    return name
+
+
+def resolve_axes(
+    df: pd.DataFrame, x: Hashable | None, y: Hashable | None, chart: str
+) -> tuple[Hashable, Hashable]:
+    """The x and y columns, inferring unspecified ones from the numeric columns.
+
+    Inference takes the first two numeric columns in frame order, which is only
+    meaningful for a frame that holds exactly the pair being plotted — name the
+    columns whenever the frame carries anything else (an index, a z coordinate).
+
+    Labels come back exactly as the frame holds them: a column label is only a
+    string by convention, and an xarray-derived frame can hand back integers or
+    timestamps, which must still be usable to look the column back up.
+    """
+    if x is not None and y is not None:
+        return check_column(df, x, "x", chart), check_column(df, y, "y", chart)
+    numeric = list(df.select_dtypes("number").columns)
+    if len(numeric) < 2:
+        raise ValueError(
+            f"{chart} needs two numeric columns to infer x and y, found "
+            f"{numeric}; pass x= and y= explicitly"
+        )
+    if x is None and y is None:
+        return numeric[0], numeric[1]
+    if x is None:
+        x_inferred = next((c for c in numeric if c != y), None)
+        if x_inferred is None:
+            raise ValueError(f"{chart} found no numeric column for x besides {y!r}")
+        return x_inferred, check_column(df, y, "y", chart)
+    y_inferred = next((c for c in numeric if c != x), None)
+    if y_inferred is None:
+        raise ValueError(f"{chart} found no numeric column for y besides {x!r}")
+    return check_column(df, x, "x", chart), y_inferred
+
+
+def plot_frame(
+    df: pd.DataFrame, columns: Sequence[Hashable], chart: str
+) -> tuple[pd.DataFrame, dict[Hashable, str]]:
+    """The plotted columns alone, renamed so every dimension name is a string.
+
+    A holoviews ``Dimension`` name has to be a string, but a column label does not,
+    so every lookup above works with the frame's own labels and the conversion
+    happens here, at the holoviews boundary, on a copy of the columns being plotted.
+
+    Returns the frame to plot and the label -> dimension name mapping.
+    """
+    # dict keys dedupe (x may also be a vdim) while keeping the requested order.
+    names = {col: str(col) for col in columns}
+    if len(set(names.values())) != len(names):
+        raise ValueError(
+            f"{chart} cannot plot columns whose labels collide once converted to "
+            f"strings: {sorted(names.values())}"
+        )
+    plot_df = df[list(names)]
+    if any(col != name for col, name in names.items()):
+        plot_df = plot_df.rename(columns=names)
+    return plot_df, names
+
+
+@dataclass(frozen=True)
+class TabularSpec:
+    """Base for a picklable spec that renders one sample's table as an element.
+
+    Subclasses add the columns and per-chart options they need and implement
+    :meth:`build`; the fields here are the ones every chart accepts. Build one with
+    the chart's factory function rather than constructing it directly — the
+    factory documents the options and is where the keyword-only boundary is.
+
+    Fields are declared with defaults so a subclass can add its own, which means
+    they land *before* the subclass's in the generated ``__init__``; the factory
+    functions pass everything by keyword, so that ordering is never visible.
+    """
+
+    # Named on the class rather than passed around so error messages say which
+    # chart rejected a column, without every helper call repeating the name.
+    chart_name: ClassVar[str] = "tabular chart"
+
+    title: str | None = None
+    xlabel: str | None = None
+    ylabel: str | None = None
+    hover: bool = True
+    data_aspect: float | None = None
+    # Read-only by contract: the frozen dataclass cannot rebind it and nothing here
+    # mutates it, so the shallow copy the factory takes is never written to.
+    opts: Mapping[str, Any] = field(default_factory=dict)
+
+    def __call__(self, obj: Any) -> Any:
+        """Render *obj*, which is the stored object alone.
+
+        This is the whole contract a ``ResultDataSet`` container has to satisfy, so
+        a spec can be declared on a result var, attached to a single sample, or
+        handed to a chart type, and the same code runs in all three cases.
+        """
+        return self.build(to_dataframe(obj, self.chart_name))
+
+    def build(self, df: pd.DataFrame) -> Any:
+        """Turn one sample's table into something panel can display."""
+        raise NotImplementedError
+
+    def element_opts(
+        self, xlabel: str | None = None, ylabel: str | None = None, **chart_opts: Any
+    ) -> dict[str, Any]:
+        """The options to apply to the built element.
+
+        *xlabel* and *ylabel* are the defaults to use when the spec does not
+        override them — normally the plotted column names. *chart_opts* are the
+        per-chart options; the spec's own ``opts`` are applied last, so anything
+        holoviews accepts can be passed through the factory without a wrapper.
+        """
+        opts: dict[str, Any] = {}
+        if (label := self.xlabel if self.xlabel is not None else xlabel) is not None:
+            opts["xlabel"] = label
+        if (label := self.ylabel if self.ylabel is not None else ylabel) is not None:
+            opts["ylabel"] = label
+        opts.update(chart_opts)
+        if self.data_aspect is not None:
+            opts["data_aspect"] = self.data_aspect
+        # Set explicitly in both directions rather than omitted when off:
+        # set_default_opts registers tools=["hover"] as a global default for most
+        # element types, so leaving the key out would put hover back and make
+        # hover=False a silent no-op.
+        opts["tools"] = ["hover"] if self.hover else []
+        if self.title is not None:
+            opts["title"] = self.title
+        opts.update(self.opts)
+        return opts
+
+    def check(self, df: pd.DataFrame, name: Hashable, role: str) -> Hashable:
+        """Validate that *name* is a column of *df*, naming this chart on failure."""
+        return check_column(df, name, role, self.chart_name)
+
+    def axes(self, df: pd.DataFrame, x: Hashable | None, y: Hashable | None):
+        """The x and y columns for this chart (see :func:`resolve_axes`)."""
+        return resolve_axes(df, x, y, self.chart_name)
+
+    def frame(self, df: pd.DataFrame, columns: Sequence[Hashable]):
+        """The plotted columns with string dimension names (see :func:`plot_frame`)."""
+        return plot_frame(df, columns, self.chart_name)
+
+    def value_columns(
+        self, df: pd.DataFrame, vdims: Sequence[Hashable], *extra: Hashable | None
+    ) -> list[Hashable]:
+        """The validated value dimensions: *vdims* plus any *extra* not already in them.
+
+        *extra* is for columns a chart option implies (the one it colours by, say),
+        which have to be carried as value dimensions to be usable by the plot but
+        must not be listed twice.
+        """
+        value_cols = list(vdims)
+        for col in value_cols:
+            self.check(df, col, "vdims entry")
+        for col in extra:
+            if col is not None and col not in value_cols:
+                value_cols.append(col)
+        return value_cols
+
+
+class TabularSpecResult(HoloviewResult):
+    """Base for chart types that render each tabular sample through a spec.
+
+    One plot per sample rather than one plot for the sweep: the rows of a sample
+    are the measurement, so averaging them across samples would destroy the thing
+    being measured. Non-tabular results are skipped — a chart of a sample's columns
+    is only defined for a tabular result.
+
+    Subclasses implement ``to_plot``, naming their spec options explicitly and
+    handing the built spec to :meth:`render_spec`.
+    """
+
+    def render_spec(
+        self,
+        spec: TabularSpec,
+        result_var: Parameter | None = None,
+        hv_dataset=None,
+        target_dimension: int = 0,
+        subsampling_divisions: int | None = None,
+        **kwargs: Any,
+    ) -> pn.panel | None:
+        """Map *spec* over every tabular sample and lay the results out.
+
+        Args:
+            spec: The chart spec to render each sample through.
+            result_var: Restrict to one result variable. Defaults to every
+                ``ResultDataSet`` in the sweep.
+            hv_dataset: Pre-built dataset to render instead of this result's own.
+            target_dimension: Dimension depth to recurse the panes down to.
+            subsampling_divisions: Level to subsample the dataset at.
+            **kwargs: Forwarded to ``map_plot_panes`` (layout and the plot-size
+                keywords every ``to_auto`` render call carries).
+
+        Returns:
+            A panel of plots, or None when the sweep has no tabular result.
+        """
+        if hv_dataset is None:
+            hv_dataset = self.to_hv_dataset(
+                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
+            )
+        elif not isinstance(hv_dataset, hv.Dataset):
+            hv_dataset = hv.Dataset(hv_dataset)
+        return self.map_plot_panes(
+            partial(self.ds_to_container, container=spec),
+            hv_dataset=hv_dataset,
+            target_dimension=target_dimension,
+            result_var=result_var,
+            result_types=(ResultDataSet,),
+            **kwargs,
+        )
+
+
+__all__ = [
+    "TabularSpec",
+    "TabularSpecResult",
+    "check_column",
+    "plot_frame",
+    "resolve_axes",
+    "to_dataframe",
+]

--- a/bencher/results/holoview_results/tabular_spec.py
+++ b/bencher/results/holoview_results/tabular_spec.py
@@ -1,56 +1,29 @@
-"""Shared machinery for chart types that plot *inside* one tabular sample.
+"""Opt-in helpers for renderers that interpret stored data as a table.
 
-Every other chart in bencher plots across the sweep: an input variable on x, a
-result variable on y, one point per sample. The charts built on this module plot
-inside a single sample — a :class:`~bencher.variables.results.ResultDataSet` whose
-rows are the measurement (landing points, a collected timeseries, a phase-space
-cloud) — where the axes are columns the benchmark measured and the sweep
-dimensions are what separate one plot from the next.
+``ResultDataSet`` is an arbitrary per-sample data store; it has no tabular
+contract. A :class:`TabularSpec` is one possible renderer for that data. It
+coerces supported table-like payloads to a DataFrame, validates columns, and
+builds a HoloViews element. Other renderers can interpret the same generic store
+without depending on this module.
 
-Each such chart is two objects with one implementation:
-
-* a :class:`TabularSpec` subclass, built by a small factory function, which is a
-  callable taking the stored object and returning a holoviews element. That makes
-  it usable directly as a declared renderer, so the plot appears in
-  ``result_vars`` order with the other results::
-
-      series = bn.ResultDataSet(container=bn.xy_curve(x="time", y="signal"))
-
-* a :class:`TabularSpecResult` subclass, so the same spec can be asked for as a
-  report-level chart type::
-
-      bench.add(bn.XYCurveResult, x="time", y="signal")
-
-This module holds the parts that do not depend on which chart it is: coercing the
-stored object to a DataFrame, validating and inferring columns, converting labels
-at the holoviews boundary, and mapping a spec over every tabular sample.
-
-A spec is a frozen dataclass rather than a closure because it has to survive
-pickling: a result var declaring ``container=`` is part of ``BenchCfg``, which
-goes into the result cache and through the collect/render split, and a local
-function cannot be pickled.
+A spec is a frozen dataclass rather than a closure because a renderer declared
+on a result variable is part of ``BenchCfg`` and must survive the result cache
+and collect/render split.
 """
 
 from __future__ import annotations
 
 from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass, field
-from functools import partial
 from typing import Any, ClassVar
 
 import holoviews as hv
 import pandas as pd
-import panel as pn
 import xarray as xr
-from param import Parameter
-
-from bencher.results.bench_result_base import ReduceType
-from bencher.results.holoview_results.holoview_result import HoloviewResult
-from bencher.variables.results import ResultDataSet
 
 
 def to_dataframe(obj: Any, chart: str) -> pd.DataFrame:
-    """Coerce a stored dataset object to a DataFrame with plottable columns."""
+    """Coerce a stored payload to a DataFrame with plottable columns."""
     if isinstance(obj, pd.DataFrame):
         return obj
     if isinstance(obj, (xr.Dataset, xr.DataArray)):
@@ -229,61 +202,8 @@ class TabularSpec:
         return value_cols
 
 
-class TabularSpecResult(HoloviewResult):
-    """Base for chart types that render each tabular sample through a spec.
-
-    One plot per sample rather than one plot for the sweep: the rows of a sample
-    are the measurement, so averaging them across samples would destroy the thing
-    being measured. Non-tabular results are skipped — a chart of a sample's columns
-    is only defined for a tabular result.
-
-    Subclasses implement ``to_plot``, naming their spec options explicitly and
-    handing the built spec to :meth:`render_spec`.
-    """
-
-    def render_spec(
-        self,
-        spec: TabularSpec,
-        result_var: Parameter | None = None,
-        hv_dataset=None,
-        target_dimension: int = 0,
-        subsampling_divisions: int | None = None,
-        **kwargs: Any,
-    ) -> pn.panel | None:
-        """Map *spec* over every tabular sample and lay the results out.
-
-        Args:
-            spec: The chart spec to render each sample through.
-            result_var: Restrict to one result variable. Defaults to every
-                ``ResultDataSet`` in the sweep.
-            hv_dataset: Pre-built dataset to render instead of this result's own.
-            target_dimension: Dimension depth to recurse the panes down to.
-            subsampling_divisions: Level to subsample the dataset at.
-            **kwargs: Forwarded to ``map_plot_panes`` (layout and the plot-size
-                keywords every ``to_auto`` render call carries).
-
-        Returns:
-            A panel of plots, or None when the sweep has no tabular result.
-        """
-        if hv_dataset is None:
-            hv_dataset = self.to_hv_dataset(
-                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
-            )
-        elif not isinstance(hv_dataset, hv.Dataset):
-            hv_dataset = hv.Dataset(hv_dataset)
-        return self.map_plot_panes(
-            partial(self.ds_to_container, container=spec),
-            hv_dataset=hv_dataset,
-            target_dimension=target_dimension,
-            result_var=result_var,
-            result_types=(ResultDataSet,),
-            **kwargs,
-        )
-
-
 __all__ = [
     "TabularSpec",
-    "TabularSpecResult",
     "check_column",
     "plot_frame",
     "resolve_axes",

--- a/bencher/results/holoview_results/tabular_spec.py
+++ b/bencher/results/holoview_results/tabular_spec.py
@@ -153,6 +153,12 @@ class TabularSpec:
         override them — normally the plotted column names. *chart_opts* are the
         per-chart options; the spec's own ``opts`` are applied last, so anything
         holoviews accepts can be passed through the factory without a wrapper.
+
+        The shared fields win over *chart_opts* for the keys they own, so a chart
+        must not pass ``title``, ``data_aspect`` or ``tools`` as a chart option:
+        the first two are only overridden when the field is set, but ``tools`` is
+        always written (see below) and a chart option would be dropped silently.
+        Pass such a value through ``opts`` instead, which is applied last.
         """
         opts: dict[str, Any] = {}
         if (label := self.xlabel if self.xlabel is not None else xlabel) is not None:
@@ -191,13 +197,20 @@ class TabularSpec:
 
         *extra* is for columns a chart option implies (the one it colours by, say),
         which have to be carried as value dimensions to be usable by the plot but
-        must not be listed twice.
+        must not be listed twice. Every column returned is checked against *df*,
+        including *extra*, so a chart that names one gets this module's
+        available-columns message rather than a bare pandas ``KeyError`` from
+        :meth:`frame`. ``None`` entries in *extra* are skipped, so an unset option
+        needs no guard at the call site.
         """
         value_cols = list(vdims)
         for col in value_cols:
             self.check(df, col, "vdims entry")
         for col in extra:
-            if col is not None and col not in value_cols:
+            if col is None:
+                continue
+            self.check(df, col, "value column")
+            if col not in value_cols:
                 value_cols.append(col)
         return value_cols
 

--- a/bencher/results/holoview_results/xy_scatter_result.py
+++ b/bencher/results/holoview_results/xy_scatter_result.py
@@ -15,117 +15,32 @@ Two ways in, same renderer:
 * explicitly, for a report-level plot::
 
       bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm", color="index")
+
+See :mod:`bencher.results.holoview_results.tabular_spec` for the machinery this and
+the other intra-sample charts share.
 """
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Mapping, Sequence
-from dataclasses import dataclass, field
-from functools import partial
-from typing import Any
+from collections.abc import Hashable, Sequence
+from dataclasses import dataclass
+from typing import Any, ClassVar
 
 import holoviews as hv
-import pandas as pd
 import panel as pn
-import xarray as xr
 from param import Parameter
 
-from bencher.results.bench_result_base import ReduceType
-from bencher.results.holoview_results.holoview_result import HoloviewResult
-from bencher.variables.results import ResultDataSet
-
-
-def _to_dataframe(obj: Any) -> pd.DataFrame:
-    """Coerce a stored dataset object to a DataFrame with plottable columns."""
-    if isinstance(obj, pd.DataFrame):
-        return obj
-    if isinstance(obj, (xr.Dataset, xr.DataArray)):
-        # reset_index so dimension coordinates become columns and can be plotted.
-        return obj.to_dataframe().reset_index()
-    if isinstance(obj, hv.Dataset):
-        return obj.dframe()
-    raise TypeError(
-        f"xy_scatter needs a DataFrame, xarray Dataset/DataArray or hv.Dataset, "
-        f"got {type(obj).__name__}"
-    )
-
-
-def _check_column(df: pd.DataFrame, name: Hashable, role: str) -> Hashable:
-    if name not in df.columns:
-        raise ValueError(
-            f"xy_scatter {role}={name!r} is not a column of the result; "
-            f"available columns: {list(df.columns)}"
-        )
-    return name
-
-
-def _resolve_axes(
-    df: pd.DataFrame, x: Hashable | None, y: Hashable | None
-) -> tuple[Hashable, Hashable]:
-    """The x and y columns, inferring unspecified ones from the numeric columns.
-
-    Inference takes the first two numeric columns in frame order, which is only
-    meaningful for a frame that holds exactly the pair being plotted — name the
-    columns whenever the frame carries anything else (an index, a z coordinate).
-
-    Labels come back exactly as the frame holds them: a column label is only a
-    string by convention, and an xarray-derived frame can hand back integers or
-    timestamps, which must still be usable to look the column back up.
-    """
-    if x is not None and y is not None:
-        return _check_column(df, x, "x"), _check_column(df, y, "y")
-    numeric = list(df.select_dtypes("number").columns)
-    if len(numeric) < 2:
-        raise ValueError(
-            "xy_scatter needs two numeric columns to infer x and y, found "
-            f"{numeric}; pass x= and y= explicitly"
-        )
-    if x is None and y is None:
-        return numeric[0], numeric[1]
-    if x is None:
-        x_inferred = next((c for c in numeric if c != y), None)
-        if x_inferred is None:
-            raise ValueError(f"xy_scatter found no numeric column for x besides {y!r}")
-        return x_inferred, _check_column(df, y, "y")
-    y_inferred = next((c for c in numeric if c != x), None)
-    if y_inferred is None:
-        raise ValueError(f"xy_scatter found no numeric column for y besides {x!r}")
-    return _check_column(df, x, "x"), y_inferred
-
-
-def _plot_frame(
-    df: pd.DataFrame, columns: Sequence[Hashable]
-) -> tuple[pd.DataFrame, dict[Hashable, str]]:
-    """The plotted columns alone, renamed so every dimension name is a string.
-
-    A holoviews ``Dimension`` name has to be a string, but a column label does not,
-    so every lookup above works with the frame's own labels and the conversion
-    happens here, at the holoviews boundary, on a copy of the columns being plotted.
-
-    Returns the frame to plot and the label -> dimension name mapping.
-    """
-    # dict keys dedupe (x may also be a vdim) while keeping the requested order.
-    names = {col: str(col) for col in columns}
-    if len(set(names.values())) != len(names):
-        raise ValueError(
-            "xy_scatter cannot plot columns whose labels collide once converted to "
-            f"strings: {sorted(names.values())}"
-        )
-    plot_df = df[list(names)]
-    if any(col != name for col, name in names.items()):
-        plot_df = plot_df.rename(columns=names)
-    return plot_df, names
+from bencher.results.holoview_results.tabular_spec import TabularSpec, TabularSpecResult
 
 
 @dataclass(frozen=True)
-class XYScatter:
+class XYScatter(TabularSpec):
     """A column spec that renders a table as an XY scatter when called.
 
-    A class rather than a closure so it survives pickling: a result var declaring
-    ``container=`` is part of ``BenchCfg``, which goes into the result cache and
-    through the collect/render split, and a local function cannot be pickled. Build
-    one with :func:`xy_scatter`.
+    Build one with :func:`xy_scatter`, which documents the options.
     """
+
+    chart_name: ClassVar[str] = "xy_scatter"
 
     x: Hashable | None = None
     y: Hashable | None = None
@@ -134,48 +49,23 @@ class XYScatter:
     size: int = 7
     cmap: str = "viridis"
     marker: str = "circle"
-    data_aspect: float | None = None
-    hover: bool = True
-    title: str | None = None
-    xlabel: str | None = None
-    ylabel: str | None = None
-    # Read-only by contract: the frozen dataclass cannot rebind it and nothing here
-    # mutates it, so the shallow copy :func:`xy_scatter` takes is never written to.
-    opts: Mapping[str, Any] = field(default_factory=dict)
 
-    def __call__(self, obj: Any) -> hv.Points:
-        df = _to_dataframe(obj)
-        x_col, y_col = _resolve_axes(df, self.x, self.y)
-        value_cols = list(self.vdims)
-        for col in value_cols:
-            _check_column(df, col, "vdims entry")
+    def build(self, df) -> hv.Points:
+        x_col, y_col = self.axes(df, self.x, self.y)
         if self.color is not None:
-            _check_column(df, self.color, "color")
-            if self.color not in value_cols:
-                value_cols.append(self.color)
+            self.check(df, self.color, "color")
+        value_cols = self.value_columns(df, self.vdims, self.color)
 
-        plot_df, names = _plot_frame(df, [x_col, y_col, *value_cols])
+        plot_df, names = self.frame(df, [x_col, y_col, *value_cols])
         x_name, y_name = names[x_col], names[y_col]
 
-        point_opts: dict[str, Any] = {
-            "size": self.size,
-            "marker": self.marker,
-            "xlabel": self.xlabel if self.xlabel is not None else x_name,
-            "ylabel": self.ylabel if self.ylabel is not None else y_name,
-        }
+        chart_opts: dict[str, Any] = {"size": self.size, "marker": self.marker}
         if self.color is not None:
-            point_opts.update(color=names[self.color], cmap=self.cmap, colorbar=True)
-        if self.data_aspect is not None:
-            point_opts["data_aspect"] = self.data_aspect
-        if self.hover:
-            point_opts["tools"] = ["hover"]
-        if self.title is not None:
-            point_opts["title"] = self.title
-        point_opts.update(self.opts)
+            chart_opts.update(color=names[self.color], cmap=self.cmap, colorbar=True)
 
         return hv.Points(
             plot_df, kdims=[x_name, y_name], vdims=[names[col] for col in value_cols]
-        ).opts(**point_opts)
+        ).opts(**self.element_opts(xlabel=x_name, ylabel=y_name, **chart_opts))
 
 
 def xy_scatter(
@@ -245,14 +135,8 @@ def xy_scatter(
     )
 
 
-class XYScatterResult(HoloviewResult):
-    """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns.
-
-    One plot per sample rather than one plot for the sweep: the rows of a sample are
-    the cloud, so averaging them across samples would destroy the thing being
-    measured. Other result types are skipped — a scatter of two columns is only
-    defined for a tabular result.
-    """
+class XYScatterResult(TabularSpecResult):
+    """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns."""
 
     def to_plot(
         self,
@@ -311,33 +195,25 @@ class XYScatterResult(HoloviewResult):
         Returns:
             A panel of scatter plots, or None when the sweep has no tabular result.
         """
-        container = xy_scatter(
-            x=x,
-            y=y,
-            color=color,
-            vdims=vdims,
-            size=size,
-            cmap=cmap,
-            marker=marker,
-            data_aspect=data_aspect,
-            hover=hover,
-            title=title,
-            xlabel=xlabel,
-            ylabel=ylabel,
-            **(opts or {}),
-        )
-
-        if hv_dataset is None:
-            hv_dataset = self.to_hv_dataset(
-                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
-            )
-        elif not isinstance(hv_dataset, hv.Dataset):
-            hv_dataset = hv.Dataset(hv_dataset)
-        return self.map_plot_panes(
-            partial(self.ds_to_container, container=container),
+        return self.render_spec(
+            xy_scatter(
+                x=x,
+                y=y,
+                color=color,
+                vdims=vdims,
+                size=size,
+                cmap=cmap,
+                marker=marker,
+                data_aspect=data_aspect,
+                hover=hover,
+                title=title,
+                xlabel=xlabel,
+                ylabel=ylabel,
+                **(opts or {}),
+            ),
+            result_var=result_var,
             hv_dataset=hv_dataset,
             target_dimension=target_dimension,
-            result_var=result_var,
-            result_types=(ResultDataSet,),
+            subsampling_divisions=subsampling_divisions,
             **kwargs,
         )

--- a/bencher/results/holoview_results/xy_scatter_result.py
+++ b/bencher/results/holoview_results/xy_scatter_result.py
@@ -16,8 +16,8 @@ Two ways in, same renderer:
 
       bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm", color="index")
 
-See :mod:`bencher.results.holoview_results.tabular_spec` for the machinery this and
-the other intra-sample charts share.
+The generic result store and sample traversal do not know that the payload is a
+table. Only the renderer below performs that interpretation.
 """
 
 from __future__ import annotations
@@ -30,7 +30,9 @@ import holoviews as hv
 import panel as pn
 from param import Parameter
 
-from bencher.results.holoview_results.tabular_spec import TabularSpec, TabularSpecResult
+from bencher.results.dataset_result import render_data_samples
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.holoview_results.tabular_spec import TabularSpec
 
 
 @dataclass(frozen=True)
@@ -135,7 +137,7 @@ def xy_scatter(
     )
 
 
-class XYScatterResult(TabularSpecResult):
+class XYScatterResult(HoloviewResult):
     """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns."""
 
     def to_plot(
@@ -195,8 +197,9 @@ class XYScatterResult(TabularSpecResult):
         Returns:
             A panel of scatter plots, or None when the sweep has no tabular result.
         """
-        return self.render_spec(
-            xy_scatter(
+        return render_data_samples(
+            self,
+            renderer=xy_scatter(
                 x=x,
                 y=y,
                 color=color,

--- a/bencher/results/holoview_results/xy_scatter_result.py
+++ b/bencher/results/holoview_results/xy_scatter_result.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar
 
 import holoviews as hv
+import pandas as pd
 import panel as pn
 from param import Parameter
 
@@ -52,8 +53,10 @@ class XYScatter(TabularSpec):
     cmap: str = "viridis"
     marker: str = "circle"
 
-    def build(self, df) -> hv.Points:
+    def build(self, df: pd.DataFrame) -> hv.Points:
         x_col, y_col = self.axes(df, self.x, self.y)
+        # value_columns validates this too; checking it here first is what names the
+        # option that was wrong ("color=") rather than the generic "value column".
         if self.color is not None:
             self.check(df, self.color, "color")
         value_cols = self.value_columns(df, self.vdims, self.color)
@@ -138,7 +141,13 @@ def xy_scatter(
 
 
 class XYScatterResult(HoloviewResult):
-    """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns."""
+    """Renders every ``ResultDataSet`` sample as an XY scatter of two of its columns.
+
+    One plot per sample rather than one plot for the sweep: the rows of a sample are
+    the cloud, so averaging them across samples would destroy the thing being
+    measured. Other result types are skipped — a scatter of two columns is only
+    defined for a tabular result.
+    """
 
     def to_plot(
         self,

--- a/bencher/results/pane_result.py
+++ b/bencher/results/pane_result.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from functools import partial
-
-import holoviews as hv
 import panel as pn
 from param import Parameter
 
-from bencher.results.bench_result_base import BenchResultBase, ReduceType
+from bencher.results.bench_result_base import BenchResultBase
 from bencher.results.video_controls import VideoControls
 from bencher.variables.results import (
     PANEL_TYPES,
@@ -30,17 +27,12 @@ class PaneResult(BenchResultBase):
         subsampling_divisions: int | None = None,
         **kwargs,
     ) -> pn.pane.panel | None:
-        if hv_dataset is None:
-            hv_dataset = self.to_hv_dataset(
-                ReduceType.SQUEEZE, subsampling_divisions=subsampling_divisions
-            )
-        elif not isinstance(hv_dataset, hv.Dataset):
-            hv_dataset = hv.Dataset(hv_dataset)
-        return self.map_plot_panes(
-            partial(self.ds_to_container, container=container),
+        return self.map_sample_panes(
+            PANEL_TYPES,
+            container=container,
+            result_var=result_var,
             hv_dataset=hv_dataset,
             target_dimension=target_dimension,
-            result_var=result_var,
-            result_types=PANEL_TYPES,
+            subsampling_divisions=subsampling_divisions,
             **kwargs,
         )

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -424,26 +424,30 @@ class ResultReference(param.Parameter):
 
 
 class ResultDataSet(param.Parameter):
-    """A tabular result: one DataFrame (or Dataset) per sample.
+    """An arbitrary picklable data payload stored for each benchmark sample.
 
-    ``container`` is an optional callback taking the stored object and returning
-    something panel can display, so a table can render as the plot it means
-    instead of as raw rows.  Declare it once on the class and every sample
+    The payload may be a DataFrame, xarray object, mapping, sequence, custom
+    dataclass, or any other object that can travel through the configured result
+    cache. Bencher stores and retrieves it without interpreting its type.
+
+    ``container`` is an optional renderer taking the stored object and returning
+    something Panel can display. Declare it once on the class and every sample
     renders through it, in ``result_vars`` order, alongside the other results::
 
-        cloud = ResultDataSet(container=my_scatter)   # my_scatter(df) -> plot
+        payload = ResultDataSet(container=render_payload)
 
         def benchmark(self):
-            self.cloud = ResultDataSet(build_frame())
+            self.payload = ResultDataSet(measure())
 
-    Per-sample overrides are honoured too (``ResultDataSet(df, container=...)``
+    Per-sample overrides are honoured too (``ResultDataSet(data, container=...)``
     inside ``benchmark()``), and an explicit ``container=`` passed to a renderer
     beats both.  The callback receives only the object — no plot kwargs — so
     single-argument callables are safe.
 
-    A declared container travels with ``BenchCfg`` into the result cache and through
-    the collect/render split, so it has to be picklable: a module-level function or a
-    callable object, not a lambda or a local function.
+    A declared renderer travels with ``BenchCfg`` into the result cache and
+    through the collect/render split, so it has to be picklable: a module-level
+    function or a callable object, not a lambda or a local function. Use
+    ``ResultReference`` instead when the payload itself is not picklable.
     """
 
     __slots__ = ["units", "obj", "container", "max_time_events"]

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -237,8 +237,8 @@ Result types declare what a benchmark function returns:
 - `ResultVideo` — a file path to a video
 - `ResultPath` — an arbitrary file path
 - `ResultString` — a string result
-- `ResultDataSet` — a table (DataFrame or xarray Dataset) per sample, optionally with a
-  `container=` callback that renders it as a plot instead of raw rows
+- `ResultDataSet` — any picklable Python payload per sample, optionally with a
+  `container=` callback that renders it without coupling storage to its data type
 - `ResultVolume` — volume data
 
 Bencher distinguishes inputs from results by type: anything that is a subclass of a result type

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -129,40 +129,42 @@ demo.
 | `bn.ResultPath()` | Downloadable file outputs | `self.artifact = "/path/to/file"` |
 | `bn.ResultContainer()` | Embeddable HTML/panel content | `self.widget = pane` |
 | `bn.ResultVec(size=3)` | Fixed-size vector results (x, y, z) | `self.position = [1.0, 2.0, 3.0]` |
-| `bn.ResultDataSet()` | A table per sample (many rows measured at one point) | `self.cloud = bn.ResultDataSet(df)` |
+| `bn.ResultDataSet()` | Any picklable data payload per sample | `self.data = bn.ResultDataSet(payload)` |
 
 **Choosing between ResultFloat and ResultBool:** If a result is binary (success/failure,
 reachable/unreachable, pass/fail), always use `ResultBool` — it locks bounds to [0, 1]
 and produces correct boolean-style plots. Only use `ResultFloat` for continuous metrics.
 See the [Result Types gallery](reference/meta/result_types/index) for examples of each type.
 
-**Rendering a table as a plot:** `ResultDataSet` shows raw rows by default. Pass
-`container=` a callable taking the stored object and returning anything panel can
-display, and every sample renders through it, in `result_vars` order alongside the
-other results:
+**Rendering stored data:** `ResultDataSet` stores the payload without interpreting
+its type. Without a renderer, Panel displays the raw object. Pass `container=` a
+callable taking the stored object and returning anything Panel can display, and every
+sample renders through it, in `result_vars` order alongside the other results:
 
 ```python
-def scatter(df):                       # -> a holoviews / panel object
-    return hv.Points(df, kdims=["x", "y"])
+def render_measurement(payload):       # -> a HoloViews / Panel object
+    return build_view(payload)
 
 class MySweep(bn.ParametrizedSweep):
-    cloud = bn.ResultDataSet(container=scatter)
+    measurement = bn.ResultDataSet(container=render_measurement)
 
     def benchmark(self):
-        self.cloud = bn.ResultDataSet(measure())     # per-sample container= also works
+        self.measurement = bn.ResultDataSet(measure())
 ```
 
-Without it, the alternative is `bench.add(bn.DataSetResult, container=scatter, ...)`,
-which appends the plot to the end of the report instead of placing it with the results
-it belongs to.
+The payload can be a DataFrame, xarray object, mapping, sequence, custom dataclass,
+or another picklable Python object. Use `ResultReference` for data that cannot be
+pickled. A per-sample `container=` also works. An explicit renderer passed through
+`bench.add(bn.DataSetResult, container=...)` overrides the declared renderer and
+appends that view to the report.
 
 A declared container is part of the benchmark config, which the result cache and the
 collect/render split both pickle, so it must be picklable: a module-level function (as
 above) or a callable object, not a lambda or a local function.
 
-**XY scatter of two measured columns:** for the common case of that container —
-scattering two columns of the table against each other — `bn.xy_scatter` builds it for
-you, so no plotting code is needed:
+**XY scatter of two measured columns:** tabular interpretation belongs to this
+renderer, not to `ResultDataSet`. `bn.xy_scatter` builds a renderer that accepts a
+DataFrame, xarray Dataset/DataArray, or HoloViews Dataset:
 
 ```python
 cloud = bn.ResultDataSet(
@@ -179,9 +181,9 @@ same spec is available as a chart type for a report-level plot —
 `to_auto(plot_list=["xy_scatter"], x=..., y=...)`.
 
 Under `over_time`, a `ResultDataSet` renders the run being reported rather than a slider
-over the history: a cell holds an index into a list of tables rebuilt on every run, so
+over the history: a cell holds an index into a payload list rebuilt on every run, so
 the indices carried in from earlier runs address the current list and a slider would show
-today's table under yesterday's label. Scalar results keep their full history.
+today's payload under yesterday's label. Scalar results keep their full history.
 
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -2,6 +2,7 @@
 
 import pickle
 import unittest
+import unittest.mock
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -10,7 +11,9 @@ import panel as pn
 import xarray as xr
 
 import bencher as bn
-from bencher.results.dataset_result import DataSetResult
+from bencher.results.bench_result_base import BenchResultBase
+from bencher.results.dataset_result import DataSetResult, render_data_samples
+from bencher.variables.results import PANEL_TYPES
 
 SCALES = [1.0, 2.0]
 
@@ -206,6 +209,79 @@ class TestDataSetResult(unittest.TestCase):
         frame = self.res.ds_to_container(point, rv, container=None)
         pd.testing.assert_frame_equal(frame, expected_frame(SCALES[1]))
         np.testing.assert_allclose(frame["y"].to_numpy(), [2.0, 4.0, 6.0])
+
+
+class NonDataSetSweep(bn.ParametrizedSweep):
+    """A sweep with a pane-type result that is not a ResultDataSet."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    label = bn.ResultString(doc="a string, not a stored payload")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.label = f"scale={self.scale:g}"
+        return self.get_results_values_as_dict()
+
+
+class TestOnlyDataSetResultsAreClaimed(unittest.TestCase):
+    """This view renders stored payloads only, unlike the general ``panes`` view.
+
+    The distinction is the reason the two exist: ``to_panes`` claims every pane-type
+    result, so a sweep without a ResultDataSet is its job, not this one's. Returning
+    None rather than falling back keeps a ``container=`` written for a stored payload
+    from being called with an unrelated result's value.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        bench = bn.Bench("test_dataset_non_dataset_result", NonDataSetSweep())
+        cls.res = bench.plot_sweep(
+            "string_sweep",
+            input_vars=["scale"],
+            result_vars=["label"],
+            run_cfg=bn.BenchRunCfg(repeats=1, cache_results=False, cache_samples=False),
+            auto_plot=False,
+        )
+
+    def test_dataset_view_declines_a_sweep_with_no_stored_payload(self):
+        self.assertIsNone(self.res.to(DataSetResult))
+
+    def test_panes_view_still_renders_it(self):
+        """Guard on the fixture: the result is renderable, just not by this view."""
+        self.assertIsInstance(self.res.to_panes(), pn.viewable.Viewable)
+
+
+class TestSharedRenderPath(unittest.TestCase):
+    """Both per-sample views go through one render path, differing only in claim.
+
+    The default report renders a declared ``container=`` through ``to_panes``, not
+    through this view, so if the two paths were separate copies a fix to one would
+    silently not reach the report.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep()
+
+    def _claimed_types(self, render) -> tuple:
+        with unittest.mock.patch.object(BenchResultBase, "map_sample_panes", autospec=True) as spy:
+            render()
+        self.assertEqual(spy.call_count, 1, "the view must delegate, not reimplement")
+        return spy.call_args.args[1]
+
+    def test_dataset_view_claims_only_stored_payloads(self):
+        self.assertEqual(
+            self._claimed_types(lambda: self.res.to(DataSetResult)), (bn.ResultDataSet,)
+        )
+
+    def test_panes_view_claims_every_pane_type(self):
+        self.assertEqual(self._claimed_types(self.res.to_panes), PANEL_TYPES)
+
+    def test_chart_types_reuse_the_same_path(self):
+        """A chart type composes the shared path rather than adding a parallel one."""
+        self.assertEqual(
+            self._claimed_types(lambda: render_data_samples(self.res)), (bn.ResultDataSet,)
+        )
 
 
 class TestArbitraryPayload(unittest.TestCase):

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -19,6 +19,10 @@ def expected_frame(scale: float) -> pd.DataFrame:
     return pd.DataFrame({"y": [scale * 1.0, scale * 2.0, scale * 3.0]})
 
 
+def arbitrary_payload(scale: float) -> dict:
+    return {"scale": scale, "samples": [scale, scale * 2.0]}
+
+
 class DataFrameSweep(bn.ParametrizedSweep):
     """1-input sweep whose worker returns a small, scale-dependent DataFrame."""
 
@@ -40,6 +44,20 @@ def per_sample_container(df: pd.DataFrame) -> pn.pane.Markdown:
 
 def explicit_container(df: pd.DataFrame) -> pn.pane.Markdown:
     return pn.pane.Markdown(f"explicit rows={len(df)}")
+
+
+def payload_container(payload: dict) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"payload scale={payload['scale']:g} samples={len(payload['samples'])}")
+
+
+class ArbitraryPayloadSweep(bn.ParametrizedSweep):
+    """The generic store has no DataFrame/xarray requirement."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=payload_container, doc="structured Python payload")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(arbitrary_payload(self.scale))
 
 
 class DeclaredContainerSweep(bn.ParametrizedSweep):
@@ -151,7 +169,7 @@ def container_output(viewable: pn.viewable.Viewable) -> list[str]:
     return [
         pane.object
         for pane in viewable.select(pn.pane.Markdown)
-        if str(pane.object).startswith(("declared", "per-sample", "explicit"))
+        if str(pane.object).startswith(("declared", "per-sample", "explicit", "payload"))
     ]
 
 
@@ -188,6 +206,26 @@ class TestDataSetResult(unittest.TestCase):
         frame = self.res.ds_to_container(point, rv, container=None)
         pd.testing.assert_frame_equal(frame, expected_frame(SCALES[1]))
         np.testing.assert_allclose(frame["y"].to_numpy(), [2.0, 4.0, 6.0])
+
+
+class TestArbitraryPayload(unittest.TestCase):
+    """ResultDataSet stores data; only its renderer interprets the payload."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(ArbitraryPayloadSweep(), "test_dataset_arbitrary_payload")
+
+    def test_payload_round_trips_without_tabular_coercion(self):
+        self.assertEqual(
+            [stored.obj for stored in self.res.dataset_list],
+            [arbitrary_payload(scale) for scale in SCALES],
+        )
+
+    def test_declared_renderer_receives_the_original_payload(self):
+        self.assertEqual(
+            container_output(self.res.to(DataSetResult)),
+            ["payload scale=1 samples=2", "payload scale=2 samples=2"],
+        )
 
 
 class TestDeclaredContainer(unittest.TestCase):

--- a/test/test_tabular_spec.py
+++ b/test/test_tabular_spec.py
@@ -110,6 +110,12 @@ class TestElementOpts(unittest.TestCase):
         element = _Probe(x="a", y="b", opts={"alpha": 0.25})(self.df)
         self.assertEqual(style_opts(element)["alpha"], 0.25)
 
+    def test_passthrough_opts_mapping_is_not_mutated(self):
+        extra_opts = {"alpha": 0.25}
+        element = _Probe(x="a", y="b", opts=extra_opts)(self.df)
+        style_opts(element)
+        self.assertEqual(extra_opts, {"alpha": 0.25})
+
     def test_passthrough_opts_win_over_the_defaults(self):
         """``**opts`` is the escape hatch, so it is applied last."""
         element = _Probe(x="a", y="b", opts={"xlabel": "override"})(self.df)

--- a/test/test_tabular_spec.py
+++ b/test/test_tabular_spec.py
@@ -1,0 +1,189 @@
+"""Tests for the intra-sample chart machinery (holoview_results/tabular_spec.py).
+
+The column helpers are exercised in depth through the charts built on them (see
+test_xy_scatter_result.py); what is tested here is the base contract every chart
+inherits, so a new chart gets it for free and cannot quietly lose it.
+"""
+
+import pickle
+import unittest
+from dataclasses import FrozenInstanceError, dataclass
+from typing import ClassVar
+
+import holoviews as hv
+import pandas as pd
+import xarray as xr
+
+from bencher.results.holoview_results.tabular_spec import (
+    TabularSpec,
+    check_column,
+    plot_frame,
+    resolve_axes,
+    to_dataframe,
+)
+
+
+@dataclass(frozen=True)
+class _Probe(TabularSpec):
+    """A minimal chart: the smallest thing a subclass has to provide."""
+
+    chart_name: ClassVar[str] = "probe_chart"
+
+    x: str | None = None
+    y: str | None = None
+
+    def build(self, df) -> hv.Curve:
+        x_col, y_col = self.axes(df, self.x, self.y)
+        plot_df, names = self.frame(df, [x_col, y_col])
+        return hv.Curve(plot_df, kdims=[names[x_col]], vdims=[names[y_col]]).opts(
+            **self.element_opts(xlabel=names[x_col], ylabel=names[y_col])
+        )
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0], "label": ["p", "q"]})
+
+
+def plot_opts(element) -> dict:
+    return hv.Store.lookup_options("bokeh", element, "plot").kwargs
+
+
+def style_opts(element) -> dict:
+    return hv.Store.lookup_options("bokeh", element, "style").kwargs
+
+
+class TestSpecContract(unittest.TestCase):
+    """What a ResultDataSet container has to satisfy, provided by the base."""
+
+    def test_called_with_the_object_alone(self):
+        """The whole container contract: one positional argument, no plot kwargs."""
+        self.assertIsInstance(_Probe(x="a", y="b")(frame()), hv.Curve)
+
+    def test_build_is_abstract(self):
+        with self.assertRaises(NotImplementedError):
+            TabularSpec()(frame())
+
+    def test_spec_round_trips_through_pickle(self):
+        """Why a spec is a frozen dataclass: it rides in BenchCfg, which is pickled."""
+        spec = _Probe(x="a", y="b", title="t", opts={"alpha": 0.5})
+        restored = pickle.loads(pickle.dumps(spec))
+        self.assertEqual(restored, spec)
+        self.assertIsInstance(restored(frame()), hv.Curve)
+
+    def test_frozen(self):
+        with self.assertRaises(FrozenInstanceError):
+            _Probe(x="a").x = "b"
+
+
+class TestElementOpts(unittest.TestCase):
+    """The options every chart shares."""
+
+    def setUp(self):
+        self.df = frame()
+
+    def test_axis_labels_default_to_the_columns(self):
+        opts = plot_opts(_Probe(x="a", y="b")(self.df))
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("a", "b"))
+
+    def test_axis_labels_can_be_overridden(self):
+        opts = plot_opts(_Probe(x="a", y="b", xlabel="A [m]", ylabel="B [s]")(self.df))
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("A [m]", "B [s]"))
+
+    def test_title_is_opt_in(self):
+        self.assertNotIn("title", plot_opts(_Probe(x="a", y="b")(self.df)))
+        self.assertEqual(plot_opts(_Probe(x="a", y="b", title="T")(self.df))["title"], "T")
+
+    def test_data_aspect_is_opt_in(self):
+        self.assertNotIn("data_aspect", plot_opts(_Probe(x="a", y="b")(self.df)))
+        self.assertEqual(plot_opts(_Probe(x="a", y="b", data_aspect=1)(self.df))["data_aspect"], 1)
+
+    def test_hover_on_by_default_and_disablable(self):
+        """hover=False has to set tools empty, not omit it.
+
+        set_default_opts registers tools=["hover"] globally for most element types,
+        so an omitted key would put hover back and make the option a no-op.
+        """
+        self.assertEqual(plot_opts(_Probe(x="a", y="b")(self.df))["tools"], ["hover"])
+        self.assertEqual(plot_opts(_Probe(x="a", y="b", hover=False)(self.df))["tools"], [])
+
+    def test_passthrough_opts_reach_holoviews(self):
+        element = _Probe(x="a", y="b", opts={"alpha": 0.25})(self.df)
+        self.assertEqual(style_opts(element)["alpha"], 0.25)
+
+    def test_passthrough_opts_win_over_the_defaults(self):
+        """``**opts`` is the escape hatch, so it is applied last."""
+        element = _Probe(x="a", y="b", opts={"xlabel": "override"})(self.df)
+        self.assertEqual(plot_opts(element)["xlabel"], "override")
+
+
+class TestSharedHelpers(unittest.TestCase):
+    """The pieces every chart's build() draws on, named by the chart that failed."""
+
+    def setUp(self):
+        self.df = frame()
+
+    def test_errors_name_the_chart(self):
+        """A chart-agnostic helper must still say which chart rejected the column."""
+        with self.assertRaises(ValueError) as ctx:
+            _Probe(x="a", y="nope")(self.df)
+        self.assertIn("probe_chart", str(ctx.exception))
+
+    def test_dataframe_passes_through_unchanged(self):
+        self.assertIs(to_dataframe(self.df, "c"), self.df)
+
+    def test_xarray_dimension_coords_become_columns(self):
+        ds = xr.Dataset({"b": ("a", [1.0, 2.0])}, coords={"a": [0.0, 1.0]})
+        self.assertEqual(sorted(to_dataframe(ds, "c").columns), ["a", "b"])
+
+    def test_hv_dataset_accepted(self):
+        self.assertEqual(len(to_dataframe(hv.Dataset(self.df), "c")), 2)
+
+    def test_non_table_names_the_chart_and_the_type(self):
+        with self.assertRaises(TypeError) as ctx:
+            to_dataframe([1, 2, 3], "probe_chart")
+        self.assertIn("probe_chart", str(ctx.exception))
+        self.assertIn("list", str(ctx.exception))
+
+    def test_check_column_reports_what_is_available(self):
+        with self.assertRaises(ValueError) as ctx:
+            check_column(self.df, "nope", "x", "c")
+        self.assertIn("'a'", str(ctx.exception))
+
+    def test_axes_inferred_skip_non_numeric_columns(self):
+        self.assertEqual(resolve_axes(self.df, None, None, "c"), ("a", "b"))
+
+    def test_plot_frame_keeps_only_the_plotted_columns(self):
+        plot_df, names = plot_frame(self.df, ["a", "b"], "c")
+        self.assertEqual(list(plot_df.columns), ["a", "b"])
+        self.assertEqual(names, {"a": "a", "b": "b"})
+
+    def test_plot_frame_does_not_mutate_the_stored_frame(self):
+        """A sample's table is rendered repeatedly; renaming must not touch it."""
+        df = pd.DataFrame({0: [1.0], 1: [2.0]})
+        plot_frame(df, [0, 1], "c")
+        self.assertEqual(list(df.columns), [0, 1])
+
+
+class TestValueColumns(unittest.TestCase):
+    """vdims plus the columns a chart option implies, without duplicates."""
+
+    def setUp(self):
+        self.spec = _Probe()
+        self.df = frame()
+
+    def test_extra_appended(self):
+        self.assertEqual(self.spec.value_columns(self.df, ["a"], "b"), ["a", "b"])
+
+    def test_extra_already_present_is_not_duplicated(self):
+        self.assertEqual(self.spec.value_columns(self.df, ["a", "b"], "b"), ["a", "b"])
+
+    def test_none_extra_ignored(self):
+        self.assertEqual(self.spec.value_columns(self.df, ["a"], None), ["a"])
+
+    def test_unknown_vdim_raises(self):
+        with self.assertRaises(ValueError):
+            self.spec.value_columns(self.df, ["nope"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_tabular_spec.py
+++ b/test/test_tabular_spec.py
@@ -190,6 +190,13 @@ class TestValueColumns(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.spec.value_columns(self.df, ["nope"])
 
+    def test_unknown_extra_raises_before_the_frame_is_built(self):
+        """An unchecked extra would reach frame() and raise a bare pandas KeyError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.spec.value_columns(self.df, ["a"], "nope")
+        self.assertIn("probe_chart", str(ctx.exception))
+        self.assertIn("'a'", str(ctx.exception), "the error should list the available columns")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_xy_scatter_result.py
+++ b/test/test_xy_scatter_result.py
@@ -349,6 +349,12 @@ class TestSpecIsPicklable(unittest.TestCase):
 class TestDeclaredOnResultVar(unittest.TestCase):
     """The declarative route: the spec on the result var, rendered in place."""
 
+    def test_default_output_replaces_the_raw_table_with_the_scatter(self):
+        res = run_sweep(DeclaredScatterSweep(), "test_xy_scatter_default", ["cloud"])
+        rendered = pn.Column(*res.to_auto())
+        self.assertEqual(len(all_points(rendered)), len(SPREADS))
+        self.assertEqual(rendered.select(pn.pane.DataFrame), [])
+
     def test_panes_pass_renders_the_scatter(self):
         res = run_sweep(DeclaredScatterSweep(), "test_xy_scatter_declared", ["cloud"])
         points = all_points(res.to_auto(plot_list=["panes"]))


### PR DESCRIPTION
Rebased on main now that #990 has merged. **No behaviour change to `xy_scatter` itself**, whose tests pass unmodified; two deliberate behaviour changes elsewhere, both below.

`xy_scatter` mixed three concerns: coercing a stored sample to a plottable frame, the options every holoviews chart accepts, and the `to_plot` body that walks every `ResultDataSet` sample. Only the middle of its `build()` was actually about scatters, so a second intra-sample chart would have copied the rest.

## Where the split landed

The first pass put the sample walk in a `TabularSpecResult` base that chart types would inherit. Review found that wrong on both counts, so it isn't what this PR contains:

- **The sample walk isn't tabular.** Retrieving each stored payload and mapping a renderer over it says nothing about the payload being a table. It is now `BenchResultBase.map_sample_panes`, which takes the result types it claims as a parameter and neither checks nor converts the payload.
- **It also wasn't one path.** `PaneResult.to_panes` held the same squeeze-then-map block with a wider `result_types`, and *that* is what the default report resolves to. Both callers now delegate to `map_sample_panes`, so a fix to the render path reaches the report and the chart types alike; a test pins each caller's claim.

So `render_data_samples` (`dataset_result.py`) is a module-level function restricted to `ResultDataSet`, which `XYScatterResult.to_plot` composes — no parallel result hierarchy, and the chart class stays an ordinary `HoloviewResult`.

`holoview_results/tabular_spec.py` is left holding only renderer-side concerns:

- **`TabularSpec`** — a frozen (therefore picklable) dataclass whose `__call__` coerces the stored payload and delegates to a subclass's `build()`. Carries the options every chart shares (`title`, `xlabel`, `ylabel`, `hover`, `data_aspect`, `**opts` passthrough) plus the column helpers (`to_dataframe`, `check_column`, `resolve_axes`, `plot_frame`, `value_columns`).

A new chart is a `build()`, a factory function, and a `to_plot` that names its own options. Exported as `bn.TabularSpec`, since writing one is what it is for.

The framing this settles: **`ResultDataSet` is a generic per-sample payload store with no tabular contract.** Tabular interpretation is opt-in, at the renderer, in a module nothing else depends on.

## Two behaviour changes

**`DataSetResult` now claims `ResultDataSet` only,** not every `PANEL_TYPES` result. It previously made `bench.add(bn.DataSetResult)` a second name for the `panes` view on a sweep with no stored payload; a `container=` written for a stored payload must not be handed an unrelated result's value. It returns `None` for such a sweep instead of falling back — use `to_panes()`, which is unchanged. Stated in the changelog and pinned by a test, alongside a guard that `panes` still renders such a sweep.

**`hover=False` was a no-op.** `set_default_opts` registers `tools=["hover"]` as a global holoviews default for most element types, so a spec that merely omitted the key got hover back. `tools` is now set in both directions (`[]` when off); `tools=` via `**opts` still wins, being applied last.

## Two decisions worth reviewing

**Chart types keep naming their options explicitly rather than accepting `**kwargs`.** Tempting to have the base introspect the factory signature and split automatically, but it can't work: `to_auto` passes plot-size keywords, and `**opts` accepts arbitrary holoviews options — a signature-based split cannot tell a pane-sizing `width` from a holoviews style `width`. This preserves the reasoning already documented in #990.

**Errors name the chart that rejected a column**, via a `chart_name` class var, so a now-shared helper's message doesn't become anonymous. `value_columns` validates the columns a chart *option* implies (`color=`) as well as the declared `vdims`, rather than letting them reach pandas as a bare `KeyError` from `frame()`.

## Tests

`test/test_tabular_spec.py` covers the base contract every chart inherits — single-argument call, pickle round-trip, frozen-ness, each shared option, non-mutation of the stored frame — so a new chart gets it for free and can't quietly lose it.

`pixi run ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
