### PR TITLE
plan 17 + implementation: single-point sweep ranges

### DIFF
--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -653,10 +653,16 @@ class FloatSweep(Number, SweepBase):
                     "Use FloatSweep(bounds=[lo, hi]) or "
                     "FloatSweep(sample_values=[...])."
                 )
+            lo, hi = self.sweep_bounds[0], self.sweep_bounds[1]
+            # A zero-width range has one distinct value.  Neither generator gives
+            # that: linspace would return `samps` copies of it, and arange an
+            # empty array.
+            if lo == hi:
+                return np.array([float(lo)])
             if self.step is None:
-                return np.linspace(self.sweep_bounds[0], self.sweep_bounds[1], samps)
+                return np.linspace(lo, hi, samps)
 
-            return np.arange(self.sweep_bounds[0], self.sweep_bounds[1], self.step, dtype=float)
+            return np.arange(lo, hi, self.step, dtype=float)
         return self.sample_values
 
 
@@ -734,6 +740,11 @@ def sweep(
             "Cannot combine 'values' with 'bounds' or 'samples'. "
             "Use values alone, or bounds/samples together."
         )
+
+    # Validate the range here rather than leaving it to resolution time: for the
+    # deferred string form that is mid-run, long after the spec was declared.
+    if bounds is not None and bounds[0] > bounds[1]:
+        raise ValueError(f"bounds low must not exceed high, got bounds={tuple(bounds)}")
 
     # If a SweepBase param object is passed, delegate to its methods directly
     if isinstance(name, SweepBase):

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -225,11 +225,24 @@ class SweepBase(param.Parameter):
         Returns:
             SweepBase: A new sweep with the specified bounds.
 
+        A zero-width range (*low* == *high*) is legal and yields a single sample at
+        that value, so a caller whose range is computed at run time does not need to
+        switch representation when it collapses.  Switching to ``sample_values``
+        would change the sweep's identity tuple and silently move the benchmark to
+        a different cache and history series.
+
         Raises:
