### PR TITLE
feat: add xy_histogram and xy_hexbin chart types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Intra-sample chart gallery examples now declare their container** rather than appending
+  a report-level plot. `res.to(XYCurveResult, ...)` and friends *add* a plot below whatever
+  `plot_sweep` already rendered, which for a `ResultDataSet` with no declared container is
+  the raw table — so the example showed the rows and the chart. Declaring
+  `container=bn.xy_curve(...)` puts the chart in the result's own position instead, which is
+  what `example_plot_xy_scatter` already did. Affects `example_plot_xy_curve`,
+  `example_plot_xy_histogram` and `example_plot_xy_hexbin`; the chart-type route is
+  unchanged and still covered by tests.
 - **`DataSetResult` now renders `ResultDataSet` results only.** It previously claimed every
   pane-type result, which made `bench.add(bn.DataSetResult)` / `plot_list=["dataset"]` a
   second name for the `panes` view on a sweep with no stored payload. Now that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than indexing a list with an array several frames later.
 
 ### Added
+- **`xy_histogram` chart type** — bins one or more measured columns of a `ResultDataSet`,
+  showing the distribution a single sample measured. Distinct from the existing
+  `histogram`, which bins a `ResultFloat` across the sweep and so shows the spread of the
+  repeats. `column=` takes a list to overlay several distributions, binned over a *shared*
+  range so they are actually comparable, and drawn translucent so the one underneath stays
+  readable; it defaults to every numeric column. `density=True` normalises instead of
+  counting, and the y axis is labelled accordingly. An empty or all-NaN column produces
+  empty bins rather than raising — numpy cannot pick a range for an empty array, and NaN is
+  how bencher marks a sample missing, so NaN rows are dropped rather than poisoning the
+  range. Gallery example: `example_plot_xy_histogram`.
+- **`xy_hexbin` chart type** — the density counterpart to `xy_scatter`, taking the same
+  axes and binning them into hexagonal tiles. For a cloud of tens of thousands of points
+  the markers saturate and where the mass actually is becomes the thing a scatter cannot
+  show. `gridsize=` sets the resolution, `min_count=1` drops empty tiles, and the colourbar
+  is on by default since a density plot without one shows shape but no magnitude. Gallery
+  example: `example_plot_xy_hexbin`.
+- **`hv.HexTiles` now carries the shared default figure size.** It was absent from
+  `HoloviewResult.DEFAULT_SIZED_ELEMENTS`, so a hexbin would have fallen back to the
+  holoviews default rather than bencher's 600x600 — the same gap Histogram/Area/ErrorBars
+  were fixed for previously.
 - **`xy_curve` chart type** — draws one or more *measured* columns of a `ResultDataSet`
   against an x column, for a benchmark that collects a whole series as one sample. The
   gap it fills: `curve` and `line` plot *across* the sweep, with one value per sample, so

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -21,6 +21,11 @@ from bencher.results.holoview_results.table_result import TableResult
 from bencher.results.holoview_results.tabular_spec import TabularSpec
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
 from bencher.results.holoview_results.xy_curve_result import XYCurveResult, xy_curve
+from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult, xy_hexbin
+from bencher.results.holoview_results.xy_histogram_result import (
+    XYHistogramResult,
+    xy_histogram,
+)
 from bencher.results.holoview_results.xy_scatter_result import XYScatterResult, xy_scatter
 from bencher.results.volume_result import VolumeResult
 

--- a/bencher/example/generated/plot_types/example_plot_xy_curve.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_curve.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 import bencher as bn
-from bencher.results.holoview_results.xy_curve_result import XYCurveResult
 
 
 class SettlingTrace(bn.ParametrizedSweep):
@@ -12,7 +11,14 @@ class SettlingTrace(bn.ParametrizedSweep):
 
     damping = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Damping ratio")
 
-    trace = bn.ResultDataSet(doc="Measured and commanded position over time")
+    trace = bn.ResultDataSet(
+        container=bn.xy_curve(
+            x="time_s",
+            y=["measured_mm", "commanded_mm"],
+            ylabel="position [mm]",
+        ),
+        doc="Measured and commanded position over time",
+    )
 
     def benchmark(self):
         t = np.linspace(0.0, 10.0, 120)
