### PR TITLE
fix: crop gallery thumbnails to the result plots

### DIFF
--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -166,19 +166,44 @@ def _boxes_below_marker(
 
 
 def _grow_region(boxes: list[dict]) -> tuple[float, float, float, float]:
-    """Union boxes in document order, stopping before the region becomes a tall strip."""
-    left, top, right, bottom = None, None, None, None
-    for box in boxes:
-        n_left = box["x"] if left is None else min(left, box["x"])
-        n_top = box["y"] if top is None else min(top, box["y"])
-        n_right = max(right or 0.0, box["x"] + box["width"])
-        n_bottom = max(bottom or 0.0, box["y"] + box["height"])
-        # Always accept the first box, even if it is an unusually tall one; the caller
-        # clamps the height afterwards.
-        if left is not None and (n_bottom - n_top) > MAX_CROP_ASPECT * (n_right - n_left):
+    """Union non-empty boxes in document order, stopping before the region becomes a strip.
+
+    Seeded from the first box, which is therefore always accepted even when it is an
+    unusually tall one; the caller clamps the height afterwards.
+    """
+    first = boxes[0]
+    left, top = first["x"], first["y"]
+    right, bottom = first["x"] + first["width"], first["y"] + first["height"]
+    for box in boxes[1:]:
+        n_left = min(left, box["x"])
+        n_top = min(top, box["y"])
+        n_right = max(right, box["x"] + box["width"])
+        n_bottom = max(bottom, box["y"] + box["height"])
+        if (n_bottom - n_top) > MAX_CROP_ASPECT * (n_right - n_left):
             break
         left, top, right, bottom = n_left, n_top, n_right, n_bottom
     return left, top, right, bottom
+
+
+def _page_size(page) -> tuple[float, float]:
+    """Return the page's scrollable width and height in a single round-trip."""
+    width, height = page.evaluate(
+        "() => [document.documentElement.scrollWidth, document.documentElement.scrollHeight]"
+    )
+    return float(width), float(height)
+
+
+def _pad_and_clamp(
+    left: float, top: float, right: float, bottom: float, page_w: float, page_h: float
+) -> dict | None:
+    """Pad a region, clamp it to the page, and convert it to a screenshot clip rect."""
+    left = max(0.0, left - CROP_PAD)
+    top = max(0.0, top - CROP_PAD)
+    right = min(page_w, right + CROP_PAD)
+    bottom = min(page_h, bottom + CROP_PAD)
+    if right - left < 1 or bottom - top < 1:
+        return None
+    return {"x": left, "y": top, "width": right - left, "height": bottom - top}
 
 
 def _results_clip(page) -> dict | None:
@@ -215,15 +240,8 @@ def _results_clip(page) -> dict | None:
     # DataFrame table — is topped rather than squeezed into an unreadable sliver.
     bottom = min(bottom, top + MAX_CROP_ASPECT * (right - left))
 
-    page_w = page.evaluate("document.documentElement.scrollWidth")
-    page_h = page.evaluate("document.documentElement.scrollHeight")
-    left = max(0.0, left - CROP_PAD)
-    top = max(0.0, top - CROP_PAD)
-    right = min(float(page_w), right + CROP_PAD)
-    bottom = min(float(page_h), bottom + CROP_PAD)
-    if right - left < 1 or bottom - top < 1:
-        return None
-    return {"x": left, "y": top, "width": right - left, "height": bottom - top}
+    page_w, page_h = _page_size(page)
+    return _pad_and_clamp(left, top, right, bottom, page_w, page_h)
 
 
 def _wait_for_results(page) -> dict | None:
@@ -278,7 +296,6 @@ def _take_thumbnail(
 
     Uses the provided playwright page if given; otherwise creates a temporary browser.
     """
-    from playwright.sync_api import sync_playwright  # pylint: disable=import-error
 
     def _screenshot_with(pg) -> bytes:
         pg.set_viewport_size({"width": width, "height": height})
@@ -296,12 +313,21 @@ def _take_thumbnail(
         clip = _results_clip(pg)
         if clip is None:
             return pg.screenshot()
+        # full_page is required here, not redundant with clip: a report's first plot can
+        # sit thousands of pixels down the page (xy_scatter's is at y≈5400 with a 900px
+        # viewport), and clip alone then fails with "Clipped area is either empty or
+        # outside the resulting image". Resizing the viewport to reach it instead would
+        # re-trigger Bokeh's responsive relayout and invalidate the measured geometry.
         return pg.screenshot(full_page=True, clip=clip)
 
     if page is not None:
         png_data = _screenshot_with(page)
         _resize_and_save_png(png_data, thumb_path)
         return
+
+    # Only the standalone path needs playwright itself; with a caller-supplied page the
+    # capture works without it installed, which keeps the crop logic unit-testable.
+    from playwright.sync_api import sync_playwright  # pylint: disable=import-error
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -75,10 +75,15 @@ MIN_RESULT_H = 80
 MAX_CROP_ASPECT = 1.3
 CROP_PAD = 8
 
-# Elements that count as "a result" when locating the interesting part of a report.
+# Candidate result elements, most to least preferred. A report's plots and media make a
+# better thumbnail than the summary DataFrame table that often precedes them, so a lower
+# tier is used only when no element from a higher tier exists below the "Results:" heading.
 # Bokeh/Panel render into shadow DOM, so these must be queried through Playwright's
 # selector engine (which pierces open shadow roots) rather than document.querySelectorAll.
-RESULT_SELECTOR = ".bk-Figure, .bk-Canvas, .bk-DataTable, video, img, table"
+RESULT_SELECTOR_TIERS = (
+    ".bk-Figure, video, img",
+    ".bk-Canvas, .bk-DataTable, table",
+)
 # Everything above the "Results:" heading is title, description and the sweep-shape
 # diagram — that text is what made naive top-of-page screenshots useless as thumbnails.
 RESULTS_HEADING_SELECTOR = "h1, h2, h3, h4"
@@ -86,11 +91,39 @@ RESULTS_HEADING_SELECTOR = "h1, h2, h3, h4"
 # is interactive chrome with no value in a static thumbnail, so it is hidden before the
 # region is measured — that way the crop is taken from the post-reflow layout.
 TOOLBAR_SELECTOR = ".bk-ToolbarPanel"
+# Text results (ResultString, ResultVec, ResultPath) render as Panel markup panes with no
+# plot to frame at all. For those the whole results section is cropped instead, using a
+# permissive selector and a lower size floor to pick up the small text panes.
+SECTION_SELECTOR = "div, pre, table, img, video, canvas"
+MIN_SECTION_W = 60
+MIN_SECTION_H = 30
+# Slack when testing whether an element starts below the "Results:" heading. Candidates
+# must *begin* below it, not merely end below it, or the report's page-spanning wrapper
+# divs qualify and stretch the crop to the full content width.
+MARKER_TOLERANCE = 4
+# How long to keep polling for a report's results to become measurable. Reports that
+# render nothing pay the full wait, so keep the budget modest.
+RESULT_WAIT_ATTEMPTS = 8
+RESULT_WAIT_INTERVAL_MS = 250
+
+
+def _query_all_frames(page, selector: str) -> list:
+    """Query every frame in the page, not just the main one.
+
+    over_time reports are a tab bar plus an iframe, so their entire report — plots and
+    "Results:" heading alike — lives in a child frame that page.query_selector_all cannot
+    see. Element bounding boxes are relative to the main frame's viewport either way, so
+    the coordinates compose directly into a top-level screenshot clip.
+    """
+    handles = []
+    for frame in page.frames:
+        handles.extend(frame.query_selector_all(selector))
+    return handles
 
 
 def _results_marker_bottom(page) -> float | None:
     """Return the document y of the bottom of the report's "Results:" heading, or None."""
-    for handle in page.query_selector_all(RESULTS_HEADING_SELECTOR):
+    for handle in _query_all_frames(page, RESULTS_HEADING_SELECTOR):
         raw = handle.text_content() or ""
         # Panel appends a "¶" anchor link to headings, so compare on letters only.
         if re.sub(r"[^a-z]", "", raw.lower()) != "results":
@@ -107,7 +140,7 @@ def _hide_toolbars(page) -> None:
     Panel/Bokeh render into shadow DOM, which a page-level stylesheet cannot reach, so
     each toolbar is hidden individually through Playwright's shadow-piercing selectors.
     """
-    for handle in page.query_selector_all(TOOLBAR_SELECTOR):
+    for handle in _query_all_frames(page, TOOLBAR_SELECTOR):
         try:
             handle.evaluate("el => { el.style.display = 'none'; }")
         except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
@@ -115,37 +148,72 @@ def _hide_toolbars(page) -> None:
             print(f"  WARNING: Could not hide plot toolbar: {e}")
 
 
-def _results_clip(page) -> dict | None:
-    """Return a screenshot clip rect covering the report's result plots, or None.
-
-    Grows a bounding box over the result elements in document order, stopping before the
-    crop gets so tall that each plot would be unreadable in the thumbnail.
-    """
-    marker_bottom = _results_marker_bottom(page)
-
+def _boxes_below_marker(
+    page, selector: str, marker_bottom: float | None, min_w: float, min_h: float
+) -> list[dict]:
+    """Return bounding boxes matching selector that sit below the "Results:" heading."""
     boxes = []
-    for handle in page.query_selector_all(RESULT_SELECTOR):
+    for handle in _query_all_frames(page, selector):
         box = handle.bounding_box()
-        if box is None or box["width"] < MIN_RESULT_W or box["height"] < MIN_RESULT_H:
+        if box is None or box["width"] < min_w or box["height"] < min_h:
             continue
-        # Drop anything that sits entirely above the "Results:" heading.
-        if marker_bottom is not None and box["y"] + box["height"] <= marker_bottom:
+        # Keep only elements that start below the "Results:" heading.
+        if marker_bottom is not None and box["y"] < marker_bottom - MARKER_TOLERANCE:
             continue
         boxes.append(box)
-    if not boxes:
-        return None
     boxes.sort(key=lambda b: (b["y"], b["x"]))
+    return boxes
 
+
+def _grow_region(boxes: list[dict]) -> tuple[float, float, float, float]:
+    """Union boxes in document order, stopping before the region becomes a tall strip."""
     left, top, right, bottom = None, None, None, None
     for box in boxes:
         n_left = box["x"] if left is None else min(left, box["x"])
         n_top = box["y"] if top is None else min(top, box["y"])
         n_right = max(right or 0.0, box["x"] + box["width"])
         n_bottom = max(bottom or 0.0, box["y"] + box["height"])
-        # Always accept the first box, even if it is an unusually tall one.
+        # Always accept the first box, even if it is an unusually tall one; the caller
+        # clamps the height afterwards.
         if left is not None and (n_bottom - n_top) > MAX_CROP_ASPECT * (n_right - n_left):
             break
         left, top, right, bottom = n_left, n_top, n_right, n_bottom
+    return left, top, right, bottom
+
+
+def _results_clip(page) -> dict | None:
+    """Return a screenshot clip rect covering the report's results, or None.
+
+    Prefers the highest tier of result element present below the "Results:" heading, and
+    falls back to the whole results section for reports whose results are plain text.
+    """
+    marker_bottom = _results_marker_bottom(page)
+
+    boxes = []
+    for selector in RESULT_SELECTOR_TIERS:
+        boxes = _boxes_below_marker(page, selector, marker_bottom, MIN_RESULT_W, MIN_RESULT_H)
+        if boxes:
+            break
+
+    if boxes:
+        left, top, right, bottom = _grow_region(boxes)
+    elif marker_bottom is not None:
+        # No plot, table or media: frame the results section itself.
+        section = _boxes_below_marker(
+            page, SECTION_SELECTOR, marker_bottom, MIN_SECTION_W, MIN_SECTION_H
+        )
+        if not section:
+            return None
+        left = min(b["x"] for b in section)
+        right = max(b["x"] + b["width"] for b in section)
+        top = marker_bottom
+        bottom = max(b["y"] + b["height"] for b in section)
+    else:
+        return None
+
+    # Clamp the height so a single tall result — a stacked video composition, a long
+    # DataFrame table — is topped rather than squeezed into an unreadable sliver.
+    bottom = min(bottom, top + MAX_CROP_ASPECT * (right - left))
 
     page_w = page.evaluate("document.documentElement.scrollWidth")
     page_h = page.evaluate("document.documentElement.scrollHeight")
@@ -156,6 +224,21 @@ def _results_clip(page) -> dict | None:
     if right - left < 1 or bottom - top < 1:
         return None
     return {"x": left, "y": top, "width": right - left, "height": bottom - top}
+
+
+def _wait_for_results(page) -> dict | None:
+    """Poll until the report's results region is measurable, or the attempts run out.
+
+    Returns the last clip attempted, which is None for a report that genuinely renders
+    nothing.
+    """
+    for attempt in range(RESULT_WAIT_ATTEMPTS):
+        clip = _results_clip(page)
+        if clip is not None:
+            return clip
+        if attempt < RESULT_WAIT_ATTEMPTS - 1:
+            page.wait_for_timeout(RESULT_WAIT_INTERVAL_MS)
+    return None
 
 
 def _resize_and_save_png(
@@ -202,6 +285,11 @@ def _take_thumbnail(
         pg.goto(html_path.resolve().as_uri(), wait_until="networkidle", timeout=15000)
         # Brief pause for Bokeh/Panel JS to render plots after network settles
         pg.wait_for_timeout(500)
+        # networkidle does not mean Bokeh has painted, and a fixed sleep is a coin flip on
+        # a cold browser: too short and the region is unmeasurable, so the thumbnail falls
+        # back to a screenshot of a blank page. Poll for the results instead.
+        if _wait_for_results(pg) is None:
+            return pg.screenshot()
         _hide_toolbars(pg)
         # Let Bokeh reflow after the toolbars are removed before measuring the crop.
         pg.wait_for_timeout(150)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -57,15 +57,127 @@ def generate_scorecard_example():
     print(f"  Generated scorecard example: {out}")
 
 
-def _resize_and_save_png(png_data: bytes, thumb_path: Path, thumb_width: int = 480) -> None:
-    """Resize screenshot PNG data to thumbnail width and save to disk."""
+# Thumbnail geometry. Screenshots are captured at THUMB_SCALE device pixels per CSS
+# pixel and downscaled, so thumbnails stay sharp on high-DPI screens. The saved PNG is
+# fitted inside THUMB_MAX_W x THUMB_MAX_H without distortion and never upscaled. This is
+# only a resolution cap — the displayed size and aspect ratio are set by
+# --gallery-thumb-aspect / --gallery-card-min-width in docs/_static/custom.css, so keep
+# these at or above 2x the widest card the CSS can produce.
+THUMB_MAX_W = 480
+THUMB_MAX_H = 480
+THUMB_SCALE = 2
+# Ignore elements smaller than this when hunting for the results region — it filters out
+# Bokeh toolbar icons, colour swatches and other chrome.
+MIN_RESULT_W = 100
+MIN_RESULT_H = 80
+# Stop growing the crop once it is this much taller than it is wide. Reports often stack
+# several full-size plots; including them all would shrink each one to an unreadable strip.
+MAX_CROP_ASPECT = 1.3
+CROP_PAD = 8
+
+# Elements that count as "a result" when locating the interesting part of a report.
+# Bokeh/Panel render into shadow DOM, so these must be queried through Playwright's
+# selector engine (which pierces open shadow roots) rather than document.querySelectorAll.
+RESULT_SELECTOR = ".bk-Figure, .bk-Canvas, .bk-DataTable, video, img, table"
+# Everything above the "Results:" heading is title, description and the sweep-shape
+# diagram — that text is what made naive top-of-page screenshots useless as thumbnails.
+RESULTS_HEADING_SELECTOR = "h1, h2, h3, h4"
+# Bokeh's pan/zoom/save toolbar sits inside .bk-Figure, so it would land in the crop. It
+# is interactive chrome with no value in a static thumbnail, so it is hidden before the
+# region is measured — that way the crop is taken from the post-reflow layout.
+TOOLBAR_SELECTOR = ".bk-ToolbarPanel"
+
+
+def _results_marker_bottom(page) -> float | None:
+    """Return the document y of the bottom of the report's "Results:" heading, or None."""
+    for handle in page.query_selector_all(RESULTS_HEADING_SELECTOR):
+        raw = handle.text_content() or ""
+        # Panel appends a "¶" anchor link to headings, so compare on letters only.
+        if re.sub(r"[^a-z]", "", raw.lower()) != "results":
+            continue
+        box = handle.bounding_box()
+        if box is not None:
+            return box["y"] + box["height"]
+    return None
+
+
+def _hide_toolbars(page) -> None:
+    """Hide Bokeh plot toolbars so they stay out of thumbnails.
+
+    Panel/Bokeh render into shadow DOM, which a page-level stylesheet cannot reach, so
+    each toolbar is hidden individually through Playwright's shadow-piercing selectors.
+    """
+    for handle in page.query_selector_all(TOOLBAR_SELECTOR):
+        try:
+            handle.evaluate("el => { el.style.display = 'none'; }")
+        except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
+            # A toolbar we cannot hide is cosmetic; keep going rather than lose the thumbnail.
+            print(f"  WARNING: Could not hide plot toolbar: {e}")
+
+
+def _results_clip(page) -> dict | None:
+    """Return a screenshot clip rect covering the report's result plots, or None.
+
+    Grows a bounding box over the result elements in document order, stopping before the
+    crop gets so tall that each plot would be unreadable in the thumbnail.
+    """
+    marker_bottom = _results_marker_bottom(page)
+
+    boxes = []
+    for handle in page.query_selector_all(RESULT_SELECTOR):
+        box = handle.bounding_box()
+        if box is None or box["width"] < MIN_RESULT_W or box["height"] < MIN_RESULT_H:
+            continue
+        # Drop anything that sits entirely above the "Results:" heading.
+        if marker_bottom is not None and box["y"] + box["height"] <= marker_bottom:
+            continue
+        boxes.append(box)
+    if not boxes:
+        return None
+    boxes.sort(key=lambda b: (b["y"], b["x"]))
+
+    left, top, right, bottom = None, None, None, None
+    for box in boxes:
+        n_left = box["x"] if left is None else min(left, box["x"])
+        n_top = box["y"] if top is None else min(top, box["y"])
+        n_right = max(right or 0.0, box["x"] + box["width"])
+        n_bottom = max(bottom or 0.0, box["y"] + box["height"])
+        # Always accept the first box, even if it is an unusually tall one.
+        if left is not None and (n_bottom - n_top) > MAX_CROP_ASPECT * (n_right - n_left):
+            break
+        left, top, right, bottom = n_left, n_top, n_right, n_bottom
+
+    page_w = page.evaluate("document.documentElement.scrollWidth")
+    page_h = page.evaluate("document.documentElement.scrollHeight")
+    left = max(0.0, left - CROP_PAD)
+    top = max(0.0, top - CROP_PAD)
+    right = min(float(page_w), right + CROP_PAD)
+    bottom = min(float(page_h), bottom + CROP_PAD)
+    if right - left < 1 or bottom - top < 1:
+        return None
+    return {"x": left, "y": top, "width": right - left, "height": bottom - top}
+
+
+def _resize_and_save_png(
+    png_data: bytes,
+    thumb_path: Path,
+    max_width: int = THUMB_MAX_W,
+    max_height: int = THUMB_MAX_H,
+) -> None:
+    """Fit screenshot PNG data inside max_width x max_height and save to disk.
+
+    Aspect ratio is preserved and the image is never upscaled, so a small result (a 200px
+    video, say) stays sharp rather than being blown up.
+    """
     from PIL import Image
 
     img = Image.open(io.BytesIO(png_data))
-    ratio = thumb_width / img.width
-    img = img.resize((thumb_width, int(img.height * ratio)), Image.Resampling.LANCZOS)
+    ratio = min(max_width / img.width, max_height / img.height, 1.0)
+    if ratio < 1.0:
+        size = (max(1, round(img.width * ratio)), max(1, round(img.height * ratio)))
+        img = img.resize(size, Image.Resampling.LANCZOS)
     thumb_path.parent.mkdir(parents=True, exist_ok=True)
-    img.save(thumb_path)
+    img.save(thumb_path, optimize=True)
 
 
 def _take_thumbnail(
@@ -74,9 +186,12 @@ def _take_thumbnail(
     page=None,
     width: int = 1200,
     height: int = 900,
-    thumb_width: int = 480,
 ) -> None:
-    """Screenshot an HTML report and save as a resized PNG thumbnail.
+    """Screenshot an HTML report's results and save as a PNG thumbnail.
+
+    The crop is centred on the report's result plots rather than the top of the page,
+    which is mostly title and description text. Falls back to the top of the page when no
+    result elements can be found.
 
     Uses the provided playwright page if given; otherwise creates a temporary browser.
     """
@@ -87,19 +202,28 @@ def _take_thumbnail(
         pg.goto(html_path.resolve().as_uri(), wait_until="networkidle", timeout=15000)
         # Brief pause for Bokeh/Panel JS to render plots after network settles
         pg.wait_for_timeout(500)
-        return pg.screenshot()
+        _hide_toolbars(pg)
+        # Let Bokeh reflow after the toolbars are removed before measuring the crop.
+        pg.wait_for_timeout(150)
+        clip = _results_clip(pg)
+        if clip is None:
+            return pg.screenshot()
+        return pg.screenshot(full_page=True, clip=clip)
 
     if page is not None:
         png_data = _screenshot_with(page)
-        _resize_and_save_png(png_data, thumb_path, thumb_width)
+        _resize_and_save_png(png_data, thumb_path)
         return
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        tmp_page = browser.new_page(viewport={"width": width, "height": height})
+        tmp_page = browser.new_page(
+            viewport={"width": width, "height": height},
+            device_scale_factor=THUMB_SCALE,
+        )
         try:
             png_data = _screenshot_with(tmp_page)
-            _resize_and_save_png(png_data, thumb_path, thumb_width)
+            _resize_and_save_png(png_data, thumb_path)
         finally:
             browser.close()
 
@@ -636,7 +760,10 @@ def generate_all(only: list[str] | None = None, force_skip_thumbnails: bool = Fa
 
             pw_context = sync_playwright().start()
             browser = pw_context.chromium.launch(headless=True)
-            page = browser.new_page(viewport={"width": 1200, "height": 900})
+            page = browser.new_page(
+                viewport={"width": 1200, "height": 900},
+                device_scale_factor=THUMB_SCALE,
+            )
             print("Started headless Chromium for thumbnail screenshots")
         except Exception as e:  # pylint: disable=broad-except  # noqa: BLE001
             skip_thumbnails = True

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -7,6 +7,20 @@
 }
 
 /* --- Gallery overview page --- */
+
+/* Thumbnail display geometry lives here — these two values control how big the gallery
+   cards are and what shape their thumbnails are shown in. They are independent of the
+   captured PNGs, which are cropped tightly around each report's plots and simply fitted
+   into whatever box these define (see THUMB_MAX_W/THUMB_MAX_H in
+   bencher/example/meta/generate_examples.py for the source resolution cap).
+
+   Square is the default because most Bench results are square Bokeh figures; a 4:3 box
+   letterboxes them and shrinks the plot for no gain. */
+:root {
+    --gallery-thumb-aspect: 1 / 1;
+    --gallery-card-min-width: 240px;
+}
+
 .gallery-container {
     max-width: 1400px;
 }
@@ -22,7 +36,7 @@
 
 .gallery-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(var(--gallery-card-min-width), 1fr));
     gap: 16px;
     margin-bottom: 16px;
 }
@@ -44,16 +58,26 @@
     transform: translateY(-2px);
 }
 
+/* Thumbnails are cropped to each report's result plots, so their dimensions vary.
+   Centre them in a fixed-aspect box to keep the grid uniform without distorting or
+   cropping the plot. */
 .gallery-thumb-wrap {
     width: 100%;
+    aspect-ratio: var(--gallery-thumb-aspect);
     overflow: hidden;
     background: #fafafa;
     border-bottom: 1px solid #eee;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .gallery-thumb {
-    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
     height: auto;
+    object-fit: contain;
     display: block;
 }
 

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -279,6 +279,9 @@ class ScreenshotPage(FakePage):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.screenshot_calls = []
+        # Left None so a missing set_viewport_size() call fails loudly rather than
+        # letting a zero-height viewport satisfy the assertions below.
+        self.viewport = None
 
     def set_viewport_size(self, size):
         self.viewport = size

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -1,7 +1,7 @@
 """Tests for gallery thumbnail cropping and resizing.
 
-Thumbnails must frame each report's result plots rather than the top of the page, which
-is title and description text. The region hunt runs against a live browser during doc
+Thumbnails must frame each report's results rather than the top of the page, which is
+title and description text. The region hunt runs against a live browser during doc
 generation; these tests exercise the geometry decisions against a stub page so the rules
 are pinned without needing playwright or Chromium.
 """
@@ -13,10 +13,17 @@ from PIL import Image
 
 from bencher.example.meta.generate_examples import (
     MAX_CROP_ASPECT,
+    RESULT_SELECTOR_TIERS,
+    RESULT_WAIT_ATTEMPTS,
+    RESULTS_HEADING_SELECTOR,
+    SECTION_SELECTOR,
     THUMB_MAX_H,
     THUMB_MAX_W,
+    TOOLBAR_SELECTOR,
+    _hide_toolbars,
     _resize_and_save_png,
     _results_clip,
+    _wait_for_results,
 )
 
 
@@ -26,6 +33,7 @@ class FakeHandle:
     def __init__(self, box=None, text=""):
         self._box = box
         self._text = text
+        self.evaluated = []
 
     def bounding_box(self):
         return self._box
@@ -33,49 +41,85 @@ class FakeHandle:
     def text_content(self):
         return self._text
 
-    def evaluate(self, _script):
-        return None
+    def evaluate(self, script):
+        self.evaluated.append(script)
+
+
+class FakeFrame:
+    """Stand-in for a playwright frame, dispatching on the real module selectors."""
+
+    def __init__(self, headings=(), tier1=(), tier2=(), section=(), toolbars=()):
+        self._by_selector = {
+            RESULTS_HEADING_SELECTOR: list(headings),
+            RESULT_SELECTOR_TIERS[0]: list(tier1),
+            RESULT_SELECTOR_TIERS[1]: list(tier2),
+            SECTION_SELECTOR: list(section),
+            TOOLBAR_SELECTOR: list(toolbars),
+        }
+
+    def query_selector_all(self, selector):
+        return self._by_selector[selector]
 
 
 class FakePage:
-    """Stand-in for a playwright page exposing only what _results_clip touches."""
+    """Stand-in for a playwright page exposing only what the crop helpers touch."""
 
-    def __init__(self, results=(), headings=(), page_w=1200, page_h=2000):
-        self._results = list(results)
-        self._headings = list(headings)
+    def __init__(self, frames=None, page_w=1200, page_h=2000, **frame_kwargs):
+        self.frames = list(frames) if frames is not None else [FakeFrame(**frame_kwargs)]
         self._page_w = page_w
         self._page_h = page_h
-
-    def query_selector_all(self, selector):
-        # _results_clip asks for headings and result elements with distinct selectors.
-        if selector.startswith("h1"):
-            return self._headings
-        return self._results
+        self.waits = []
 
     def evaluate(self, script):
         return self._page_w if "scrollWidth" in script else self._page_h
+
+    def wait_for_timeout(self, ms):
+        self.waits.append(ms)
+
+
+class SlowRenderPage(FakePage):
+    """A page whose results only become measurable after `renders_after` polls.
+
+    Models Bokeh painting late on a cold browser, which used to yield a blank thumbnail.
+    """
+
+    def __init__(self, renders_after, **kwargs):
+        self._renders_after = renders_after
+        self._polls = 0
+        self._late = FakeFrame(
+            headings=[_heading("Results: ¶", 700)],
+            tier1=[FakeHandle(box=_box(10, 740, 600, 600))],
+        )
+        super().__init__(**kwargs)
+
+    @property
+    def frames(self):
+        self._polls += 1
+        return [self._late] if self._polls > self._renders_after else [FakeFrame()]
+
+    @frames.setter
+    def frames(self, value):
+        pass  # the property above decides what is visible
 
 
 def _box(x, y, w, h):
     return {"x": x, "y": y, "width": w, "height": h}
 
 
-def _heading(text, y, h=26):
-    return FakeHandle(box=_box(10, y, 100, h), text=text)
+def _heading(text, bottom, h=26):
+    """A heading whose bottom edge is at `bottom` — that edge is what the crop keys off."""
+    return FakeHandle(box=_box(10, bottom - h, 100, h), text=text)
 
 
 class TestResultsClip:
-    def test_returns_none_when_no_results(self):
+    def test_returns_none_when_page_is_empty(self):
         assert _results_clip(FakePage()) is None
 
     def test_ignores_content_above_results_heading(self):
         """The sweep-shape diagram above "Results:" must not be mistaken for a plot."""
         diagram = FakeHandle(box=_box(10, 300, 350, 250))
         plot = FakeHandle(box=_box(10, 740, 600, 600))
-        page = FakePage(
-            results=[diagram, plot],
-            headings=[_heading("Results: ¶", 700)],
-        )
+        page = FakePage(tier1=[diagram, plot], headings=[_heading("Results: ¶", 700)])
         clip = _results_clip(page)
         # Crop starts at the plot, not the diagram at y=300.
         assert clip["y"] > 700
@@ -86,45 +130,137 @@ class TestResultsClip:
         above = FakeHandle(box=_box(10, 100, 350, 250))
         plot = FakeHandle(box=_box(10, 740, 600, 600))
         for text in ("Results:", "Results: ¶", "  results ¶ "):
-            page = FakePage(results=[above, plot], headings=[_heading(text, 700)])
+            page = FakePage(tier1=[above, plot], headings=[_heading(text, 700)])
             assert _results_clip(page)["y"] > 700, f"failed for {text!r}"
 
     def test_unrelated_heading_does_not_filter(self):
         plot = FakeHandle(box=_box(10, 740, 600, 600))
-        page = FakePage(results=[plot], headings=[_heading("Results over time", 700)])
+        page = FakePage(tier1=[plot], headings=[_heading("Results over time", 700)])
+        assert _results_clip(page)["y"] == pytest.approx(732, abs=2)
+
+    def test_excludes_wrappers_that_only_end_below_the_marker(self):
+        """A page-spanning wrapper div would otherwise stretch the crop to full width."""
+        wrapper = FakeHandle(box=_box(0, 100, 1013, 850))
+        text = FakeHandle(box=_box(10, 620, 280, 45))
+        page = FakePage(section=[wrapper, text], headings=[_heading("Results:", 600)])
         clip = _results_clip(page)
-        assert clip["y"] == pytest.approx(732, abs=2)
+        assert clip["width"] < 400, "wrapper div leaked into the crop"
 
     def test_skips_toolbar_sized_elements(self):
         """Small chrome (toolbar icons, swatches) must not define the crop."""
         icon = FakeHandle(box=_box(570, 700, 20, 20))
         plot = FakeHandle(box=_box(10, 740, 600, 600))
-        clip = _results_clip(FakePage(results=[icon, plot]))
+        clip = _results_clip(FakePage(tier1=[icon, plot]))
         assert clip["x"] == pytest.approx(2, abs=1)
         assert clip["width"] == pytest.approx(616, abs=2)
 
     def test_stops_before_crop_becomes_a_tall_strip(self):
         """Stacked plots must not all be included, or each becomes unreadable."""
         plots = [FakeHandle(box=_box(10, 740 + i * 620, 600, 600)) for i in range(3)]
-        clip = _results_clip(FakePage(results=plots, page_h=4000))
+        clip = _results_clip(FakePage(tier1=plots, page_h=4000))
         assert clip["height"] / clip["width"] <= MAX_CROP_ASPECT
         # Only the first plot is framed.
         assert clip["height"] == pytest.approx(616, abs=2)
 
-    def test_single_tall_result_is_still_captured(self):
-        """A lone result taller than the aspect cap must not be dropped entirely."""
-        tall = FakeHandle(box=_box(10, 200, 200, 900))
-        clip = _results_clip(FakePage(results=[tall]))
+    def test_single_tall_result_is_topped_not_squeezed(self):
+        """A 200x1200 stacked video composition must not become a 7:1 sliver."""
+        tall = FakeHandle(box=_box(128, 557, 200, 1200))
+        clip = _results_clip(FakePage(tier1=[tall]))
         assert clip is not None
-        assert clip["height"] == pytest.approx(916, abs=2)
+        assert clip["height"] / clip["width"] <= MAX_CROP_ASPECT
 
     def test_clip_is_clamped_to_page_bounds(self):
         plot = FakeHandle(box=_box(0, 0, 600, 600))
-        clip = _results_clip(FakePage(results=[plot], page_w=600, page_h=600))
+        clip = _results_clip(FakePage(tier1=[plot], page_w=600, page_h=600))
         assert clip["x"] == 0
         assert clip["y"] == 0
         assert clip["x"] + clip["width"] <= 600
         assert clip["y"] + clip["height"] <= 600
+
+
+class TestSelectorTiers:
+    def test_plot_is_preferred_over_a_preceding_table(self):
+        """xy_scatter leads with a 226x1587 DataFrame table; the figure makes a better thumb."""
+        table = FakeHandle(box=_box(128, 578, 226, 1587))
+        figure = FakeHandle(box=_box(128, 5382, 600, 600))
+        page = FakePage(
+            tier1=[figure],
+            tier2=[table],
+            headings=[_heading("Results:", 560)],
+            page_h=7259,
+        )
+        clip = _results_clip(page)
+        assert clip["y"] == pytest.approx(5374, abs=4), "table won over the figure"
+        assert clip["height"] == pytest.approx(616, abs=2)
+
+    def test_table_is_used_when_no_plot_exists(self):
+        table = FakeHandle(box=_box(128, 578, 400, 300))
+        page = FakePage(tier2=[table], headings=[_heading("Results:", 560)])
+        clip = _results_clip(page)
+        assert clip["y"] == pytest.approx(570, abs=4)
+
+    def test_text_results_fall_back_to_the_results_section(self):
+        """ResultString/ResultVec render as markup panes with no plot to frame."""
+        pane = FakeHandle(box=_box(10, 629, 277, 41))
+        column = FakeHandle(box=_box(10, 624, 297, 51))
+        page = FakePage(section=[column, pane], headings=[_heading("Results: ¶", 612)])
+        clip = _results_clip(page)
+        assert clip is not None
+        assert clip["y"] == pytest.approx(604, abs=4)
+        # Framed to the text column, not stretched to the report's full content width.
+        assert clip["width"] == pytest.approx(313, abs=4)
+
+    def test_section_fallback_needs_a_results_marker(self):
+        """Without a marker there is no way to tell results from page furniture."""
+        pane = FakeHandle(box=_box(10, 629, 277, 41))
+        assert _results_clip(FakePage(section=[pane])) is None
+
+
+class TestFrames:
+    def test_finds_results_inside_a_child_frame(self):
+        """over_time reports are a tab bar plus an iframe holding the whole report."""
+        main = FakeFrame()
+        child = FakeFrame(
+            headings=[_heading("Results: ¶", 769)],
+            tier1=[FakeHandle(box=_box(10, 891, 600, 600))],
+        )
+        clip = _results_clip(FakePage(frames=[main, child], page_h=2233))
+        assert clip is not None, "child frame content was not found"
+        assert clip["y"] == pytest.approx(883, abs=4)
+        assert clip["height"] == pytest.approx(616, abs=2)
+
+    def test_hides_toolbars_in_every_frame(self):
+        main_toolbar = FakeHandle(box=_box(570, 100, 30, 510))
+        child_toolbar = FakeHandle(box=_box(570, 900, 30, 510))
+        page = FakePage(
+            frames=[FakeFrame(toolbars=[main_toolbar]), FakeFrame(toolbars=[child_toolbar])]
+        )
+        _hide_toolbars(page)
+        assert main_toolbar.evaluated, "main frame toolbar not hidden"
+        assert child_toolbar.evaluated, "child frame toolbar not hidden"
+
+
+class TestWaitForResults:
+    def test_returns_immediately_when_results_are_already_rendered(self):
+        page = FakePage(
+            headings=[_heading("Results: ¶", 700)],
+            tier1=[FakeHandle(box=_box(10, 740, 600, 600))],
+        )
+        assert _wait_for_results(page) is not None
+        assert page.waits == [], "slept despite results being ready"
+
+    def test_waits_for_a_late_rendering_report(self):
+        """A fixed sleep was a coin flip on a cold browser; polling must ride it out."""
+        page = SlowRenderPage(renders_after=3)
+        clip = _wait_for_results(page)
+        assert clip is not None, "gave up before Bokeh painted"
+        assert clip["height"] == pytest.approx(616, abs=2)
+
+    def test_gives_up_on_a_report_that_renders_nothing(self):
+        page = FakePage()
+        assert _wait_for_results(page) is None
+        # Bounded: does not sleep after the final attempt.
+        assert len(page.waits) == RESULT_WAIT_ATTEMPTS - 1
 
 
 def _png_bytes(width, height):

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -7,6 +7,7 @@ are pinned without needing playwright or Chromium.
 """
 
 import io
+from pathlib import Path
 
 import pytest
 from PIL import Image
@@ -71,7 +72,10 @@ class FakePage:
         self.waits = []
 
     def evaluate(self, script):
-        return self._page_w if "scrollWidth" in script else self._page_h
+        assert "scrollWidth" in script and "scrollHeight" in script, (
+            "page size should be fetched in a single round-trip"
+        )
+        return [self._page_w, self._page_h]
 
     def wait_for_timeout(self, ms):
         self.waits.append(ms)
@@ -267,6 +271,59 @@ def _png_bytes(width, height):
     buf = io.BytesIO()
     Image.new("RGB", (width, height), "white").save(buf, format="PNG")
     return buf.getvalue()
+
+
+class ScreenshotPage(FakePage):
+    """A page that records how screenshot() was called."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.screenshot_calls = []
+
+    def set_viewport_size(self, size):
+        self.viewport = size
+
+    def goto(self, _url, **_kwargs):
+        return None
+
+    def screenshot(self, **kwargs):
+        self.screenshot_calls.append(kwargs)
+        return _png_bytes(200, 200)
+
+
+class TestScreenshotArgs:
+    """Regression guard for the clip/full_page interaction.
+
+    A report's first plot can sit thousands of pixels down the page (xy_scatter's is at
+    y~5400 in a 900px viewport). Playwright's `clip` alone cannot reach past the viewport
+    and raises "Clipped area is either empty or outside the resulting image", so
+    `full_page=True` is required alongside it rather than redundant with it.
+    """
+
+    def _take(self, page, tmp_path):
+        from bencher.example.meta.generate_examples import _take_thumbnail
+
+        _take_thumbnail(Path("report.html"), tmp_path / "thumb.png", page=page)
+        return page.screenshot_calls[-1]
+
+    def test_clip_screenshot_also_passes_full_page(self, tmp_path):
+        page = ScreenshotPage(
+            headings=[_heading("Results: ¶", 560)],
+            tier1=[FakeHandle(box=_box(128, 5382, 600, 600))],
+            page_h=7259,
+        )
+        call = self._take(page, tmp_path)
+        assert call.get("clip") is not None, "expected a cropped screenshot"
+        assert call.get("full_page") is True, (
+            "clip beyond the viewport needs full_page; see _screenshot_with"
+        )
+        assert call["clip"]["y"] > page.viewport["height"], "test no longer covers the case"
+
+    def test_fallback_screenshot_passes_neither(self, tmp_path):
+        """A report that renders nothing falls back to a plain viewport capture."""
+        page = ScreenshotPage()
+        call = self._take(page, tmp_path)
+        assert call == {}
 
 
 class TestResizeAndSave:

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -1,0 +1,160 @@
+"""Tests for gallery thumbnail cropping and resizing.
+
+Thumbnails must frame each report's result plots rather than the top of the page, which
+is title and description text. The region hunt runs against a live browser during doc
+generation; these tests exercise the geometry decisions against a stub page so the rules
+are pinned without needing playwright or Chromium.
+"""
+
+import io
+
+import pytest
+from PIL import Image
+
+from bencher.example.meta.generate_examples import (
+    MAX_CROP_ASPECT,
+    THUMB_MAX_H,
+    THUMB_MAX_W,
+    _resize_and_save_png,
+    _results_clip,
+)
+
+
+class FakeHandle:
+    """Stand-in for a playwright element handle."""
+
+    def __init__(self, box=None, text=""):
+        self._box = box
+        self._text = text
+
+    def bounding_box(self):
+        return self._box
+
+    def text_content(self):
+        return self._text
+
+    def evaluate(self, _script):
+        return None
+
+
+class FakePage:
+    """Stand-in for a playwright page exposing only what _results_clip touches."""
+
+    def __init__(self, results=(), headings=(), page_w=1200, page_h=2000):
+        self._results = list(results)
+        self._headings = list(headings)
+        self._page_w = page_w
+        self._page_h = page_h
+
+    def query_selector_all(self, selector):
+        # _results_clip asks for headings and result elements with distinct selectors.
+        if selector.startswith("h1"):
+            return self._headings
+        return self._results
+
+    def evaluate(self, script):
+        return self._page_w if "scrollWidth" in script else self._page_h
+
+
+def _box(x, y, w, h):
+    return {"x": x, "y": y, "width": w, "height": h}
+
+
+def _heading(text, y, h=26):
+    return FakeHandle(box=_box(10, y, 100, h), text=text)
+
+
+class TestResultsClip:
+    def test_returns_none_when_no_results(self):
+        assert _results_clip(FakePage()) is None
+
+    def test_ignores_content_above_results_heading(self):
+        """The sweep-shape diagram above "Results:" must not be mistaken for a plot."""
+        diagram = FakeHandle(box=_box(10, 300, 350, 250))
+        plot = FakeHandle(box=_box(10, 740, 600, 600))
+        page = FakePage(
+            results=[diagram, plot],
+            headings=[_heading("Results: ¶", 700)],
+        )
+        clip = _results_clip(page)
+        # Crop starts at the plot, not the diagram at y=300.
+        assert clip["y"] > 700
+        assert clip["height"] == pytest.approx(616, abs=2)
+
+    def test_matches_heading_despite_panel_anchor_suffix(self):
+        """Panel appends a "¶" anchor to headings; matching must tolerate it."""
+        above = FakeHandle(box=_box(10, 100, 350, 250))
+        plot = FakeHandle(box=_box(10, 740, 600, 600))
+        for text in ("Results:", "Results: ¶", "  results ¶ "):
+            page = FakePage(results=[above, plot], headings=[_heading(text, 700)])
+            assert _results_clip(page)["y"] > 700, f"failed for {text!r}"
+
+    def test_unrelated_heading_does_not_filter(self):
+        plot = FakeHandle(box=_box(10, 740, 600, 600))
+        page = FakePage(results=[plot], headings=[_heading("Results over time", 700)])
+        clip = _results_clip(page)
+        assert clip["y"] == pytest.approx(732, abs=2)
+
+    def test_skips_toolbar_sized_elements(self):
+        """Small chrome (toolbar icons, swatches) must not define the crop."""
+        icon = FakeHandle(box=_box(570, 700, 20, 20))
+        plot = FakeHandle(box=_box(10, 740, 600, 600))
+        clip = _results_clip(FakePage(results=[icon, plot]))
+        assert clip["x"] == pytest.approx(2, abs=1)
+        assert clip["width"] == pytest.approx(616, abs=2)
+
+    def test_stops_before_crop_becomes_a_tall_strip(self):
+        """Stacked plots must not all be included, or each becomes unreadable."""
+        plots = [FakeHandle(box=_box(10, 740 + i * 620, 600, 600)) for i in range(3)]
+        clip = _results_clip(FakePage(results=plots, page_h=4000))
+        assert clip["height"] / clip["width"] <= MAX_CROP_ASPECT
+        # Only the first plot is framed.
+        assert clip["height"] == pytest.approx(616, abs=2)
+
+    def test_single_tall_result_is_still_captured(self):
+        """A lone result taller than the aspect cap must not be dropped entirely."""
+        tall = FakeHandle(box=_box(10, 200, 200, 900))
+        clip = _results_clip(FakePage(results=[tall]))
+        assert clip is not None
+        assert clip["height"] == pytest.approx(916, abs=2)
+
+    def test_clip_is_clamped_to_page_bounds(self):
+        plot = FakeHandle(box=_box(0, 0, 600, 600))
+        clip = _results_clip(FakePage(results=[plot], page_w=600, page_h=600))
+        assert clip["x"] == 0
+        assert clip["y"] == 0
+        assert clip["x"] + clip["width"] <= 600
+        assert clip["y"] + clip["height"] <= 600
+
+
+def _png_bytes(width, height):
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestResizeAndSave:
+    def test_large_image_is_fitted_inside_max_box(self, tmp_path):
+        out = tmp_path / "thumb.png"
+        _resize_and_save_png(_png_bytes(1232, 1232), out)
+        w, h = Image.open(out).size
+        assert w <= THUMB_MAX_W and h <= THUMB_MAX_H
+        # Square input stays square — no distortion to fill the box.
+        assert w == h == THUMB_MAX_H
+
+    def test_aspect_ratio_is_preserved(self, tmp_path):
+        out = tmp_path / "thumb.png"
+        _resize_and_save_png(_png_bytes(2000, 1000), out)
+        w, h = Image.open(out).size
+        assert w / h == pytest.approx(2.0, abs=0.02)
+
+    def test_small_image_is_not_upscaled(self, tmp_path):
+        """Upscaling a small result (a 200px video, say) would only blur it."""
+        out = tmp_path / "thumb.png"
+        _resize_and_save_png(_png_bytes(220, 200), out)
+        assert Image.open(out).size == (220, 200)
+
+    def test_creates_missing_parent_directory(self, tmp_path):
+        out = tmp_path / "nested" / "dir" / "thumb.png"
+        _resize_and_save_png(_png_bytes(600, 600), out)
+        assert out.is_file()


### PR DESCRIPTION
Thumbnails screenshotted the top 1200x900 of each report at scroll position 0, but a Bench report's first plot starts around y=740 -- below the title, description, sweep-shape diagram and the data-collection parameters button. Every thumbnail in the gallery showed only heading text, with the plot cut off just as it entered frame.

_take_thumbnail now locates the results region and clips to it:

- Find the "## Results:" heading and discard candidates above it, so the 350x250 sweep-shape diagram is no longer mistaken for the plot.
- Collect result elements at least 100x80 so toolbar icons and colour swatches cannot define the crop.
- Grow the box in document order, stopping before it exceeds 1.3x taller than wide; reports stack several full-size plots and including them all shrank each to an unreadable strip.
- Hide the Bokeh toolbar before measuring, so the crop is taken from the post-reflow layout.
- Capture at device_scale_factor=2 and downscale, keeping thumbnails sharp on high-DPI screens.

Element discovery has to go through Playwright's shadow-piercing query_selector_all: Bokeh renders into shadow DOM, so an in-page document.querySelectorAll finds nothing at all, not even the heading.

Crops are now tight to each plot, so the PNGs vary in size. Display geometry is therefore decoupled into --gallery-thumb-aspect and --gallery-card-min-width, with the thumbnail centred via object-fit: contain so no plot is distorted or clipped. Square is the default because most results are square Bokeh figures, which a 4:3 box only letterboxes. THUMB_MAX_W/THUMB_MAX_H are now purely a resolution cap.

## Summary by Sourcery

Center gallery thumbnails on report result plots and decouple thumbnail resolution from display geometry.

New Features:
- Crop report thumbnails around detected result plots instead of the top of the page.
- Configure gallery thumbnail/card aspect and sizing via CSS variables to support varying thumbnail dimensions.

Bug Fixes:
- Prevent gallery thumbnails from showing only heading text with plots cut off.
- Avoid including Bokeh toolbars and small UI chrome in thumbnail crops.

Enhancements:
- Capture high-DPI screenshots and downscale them to keep thumbnails sharp without upscaling smaller results.
- Limit crop height relative to width so stacked plots do not produce unreadably thin thumbnails.
- Tightly fit thumbnails within a max-resolution box while preserving aspect ratio and optimizing PNG size.

Tests:
- Add unit tests for result-region clipping logic using fake Playwright page/element handles.
- Add unit tests verifying thumbnail resizing preserves aspect ratio, avoids upscaling, and respects max dimensions.