### PR TITLE
docs(plans): record how the intra-sample chart family fits A1/A2

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -57,6 +57,16 @@ Sequencing: A1 Phases 0, 2, and 3 have landed (#932, #970, #973/v1.114.0; Phase 
 dropped — see the A1 addendum); A4 Phase C1–C2 can start immediately; A3 Phase D2
 gates A4 Phase C4; A2's ranking phases (S3–S4) come last.
 
+**Update (2026-07-29):** the intra-sample chart family (`xy_scatter`, merged #990;
+`TabularSpec` base plus `xy_curve`/`xy_histogram`/`xy_hexbin` in #991–#993) turns out to
+be a working prototype of A2's two unlanded designs — a picklable name+kwargs plot spec
+(§2.4/S3) and a chart type whose eligibility is declarable rather than checked inside
+`to_plot` (S2). Read **A2 §2.5** before starting S2 or S3, and the **A1 addendum item
+4a** for what it implies about getting renderers off the god class and about
+"backends over plotters". Because the family is registered named-only (`auto=False`),
+it is the lowest-risk place to prove declarative matching: automatic selection never
+consults it, so a wrong filter cannot change any existing report.
+
 ## State of the repo (review summary, 2026-06-11)
 
 > **Update (2026-07-06):** the snapshot below is preserved as written. Since then:

--- a/plans/architecture/A1-rendering-backend-unification.md
+++ b/plans/architecture/A1-rendering-backend-unification.md
@@ -163,16 +163,25 @@ above:
    goals in this doc — getting renderers off the god class, and swapping backends under
    stable chart names.
 
-   **It already has the §4 seam, and confines the god-class dependency to one method.**
+   **It already has the §4 seam, and confines the god-class dependency to one function.**
    A `TabularSpec.build(df) -> element` touches no `self.ds`, `bench_cfg`,
    `plt_cnt_cfg`, or registry: it is a pure, picklable function of one sample's table.
-   Everything BenchResult-bound lives in `TabularSpecResult.render_spec` — one ~20-line
-   method that walks the samples via `to_hv_dataset` / `map_plot_panes` /
-   `ds_to_container`, shared by every chart in the family. Contrast `BarResult.to_plot`,
-   which goes straight into `BenchResultBase.filter`. When the built-ins are ported off
-   `legacy_result` (A3 Phase D5), this family is **one** site to port regardless of how
-   many charts it has grown to, and the porting question is narrow and answerable:
-   "how does a plugin iterate samples of a `BenchData`?"
+   Everything BenchResult-bound lives in `render_data_samples` (`dataset_result.py`) —
+   a module-level function, not a base class the charts inherit, which each chart's
+   `to_plot` composes and which delegates to `BenchResultBase.map_sample_panes`. That
+   sample walk is shared with `PaneResult.to_panes`, i.e. with the path the default
+   report already takes, so it is *the* per-sample render path rather than a second one
+   for this family. Contrast `BarResult.to_plot`, which goes straight into
+   `BenchResultBase.filter`. When the built-ins are ported off `legacy_result` (A3 Phase
+   D5), this family is **one** site to port regardless of how many charts it has grown
+   to, and the porting question is narrow and answerable: "how does a plugin iterate
+   samples of a `BenchData`?"
+
+   Note that the chart classes deliberately subclass `HoloviewResult` rather than a
+   family-specific result base: the shared behaviour is a function they call, so nothing
+   about the family depends on a place in the `BenchResult` MRO. That is what makes the
+   porting site a single call, and it is the shape a plugin wants — the god-class
+   inheritance is incidental and drops out when `legacy_result` does.
 
    **The spec is the backend-neutral half of a chart type**, which is what addendum
    item 2 ("backends over plotters") needs. The fields — `x`, `y`, `color`, `bins`,

--- a/plans/architecture/A1-rendering-backend-unification.md
+++ b/plans/architecture/A1-rendering-backend-unification.md
@@ -158,6 +158,49 @@ above:
    (`PlotFilter.match_all()` decorator default, `(name, backend)` keying);
    #970 wraps the built-in chart set and routes `to_auto` through
    `registry.select()` with output parity verified against the legacy callback loop.
+4a. **Note on the intra-sample chart family, 2026-07-29** (`xy_scatter` merged in #990;
+   `TabularSpec` base and three more charts in #991–#993). Relevant to the two live
+   goals in this doc — getting renderers off the god class, and swapping backends under
+   stable chart names.
+
+   **It already has the §4 seam, and confines the god-class dependency to one method.**
+   A `TabularSpec.build(df) -> element` touches no `self.ds`, `bench_cfg`,
+   `plt_cnt_cfg`, or registry: it is a pure, picklable function of one sample's table.
+   Everything BenchResult-bound lives in `TabularSpecResult.render_spec` — one ~20-line
+   method that walks the samples via `to_hv_dataset` / `map_plot_panes` /
+   `ds_to_container`, shared by every chart in the family. Contrast `BarResult.to_plot`,
+   which goes straight into `BenchResultBase.filter`. When the built-ins are ported off
+   `legacy_result` (A3 Phase D5), this family is **one** site to port regardless of how
+   many charts it has grown to, and the porting question is narrow and answerable:
+   "how does a plugin iterate samples of a `BenchData`?"
+
+   **The spec is the backend-neutral half of a chart type**, which is what addendum
+   item 2 ("backends over plotters") needs. The fields — `x`, `y`, `color`, `bins`,
+   `gridsize`, `sort`, `density` — say what the chart *is*, with no holoviews in them;
+   only `build()` is holoviews. So the spec's field set is a candidate declarative
+   signature for the chart type, and a second backend supplies element construction
+   under the same name.
+
+   *Caveat, and the one thing that would have to change:* today `chart_name`, the
+   fields, and the holoviews `build()` live on the same class, so `(xy_scatter, rerun)`
+   cannot be registered without duplicating the field list. Serving the backend-swap
+   goal properly means splitting the spec (backend-neutral data, one per chart type)
+   from the builder (one per `(chart type, backend)`), with the registry resolving the
+   pair. That is a real refactor, not free — but it is a *smaller* one than the same
+   split for the legacy renderers, where the chart's options are entangled with
+   plumbing kwargs in a `to_plot` signature.
+
+   **It also localizes the `**kwargs` collision.** These chart types must name every
+   option explicitly (documented in `xy_scatter_result.py`'s `to_plot`) because
+   `**kwargs` belongs to `map_plot_panes` while `**opts` belongs to holoviews, and
+   `to_auto` rides plot-size keywords through the same dict — so `width` is ambiguous
+   and no signature-based split can disambiguate it. `LegacyResultPlugin` papers over
+   this with `_declared_kwargs` filtering (`builtins.py:51-63`). A spec-shaped plugin
+   removes the ambiguity structurally rather than by introspection, because the chart
+   config and the render kwargs become two parameters instead of one namespace:
+   `SpecPlugin(name="xy_scatter", spec=XYScatter(...)).render(data)`. Worth weighing as
+   the shape the plugin contract converges on, not just a convenience for four charts.
+
 4. **Revised Phase 3 landed** (`feature/plugin-named-plotters`): named-only plugins
    (`auto=False` — in the registry, selectable by name, never auto-selected) cover the
    remaining result types: violin, scatter_jitter, scatter, band, table (holoviews);

--- a/plans/architecture/A2-plot-selection-redesign.md
+++ b/plans/architecture/A2-plot-selection-redesign.md
@@ -108,6 +108,76 @@ bench.plot_sweep(..., plots=["heatmap", {"name": "curve", "agg_fn": "median"}])
 - This is what makes the collect/render split clean: the render process receives
   data + *names*, never live function objects (see A3).
 
+## 2.5 The intra-sample chart family is an accidental prototype of S2 and S3
+
+Added 2026-07-29, after `xy_scatter` landed (#990) and the `TabularSpec` base was
+proposed (#991–#993). Worth reading before starting S2 or S3: a working instance of
+both target designs already exists, for one family of charts, and it arrived by a
+different route (needing a *picklable* renderer for the collect/render split).
+
+`bn.xy_scatter(x=..., y=...)` returns a frozen dataclass
+(`holoview_results/xy_scatter_result.py:120`) that is callable as `obj -> element`. It
+exists because a container declared on a result var rides in `BenchCfg`, which the
+result cache and the collect/render split both pickle, so a closure was not an option.
+`#991` generalizes it to a `TabularSpec` base; `#992`/`#993` add `xy_curve`,
+`xy_histogram`, `xy_hexbin` on top.
+
+**It is already §2.4's plot spec.** A spec is "plugin name + kwargs, trivially
+picklable, YAML-able, CLI-able". `TabularSpec` carries `chart_name` (a ClassVar holding
+exactly the registry name) plus dataclass fields (exactly the kwargs), is frozen, and
+has a pickle round-trip test. The round-trip §2.4 asks for is mechanical:
+
+```python
+spec_to_dict = lambda s: {"name": s.chart_name, **dataclasses.asdict(s)}
+dict_to_spec = lambda d: registry.get(d["name"]).spec_factory(**without_name(d))
+```
+
+The gap is only *where* it is used: today the spec fills the per-result-var `container=`
+slot, not the report-level `plots=` slot. So S3 can be prototyped against four real
+charts instead of being designed in the abstract — and the pickling constraint that
+motivates S3 is the same constraint that produced the spec, which is good evidence the
+shape is right.
+
+**It is the safest possible pilot for S2.** The blocker on centralizing matching is
+risk: the built-ins register `PlotFilter.match_all()` and shape-check inside `to_plot`,
+so lifting a filter into the registry can silently remove a plot from every existing
+report. The `xy_*` family is immune to that, because it is registered **named-only**
+(`auto=False`, `builtins.py:165`) — automatic selection never consults it, so a filter
+that is too narrow cannot change any existing report's output. It is also the only
+family whose eligibility is a *one-line* declarative fact: "at least one result var of
+kind `dataset`".
+
+And `PltCntCfg.result_kinds` — added by S1, currently **computed but not consumed** —
+is precisely that fact, already available on `BenchData.plt_cnt_cfg`.
+
+Note that this filter would be load-bearing rather than cosmetic: `include`
+(i.e. `plot_list=[...]`) does **not** bypass `match`; only `only=` does
+(`registry.py:258-268` vs `:207`). So a named `xy_scatter` on a sweep with no tabular
+result would be rejected *with a reason* in `explain_selection()`, where today it
+renders nothing and says "chosen".
+
+### Recommended shape for the `result_kinds` predicate
+
+`PlotFilter` is uniformly `VarRange`-over-counts, and §1 says to keep that DSL. The
+predicate should therefore also be a count, keyed by kind:
+
+```python
+kind_ranges: dict[str, VarRange] = field(default_factory=dict)   # kind -> count range
+# xy_* charts: {"dataset": VarRange(1, None)}
+```
+
+Unspecified kinds are unconstrained, so every existing filter is unaffected. This
+generalizes rather than special-cases — `panel_range` is the same idea with the kinds
+pre-summed, and `cat_levels` (also unconsumed since S1) can later join by the same
+route. Rejected alternative: a bare `result_kinds: frozenset[str]` membership test,
+which cannot express "exactly one" or "no image results" and would be a second
+matching idiom alongside `VarRange`.
+
+**Suggested sequencing.** `xy_scatter` is in main, so the pilot branches off main and
+does not queue behind #991–#993: extend `PlotFilter` with `kind_ranges`, give
+`xy_scatter` a real filter, assert `explain_selection()` names the reason. #993 then
+extends it to the other three charts as a one-line registration change each.
+
 ## 3. Migration phases
 
 **Phase S1 — signature enrichment. [DONE — PR #983]** Extend `PltCntCfg` with the new
@@ -125,7 +195,9 @@ not yet centralized.
 
 **Phase S3 — plot specs.** Implement name+kwargs specs, registry lookup by name,
 deprecation shim for callables. Update YAML sweep format and docs. Verify: round-trip
-a spec through save→load→render (`pixi run test-split`).
+a spec through save→load→render (`pixi run test-split`). *See §2.5:* `TabularSpec` is
+already a working name+kwargs spec for the `xy_*` family, so start by lifting it from
+the `container=` slot to the `plots=` slot rather than designing a parallel mechanism.
 
 **Phase S4 — ranking.** Add `specificity`/`intent`, implement `best_per_intent` behind
 `plot_policy` (default still `all_matching`). Regenerate the full gallery

--- a/plans/architecture/A2-plot-selection-redesign.md
+++ b/plans/architecture/A2-plot-selection-redesign.md
@@ -151,10 +151,11 @@ And `PltCntCfg.result_kinds` — added by S1, currently **computed but not consu
 is precisely that fact, already available on `BenchData.plt_cnt_cfg`.
 
 Note that this filter would be load-bearing rather than cosmetic: `include`
-(i.e. `plot_list=[...]`) does **not** bypass `match`; only `only=` does
-(`registry.py:258-268` vs `:207`). So a named `xy_scatter` on a sweep with no tabular
-result would be rejected *with a reason* in `explain_selection()`, where today it
-renders nothing and says "chosen".
+(i.e. `plot_list=[...]`) does **not** bypass `match` — in `PluginRegistry.select` it only
+filters by name and the loop still reaches `plugin.match.matches_result`; only the
+`only=` short-circuit above that loop skips the filter. So a named `xy_scatter` on a
+sweep with no tabular result would be rejected *with a reason* in
+`explain_selection()`, where today it renders nothing and says "chosen".
 
 ### Recommended shape for the `result_kinds` predicate
 


### PR DESCRIPTION
Docs-only. No code changes, so no behaviour risk — but it's the input to the next A2 phase, so worth reading before S2/S3 start.

`#990` is merged and `#991`–`#993` are open. Working through where that family sits relative to the in-flight plugin work, it turns out to be a **prototype of two designs A2 hasn't landed yet** — arrived at from the other direction. A declared container rides in `BenchCfg`, which the result cache and collect/render split both pickle, so the renderer *had* to be a frozen dataclass rather than a closure. That constraint is the same one A2 §2.4 gives as the motivation for plot specs.

## A2 §2.5 (new)

**It is already §2.4's plot spec.** `TabularSpec` carries `chart_name` (exactly the registry name) plus dataclass fields (exactly the kwargs), is frozen, and has a pickle round-trip test. The only gap is *which slot* it fills: `container=` (per result var) rather than `plots=` (report level). So S3 is a lift, not a new mechanism, and it can be validated against four real charts instead of designed in the abstract.

**It is the safest possible S2 pilot.** The blocker on centralizing matching is that lifting a filter out of `to_plot` can silently drop a plot from every existing report. The `xy_*` family is immune: registered named-only (`auto=False`), so automatic selection never consults it. Its eligibility is also a one-line declarative fact — "a result var of kind `dataset`" — and `PltCntCfg.result_kinds`, added by S1, computes exactly that and is **currently consumed by nothing**.

One mechanic worth knowing before designing this: `include`/`plot_list` does **not** bypass `match` — only `only=` does (`registry.py:258-268` vs `:207`). So the filter would be load-bearing, not cosmetic: a named `xy_scatter` on a sweep with no tabular result gets rejected *with a reason* in `explain_selection()`, where today it renders nothing and reports "chosen".

**Recommended predicate shape:** `kind_ranges: dict[str, VarRange]` (kind → count range), keeping the VarRange-over-counts idiom §1 says to preserve. Unspecified kinds unconstrained, so every existing filter is unaffected; `panel_range` is the same idea pre-summed, and `cat_levels` can join later by the same route. Rejected a bare `frozenset` membership test — it can't express "exactly one" or "no image results", and would be a second matching idiom.

## A1 addendum 4a (new)

**The family already has the §4 seam.** `TabularSpec.build(df) -> element` touches no `self.ds`/`bench_cfg`/`plt_cnt_cfg`/registry — pure and picklable. Everything god-class-bound is one shared ~20-line `render_spec`. So however many charts it grows, it stays **one** porting site for A3 Phase D5, and the porting question is narrow: "how does a plugin iterate samples of a `BenchData`?"

**The spec is the backend-neutral half of a chart type** — `x`, `y`, `bins`, `gridsize`, `sort` say what the chart *is*, with no holoviews in them — which is what "backends over plotters" (addendum item 2) needs. Flagged with the caveat that matters: `chart_name`, the fields, and the holoviews `build()` currently share one class, so `(xy_scatter, rerun)` can't be registered without duplicating the field list. Doing it properly means splitting spec from builder — a real refactor, though a smaller one than the same split on the legacy renderers.

**The `**kwargs` collision is structural, not incidental.** These charts must name every option explicitly because `**kwargs` belongs to `map_plot_panes` while `**opts` belongs to holoviews, and `to_auto` rides plot-size keywords through the same dict — `width` is genuinely ambiguous. `LegacyResultPlugin` papers over this with `_declared_kwargs` introspection. A spec-shaped plugin removes the ambiguity by making chart config and render kwargs two parameters instead of one namespace. Worth weighing as the shape the contract converges on.

## Suggested follow-up (not in this PR)

An S2 pilot can branch off **main** and skip the `#991`–`#993` queue, since `xy_scatter` is already merged: add `kind_ranges` to `PlotFilter`, give `xy_scatter` a real filter, assert `explain_selection()` names the reason. `#993` then extends it to the other three as a one-line registration change each.

I've left that unimplemented deliberately — it changes shared selection machinery that every plugin matches through, and the predicate shape is a design call worth confirming first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document how the intra-sample xy_* chart family serves as a working prototype for upcoming A2 plot spec and matching designs, and how it supports A1 backend-unification goals.

Documentation:
- Add A2 §2.5 describing the intra-sample chart family as a picklable name+kwargs plot spec and safest pilot for declarative plot matching.
- Extend A1 architecture doc with addendum 4a explaining how the TabularSpec-based charts isolate backend-specific rendering and clarify the spec/builder split for future plugins.
- Update the plans README to flag the xy_* chart family as the recommended starting point for implementing A2 S2/S3 and related backend-unification work.