@@ -25,10 +31,7 @@ class SettlingTrace(bn.ParametrizedSweep):
 def example_plot_xy_curve(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Plot Type: Xy Curve."""
     bench = SettlingTrace().to_bench(run_cfg)
-    res = bench.plot_sweep(input_vars=["damping"], result_vars=["trace"])
-    bench.report.append(
-        res.to(XYCurveResult, x="time_s", y=["measured_mm", "commanded_mm"], ylabel="position [mm]")
-    )
+    bench.plot_sweep(input_vars=["damping"], result_vars=["trace"])
 
     return bench
 

--- a/bencher/example/generated/plot_types/example_plot_xy_hexbin.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_hexbin.py
@@ -1,0 +1,41 @@
+"""Auto-generated example: Plot Type: Xy Hexbin."""
+
+import numpy as np
+import pandas as pd
+
+import bencher as bn
+from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult
+
+
+class DenseCloud(bn.ParametrizedSweep):
+    """Too many points to read as markers, so the marks become counts."""
+
+    spread = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Positioning noise")
+
+    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+
+    def benchmark(self):
+        rng = np.random.default_rng(0)
+        self.touches = bn.ResultDataSet(
+            pd.DataFrame(
+                {
+                    "dx_mm": rng.normal(0.0, self.spread, 20000),
+                    "dy_mm": rng.normal(0.0, self.spread, 20000),
+                }
+            )
+        )
+
+
+def example_plot_xy_hexbin(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Plot Type: Xy Hexbin."""
+    bench = DenseCloud().to_bench(run_cfg)
+    res = bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
+    bench.report.append(
+        res.to(XYHexbinResult, x="dx_mm", y="dy_mm", gridsize=30, min_count=1, data_aspect=1)
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_plot_xy_hexbin, subsampling_divisions=3)

--- a/bencher/example/generated/plot_types/example_plot_xy_hexbin.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_hexbin.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 import bencher as bn
-from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult
 
 
 class DenseCloud(bn.ParametrizedSweep):
@@ -12,7 +11,16 @@ class DenseCloud(bn.ParametrizedSweep):
 
     spread = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Positioning noise")
 
-    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+    touches = bn.ResultDataSet(
+        container=bn.xy_hexbin(
+            x="dx_mm",
+            y="dy_mm",
+            gridsize=30,
+            min_count=1,
+            data_aspect=1,
+        ),
+        doc="Landing points, one row per touch",
+    )
 
     def benchmark(self):
         rng = np.random.default_rng(0)
@@ -29,10 +37,7 @@ class DenseCloud(bn.ParametrizedSweep):
 def example_plot_xy_hexbin(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Plot Type: Xy Hexbin."""
     bench = DenseCloud().to_bench(run_cfg)
-    res = bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
-    bench.report.append(
-        res.to(XYHexbinResult, x="dx_mm", y="dy_mm", gridsize=30, min_count=1, data_aspect=1)
-    )
+    bench.plot_sweep(input_vars=["spread"], result_vars=["touches"])
 
     return bench
 

--- a/bencher/example/generated/plot_types/example_plot_xy_histogram.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_histogram.py
@@ -1,0 +1,44 @@
+"""Auto-generated example: Plot Type: Xy Histogram."""
+
+import numpy as np
+import pandas as pd
+
+import bencher as bn
+from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult
+
+
+class LatencySamples(bn.ParametrizedSweep):
+    """Every request timed, not just the mean: the sample *is* the distribution."""
+
+    concurrency = bn.IntSweep(default=4, bounds=[1, 16], doc="Concurrent requests")
+
+    latencies = bn.ResultDataSet(doc="One row per request, measured and baseline")
+
+    def benchmark(self):
+        rng = np.random.default_rng(self.concurrency)
+        scale = 1.0 + 0.4 * self.concurrency
+        self.latencies = bn.ResultDataSet(
+            pd.DataFrame(
+                {
+                    "latency_ms": rng.gamma(3.0, scale, 4000),
+                    "baseline_ms": rng.gamma(3.0, 1.4, 4000),
+                }
+            )
+        )
+
+
+def example_plot_xy_histogram(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Plot Type: Xy Histogram."""
+    bench = LatencySamples().to_bench(run_cfg)
+    res = bench.plot_sweep(input_vars=["concurrency"], result_vars=["latencies"])
+    bench.report.append(
+        res.to(
+            XYHistogramResult, column=["latency_ms", "baseline_ms"], bins=40, xlabel="latency [ms]"
+        )
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_plot_xy_histogram, subsampling_divisions=3)

--- a/bencher/example/generated/plot_types/example_plot_xy_histogram.py
+++ b/bencher/example/generated/plot_types/example_plot_xy_histogram.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 
 import bencher as bn
-from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult
 
 
 class LatencySamples(bn.ParametrizedSweep):
@@ -12,7 +11,14 @@ class LatencySamples(bn.ParametrizedSweep):
 
     concurrency = bn.IntSweep(default=4, bounds=[1, 16], doc="Concurrent requests")
 
-    latencies = bn.ResultDataSet(doc="One row per request, measured and baseline")
+    latencies = bn.ResultDataSet(
+        container=bn.xy_histogram(
+            column=["latency_ms", "baseline_ms"],
+            bins=40,
+            xlabel="latency [ms]",
+        ),
+        doc="One row per request, measured and baseline",
+    )
 
     def benchmark(self):
         rng = np.random.default_rng(self.concurrency)
@@ -30,12 +36,7 @@ class LatencySamples(bn.ParametrizedSweep):
 def example_plot_xy_histogram(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     """Plot Type: Xy Histogram."""
     bench = LatencySamples().to_bench(run_cfg)
-    res = bench.plot_sweep(input_vars=["concurrency"], result_vars=["latencies"])
-    bench.report.append(
-        res.to(
-            XYHistogramResult, column=["latency_ms", "baseline_ms"], bins=40, xlabel="latency [ms]"
-        )
-    )
+    bench.plot_sweep(input_vars=["concurrency"], result_vars=["latencies"])
 
     return bench
 

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -128,6 +128,53 @@ class SettlingTrace(bn.ParametrizedSweep):
             pd.DataFrame({"time_s": t, "measured_mm": settled, "commanded_mm": np.ones_like(t)})
         )"""
 
+_LATENCY_SAMPLES_CODE = """\
+import numpy as np
+import pandas as pd
+
+
+class LatencySamples(bn.ParametrizedSweep):
+    \"\"\"Every request timed, not just the mean: the sample *is* the distribution.\"\"\"
+
+    concurrency = bn.IntSweep(default=4, bounds=[1, 16], doc="Concurrent requests")
+
+    latencies = bn.ResultDataSet(doc="One row per request, measured and baseline")
+
+    def benchmark(self):
+        rng = np.random.default_rng(self.concurrency)
+        scale = 1.0 + 0.4 * self.concurrency
+        self.latencies = bn.ResultDataSet(
+            pd.DataFrame(
+                {
+                    "latency_ms": rng.gamma(3.0, scale, 4000),
+                    "baseline_ms": rng.gamma(3.0, 1.4, 4000),
+                }
+            )
+        )"""
+
+_DENSE_CLOUD_CODE = """\
+import numpy as np
+import pandas as pd
+
+
+class DenseCloud(bn.ParametrizedSweep):
+    \"\"\"Too many points to read as markers, so the marks become counts.\"\"\"
+
+    spread = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Positioning noise")
+
+    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+
+    def benchmark(self):
+        rng = np.random.default_rng(0)
+        self.touches = bn.ResultDataSet(
+            pd.DataFrame(
+                {
+                    "dx_mm": rng.normal(0.0, self.spread, 20000),
+                    "dy_mm": rng.normal(0.0, self.spread, 20000),
+                }
+            )
+        )"""
+
 _HEATMAP_DEMO_CODE = """\
 import math
 
@@ -337,6 +384,41 @@ PLOT_CONFIGS = {
         "result_vars": '["trace"]',
         "benchable_class": "SettlingTrace",
         "class_code": _SETTLING_TRACE_CODE,
+    },
+    # The distribution a single sample measured, unlike `histogram`, which bins one
+    # value per sample and so shows the spread of the repeats instead.
+    "xy_histogram": {
+        "float_dims": 0,
+        "cat_dims": 0,
+        "repeats": 1,
+        "plot_call": (
+            'res.to(XYHistogramResult, column=["latency_ms", "baseline_ms"], bins=40, '
+            'xlabel="latency [ms]")'
+        ),
+        "extra_import": (
+            "from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult"
+        ),
+        "input_vars": '["concurrency"]',
+        "result_vars": '["latencies"]',
+        "benchable_class": "LatencySamples",
+        "class_code": _LATENCY_SAMPLES_CODE,
+    },
+    # Same axes as xy_scatter; at this many points the markers saturate and the
+    # shape of the distribution is what a scatter loses.
+    "xy_hexbin": {
+        "float_dims": 1,
+        "cat_dims": 0,
+        "repeats": 1,
+        "plot_call": (
+            'res.to(XYHexbinResult, x="dx_mm", y="dy_mm", gridsize=30, min_count=1, data_aspect=1)'
+        ),
+        "extra_import": (
+            "from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult"
+        ),
+        "input_vars": '["spread"]',
+        "result_vars": '["touches"]',
+        "benchable_class": "DenseCloud",
+        "class_code": _DENSE_CLOUD_CODE,
     },
 }
 

--- a/bencher/example/meta/generate_meta_plot_types.py
+++ b/bencher/example/meta/generate_meta_plot_types.py
@@ -119,7 +119,14 @@ class SettlingTrace(bn.ParametrizedSweep):
 
     damping = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Damping ratio")
 
-    trace = bn.ResultDataSet(doc="Measured and commanded position over time")
+    trace = bn.ResultDataSet(
+        container=bn.xy_curve(
+            x="time_s",
+            y=["measured_mm", "commanded_mm"],
+            ylabel="position [mm]",
+        ),
+        doc="Measured and commanded position over time",
+    )
 
     def benchmark(self):
         t = np.linspace(0.0, 10.0, 120)
@@ -138,7 +145,14 @@ class LatencySamples(bn.ParametrizedSweep):
 
     concurrency = bn.IntSweep(default=4, bounds=[1, 16], doc="Concurrent requests")
 
-    latencies = bn.ResultDataSet(doc="One row per request, measured and baseline")
+    latencies = bn.ResultDataSet(
+        container=bn.xy_histogram(
+            column=["latency_ms", "baseline_ms"],
+            bins=40,
+            xlabel="latency [ms]",
+        ),
+        doc="One row per request, measured and baseline",
+    )
 
     def benchmark(self):
         rng = np.random.default_rng(self.concurrency)
@@ -162,7 +176,16 @@ class DenseCloud(bn.ParametrizedSweep):
 
     spread = bn.FloatSweep(default=0.5, bounds=[0.2, 1.0], doc="Positioning noise")
 
-    touches = bn.ResultDataSet(doc="Landing points, one row per touch")
+    touches = bn.ResultDataSet(
+        container=bn.xy_hexbin(
+            x="dx_mm",
+            y="dy_mm",
+            gridsize=30,
+            min_count=1,
+            data_aspect=1,
+        ),
+        doc="Landing points, one row per touch",
+    )
 
     def benchmark(self):
         rng = np.random.default_rng(0)
@@ -373,13 +396,8 @@ PLOT_CONFIGS = {
         "float_dims": 1,
         "cat_dims": 0,
         "repeats": 1,
-        "plot_call": (
-            'res.to(XYCurveResult, x="time_s", y=["measured_mm", "commanded_mm"], '
-            'ylabel="position [mm]")'
-        ),
-        "extra_import": (
-            "from bencher.results.holoview_results.xy_curve_result import XYCurveResult"
-        ),
+        # Declared, as for xy_scatter: the series is the result, not an extra plot.
+        "plot_call": None,
         "input_vars": '["damping"]',
         "result_vars": '["trace"]',
         "benchable_class": "SettlingTrace",
@@ -391,13 +409,9 @@ PLOT_CONFIGS = {
         "float_dims": 0,
         "cat_dims": 0,
         "repeats": 1,
-        "plot_call": (
-            'res.to(XYHistogramResult, column=["latency_ms", "baseline_ms"], bins=40, '
-            'xlabel="latency [ms]")'
-        ),
-        "extra_import": (
-            "from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult"
-        ),
+        # Declared on the result var, so the histogram takes the raw table's place in
+        # the normal result position instead of being appended below it.
+        "plot_call": None,
         "input_vars": '["concurrency"]',
         "result_vars": '["latencies"]',
         "benchable_class": "LatencySamples",
@@ -409,12 +423,8 @@ PLOT_CONFIGS = {
         "float_dims": 1,
         "cat_dims": 0,
         "repeats": 1,
-        "plot_call": (
-            'res.to(XYHexbinResult, x="dx_mm", y="dy_mm", gridsize=30, min_count=1, data_aspect=1)'
-        ),
-        "extra_import": (
-            "from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult"
-        ),
+        # Declared, as for xy_scatter: the density is the result, not an extra plot.
+        "plot_call": None,
         "input_vars": '["spread"]',
         "result_vars": '["touches"]',
         "benchable_class": "DenseCloud",

--- a/bencher/plugins/builtins.py
+++ b/bencher/plugins/builtins.py
@@ -107,6 +107,8 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
     from bencher.results.holoview_results.table_result import TableResult
     from bencher.results.holoview_results.tabulator_result import TabulatorResult
     from bencher.results.holoview_results.xy_curve_result import XYCurveResult
+    from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult
+    from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult
     from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
     from bencher.results.rerun_result import RerunResult
     from bencher.results.video_summary import VideoSummaryResult
@@ -127,6 +129,8 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
         ("rerun", "rerun", RerunResult.to_rerun),
         ("xy_scatter", "holoviews", XYScatterResult.to_plot),
         ("xy_curve", "holoviews", XYCurveResult.to_plot),
+        ("xy_histogram", "holoviews", XYHistogramResult.to_plot),
+        ("xy_hexbin", "holoviews", XYHexbinResult.to_plot),
     ]
 
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -44,6 +44,8 @@ from bencher.results.holoview_results.surface_result import SurfaceResult
 from bencher.results.holoview_results.table_result import TableResult
 from bencher.results.holoview_results.tabulator_result import TabulatorResult
 from bencher.results.holoview_results.xy_curve_result import XYCurveResult
+from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult
+from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult
 from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
 from bencher.results.optuna_result import OptunaResult
 from bencher.results.pane_result import PaneResult
@@ -79,6 +81,8 @@ class BenchResult(
     TabulatorResult,
     XYScatterResult,
     XYCurveResult,
+    XYHistogramResult,
+    XYHexbinResult,
     HoloviewResult,
     VideoSummaryResult,
     DataSetResult,

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -47,6 +47,7 @@ class HoloviewResult(PaneResult):
         hv.Histogram,
         hv.Area,
         hv.ErrorBars,
+        hv.HexTiles,
     )
 
     @staticmethod

--- a/bencher/results/holoview_results/tabular_spec.py
+++ b/bencher/results/holoview_results/tabular_spec.py
@@ -115,6 +115,30 @@ def resolve_axes(
     return check_column(df, x, "x", chart), y_inferred
 
 
+def resolve_columns(
+    df: pd.DataFrame, columns: Hashable | Sequence[Hashable] | None, role: str, chart: str
+) -> list[Hashable]:
+    """The one-or-more columns a single-axis chart plots, inferred when omitted.
+
+    A bare label is accepted as a single column, so the common case reads as
+    ``column="dx_mm"`` rather than ``column=["dx_mm"]``. Inference takes *every*
+    numeric column, which is the useful default for a frame holding only the
+    measurement — name the columns whenever the frame carries anything else.
+    """
+    if columns is None:
+        numeric = list(df.select_dtypes("number").columns)
+        if not numeric:
+            raise ValueError(
+                f"{chart} needs at least one numeric column to plot, found none; "
+                f"pass {role}= explicitly"
+            )
+        return numeric
+    declared = list(columns) if isinstance(columns, (list, tuple)) else [columns]
+    if not declared:
+        raise ValueError(f"{chart} {role}= is empty; name at least one column")
+    return [check_column(df, col, role, chart) for col in declared]
+
+
 def plot_frame(
     df: pd.DataFrame, columns: Sequence[Hashable], chart: str
 ) -> tuple[pd.DataFrame, dict[Hashable, str]]:
@@ -221,6 +245,10 @@ class TabularSpec:
         """The x and y columns for this chart (see :func:`resolve_axes`)."""
         return resolve_axes(df, x, y, self.chart_name)
 
+    def columns(self, df: pd.DataFrame, columns: Hashable | Sequence[Hashable] | None, role: str):
+        """The one-or-more columns for this chart (see :func:`resolve_columns`)."""
+        return resolve_columns(df, columns, role, self.chart_name)
+
     def frame(self, df: pd.DataFrame, columns: Sequence[Hashable]):
         """The plotted columns with string dimension names (see :func:`plot_frame`)."""
         return plot_frame(df, columns, self.chart_name)
@@ -256,5 +284,6 @@ __all__ = [
     "plot_frame",
     "promote_named_index",
     "resolve_axes",
+    "resolve_columns",
     "to_dataframe",
 ]

--- a/bencher/results/holoview_results/xy_hexbin_result.py
+++ b/bencher/results/holoview_results/xy_hexbin_result.py
@@ -1,0 +1,220 @@
+"""Bin two *measured* columns of a tabular result into hexagonal tiles.
+
+The density counterpart to ``xy_scatter``, and the reason to reach for it is
+overplotting: a cloud of sixty points reads fine as points, but at tens of thousands
+the markers saturate and the shape of the distribution — where the mass actually is —
+is exactly what gets lost. Same axes, same options; the marks become counts.
+
+Two ways in, same renderer:
+
+* declaratively, so the density renders with the other results in ``result_vars``
+  order::
+
+      cloud = bn.ResultDataSet(container=bn.xy_hexbin(x="dx_mm", y="dy_mm"))
+
+* explicitly, for a report-level plot::
+
+      bench.add(bn.XYHexbinResult, x="dx_mm", y="dy_mm", gridsize=40)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import holoviews as hv
+import panel as pn
+from param import Parameter
+
+from bencher.results.dataset_result import render_data_samples
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.holoview_results.tabular_spec import TabularSpec
+
+
+@dataclass(frozen=True)
+class XYHexbin(TabularSpec):
+    """A column spec that renders a table as hexagonally-binned density when called.
+
+    Build one with :func:`xy_hexbin`, which documents the options.
+    """
+
+    chart_name: ClassVar[str] = "xy_hexbin"
+
+    x: Hashable | None = None
+    y: Hashable | None = None
+    gridsize: int = 25
+    cmap: str = "viridis"
+    min_count: int | None = None
+    colorbar: bool = True
+
+    def build(self, df) -> hv.HexTiles:
+        x_col, y_col = self.axes(df, self.x, self.y)
+        plot_df, names = self.frame(df, [x_col, y_col])
+        x_name, y_name = names[x_col], names[y_col]
+
+        chart_opts: dict[str, Any] = {
+            "gridsize": self.gridsize,
+            "cmap": self.cmap,
+            "colorbar": self.colorbar,
+        }
+        if self.min_count is not None:
+            chart_opts["min_count"] = self.min_count
+
+        return hv.HexTiles(plot_df, kdims=[x_name, y_name]).opts(
+            **self.element_opts(xlabel=x_name, ylabel=y_name, **chart_opts)
+        )
+
+
+def xy_hexbin(
+    x: Hashable | None = None,
+    y: Hashable | None = None,
+    *,
+    gridsize: int = 25,
+    cmap: str = "viridis",
+    min_count: int | None = None,
+    colorbar: bool = True,
+    data_aspect: float | None = None,
+    hover: bool = True,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    **opts: Any,
+) -> XYHexbin:
+    """Build a container callback that hex-bins two columns of a table.
+
+    The result takes the stored object alone, which is exactly what
+    ``ResultDataSet(container=...)`` and ``ds_to_container`` hand it, so one spec
+    works declaratively and through :class:`XYHexbinResult`.
+
+    Args:
+        x: Column label for the x axis, as the frame holds it. Inferred from the
+            numeric columns when omitted.
+        y: Column label for the y axis. Inferred from the numeric columns when omitted.
+        gridsize: Number of hexagons across the x axis. Raise it for a large cloud,
+            lower it for a sparse one — too fine and every tile holds one point, which
+            is a scatter with worse marks.
+        cmap: Colourmap for the counts.
+        min_count: Hide tiles with fewer than this many points. Set to 1 to drop empty
+            tiles rather than drawing them at zero.
+        colorbar: Show the count scale. On by default, since a density plot without one
+            shows shape but no magnitude.
+        data_aspect: Set to 1 to force equal x/y scaling — the honest choice for a
+            cloud of positions, where an auto-scaled aspect makes an elongated cloud
+            look round. Left unset otherwise.
+        hover: Enable the hover tool.
+        title: Plot title.
+        xlabel: X axis label. Defaults to the column name.
+        ylabel: Y axis label. Defaults to the column name.
+        **opts: Passed through to ``hv.HexTiles.opts``, so anything holoviews accepts
+            (``alpha``, ``line_color``, ``width``, ...) works without a wrapper.
+
+    Returns:
+        An :class:`XYHexbin` mapping the stored object to an ``hv.HexTiles`` element.
+
+    Raises:
+        ValueError: at call time, if a named column is absent or x/y cannot be inferred.
+        TypeError: at call time, if the stored object is not a table.
+    """
+    return XYHexbin(
+        x=x,
+        y=y,
+        gridsize=gridsize,
+        cmap=cmap,
+        min_count=min_count,
+        colorbar=colorbar,
+        data_aspect=data_aspect,
+        hover=hover,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        opts=dict(opts),
+    )
+
+
+class XYHexbinResult(HoloviewResult):
+    """Renders every ``ResultDataSet`` sample as a hex-binned density of two columns.
+
+    One plot per sample rather than one plot for the sweep: the rows of a sample are
+    the density, so pooling them across samples would destroy the thing being
+    measured. Other result types are skipped — binning two columns is only defined for
+    a tabular result.
+    """
+
+    def to_plot(
+        self,
+        result_var: Parameter | None = None,
+        x: Hashable | None = None,
+        y: Hashable | None = None,
+        *,
+        gridsize: int = 25,
+        cmap: str = "viridis",
+        min_count: int | None = None,
+        colorbar: bool = True,
+        data_aspect: float | None = None,
+        hover: bool = True,
+        title: str | None = None,
+        xlabel: str | None = None,
+        ylabel: str | None = None,
+        opts: dict[str, Any] | None = None,
+        hv_dataset=None,
+        target_dimension: int = 0,
+        subsampling_divisions: int | None = None,
+        **kwargs: Any,
+    ) -> pn.panel | None:
+        """Hex-bin columns *x* against *y* for each tabular result sample.
+
+        The hexbin options are named rather than swept up into ``**kwargs``, because
+        ``**kwargs`` belongs to ``map_plot_panes``: every render path adds keywords of
+        its own (``to()`` always passes ``override``/``agg_over_dims``/``agg_fn``,
+        ``to_auto`` adds the plot-size and ``pane_layout`` keywords), and those must
+        not end up in the element's opts. :func:`xy_hexbin` documents what each one
+        does.
+
+        Args:
+            result_var: Restrict to one result variable. Defaults to every
+                ``ResultDataSet`` in the sweep.
+            x: Column on the x axis (see :func:`xy_hexbin` for x/y inference and every
+                option from *gridsize* to *ylabel*, which are passed straight on).
+            y: Column on the y axis.
+            gridsize: Number of hexagons across the x axis.
+            cmap: Colourmap for the counts.
+            min_count: Hide tiles with fewer than this many points.
+            colorbar: Show the count scale.
+            data_aspect: Set to 1 to force equal x/y scaling.
+            hover: Enable the hover tool.
+            title: Plot title.
+            xlabel: X axis label.
+            ylabel: Y axis label.
+            opts: Extra ``hv.HexTiles.opts`` keywords.
+            hv_dataset: Pre-built dataset to render instead of this result's own.
+            target_dimension: Dimension depth to recurse the panes down to.
+            subsampling_divisions: Level to subsample the dataset at.
+            **kwargs: Forwarded to ``map_plot_panes`` (layout and the plot-size
+                keywords every ``to_auto`` render call carries).
+
+        Returns:
+            A panel of hexbin plots, or None when the sweep has no tabular result.
+        """
+        return render_data_samples(
+            self,
+            renderer=xy_hexbin(
+                x=x,
+                y=y,
+                gridsize=gridsize,
+                cmap=cmap,
+                min_count=min_count,
+                colorbar=colorbar,
+                data_aspect=data_aspect,
+                hover=hover,
+                title=title,
+                xlabel=xlabel,
+                ylabel=ylabel,
+                **(opts or {}),
+            ),
+            result_var=result_var,
+            hv_dataset=hv_dataset,
+            target_dimension=target_dimension,
+            subsampling_divisions=subsampling_divisions,
+            **kwargs,
+        )

--- a/bencher/results/holoview_results/xy_histogram_result.py
+++ b/bencher/results/holoview_results/xy_histogram_result.py
@@ -1,0 +1,238 @@
+"""Bin one or more *measured* columns of a tabular result into a histogram.
+
+``HistogramResult`` bins a ``ResultFloat`` across the sweep: the values it counts are
+one per sample, so what it shows is the spread of the repeats. This bins inside a
+single sample — a ``ResultDataSet`` whose rows are the measurement — so what it shows
+is the distribution the sample itself measured, and the sweep dimensions separate one
+distribution from the next.
+
+Two ways in, same renderer:
+
+* declaratively, so the distribution renders with the other results in
+  ``result_vars`` order::
+
+      errors = bn.ResultDataSet(container=bn.xy_histogram("error_mm", bins=30))
+
+* explicitly, for a report-level plot::
+
+      bench.add(bn.XYHistogramResult, column=["error_mm", "baseline_mm"])
+"""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Sequence
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import holoviews as hv
+import numpy as np
+import panel as pn
+from param import Parameter
+
+from bencher.results.dataset_result import render_data_samples
+from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.holoview_results.tabular_spec import TabularSpec
+
+# Enough transparency that an overlaid distribution is still readable underneath.
+# Only applied when there is more than one, and `**opts` still overrides it.
+_OVERLAY_ALPHA = 0.55
+
+
+@dataclass(frozen=True)
+class XYHistogram(TabularSpec):
+    """A column spec that renders a table as one or more histograms when called.
+
+    Build one with :func:`xy_histogram`, which documents the options.
+    """
+
+    chart_name: ClassVar[str] = "xy_histogram"
+
+    column: Hashable | tuple[Hashable, ...] | None = None
+    bins: int = 20
+    bin_range: tuple[float, float] | None = None
+    density: bool = False
+
+    def build(self, df) -> hv.Overlay:
+        cols = self.columns(df, self.column, "column")
+        plot_df, names = self.frame(df, cols)
+
+        # One shared bin range across the overlay, so two distributions drawn
+        # together are actually comparable rather than each binned to its own span.
+        bin_range = self.bin_range
+        if bin_range is None and len(cols) > 1:
+            values = plot_df.to_numpy(dtype=float, na_value=np.nan)
+            if np.isfinite(values).any():
+                bin_range = (float(np.nanmin(values)), float(np.nanmax(values)))
+
+        single = len(cols) == 1
+        y_name = "density" if self.density else "count"
+        opts = self.element_opts(
+            xlabel=names[cols[0]] if single else None,
+            ylabel=y_name,
+            **({} if single else {"alpha": _OVERLAY_ALPHA}),
+        )
+
+        overlay = hv.Overlay()
+        for col in cols:
+            name = names[col]
+            counts, edges = self._counts(plot_df[name].to_numpy(dtype=float), bin_range)
+            overlay *= hv.Histogram(
+                (edges, counts), kdims=[name if single else "value"], vdims=[y_name], label=name
+            ).opts(**opts)
+        # legend_position is an Overlay option, not a Histogram one.
+        return overlay if single else overlay.opts(legend_position="right")
+
+    def _counts(self, values, bin_range) -> tuple[Any, Any]:
+        """Bin *values*, tolerating a column that is empty or all-NaN.
+
+        numpy cannot pick a range for an empty array and raises; a run that measured
+        nothing should be an empty plot, so the bins are produced anyway and left at
+        zero. NaN is how bencher marks a sample missing, so it is dropped rather than
+        poisoning the whole range.
+        """
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            edges = np.linspace(*(bin_range or (0.0, 1.0)), self.bins + 1)
+            return np.zeros(self.bins), edges
+        return np.histogram(finite, bins=self.bins, range=bin_range, density=self.density)
+
+
+def xy_histogram(
+    column: Hashable | Sequence[Hashable] | None = None,
+    *,
+    bins: int = 20,
+    bin_range: tuple[float, float] | None = None,
+    density: bool = False,
+    hover: bool = True,
+    title: str | None = None,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
+    data_aspect: float | None = None,
+    **opts: Any,
+) -> XYHistogram:
+    """Build a container callback that bins columns of a table into histograms.
+
+    The result takes the stored object alone, which is exactly what
+    ``ResultDataSet(container=...)`` and ``ds_to_container`` hand it, so one spec
+    works declaratively and through :class:`XYHistogramResult`.
+
+    Args:
+        column: Column label to bin, or a sequence of labels to overlay several
+            distributions with a legend. Defaults to every numeric column, which is
+            what a frame holding only the measurement wants.
+        bins: Number of bins.
+        bin_range: ``(low, high)`` to bin over. Defaults to the data's own span for a
+            single column, and to the span across all of them for an overlay, so two
+            distributions drawn together are comparable.
+        density: Normalise to a probability density instead of counting rows.
+        hover: Enable the hover tool.
+        title: Plot title.
+        xlabel: X axis label. Defaults to the column name for a single distribution,
+            and is left to holoviews for several.
+        ylabel: Y axis label. Defaults to ``"count"``, or ``"density"``.
+        data_aspect: Forces the x/y scale ratio. Left unset by default.
+        **opts: Passed through to ``hv.Histogram.opts``, so anything holoviews accepts
+            (``alpha``, ``color``, ``line_color``, ...) works without a wrapper.
+
+    Returns:
+        An :class:`XYHistogram` mapping the stored object to an ``hv.Overlay``.
+
+    Raises:
+        ValueError: at call time, if a named column is absent or none can be inferred.
+        TypeError: at call time, if the stored object is not a table.
+    """
+    return XYHistogram(
+        column=tuple(column) if isinstance(column, (list, tuple)) else column,
+        bins=bins,
+        bin_range=bin_range,
+        density=density,
+        hover=hover,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        data_aspect=data_aspect,
+        opts=dict(opts),
+    )
+
+
+class XYHistogramResult(HoloviewResult):
+    """Renders every ``ResultDataSet`` sample as a histogram of its own rows.
+
+    One plot per sample rather than one plot for the sweep: the rows of a sample are
+    the distribution, so pooling them across samples would destroy the thing being
+    measured. Other result types are skipped — binning a column is only defined for a
+    tabular result.
+    """
+
+    def to_plot(
+        self,
+        result_var: Parameter | None = None,
+        column: Hashable | Sequence[Hashable] | None = None,
+        *,
+        bins: int = 20,
+        bin_range: tuple[float, float] | None = None,
+        density: bool = False,
+        hover: bool = True,
+        title: str | None = None,
+        xlabel: str | None = None,
+        ylabel: str | None = None,
+        data_aspect: float | None = None,
+        opts: dict[str, Any] | None = None,
+        hv_dataset=None,
+        target_dimension: int = 0,
+        subsampling_divisions: int | None = None,
+        **kwargs: Any,
+    ) -> pn.panel | None:
+        """Bin *column* for each tabular result sample.
+
+        The histogram options are named rather than swept up into ``**kwargs``,
+        because ``**kwargs`` belongs to ``map_plot_panes``: every render path adds
+        keywords of its own (``to()`` always passes
+        ``override``/``agg_over_dims``/``agg_fn``, ``to_auto`` adds the plot-size and
+        ``pane_layout`` keywords), and those must not end up in the element's opts.
+        :func:`xy_histogram` documents what each one does.
+
+        Args:
+            result_var: Restrict to one result variable. Defaults to every
+                ``ResultDataSet`` in the sweep.
+            column: Column, or sequence of columns, to bin (see :func:`xy_histogram`
+                for inference and every option from *bins* to *data_aspect*, which
+                are passed straight on).
+            bins: Number of bins.
+            bin_range: ``(low, high)`` to bin over.
+            density: Normalise to a probability density.
+            hover: Enable the hover tool.
+            title: Plot title.
+            xlabel: X axis label.
+            ylabel: Y axis label.
+            data_aspect: Forces the x/y scale ratio.
+            opts: Extra ``hv.Histogram.opts`` keywords.
+            hv_dataset: Pre-built dataset to render instead of this result's own.
+            target_dimension: Dimension depth to recurse the panes down to.
+            subsampling_divisions: Level to subsample the dataset at.
+            **kwargs: Forwarded to ``map_plot_panes`` (layout and the plot-size
+                keywords every ``to_auto`` render call carries).
+
+        Returns:
+            A panel of histograms, or None when the sweep has no tabular result.
+        """
+        return render_data_samples(
+            self,
+            renderer=xy_histogram(
+                column=column,
+                bins=bins,
+                bin_range=bin_range,
+                density=density,
+                hover=hover,
+                title=title,
+                xlabel=xlabel,
+                ylabel=ylabel,
+                data_aspect=data_aspect,
+                **(opts or {}),
+            ),
+            result_var=result_var,
+            hv_dataset=hv_dataset,
+            target_dimension=target_dimension,
+            subsampling_divisions=subsampling_divisions,
+            **kwargs,
+        )

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -172,6 +172,8 @@ measured, and the sweep dimensions separate one plot from the next.
 |---|---|---|
 | `bn.xy_scatter(x=, y=)` | an unordered cloud of points | landing points, hit locations, a phase-space cloud |
 | `bn.xy_curve(x=, y=)` | a connected series | a signal collected over time, a convergence trace |
+| `bn.xy_histogram(column=)` | a binned distribution | every request timed, not just the mean |
+| `bn.xy_hexbin(x=, y=)` | hex-binned density | the same cloud when there are too many points to read as markers |
 
 ```python
 cloud = bn.ResultDataSet(
@@ -180,11 +182,18 @@ cloud = bn.ResultDataSet(
 trace = bn.ResultDataSet(
     container=bn.xy_curve(x="time_s", y=["measured_mm", "commanded_mm"])
 )
+latencies = bn.ResultDataSet(container=bn.xy_histogram("latency_ms", bins=40))
 ```
 
-Do not reach for `scatter`, `curve` or `line` for this: those plot *across* the sweep,
-with one value per sample, so an input variable is their x axis. These take both axes
-from within a single sample.
+Do not reach for `scatter`, `curve`, `line` or `histogram` for this: those plot *across*
+the sweep, with one value per sample, so an input variable is their x axis and what a
+`histogram` shows is the spread of the repeats. These take their axes from within a
+single sample.
+
+Pick between `xy_scatter` and `xy_hexbin` by point count: markers show individual
+outliers and stop working once they saturate, which is the point at which where the mass
+actually is becomes the thing you cannot see. A few hundred points scatter fine; tens of
+thousands want hexbin.
 
 What each builder returns is a picklable spec object, so it satisfies the constraint
 above. Columns are validated — a typo names the available columns instead of rendering
@@ -193,17 +202,28 @@ pair being plotted. A frame built with `Dataset.to_pandas()` keeps its dimension
 coordinate in the *index* rather than a column; a named index is promoted, so
 `x="time"` works on one.
 
-Notable options: `xy_scatter(data_aspect=1)` forces equal x/y scaling, which a cloud of
-positions wants — an auto-scaled aspect makes an elongated cloud look round.
-`xy_curve(y=[...])` overlays several series with a legend, `markers=True` adds a marker
-per row so a sparse series is visible, and `sort=False` keeps the frame's row order for
-a trajectory that doubles back in x rather than sorting it into a function of x. Anything
-else holoviews accepts (`alpha`, `line_width`, `color`, ...) passes straight through.
+Notable options:
+
+- `xy_scatter(data_aspect=1)` and `xy_hexbin(data_aspect=1)` force equal x/y scaling,
+  which a cloud of positions wants — an auto-scaled aspect makes an elongated cloud look
+  round.
+- `xy_curve(y=[...])` overlays several series with a legend, `markers=True` adds a marker
+  per row so a sparse series is visible, and `sort=False` keeps the frame's row order for
+  a trajectory that doubles back in x rather than sorting it into a function of x.
+- `xy_histogram(column=[...])` overlays several distributions, binned over a shared range
+  so they are comparable; `density=True` normalises instead of counting.
+- `xy_hexbin(gridsize=)` sets how many hexagons span the x axis, and `min_count=1` drops
+  empty tiles rather than drawing them at zero.
+
+Anything else holoviews accepts (`alpha`, `line_width`, `color`, ...) passes straight
+through.
 
 Each is also available as a chart type for a report-level plot —
-`bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")` or
-`bench.add(bn.XYCurveResult, x="time_s", y="measured_mm")` — or by name via
-`to_auto(plot_list=["xy_scatter"], x=..., y=...)`. They are never selected
+`bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")`,
+`bench.add(bn.XYCurveResult, x="time_s", y="measured_mm")`,
+`bench.add(bn.XYHistogramResult, column="latency_ms")`,
+`bench.add(bn.XYHexbinResult, x="dx_mm", y="dy_mm")` — or by name via
+`to_auto(plot_list=["xy_scatter"], x=..., y=...)`. None of them are ever selected
 automatically, so no existing report gains a plot it did not ask for.
 
 Under `over_time`, a `ResultDataSet` renders the run being reported rather than a slider

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -192,8 +192,8 @@ single sample.
 
 Pick between `xy_scatter` and `xy_hexbin` by point count: markers show individual
 outliers and stop working once they saturate, which is the point at which where the mass
-actually is becomes the thing you cannot see. A few hundred points scatter fine; tens of
-thousands want hexbin.
+actually sits becomes the thing you cannot see. A few hundred points scatter fine; tens
+of thousands want hexbin.
 
 What each builder returns is a picklable spec object, so it satisfies the constraint
 above. Columns are validated — a typo names the available columns instead of rendering
@@ -218,8 +218,11 @@ Notable options:
 Anything else holoviews accepts (`alpha`, `line_width`, `color`, ...) passes straight
 through.
 
-Each is also available as a chart type for a report-level plot —
-`bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")`,
+A declared container is the preferred route: the chart takes the raw table's place in the
+normal result position, so the report shows the plot and not the rows behind it. Each is
+*also* available as a chart type for a report-level plot, which is *appended* to whatever
+`plot_sweep` already rendered (so declare the container as well if the table below it is
+not wanted) — `bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")`,
 `bench.add(bn.XYCurveResult, x="time_s", y="measured_mm")`,
 `bench.add(bn.XYHistogramResult, column="latency_ms")`,
 `bench.add(bn.XYHexbinResult, x="dx_mm", y="dy_mm")` — or by name via

--- a/test/test_xy_distribution_results.py
+++ b/test/test_xy_distribution_results.py
@@ -165,6 +165,21 @@ class TestXYHistogramFactory(unittest.TestCase):
         element = only(xy_histogram("error_mm", alpha=0.2)(self.df))
         self.assertEqual(style_opts(element)["alpha"], 0.2)
 
+    def test_explicit_labels_win_over_the_derived_defaults(self):
+        """count/density and the column name are defaults, not overrides."""
+        spec = xy_histogram("error_mm", density=True, xlabel="error [mm]", ylabel="probability")
+        opts = plot_opts(only(spec(self.df)))
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("error [mm]", "probability"))
+
+    def test_explicit_ylabel_survives_an_overlay(self):
+        overlay = xy_histogram(["error_mm", "baseline_mm"], ylabel="fraction")(self.df)
+        self.assertEqual(plot_opts(first(overlay))["ylabel"], "fraction")
+
+    def test_opts_override_the_overlay_translucency(self):
+        """`opts` is applied last, so it beats the alpha the overlay would pick."""
+        overlay = xy_histogram(["error_mm", "baseline_mm"], alpha=1.0)(self.df)
+        self.assertEqual(style_opts(first(overlay))["alpha"], 1.0)
+
     def test_missing_column_names_the_chart_and_what_is_available(self):
         with self.assertRaises(ValueError) as ctx:
             xy_histogram("nope")(self.df)
@@ -251,6 +266,20 @@ class TestXYHexbinFactory(unittest.TestCase):
     def test_axis_labels_default_to_column_names(self):
         opts = plot_opts(xy_hexbin(x="error_mm", y="baseline_mm")(self.df))
         self.assertEqual((opts["xlabel"], opts["ylabel"]), ("error_mm", "baseline_mm"))
+
+    def test_explicit_labels_win_over_the_column_names(self):
+        opts = plot_opts(
+            xy_hexbin(x="error_mm", y="baseline_mm", xlabel="error [mm]", ylabel="baseline [mm]")(
+                self.df
+            )
+        )
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("error [mm]", "baseline [mm]"))
+
+    def test_opts_are_applied_after_the_chart_options(self):
+        """`opts` goes on last, so an unexposed holoviews keyword is never dropped."""
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm", gridsize=13, alpha=0.4)(self.df)
+        self.assertEqual(style_opts(tiles)["alpha"], 0.4)
+        self.assertEqual(plot_opts(tiles)["gridsize"], 13, "the chart option must still apply")
 
     def test_missing_column_names_the_chart(self):
         with self.assertRaises(ValueError) as ctx:

--- a/test/test_xy_distribution_results.py
+++ b/test/test_xy_distribution_results.py
@@ -1,0 +1,389 @@
+"""Tests for xy_histogram and xy_hexbin — the two intra-sample density charts.
+
+Both live here because they answer the same question about one sample's rows
+("where is the mass?") in one and two dimensions, and share their fixtures.
+"""
+
+import pickle
+import unittest
+
+import holoviews as hv
+import numpy as np
+import pandas as pd
+import panel as pn
+
+import bencher as bn
+from bencher.plugins import get_registry
+from bencher.results.holoview_results.xy_hexbin_result import XYHexbinResult, xy_hexbin
+from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult, xy_histogram
+from test.helpers import run_cfg_with
+
+SPREADS = [1.0, 2.0]
+ROWS_PER_SAMPLE = 200
+
+
+def cloud_frame(spread: float) -> pd.DataFrame:
+    """A deterministic cloud whose rows are the measurement."""
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "error_mm": rng.normal(0.0, spread, ROWS_PER_SAMPLE),
+            "baseline_mm": rng.normal(1.0, spread, ROWS_PER_SAMPLE),
+        }
+    )
+
+
+class CloudSweep(bn.ParametrizedSweep):
+    """Each sample measures a cloud of points, plus one scalar."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+
+    cloud = bn.ResultDataSet(doc="measured points, one row each")
+    peak = bn.ResultFloat(units="mm", doc="a scalar that is not a distribution")
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(cloud_frame(self.spread))
+        self.peak = self.spread
+
+
+class DeclaredHistogramSweep(bn.ParametrizedSweep):
+    """The spec lives on the result var, so the distribution renders in place."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    cloud = bn.ResultDataSet(container=xy_histogram("error_mm", bins=8))
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(cloud_frame(self.spread))
+
+
+class DeclaredHexbinSweep(bn.ParametrizedSweep):
+    """Same, for the two-dimensional density."""
+
+    spread = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    cloud = bn.ResultDataSet(container=xy_hexbin(x="error_mm", y="baseline_mm", data_aspect=1))
+
+    def benchmark(self):
+        self.cloud = bn.ResultDataSet(cloud_frame(self.spread))
+
+
+def run_sweep(worker: bn.ParametrizedSweep, name: str, result_vars: list[str]):
+    bench = bn.Bench(name, worker, run_cfg=run_cfg_with(1))
+    return bench.plot_sweep(
+        name, input_vars=["spread"], result_vars=result_vars, plot_callbacks=False
+    )
+
+
+def elements_of(viewable: pn.viewable.Viewable, kind: type) -> list:
+    """Every element of *kind* in a rendered pane tree, flattened out of overlays."""
+    found = []
+    for pane in viewable.select(pn.pane.HoloViews):
+        obj = pane.object
+        if isinstance(obj, hv.Overlay):
+            found.extend(e for e in obj.values() if isinstance(e, kind))
+        elif isinstance(obj, kind):
+            found.append(obj)
+    return found
+
+
+def only(overlay: hv.Overlay):
+    """The single element of a one-series overlay."""
+    (element,) = overlay.values()
+    return element
+
+
+def first(overlay: hv.Overlay):
+    """The first element of a multi-series overlay."""
+    return next(iter(overlay.values()))
+
+
+def plot_opts(element) -> dict:
+    return hv.Store.lookup_options("bokeh", element, "plot").kwargs
+
+
+def style_opts(element) -> dict:
+    return hv.Store.lookup_options("bokeh", element, "style").kwargs
+
+
+class TestXYHistogramFactory(unittest.TestCase):
+    """The container callback: a table in, an overlay of histograms out."""
+
+    def setUp(self):
+        self.df = cloud_frame(1.0)
+
+    def test_named_column_is_binned(self):
+        element = only(xy_histogram("error_mm", bins=10)(self.df))
+        self.assertIsInstance(element, hv.Histogram)
+        self.assertEqual(len(element), 10)
+        self.assertEqual(sum(element["count"]), ROWS_PER_SAMPLE, "every row must be counted")
+
+    def test_takes_the_object_alone(self):
+        """No plot kwargs: the callback must be usable as a ResultDataSet container."""
+        self.assertIsInstance(xy_histogram("error_mm")(self.df), hv.Overlay)
+
+    def test_bins_are_configurable(self):
+        self.assertEqual(len(only(xy_histogram("error_mm", bins=5)(self.df))), 5)
+
+    def test_column_defaults_to_every_numeric_column(self):
+        overlay = xy_histogram()(self.df)
+        self.assertEqual([e.label for e in overlay.values()], ["error_mm", "baseline_mm"])
+
+    def test_several_columns_overlay_with_a_legend(self):
+        overlay = xy_histogram(["error_mm", "baseline_mm"])(self.df)
+        self.assertEqual(len(overlay), 2)
+        self.assertEqual(plot_opts(overlay)["legend_position"], "right")
+
+    def test_overlaid_distributions_share_one_bin_range(self):
+        """Two distributions binned to their own spans would not be comparable."""
+        overlay = xy_histogram(["error_mm", "baseline_mm"], bins=10)(self.df)
+        ranges = {tuple(e.range("value")) for e in overlay.values()}
+        self.assertEqual(len(ranges), 1)
+
+    def test_overlaid_distributions_are_translucent(self):
+        """An opaque histogram drawn on top would hide the one underneath."""
+        overlay = xy_histogram(["error_mm", "baseline_mm"])(self.df)
+        self.assertLess(style_opts(first(overlay))["alpha"], 1.0)
+
+    def test_a_single_distribution_is_not_made_translucent(self):
+        self.assertIsNone(style_opts(only(xy_histogram("error_mm")(self.df))).get("alpha"))
+
+    def test_explicit_bin_range_is_honoured(self):
+        element = only(xy_histogram("error_mm", bins=4, bin_range=(-1.0, 1.0))(self.df))
+        low, high = element.range("error_mm")
+        self.assertAlmostEqual(low, -1.0)
+        self.assertAlmostEqual(high, 1.0)
+
+    def test_density_normalises_and_relabels_the_y_axis(self):
+        element = only(xy_histogram("error_mm", density=True)(self.df))
+        self.assertEqual([d.name for d in element.vdims], ["density"])
+        self.assertEqual(plot_opts(element)["ylabel"], "density")
+
+    def test_counting_labels_the_y_axis_count(self):
+        element = only(xy_histogram("error_mm")(self.df))
+        self.assertEqual(plot_opts(element)["ylabel"], "count")
+
+    def test_extra_opts_reach_holoviews(self):
+        element = only(xy_histogram("error_mm", alpha=0.2)(self.df))
+        self.assertEqual(style_opts(element)["alpha"], 0.2)
+
+    def test_missing_column_names_the_chart_and_what_is_available(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_histogram("nope")(self.df)
+        message = str(ctx.exception)
+        self.assertIn("xy_histogram", message)
+        self.assertIn("error_mm", message, "the error should list the available columns")
+
+    def test_empty_column_list_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_histogram([])(self.df)
+        self.assertIn("at least one column", str(ctx.exception))
+
+    def test_frame_with_no_numeric_column_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_histogram()(pd.DataFrame({"label": ["a", "b"]}))
+        self.assertIn("column=", str(ctx.exception))
+
+    def test_non_table_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            xy_histogram("a")([1, 2, 3])
+        self.assertIn("xy_histogram", str(ctx.exception))
+
+
+class TestHistogramMissingData(unittest.TestCase):
+    """numpy cannot bin an empty array; a run that measured nothing is not a crash."""
+
+    def test_empty_frame_gives_empty_bins(self):
+        element = only(xy_histogram("v", bins=6)(pd.DataFrame({"v": []}, dtype=float)))
+        self.assertEqual(len(element), 6)
+        self.assertEqual(set(element["count"]), {0.0})
+
+    def test_all_nan_column_gives_empty_bins(self):
+        """NaN is how bencher marks a sample missing, not a value to bin."""
+        element = only(xy_histogram("v", bins=6)(pd.DataFrame({"v": [np.nan] * 4})))
+        self.assertEqual(set(element["count"]), {0.0})
+
+    def test_nan_rows_are_dropped_not_counted(self):
+        element = only(xy_histogram("v")(pd.DataFrame({"v": [1.0, np.nan, 2.0, 2.0]})))
+        self.assertEqual(sum(element["count"]), 3)
+
+
+class TestXYHexbinFactory(unittest.TestCase):
+    """The container callback: a table in, hexagonally-binned density out."""
+
+    def setUp(self):
+        self.df = cloud_frame(1.0)
+
+    def test_named_columns_become_the_axes(self):
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm")(self.df)
+        self.assertIsInstance(tiles, hv.HexTiles)
+        self.assertEqual([d.name for d in tiles.kdims], ["error_mm", "baseline_mm"])
+        self.assertEqual(len(tiles), ROWS_PER_SAMPLE)
+
+    def test_takes_the_object_alone(self):
+        self.assertIsInstance(xy_hexbin(x="error_mm", y="baseline_mm")(self.df), hv.HexTiles)
+
+    def test_gridsize_and_cmap_reach_the_element(self):
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm", gridsize=13, cmap="magma")(self.df)
+        self.assertEqual(plot_opts(tiles)["gridsize"], 13)
+        self.assertEqual(style_opts(tiles)["cmap"], "magma")
+
+    def test_colorbar_on_by_default(self):
+        """A density plot without one shows shape but no magnitude."""
+        self.assertTrue(plot_opts(xy_hexbin(x="error_mm", y="baseline_mm")(self.df))["colorbar"])
+        off = xy_hexbin(x="error_mm", y="baseline_mm", colorbar=False)(self.df)
+        self.assertFalse(plot_opts(off)["colorbar"])
+
+    def test_min_count_is_opt_in(self):
+        self.assertNotIn("min_count", plot_opts(xy_hexbin(x="error_mm", y="baseline_mm")(self.df)))
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm", min_count=1)(self.df)
+        self.assertEqual(plot_opts(tiles)["min_count"], 1)
+
+    def test_data_aspect_is_opt_in(self):
+        self.assertNotIn(
+            "data_aspect", plot_opts(xy_hexbin(x="error_mm", y="baseline_mm")(self.df))
+        )
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm", data_aspect=1)(self.df)
+        self.assertEqual(plot_opts(tiles)["data_aspect"], 1)
+
+    def test_axes_inferred_from_numeric_columns(self):
+        tiles = xy_hexbin()(self.df)
+        self.assertEqual([d.name for d in tiles.kdims], ["error_mm", "baseline_mm"])
+
+    def test_axis_labels_default_to_column_names(self):
+        opts = plot_opts(xy_hexbin(x="error_mm", y="baseline_mm")(self.df))
+        self.assertEqual((opts["xlabel"], opts["ylabel"]), ("error_mm", "baseline_mm"))
+
+    def test_missing_column_names_the_chart(self):
+        with self.assertRaises(ValueError) as ctx:
+            xy_hexbin(x="error_mm", y="nope")(self.df)
+        self.assertIn("xy_hexbin", str(ctx.exception))
+
+    def test_empty_frame_with_the_columns_renders(self):
+        tiles = xy_hexbin(x="error_mm", y="baseline_mm")(self.df.iloc[:0])
+        self.assertEqual(len(tiles), 0)
+
+    def test_non_table_rejected(self):
+        with self.assertRaises(TypeError) as ctx:
+            xy_hexbin(x="a", y="b")([1, 2, 3])
+        self.assertIn("xy_hexbin", str(ctx.exception))
+
+    def test_hextiles_carries_the_shared_default_size(self):
+        """HexTiles was not in DEFAULT_SIZED_ELEMENTS, so it fell back to a smaller figure."""
+        self.assertEqual(plot_opts(xy_hexbin()(self.df))["width"], 600)
+
+
+class TestChartTypes(unittest.TestCase):
+    """Both as report-level chart types: one plot per sample, tabular results only."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(CloudSweep(), "test_xy_distribution", ["cloud", "peak"])
+
+    def test_histogram_one_plot_per_sample(self):
+        found = elements_of(self.res.to(XYHistogramResult, column="error_mm"), hv.Histogram)
+        self.assertEqual(len(found), len(SPREADS))
+        for element in found:
+            self.assertEqual(sum(element["count"]), ROWS_PER_SAMPLE)
+
+    def test_hexbin_one_plot_per_sample(self):
+        found = elements_of(self.res.to(XYHexbinResult, x="error_mm", y="baseline_mm"), hv.HexTiles)
+        self.assertEqual(len(found), len(SPREADS))
+
+    def test_histogram_options_reach_the_elements(self):
+        found = elements_of(
+            self.res.to(XYHistogramResult, column="error_mm", bins=7, density=True), hv.Histogram
+        )
+        self.assertEqual(len(found[0]), 7)
+        self.assertEqual([d.name for d in found[0].vdims], ["density"])
+
+    def test_hexbin_options_reach_the_elements(self):
+        found = elements_of(
+            self.res.to(XYHexbinResult, x="error_mm", y="baseline_mm", gridsize=11, data_aspect=1),
+            hv.HexTiles,
+        )
+        self.assertEqual(plot_opts(found[0])["gridsize"], 11)
+        self.assertEqual(plot_opts(found[0])["data_aspect"], 1)
+
+    def test_scalar_results_are_skipped(self):
+        """`peak` is in the sweep; a distribution of a sample's rows is undefined for it."""
+        self.assertIsNone(self.res.to(XYHistogramResult, result_var=CloudSweep.param.peak))
+        self.assertIsNone(self.res.to(XYHexbinResult, result_var=CloudSweep.param.peak))
+
+    def test_bad_column_raises_rather_than_plotting_nothing(self):
+        with self.assertRaises(ValueError):
+            self.res.to(XYHistogramResult, column="nope")
+        with self.assertRaises(ValueError):
+            self.res.to(XYHexbinResult, x="error_mm", y="nope")
+
+
+class TestPlugins(unittest.TestCase):
+    """Registered as named-only chart types, like xy_scatter and xy_curve."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(CloudSweep(), "test_xy_distribution_plugin", ["cloud", "peak"])
+
+    def test_registered_under_their_chart_type_names(self):
+        for name in ("xy_histogram", "xy_hexbin"):
+            plugin = get_registry().get(name)
+            self.assertIsNotNone(plugin, name)
+            self.assertEqual(plugin.backend, "holoviews", name)
+            self.assertFalse(plugin.auto, f"{name} must not be selected automatically")
+
+    def test_absent_from_automatic_selection(self):
+        auto = [p.name for p in get_registry().select(self.res.to_bench_data())]
+        self.assertIn("panes", auto, "guard: automatic selection is non-empty here")
+        self.assertNotIn("xy_histogram", auto)
+        self.assertNotIn("xy_hexbin", auto)
+
+    def test_histogram_renders_through_to_auto_by_name(self):
+        res = run_sweep(CloudSweep(), "test_xy_histogram_auto", ["cloud", "peak"])
+        rendered = res.to_auto(plot_list=["xy_histogram"], column="error_mm")
+        found = elements_of(pn.Column(*rendered), hv.Histogram)
+        self.assertEqual(len(found), len(SPREADS))
+
+    def test_hexbin_renders_through_to_auto_by_name(self):
+        res = run_sweep(CloudSweep(), "test_xy_hexbin_auto", ["cloud", "peak"])
+        rendered = res.to_auto(plot_list=["xy_hexbin"], x="error_mm", y="baseline_mm")
+        found = elements_of(pn.Column(*rendered), hv.HexTiles)
+        self.assertEqual(len(found), len(SPREADS))
+
+
+class TestSpecsArePicklable(unittest.TestCase):
+    """Why these are classes and not closures: they ride in BenchCfg, which is pickled."""
+
+    def test_histogram_spec_round_trips(self):
+        spec = xy_histogram(["error_mm", "baseline_mm"], bins=12, density=True, alpha=0.4)
+        restored = pickle.loads(pickle.dumps(spec))
+        self.assertEqual(restored, spec)
+        self.assertEqual(len(restored(cloud_frame(1.0))), 2)
+
+    def test_hexbin_spec_round_trips(self):
+        spec = xy_hexbin(x="error_mm", y="baseline_mm", gridsize=9, data_aspect=1)
+        restored = pickle.loads(pickle.dumps(spec))
+        self.assertEqual(restored, spec)
+        self.assertIsInstance(restored(cloud_frame(1.0)), hv.HexTiles)
+
+    def test_result_vars_declaring_specs_pickle(self):
+        for cls in (DeclaredHistogramSweep, DeclaredHexbinSweep):
+            rv = pickle.loads(pickle.dumps(cls.param.cloud))
+            self.assertEqual(rv.container, cls.param.cloud.container, cls.__name__)
+
+
+class TestDeclaredOnResultVar(unittest.TestCase):
+    """The declarative route: the spec on the result var, rendered in place."""
+
+    def test_histogram_renders_through_the_panes_pass(self):
+        res = run_sweep(DeclaredHistogramSweep(), "test_xy_histogram_declared", ["cloud"])
+        found = elements_of(res.to_auto(plot_list=["panes"]), hv.Histogram)
+        self.assertEqual(len(found), len(SPREADS))
+        self.assertEqual(len(found[0]), 8, "the declared bin count must survive the round trip")
+
+    def test_hexbin_renders_through_the_panes_pass(self):
+        res = run_sweep(DeclaredHexbinSweep(), "test_xy_hexbin_declared", ["cloud"])
+        found = elements_of(res.to_auto(plot_list=["panes"]), hv.HexTiles)
+        self.assertEqual(len(found), len(SPREADS))
+        self.assertEqual(plot_opts(found[0])["data_aspect"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #992. Two more intra-sample charts on the `TabularSpec` base, both answering "where is the mass in this sample's rows?" — in one and two dimensions.

## `xy_histogram`

Bins measured columns of a `ResultDataSet`. The existing `histogram` bins a `ResultFloat` *across* the sweep, so what it shows is the spread of the repeats, not the distribution a single sample measured (every request timed, rather than the mean).

- `column=` takes a list to overlay several, **binned over a shared range** so they're actually comparable — binned to their own spans they would look alike regardless of where they sit — and drawn translucent so the lower one stays readable.
- Defaults to every numeric column.
- `density=True` normalises instead of counting, and relabels the y axis accordingly.
- An empty or all-NaN column produces **empty bins rather than raising**: numpy can't pick a range for an empty array, and NaN is how bencher marks a sample missing, so NaN rows are dropped rather than poisoning the range.

## `xy_hexbin`

The density counterpart to `xy_scatter`, same axes and options. At tens of thousands of points the markers saturate, and the shape of the distribution is precisely what a scatter then loses. `gridsize=` sets resolution, `min_count=1` drops empty tiles, and the colourbar is on by default since density without a scale shows shape but no magnitude.

## Also

`hv.HexTiles` added to `HoloviewResult.DEFAULT_SIZED_ELEMENTS` — it was absent, so a hexbin would have taken the holoviews default size instead of bencher's 600x600. Same gap that was fixed for Histogram/Area/ErrorBars previously, and the existing coverage test picks it up automatically.

## Rebase note (2026-07-29)

Rebased onto #992's rebased tip. `TabularSpecResult` is gone from #991 after review, so `XYHistogramResult` and `XYHexbinResult` subclass `HoloviewResult` and compose `render_data_samples` — the same per-sample path `PaneResult.to_panes` and the default report take — instead of inheriting a family-specific result base. Both `build()` implementations, `resolve_columns`, and the tests are unchanged.

## Tests

`test/test_xy_distribution_results.py`, 46 tests, both charts sharing fixtures: factories, the shared bin range, translucency, missing/empty data, both chart types, plugin registration, pickling, both declarative routes.

## Examples

`example_plot_xy_histogram` (4000 timed requests per sample, measured vs baseline) and `example_plot_xy_hexbin` (20000 points, where a scatter stops working).

`pixi run ci` clean; full suite 2077 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce intra-sample histogram and hexbin chart types for tabular results and wire them into the plotting, plugin, and example infrastructure.

New Features:
- Add xy_histogram chart type to bin one or more measured columns of a ResultDataSet within a single sample.
- Add xy_hexbin chart type as a hex-binned density counterpart to xy_scatter for dense point clouds.

Enhancements:
- Share column resolution logic for single-axis tabular charts via resolve_columns in TabularSpec.
- Register hv.HexTiles for the shared default Holoviews figure size and expose new xy chart types through BenchResult, plugins, and the public API.
- Provide new example benchmark configurations and gallery examples demonstrating xy_histogram and xy_hexbin usage.

Documentation:
- Document xy_histogram and xy_hexbin usage, options, and selection guidance in the user guide.
- Update changelog with details of the new intra-sample histogram and hexbin chart types.

Tests:
- Add comprehensive test suite covering xy_histogram and xy_hexbin factories, plugin registration, result rendering paths, pickling, and handling of missing/empty data.