-            ValueError: If *low* >= *high* or the sweep has no bounds attributes.
+            ValueError: If *low* > *high*, if *samples* > 1 is requested for a
+                zero-width range, or the sweep has no bounds attributes.
         """
-        if low >= high:
-            raise ValueError(f"low must be less than high, got low={low}, high={high}")
+        if low > high:
+            raise ValueError(f"low must not exceed high, got low={low}, high={high}")
+        if low == high and samples is not None and samples > 1:
+            raise ValueError(
+                f"samples={samples} was requested for the zero-width range "
+                f"[{low}, {high}], which has exactly one distinct value. Pass "
+                f"samples=1 or omit it."
+            )
         low, high = self._coerce_bound(low), self._coerce_bound(high)
         output = deepcopy(self)
         if hasattr(output, "softbounds"):

--- a/plans/17-single-point-sweep-ranges.md
+++ b/plans/17-single-point-sweep-ranges.md
@@ -1,0 +1,191 @@
+# Plan 17 — Single-Point Sweep Ranges
+
+**Goal:** Let a bounded sweep collapse to a single point. `with_bounds(x, x)`
+currently raises, so every caller whose range is computed at run time needs a
+branch to switch representation when the range degenerates — and the workaround
+lands the run in a *different* cache and history series than the same point taken
+from a range.
+
+**Branch name:** `fix/degenerate-sweep-bounds`
+
+**⚠️ Read first:** this changes what a sweep's shape-affecting fields look like
+for one previously-impossible input, so re-read the hashing contract in
+`bencher/variables/sweep_base.py:110-125` before starting. No existing valid
+input may change identity.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — A collapsed range is rejected
+
+`SweepBase.with_bounds(low, high, samples)` raises when the bounds are equal:
+
+```python
+if low >= high:
+    raise ValueError(f"low must be less than high, got low={low}, high={high}")
+```
+
+(`bencher/variables/sweep_base.py:232-233`). A one-point range is perfectly
+well-defined — take one sample at that value — and rejecting it means any caller
+computing bounds at run time (from configuration, a measured limit, a CLI flag,
+an environment override, a previous sweep's optimum) must special-case the
+degenerate case.
+
+### P2 — Both declarative entry points inherit the raise
+
+- `bn.sweep(name, bounds=(x, x))` with a `SweepBase` object delegates straight
+  to `with_bounds` (`bencher/variables/inputs.py:748-749`).
+- The deferred string form returns a spec dict (`bencher/variables/inputs.py:753`)
+  that `SweepExecutor.convert_vars_to_params` resolves by calling `with_bounds`
+  (`bencher/sweep_executor.py:135-137`).
+
+So there is no spelling of "sweep this range, which happens to be one point"
+that works.
+
+### P3 — The workaround silently moves the series
+
+The available workaround is to switch representation: pass `values=[x]` instead
+of `bounds=(x, x)`, which routes to `with_sample_values` rather than
+`with_bounds`. Those set *different* shape-affecting fields, and both are folded into the
+sweep's identity tuple — `_sweep_identity()` appends `sweep_bounds` and
+`sample_values` for `IntSweep` (`bencher/variables/inputs.py:542-545`) and those
+plus `step` for `FloatSweep` (`bencher/variables/inputs.py:634-637`), per the
+contract at `bencher/variables/sweep_base.py:112-125`.
+
+The consequence is not cosmetic. A caller who sweeps `[0.1, 0.9]` on most runs
+and collapses to a single point on some runs is, on those runs, writing to a
+different cache key and a different history key than the range form would
+produce — so the collapsed run does not append to the trend it looks like it
+belongs to. Under plan 15 it would be reported; today it is silent, and it is
+caused entirely by having to change representation to express a legal range.
+
+### P4 — The error arrives late for the deferred form
+
+For `bn.sweep("x", bounds=(lo, hi))` the bounds are not validated when the spec
+is built, only when `plot_sweep` resolves it (`bencher/sweep_executor.py:135`).
+A computed range that collapses therefore fails partway into a run rather than at
+declaration time.
+
+---
+
+## Proposed design
+
+### D1 — Accept `low == high` as a one-sample range
+
+Change the guard to reject only `low > high`:
+
+```python
+if low > high:
+    raise ValueError(f"low must not exceed high, got low={low}, high={high}")
+```
+
+A sweep whose bounds are equal yields exactly one sample at that value, at every
+sampling resolution — `subsampling_divisions` cannot subdivide a zero-width
+interval, so the sample count is 1 regardless.
+
+**Relaxing the guard alone is not sufficient**, because the sample-generation
+paths do not degrade gracefully:
+
+| Sweep type | Zero-width behavior today | Needed |
+|---|---|---|
+| `IntSweep` (`bencher/variables/inputs.py:556-560`) | `range(x, x + 1)` → `[x]` | already correct |
+| `FloatSweep`, no `step` (`bencher/variables/inputs.py:657`) | `np.linspace(x, x, N)` → **N copies of `x`** | one sample |
+| `FloatSweep`, with `step` (`bencher/variables/inputs.py:659`) | `np.arange(x, x, step)` → **empty** | one sample |
+
+So D1 is two changes: relax the comparison, and short-circuit
+`values()` to a single-element list when the range is zero-width — before the
+`linspace`/`arange` call, in the shared base if the check can live there.
+
+The same relaxation applies to `with_samples` and any other bounds validation
+reachable from `bn.sweep`; audit for other `>=` comparisons on bounds.
+
+### D2 — `samples` on a degenerate range
+
+`with_bounds(x, x, samples=5)` asks for something that does not exist. Two
+defensible answers:
+
+1. **Raise**, naming the contradiction — the caller asked for 5 samples of a
+   zero-width range and probably has a bug upstream.
+2. **Clamp to 1**, silently or with a warning — friendlier to a generic caller
+   that always passes `samples=N` and does not inspect the range.
+
+**Recommendation: raise.** A caller who computes bounds and passes an explicit
+sample count is in a position to handle the degenerate case, and silently
+returning 1 sample where 5 were requested is the kind of quiet disagreement
+between declaration and data this plan exists to remove. **OWNER DECISION** —
+option 2 is reasonable if the friendlier default is preferred; the tests below
+assume option 1.
+
+### D3 — Validate the deferred spec early
+
+`bn.sweep(name, bounds=(lo, hi))` should reject `lo > hi` when the spec is built
+(`bencher/variables/inputs.py:726-737`, alongside the existing `samples <= 0` and
+`values`-with-`bounds` checks) rather than at resolution time. This is
+independent of D1 and worth doing regardless: it turns a mid-run failure into a
+declaration-time one.
+
+### D4 — Document the equivalence and the non-equivalence
+
+At `with_bounds` and at `bn.sweep`: a zero-width range is one sample, and
+`bounds=(x, x)` is **not** interchangeable with `values=[x]` for identity
+purposes — they are different declarations and hash differently. Callers who
+sometimes collapse a range should keep using the bounds form so the series stays
+put.
+
+---
+
+## Phased steps
+
+1. Relax the guard in `with_bounds` (D1); make the sample-generation path return
+   exactly one value for a zero-width range, for every bounded sweep type.
+2. Decide and implement D2.
+3. Add the early bounds validation to `bn.sweep` (D3).
+4. Documentation and a `CHANGELOG.md` entry (D4).
+
+## Tests / acceptance criteria
+
+- `with_bounds(x, x)` on every bounded sweep type yields exactly one sample,
+  equal to `x`, at subsampling divisions 1 through 6.
+- `with_bounds(hi, lo)` with `hi > lo` still raises.
+- `bn.sweep("x", bounds=(x, x))` resolves through `plot_sweep` and produces a
+  dataset with a length-1 coordinate for `x`.
+- A full sweep with one degenerate input variable and one normal one produces the
+  expected `(1, N)` dataset shape and does not error in xarray broadcasting.
+- **Identity guard:** `bounds=(x, x)` and `values=[x]` produce *different*
+  `hash_persistent()` values, asserted explicitly so the distinction is a
+  documented contract rather than an accident, and so a later "simplification"
+  that routes one to the other is caught.
+- Existing golden hashes and every currently-valid bounds input are unchanged —
+  `test_sweep_bounds_change_bench_hash` (`test/test_hash_persistent.py:818`) is
+  the anchor.
+- `bn.sweep("x", bounds=(5, 1))` raises at spec-construction time (D3).
+
+## Migration & compatibility
+
+Strictly a relaxation: an input that raised now succeeds. No currently-working
+call changes behavior, and no hash moves. D3 moves one error earlier, which is
+observable only for code that constructs an invalid spec and never resolves it.
+
+## Risks
+
+- **Shipping D1 as a one-line guard change.** Relaxing the comparison without
+  the `values()` short-circuit is worse than the status quo: a `linspace` sweep
+  would silently take N samples at the same point (N× the run time, duplicate
+  coordinates), and a `step` sweep would take none. The per-type table in D1 is
+  the checklist.
+- **Integer bound coercion.** `IntSweep._coerce_bound`
+  (`bencher/variables/inputs.py:539-540`) casts through `int()`; confirm two
+  distinct floats cannot coerce to an accidentally zero-width integer range, and
+  that a genuinely zero-width one survives coercion.
+- **Duplicate coordinates reaching xarray.** If a short-circuit is missed for one
+  sweep type, the failure surfaces far away as an xarray indexing or
+  broadcasting error. Assert on dataset shape in the tests, not just on
+  `values()`.
+
+## Coordination
+
+- **Plan 15/16** — P3's silent series move is exactly the class of drift plan 15
+  reports and plan 16 makes assertable; this plan removes one of its causes.
+- **Plan 18** — a reusable sweep declaration is much less useful if a computed
+  range cannot degenerate, since that is when specs are built programmatically.

--- a/plans/17-single-point-sweep-ranges.md
+++ b/plans/17-single-point-sweep-ranges.md
@@ -10,8 +10,16 @@ from a range.
 
 **⚠️ Read first:** this changes what a sweep's shape-affecting fields look like
 for one previously-impossible input, so re-read the hashing contract in
-`bencher/variables/sweep_base.py:110-125` before starting. No existing valid
-input may change identity.
+`SweepBase._sweep_identity` (`bencher/variables/sweep_base.py:112-125`) before
+starting. No existing valid input may change identity.
+
+**Status: implemented in this PR** (D1 through D4). One existing test changed
+deliberately: `test_with_bounds_invalid_range` asserted the old `low >= high`
+rule, and now covers the inverted range only, with two new cases for the
+zero-width one. D2's owner decision was resolved as **raise** — `samples > 1`
+over a zero-width range is a contradiction the caller is in a position to fix,
+and silently returning one sample where five were requested is the quiet
+declaration/data disagreement this plan exists to remove.
 
 ---
 
@@ -127,20 +135,19 @@ declaring the feature done.
 
 ### D2 — `samples` on a degenerate range
 
-`with_bounds(x, x, samples=5)` asks for something that does not exist. Two
-defensible answers:
+`with_bounds(x, x, samples=5)` asks for something that does not exist.
 
-1. **Raise**, naming the contradiction — the caller asked for 5 samples of a
-   zero-width range and probably has a bug upstream.
-2. **Clamp to 1**, silently or with a warning — friendlier to a generic caller
-   that always passes `samples=N` and does not inspect the range.
+**Decided: raise**, naming the contradiction. A caller who computes bounds and
+passes an explicit sample count is in a position to handle the degenerate case,
+and silently returning one sample where five were requested is the kind of quiet
+disagreement between declaration and data this plan exists to remove. `samples=1`
+over a zero-width range is accepted, since it agrees with what will happen.
 
-**Recommendation: raise.** A caller who computes bounds and passes an explicit
-sample count is in a position to handle the degenerate case, and silently
-returning 1 sample where 5 were requested is the kind of quiet disagreement
-between declaration and data this plan exists to remove. **OWNER DECISION** —
-option 2 is reasonable if the friendlier default is preferred; the tests below
-assume option 1.
+*Considered and rejected: clamp to 1*, with or without a warning. It is friendlier
+to a generic caller that always passes `samples=N` without inspecting the range,
+but it buys that friendliness by making the sweep quietly disagree with its own
+declaration — and a caller in that position can pass `samples=None` to get the
+same behaviour explicitly.
 
 ### D3 — Validate the deferred spec early
 

--- a/plans/17-single-point-sweep-ranges.md
+++ b/plans/17-single-point-sweep-ranges.md
@@ -53,12 +53,26 @@ sweep's identity tuple — `_sweep_identity()` appends `sweep_bounds` and
 plus `step` for `FloatSweep` (`bencher/variables/inputs.py:634-637`), per the
 contract at `bencher/variables/sweep_base.py:112-125`.
 
-The consequence is not cosmetic. A caller who sweeps `[0.1, 0.9]` on most runs
-and collapses to a single point on some runs is, on those runs, writing to a
-different cache key and a different history key than the range form would
-produce — so the collapsed run does not append to the trend it looks like it
-belongs to. Under plan 15 it would be reported; today it is silent, and it is
-caused entirely by having to change representation to express a legal range.
+The consequence is not cosmetic, though it is narrower than it first looks.
+Measured on `main` @ `7dad0cd4`, the three history keys for one `FloatSweep` are
+all distinct:
+
+| Declaration | `hash_persistent(include_result_vars=False)` |
+|---|---|
+| `bounds=(0.1, 0.9)` | `7b4d500d…` |
+| `values=[0.3]` | `268bc527…` |
+| `bounds=(0.3, 0.3)` | `86842759…` |
+
+Collapsing a range to a point is a genuinely different input space, so its key
+*should* differ from the range's — that reset is correct, not a defect, and this
+plan does not change it. The defect is the third row against the second: two
+spellings of *the same single measured point* carry different identities. A
+project that expresses a collapsed range as `values=[x]` today, and later drops
+that workaround once bounds accept a point, silently forks the single-point trend
+at the moment of the cleanup — the reward for removing a workaround is losing the
+history it accumulated. Under plan 15 that would at least be reported; today it is
+silent, and it is caused entirely by having to change representation to express a
+legal range.
 
 ### P4 — The error arrives late for the deferred form
 
@@ -99,6 +113,17 @@ So D1 is two changes: relax the comparison, and short-circuit
 
 The same relaxation applies to `with_samples` and any other bounds validation
 reachable from `bn.sweep`; audit for other `>=` comparisons on bounds.
+
+**A collapsed axis is squeezed out of the dataset, not kept as length 1.** Verified
+on `main` @ `7dad0cd4`: an input variable yielding one value produces
+`sizes == {}` for that dimension while still appearing in
+`BenchCfg.input_vars` — and this is pre-existing behavior, identical for the
+`values=[x]` workaround, so it is not something this plan introduces or should
+change. It does mean the acceptance tests must assert "no such dimension", not
+"dimension of length 1"; assuming the latter is the first thing an implementer
+will get wrong. It also means a collapsed sweep produces a zero-dimensional
+dataset, which is worth a glance against the `over_time` rendering path before
+declaring the feature done.
 
 ### D2 — `samples` on a degenerate range
 

--- a/test/test_degenerate_sweep_bounds.py
+++ b/test/test_degenerate_sweep_bounds.py
@@ -1,0 +1,148 @@
+"""A bounded sweep may collapse to a single point.
+
+A caller whose range is computed at run time should not have to switch to
+``sample_values`` when the range degenerates: that changes the sweep's identity
+tuple and moves the benchmark to a different cache and history series.  Relaxing
+the guard is not enough on its own -- ``linspace(x, x, N)`` returns N copies and
+``arange(x, x, step)`` returns nothing -- so ``values()`` short-circuits.
+"""
+
+import numpy as np
+import pytest
+
+import bencher as bn
+
+
+class Cfg(bn.ParametrizedSweep):
+    f = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0])
+    i = bn.IntSweep(default=2, bounds=[1, 8])
+    y = bn.ResultFloat()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.y = float(self.f) + float(self.i)
+        return self.get_results_values_as_dict()
+
+
+class StepCfg(bn.ParametrizedSweep):
+    f = bn.FloatSweep(default=0.5, bounds=[0.0, 1.0], step=0.25)
+    y = bn.ResultFloat()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.y = float(self.f)
+        return self.get_results_values_as_dict()
+
+
+@pytest.mark.parametrize("divisions", [1, 2, 3, 4, 5, 6])
+def test_float_zero_width_is_one_sample_at_every_resolution(divisions):
+    """subsampling cannot subdivide a zero-width interval."""
+    sweep = Cfg.param.f.with_bounds(0.3, 0.3)
+    sweep = sweep.with_subsampling_divisions(divisions, divisions)
+    assert list(sweep.values()) == [pytest.approx(0.3)]
+
+
+@pytest.mark.parametrize("divisions", [1, 3, 5])
+def test_int_zero_width_is_one_sample(divisions):
+    sweep = Cfg.param.i.with_bounds(4, 4)
+    sweep = sweep.with_subsampling_divisions(divisions, divisions)
+    assert list(sweep.values()) == [4]
+
+
+def test_step_based_zero_width_is_one_sample_not_empty():
+    """arange(x, x, step) is empty; the short-circuit must precede it."""
+    sweep = StepCfg.param.f.with_bounds(0.5, 0.5)
+    assert list(sweep.values()) == [pytest.approx(0.5)]
+
+
+def test_inverted_bounds_still_raise():
+    with pytest.raises(ValueError, match="must not exceed"):
+        Cfg.param.f.with_bounds(0.9, 0.1)
+
+
+def test_explicit_multiple_samples_on_a_point_raises():
+    with pytest.raises(ValueError, match="zero-width"):
+        Cfg.param.f.with_bounds(0.3, 0.3, samples=5)
+
+
+def test_samples_one_on_a_point_is_allowed():
+    assert list(Cfg.param.f.with_bounds(0.3, 0.3, samples=1).values()) == [pytest.approx(0.3)]
+
+
+def test_sweep_helper_accepts_a_collapsed_range():
+    """The deferred string form is the one a computed range flows through.
+
+    Bencher squeezes a single-valued input var out of the dataset dimensions, so
+    the result is zero-dimensional -- exactly what the pre-existing
+    ``values=[x]`` workaround produces. What matters is that the point was
+    sampled at the collapsed value.
+    """
+    res = (
+        Cfg()
+        .to_bench()
+        .plot_sweep(
+            input_vars=[bn.sweep("f", bounds=(0.3, 0.3))],
+            result_vars=["y"],
+            auto_plot=False,
+        )
+    )
+    ds = res.to_dataset()
+    assert "f" not in ds.sizes
+    # y = f + i, with i at its default of 2.
+    assert float(ds["y"].values) == pytest.approx(0.3 + 2)
+
+
+def test_collapsed_bounds_and_explicit_value_agree_on_shape():
+    """The new path must behave as the workaround it replaces, shape-wise."""
+    shapes = []
+    for iv in (bn.sweep("f", bounds=(0.3, 0.3)), bn.sweep("f", [0.3])):
+        ds = (
+            Cfg()
+            .to_bench()
+            .plot_sweep(input_vars=[iv], result_vars=["y"], auto_plot=False)
+            .to_dataset()
+        )
+        shapes.append((dict(ds.sizes), float(ds["y"].values)))
+    assert shapes[0] == shapes[1]
+
+
+def test_sweep_helper_rejects_inverted_bounds_at_construction():
+    """Not at resolution time, which for a deferred spec is mid-run."""
+    with pytest.raises(ValueError, match="low must not exceed high"):
+        bn.sweep("f", bounds=(0.9, 0.1))
+
+
+def test_mixed_degenerate_and_normal_inputs_give_the_expected_shape():
+    res = (
+        Cfg()
+        .to_bench()
+        .plot_sweep(
+            input_vars=[bn.sweep("f", bounds=(0.3, 0.3)), bn.sweep("i", bounds=(1, 4))],
+            result_vars=["y"],
+            auto_plot=False,
+        )
+    )
+    ds = res.to_dataset()
+    # The collapsed axis is squeezed away; the swept one survives.
+    assert "f" not in ds.sizes
+    assert ds.sizes["i"] > 1
+    assert not np.isnan(ds["y"].values).any()
+
+
+def test_collapsed_bounds_and_sample_values_are_different_identities():
+    """A documented contract, so a later 'simplification' cannot merge the two.
+
+    ``bounds=(x, x)`` and ``values=[x]`` sample the same point but are different
+    declarations; the identity tuple folds bounds and sample_values separately.
+    """
+    by_bounds = Cfg.param.f.with_bounds(0.3, 0.3)
+    by_values = Cfg.param.f.with_sample_values([0.3])
+    assert list(by_bounds.values()) == list(by_values.values())
+    assert by_bounds.hash_persistent() != by_values.hash_persistent()
+
+
+def test_existing_ranges_are_unaffected():
+    """No currently-valid bounds input may change identity or sample count."""
+    normal = Cfg.param.f.with_bounds(0.0, 1.0)
+    assert len(list(normal.values())) > 1
+    assert normal.hash_persistent() == Cfg.param.f.with_bounds(0.0, 1.0).hash_persistent()

--- a/test/test_sweep_base.py
+++ b/test/test_sweep_base.py
@@ -294,11 +294,24 @@ class TestSweepBase(unittest.TestCase):
         original.step = None  # pylint: disable=attribute-defined-outside-init
 
     def test_with_bounds_invalid_range(self):
-        """with_bounds(low >= high) raises ValueError."""
-        with self.assertRaises(ValueError, msg="low must be less than high"):
-            AllSweepVars.param.var_float.with_bounds(5.0, 5.0)
-        with self.assertRaises(ValueError, msg="low must be less than high"):
+        """with_bounds(low > high) raises ValueError."""
+        with self.assertRaises(ValueError, msg="low must not exceed high"):
             AllSweepVars.param.var_float.with_bounds(10.0, 2.0)
+
+    def test_with_bounds_zero_width_is_one_sample(self):
+        """A zero-width range is legal and yields a single sample.
+
+        Previously rejected alongside an inverted range. Expressing a collapsed
+        range as ``sample_values`` instead changes the sweep's identity, so a
+        caller with a computed range had no way to stay in one series.
+        """
+        collapsed = AllSweepVars.param.var_float.with_bounds(5.0, 5.0)
+        self.assertEqual(list(collapsed.values()), [5.0])
+
+    def test_with_bounds_zero_width_rejects_multiple_samples(self):
+        """samples > 1 over a zero-width range is a contradiction."""
+        with self.assertRaises(ValueError, msg="zero-width"):
+            AllSweepVars.param.var_float.with_bounds(5.0, 5.0, samples=5)
 
     def test_callable_conflicts_raise(self):
         """Passing values together with bounds or samples raises ValueError."""


### PR DESCRIPTION
Plan 17 **and its implementation**. `plans/17-single-point-sweep-ranges.md` stays as the
design record; the code is the last two commits.

## The defect

`with_bounds` rejected `low == high`, so any caller whose range is computed at run time —
from configuration, a measured limit, a CLI flag, a previous sweep's optimum — needed a
branch to switch representation when the range collapsed. Both declarative entry points
inherited the raise.

The workaround costs identity. Measured on `main` @ `7dad0cd4`:

| Declaration | `hash_persistent(include_result_vars=False)` |
|---|---|
| `bounds=(0.1, 0.9)` | `7b4d500d…` |
| `values=[0.3]` | `268bc527…` |
| `bounds=(0.3, 0.3)` | `86842759…` |

Collapsing a range *is* a different input space, so row 1 differing from row 3 is correct
and unchanged by this PR — the plan originally overstated this and has been corrected. The
defect is row 3 against row 2: two spellings of the same single measured point carry
different identities, so a project that uses `values=[x]` today and drops the workaround
later silently forks that trend at the moment of the cleanup.

## The fix

Relaxing the guard is **not sufficient on its own**, because neither generator handles a
zero-width range:

| Sweep type | Zero-width before | Now |
|---|---|---|
| `IntSweep` | `range(x, x+1)` → `[x]` | unchanged |
| `FloatSweep`, no `step` | `np.linspace(x, x, N)` → **N copies** | one sample |
| `FloatSweep`, with `step` | `np.arange(x, x, step)` → **empty** | one sample |

So `values()` short-circuits before either call. Also: `samples > 1` over a zero-width
range now raises rather than returning N identical samples (D2, resolved as *raise* —
`samples=1` is accepted), and `bn.sweep()` validates an inverted range at construction
instead of at resolution time, which for a deferred spec is mid-run.

## One existing test changed deliberately

`test_with_bounds_invalid_range` asserted the old `low >= high` rule. It now covers the
inverted range only, plus two new cases for the zero-width one. Flagging it here so it is
not discovered in the diff.

## Validation

- This repo: **2084 passed, 3 skipped**; 19 new tests including every bounded sweep type at
  subsampling divisions 1–6, the step-based path, and an identity guard asserting
  `bounds=(x,x)` and `values=[x]` stay *distinct* so a later "simplification" cannot merge
  them.
- An external project's benchmark suite: **1132 passed** — a regression check rather than a
  feature test, since `values()` is on every sweep's path.

## Behaviour worth knowing (pre-existing, not introduced here)

A single-valued input var is **squeezed out of the dataset** — `sizes == {}` for that
dimension, while the variable still appears in `BenchCfg.input_vars` — and identically so
for the `values=[x]` workaround. Tests must assert "no such dimension", not "dimension of
length 1"; that is the first thing an implementer gets wrong, so the plan now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
