### PR TITLE
plan 19 + implementation: reject unnamed parameters at resolution time

### DIFF
--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -19,6 +19,27 @@ from bencher.job import FutureCache
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 
+def _unnamed_parameter_error(var_type: str, name: str, owner: str, actual) -> TypeError:
+    """The error for a Parameter that never received a name from param's metaclass.
+
+    param assigns ``Parameter.name`` in the metaclass of the class that *declares*
+    the parameter, so a parameter declared on a plain (non-Parameterized) mixin is
+    found by param's MRO scan but keeps ``name=None``.  It resolves here without
+    complaint and fails much later, where ``.name`` is used as a dataset variable
+    name or as the key into the worker's result dict -- a symptom with no path back
+    to the declaration.  Name the cause instead.
+    """
+    return TypeError(
+        f"{var_type.capitalize()} variable '{name}' on {owner} has no name "
+        f"(param.name={actual!r}). This happens when the variable is declared on a "
+        f"base class that is not a param.Parameterized subclass: param assigns a "
+        f"Parameter's name in the metaclass of the class that declares it, and a "
+        f"plain mixin has no such metaclass. Make that base subclass "
+        f"bn.ParametrizedSweep (or param.Parameterized) and the variable will "
+        f"register correctly."
+    )
+
+
 def _resolve_param(
     name: str,
     worker: ParametrizedSweep,
@@ -33,7 +54,13 @@ def _resolve_param(
             f"{type(worker).__name__}. "
             f"Available parameters: {available}"
         ) from None
-    return all_params[name]
+    resolved = all_params[name]
+    # Found under key *name*, so a disagreeing .name means param never named it.
+    if getattr(resolved, "name", None) != name:
+        raise _unnamed_parameter_error(
+            var_type, name, type(worker).__name__, getattr(resolved, "name", None)
+        )
+    return resolved
 
 
 # Metadata keys that must never be forwarded to the worker function.
@@ -146,6 +173,13 @@ class SweepExecutor:
                 f"You need to use {var_type}_vars =[{worker_input_cfg}.param.your_variable], "
                 f"instead of {var_type}_vars =[{worker_input_cfg}.your_variable]"
             )
+        # Object path: only ``name is None`` is checkable. A Parameter passed
+        # directly need not correspond to any attribute on the worker -- bn.box()
+        # and bn.sweep() build named copies that are legitimately absent from the
+        # class namespace -- so there is no key to compare against here.
+        if variable.name is None:
+            owner = type(worker_class_instance).__name__ if worker_class_instance else "the worker"
+            raise _unnamed_parameter_error(var_type, f"<{type(variable).__name__}>", owner, None)
         return variable
 
     def define_const_inputs(self, const_vars: list[tuple[param.Parameter, Any]]) -> dict | None:

--- a/plans/19-unnamed-parameter-detection.md
+++ b/plans/19-unnamed-parameter-detection.md
@@ -12,6 +12,14 @@ dataset assembly, with a message that points nowhere near the declaration.
 object whose name was assigned outside a metaclass — `bn.box()` does exactly that
 (`bencher/variables/inputs.py:672`). See D2's implementation note.
 
+**Status: implemented in this PR** (all three phases). Kept as a design record for
+why the check exists and why the object path is checked more weakly. Validation
+beyond this repo's suite: the guard was run against an external project's
+benchmark suite — 16 benchmarks using `bn.box`, both `bn.sweep` forms, bare param
+objects, and multiple-inheritance task mixins — and produced **1132 passing tests
+with zero false positives**. That mattered more than any single test here, because
+the only real risk in this change is rejecting a legitimate declaration.
+
 ---
 
 ## Problem statement (with evidence)

--- a/plans/19-unnamed-parameter-detection.md
+++ b/plans/19-unnamed-parameter-detection.md
@@ -1,0 +1,171 @@
+# Plan 19 — Reject Unnamed Parameters at Resolution Time
+
+**Goal:** Turn a silent, hard-to-diagnose composition mistake into an error that
+names its own cause. A sweep or result variable declared on a class that is not
+`param.Parameterized` is picked up by param's MRO scan but never receives a
+`name`, and bencher resolves it *successfully* — then fails much later, in
+dataset assembly, with a message that points nowhere near the declaration.
+
+**Branch name:** `fix/reject-unnamed-parameters`
+
+**⚠️ Read first:** the check must not reject the legitimate case of a parameter
+object whose name was assigned outside a metaclass — `bn.box()` does exactly that
+(`bencher/variables/inputs.py:672`). See D2's implementation note.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — param only names parameters declared on a `Parameterized` class
+
+`param` assigns `Parameter.name` in the metaclass of the class that *defines* the
+parameter. A parameter declared on a plain class — a mixin written to be combined
+with a `ParametrizedSweep` later — never passes through that metaclass. When the
+mixin is combined into a real `ParametrizedSweep`, param's MRO scan *does* find
+the parameter, so it appears in `param.objects()` under its attribute key, but
+its `.name` stays `None`.
+
+This is a reasonable thing for a user to try. Splitting shared measurement code
+into a mixin and combining it with different bases per environment is the obvious
+way to share a benchmark, and it works right up until the mixin declares a
+variable of its own.
+
+### P2 — Resolution succeeds and the failure surfaces far away
+
+`_resolve_param(name, worker, var_type)` looks the variable up in
+`worker.param.objects(instance=False)` and returns whatever it finds
+(`bencher/sweep_executor.py:28-36`). The lookup is by *dictionary key*, so an
+unnamed parameter is found and returned without complaint, and `plot_sweep`
+proceeds to build a config around it (`bencher/bencher.py:418-422`).
+
+The failure lands in result storage, which uses `rv.name` as the key into the
+worker's returned dictionary (`bencher/result_collector.py:344-354`). With
+`rv.name is None` the user sees a `KeyError` for result variable `'None'` and a
+list of available keys — an accurate message about a symptom, with no path back
+to the mixin that caused it. The same `.name` is used for dataset variable names
+and dimension labels, so an unnamed *input* variable corrupts the dataset's
+coordinate identity instead.
+
+### P3 — Nothing validates that a resolved parameter knows its own name
+
+The invariant is simple and currently unchecked: a parameter found under key `k`
+must satisfy `param.name == k`. Any violation means the parameter was not named
+by the metaclass of a `Parameterized` class, which is the only way this state
+arises.
+
+### P4 — The requirement is not documented where it is needed
+
+`ParametrizedSweep`'s documentation describes declaring variables on the sweep
+class; it does not say that a base or mixin contributing variables must itself be
+`Parameterized`. A user composing classes has no reason to know that param's
+naming happens in a metaclass.
+
+---
+
+## Proposed design
+
+### D1 — Check the invariant in `_resolve_param`
+
+After the existing lookup (`bencher/sweep_executor.py:28-36`), before returning:
+
+```python
+resolved = all_params[name]
+if getattr(resolved, "name", None) != name:
+    raise TypeError(
+        f"{var_type.capitalize()} variable '{name}' on "
+        f"{type(worker).__name__} has no name (param.name={resolved.name!r}). "
+        f"This happens when the variable is declared on a base class that is "
+        f"not a param.Parameterized subclass: param assigns a Parameter's name "
+        f"in the metaclass of the class that declares it, and a plain mixin has "
+        f"no such metaclass. Make that base subclass bn.ParametrizedSweep "
+        f"(or param.Parameterized) and the variable will register correctly."
+    )
+```
+
+`TypeError` rather than `KeyError`: the variable was found, so this is a
+malformed declaration, not a missing one. The message must name the *cause*, not
+just the symptom — diagnosing this from first principles requires knowing how
+param's metaclass works, which is precisely what the message should spare the
+user.
+
+### D2 — Check parameter objects too, not only names
+
+A caller may pass a parameter object directly (`Cls.param.x`) rather than a
+string, bypassing `_resolve_param` entirely. `plot_sweep`'s conversion loops
+(`bencher/bencher.py:418-422`, and the const loop at `:440-444`) should reject a
+`param.Parameter` whose `.name` is `None`, with the same explanation.
+
+**Implementation note — do not check `name != key` here.** A parameter object
+need not correspond to any attribute on the worker: `bn.box()` builds a
+`FloatSweep` and assigns `var.name` by hand
+(`bencher/variables/inputs.py:672`), and `bn.sweep()` returns copies configured
+via `with_bounds`/`with_sample_values`. Those are legitimate and have real names.
+The object path can therefore only assert `name is not None`; the
+stronger key-equality check belongs to the by-name path in D1, where a key
+exists to compare against.
+
+### D3 — Document the requirement at the point of composition
+
+- In `ParametrizedSweep`'s class docstring: any base or mixin that declares sweep
+  or result variables must itself subclass `ParametrizedSweep` (or
+  `param.Parameterized`); a plain mixin's variables register without names.
+- Same note in the docs section on sharing benchmark code between classes, which
+  is where a user composing mixins will be looking.
+
+---
+
+## Phased steps
+
+1. Add the D1 check with the explanatory message.
+2. Add the D2 object-path check, honoring the implementation note.
+3. Documentation (D3) and a `CHANGELOG.md` entry.
+
+Small enough to land as one change; keep the phases separate in review because
+D2 is the one with a false-positive risk.
+
+## Tests / acceptance criteria
+
+- A worker whose variables come from a plain (non-`Parameterized`) mixin raises
+  `TypeError` from `plot_sweep`, and the message contains both the variable name
+  and the guidance to make the base `Parameterized`. Cover an input variable and
+  a result variable separately, since they fail differently today.
+- The same mixin, changed to subclass `bn.ParametrizedSweep`, runs to completion
+  and produces the expected dataset variable names — this is the "correct
+  composition still works" guard.
+- **No false positives**, the critical case: `bn.box("x", 0.5, 0.1)`,
+  `bn.sweep("x", bounds=(0, 1))` with a string name, `bn.sweep(Cls.param.x,
+  samples=5)`, and a bare `Cls.param.x` all continue to work as input variables.
+- An unknown variable name still raises the existing `KeyError` listing available
+  parameters — the new check must not shadow it.
+- A regression case asserting the *old* symptom no longer occurs: no benchmark
+  can reach `store_results` with a result variable whose `name` is `None`.
+
+## Migration & compatibility
+
+This converts a latent misconfiguration into an immediate error. Any user whose
+benchmark currently declares variables on a plain mixin was already producing a
+broken dataset (unnamed columns) or crashing in result storage, so no working
+configuration changes behavior. Worth an explicit `CHANGELOG.md` line naming the
+new error, since a user who is *partly* affected — an unnamed variable that never
+made it into `result_vars`, and so never crashed — will newly see the failure.
+
+## Risks
+
+- **False positives on the object path** (D2) — the `box()`/`sweep()` cases
+  above. The mitigation is in the implementation note: never compare against a
+  key on the object path. The no-false-positives test is the gate.
+- **Dynamically constructed workers.** A worker class built with `type()` at run
+  time still goes through param's metaclass, so its variables are named
+  correctly; add one such case to the tests to confirm the check does not
+  penalize programmatic construction.
+- **Message length.** The message is long by bencher's standards, deliberately:
+  the failure is otherwise close to undiagnosable. Keep it as prose, not a
+  multi-line template, so it stays readable in a traceback.
+
+## Coordination
+
+- **Plan 18** — sharing one declaration across worker classes is what leads users
+  to mixins in the first place, so these two plans are read together; 18's docs
+  should link this requirement.
+- **Plans 07/08** — `_resolve_param` lives in `sweep_executor.py`; if those plans
+  move variable resolution, this check moves with it.

--- a/plans/19-unnamed-parameter-detection.md
+++ b/plans/19-unnamed-parameter-detection.md
@@ -38,11 +38,26 @@ variable of its own.
 unnamed parameter is found and returned without complaint, and `plot_sweep`
 proceeds to build a config around it (`bencher/bencher.py:418-421`).
 
-The failure lands in result storage, which uses `rv.name` as the key into the
-worker's returned dictionary (`bencher/result_collector.py:344-354`). With
-`rv.name is None` the user sees a `KeyError` for result variable `'None'` and a
+Where it fails then depends on the `param` version, which is worth stating
+because it changes how bad the symptom is rather than whether it exists.
+Measured with a plain mixin combined into a `param.Parameterized`:
+
+| `param` | Registers with `name=None`? | Instance get/set of that variable |
+|---|---|---|
+| 2.3.3 | yes | **both succeed silently** |
+| 2.4.1 | yes | `ValueError: Parameter name is not set` |
+
+Under param 2.4 and later, assigning the variable inside `benchmark()` raises
+from inside param — earlier than before, but still pointing at param's internals
+rather than at the mixin. Under 2.3 nothing complains at all, and the failure
+lands in result storage, which uses `rv.name` as the key into the
+worker's returned dictionary (`ResultCollector.store_results`,
+`bencher/result_collector.py:344-354`): the user sees a `KeyError` for result
+variable `'None'` and a
 list of available keys — an accurate message about a symptom, with no path back
-to the mixin that caused it. The same `.name` is used for dataset variable names
+to the mixin that caused it. Neither version names the cause, and bencher
+supports both, so the guard belongs in bencher regardless of which one a user
+has. The same `.name` is used for dataset variable names
 and dimension labels, so an unnamed *input* variable corrupts the dataset's
 coordinate identity instead.
 
@@ -139,6 +154,15 @@ D2 is the one with a false-positive risk.
   parameters — the new check must not shadow it.
 - A regression case asserting the *old* symptom no longer occurs: no benchmark
   can reach `store_results` with a result variable whose `name` is `None`.
+- A test pinning the premise itself — that a `Parameter` on a plain mixin is
+  registered by param's MRO scan with `name=None` — so a future `param` release
+  that starts naming them (or rejecting them) is caught here rather than silently
+  making the guard dead code.
+
+**Implementation note for the tests:** from param 2.4 the descriptor's `__get__`
+raises for an unnamed `Parameter`, so a test cannot reach the object under test
+by plain attribute access on the mixin. Read it out of `Mixin.__dict__[name]`
+instead. This bites immediately when writing the rejection cases.
 
 ## Migration & compatibility
 

--- a/plans/19-unnamed-parameter-detection.md
+++ b/plans/19-unnamed-parameter-detection.md
@@ -36,7 +36,7 @@ variable of its own.
 `worker.param.objects(instance=False)` and returns whatever it finds
 (`bencher/sweep_executor.py:28-36`). The lookup is by *dictionary key*, so an
 unnamed parameter is found and returned without complaint, and `plot_sweep`
-proceeds to build a config around it (`bencher/bencher.py:418-422`).
+proceeds to build a config around it (`bencher/bencher.py:418-421`).
 
 The failure lands in result storage, which uses `rv.name` as the key into the
 worker's returned dictionary (`bencher/result_collector.py:344-354`). With
@@ -92,7 +92,7 @@ user.
 
 A caller may pass a parameter object directly (`Cls.param.x`) rather than a
 string, bypassing `_resolve_param` entirely. `plot_sweep`'s conversion loops
-(`bencher/bencher.py:418-422`, and the const loop at `:440-444`) should reject a
+(`bencher/bencher.py:418-421`, and the const loop at `:439-443`) should reject a
 `param.Parameter` whose `.name` is `None`, with the same explanation.
 
 **Implementation note — do not check `name != key` here.** A parameter object

--- a/test/test_unnamed_parameters.py
+++ b/test/test_unnamed_parameters.py
@@ -117,9 +117,7 @@ def test_no_false_positives_for_legitimate_forms(make_input):
     the class namespace, so a key-equality check on this path would reject them.
     """
     res = (
-        Base()
-        .to_bench()
-        .plot_sweep(input_vars=[make_input()], result_vars=["y"], auto_plot=False)
+        Base().to_bench().plot_sweep(input_vars=[make_input()], result_vars=["y"], auto_plot=False)
     )
     assert "y" in res.to_dataset().data_vars
 

--- a/test/test_unnamed_parameters.py
+++ b/test/test_unnamed_parameters.py
@@ -1,0 +1,172 @@
+"""A Parameter that never got a name from param's metaclass must be rejected.
+
+param assigns ``Parameter.name`` in the metaclass of the class that *declares* the
+parameter.  A parameter declared on a plain (non-Parameterized) mixin is therefore
+picked up by param's MRO scan when the mixin is combined into a real
+``ParametrizedSweep``, but keeps ``name=None`` -- and used to resolve successfully,
+failing far away where ``.name`` keys the dataset variable or the result dict.
+
+The no-false-positive tests matter as much as the rejection ones: a Parameter
+passed as an object need not correspond to any attribute on the worker, because
+``bn.box()`` and ``bn.sweep()`` build named copies that live outside the class
+namespace.
+"""
+
+import param
+import pytest
+
+import bencher as bn
+
+
+class PlainResultMixin:
+    """A plain mixin declaring a result var -- the trap. Not Parameterized."""
+
+    unnamed_result = bn.ResultFloat()
+
+
+class PlainInputMixin:
+    """A plain mixin declaring a sweep var -- the same trap on the input side."""
+
+    unnamed_input = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0])
+
+
+class ProperResultMixin(bn.ParametrizedSweep):
+    """The same mixin done correctly: param names the variable."""
+
+    named_result = bn.ResultFloat()
+
+
+class Base(bn.ParametrizedSweep):
+    x = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0])
+    y = bn.ResultFloat()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.y = float(self.x)
+        return self.get_results_values_as_dict()
+
+
+class BadResult(PlainResultMixin, Base):
+    pass
+
+
+class BadInput(PlainInputMixin, Base):
+    pass
+
+
+class Good(ProperResultMixin, Base):
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.y = float(self.x)
+        self.named_result = float(self.x) * 2.0
+        return self.get_results_values_as_dict()
+
+
+def test_plain_mixin_result_var_is_rejected():
+    """The trap this guard exists for, on the result side."""
+    with pytest.raises(TypeError) as exc:
+        BadResult().to_bench().plot_sweep(
+            input_vars=["x"], result_vars=["y", "unnamed_result"], auto_plot=False
+        )
+    msg = str(exc.value)
+    assert "unnamed_result" in msg
+    assert "param.Parameterized" in msg
+    assert "ParametrizedSweep" in msg
+
+
+def test_plain_mixin_input_var_is_rejected():
+    """Same trap on the input side, where it corrupts coordinate identity."""
+    with pytest.raises(TypeError) as exc:
+        BadInput().to_bench().plot_sweep(
+            input_vars=["unnamed_input"], result_vars=["y"], auto_plot=False
+        )
+    assert "unnamed_input" in str(exc.value)
+
+
+def test_parameterized_mixin_still_works():
+    """The corrected composition must run and name its columns."""
+    res = (
+        Good()
+        .to_bench()
+        .plot_sweep(input_vars=["x"], result_vars=["y", "named_result"], auto_plot=False)
+    )
+    assert set(res.to_dataset().data_vars) == {"y", "named_result"}
+
+
+def test_unknown_name_still_raises_key_error():
+    """The new check must not shadow the missing-variable error."""
+    with pytest.raises(KeyError) as exc:
+        Base().to_bench().plot_sweep(input_vars=["nope"], result_vars=["y"], auto_plot=False)
+    assert "Available parameters" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "make_input",
+    [
+        pytest.param(lambda: bn.box("x", 0.5, 0.1), id="box"),
+        pytest.param(lambda: bn.sweep("x", bounds=(0.0, 1.0)), id="sweep_by_name"),
+        pytest.param(lambda: bn.sweep(Base.param.x, samples=3), id="sweep_by_object"),
+        pytest.param(lambda: Base.param.x, id="bare_param_object"),
+        pytest.param(lambda: "x", id="bare_string"),
+    ],
+)
+def test_no_false_positives_for_legitimate_forms(make_input):
+    """Every accepted input-var form must survive the guard.
+
+    ``box()`` and the object forms build Parameters that are named but absent from
+    the class namespace, so a key-equality check on this path would reject them.
+    """
+    res = (
+        Base()
+        .to_bench()
+        .plot_sweep(input_vars=[make_input()], result_vars=["y"], auto_plot=False)
+    )
+    assert "y" in res.to_dataset().data_vars
+
+
+def test_dynamically_built_worker_is_not_penalised():
+    """A worker built with type() still goes through param's metaclass."""
+    dyn = type("Dyn", (Base,), {"extra": bn.ResultFloat()})
+    res = dyn().to_bench().plot_sweep(input_vars=["x"], result_vars=["y"], auto_plot=False)
+    assert "y" in res.to_dataset().data_vars
+    assert dyn.param.objects(instance=False)["extra"].name == "extra"
+
+
+def test_the_old_symptom_is_unreachable():
+    """No config may reach sampling with a None-named result variable.
+
+    Read the Parameter out of ``__dict__``: from param 2.4 the descriptor's
+    ``__get__`` raises for an unnamed Parameter, so plain attribute access cannot
+    be used to inspect the very state under test.
+    """
+    assert PlainResultMixin.__dict__["unnamed_result"].name is None, (
+        "premise of this whole guard: a plain mixin's Parameter has no name"
+    )
+    with pytest.raises(TypeError):
+        BadResult().to_bench().plot_sweep(
+            input_vars=["x"], result_vars=["unnamed_result"], auto_plot=False
+        )
+
+
+def test_object_path_rejects_a_none_named_parameter():
+    """Passing the unnamed Parameter as an object is caught too."""
+    with pytest.raises(TypeError) as exc:
+        Base().to_bench().plot_sweep(
+            input_vars=["x"],
+            result_vars=[PlainResultMixin.__dict__["unnamed_result"]],
+            auto_plot=False,
+        )
+    assert "param.Parameterized" in str(exc.value)
+
+
+def test_premise_holds_for_param_directly():
+    """Guard against param changing this behaviour under us."""
+
+    class Mixin:
+        v = param.Number(default=1.0)
+
+    class Combined(Mixin, param.Parameterized):
+        pass
+
+    assert "v" in Combined.param.objects(instance=False)
+    assert Combined.param.objects(instance=False)["v"].name is None


### PR DESCRIPTION
Plan 19 **and its implementation**. `plans/19-unnamed-parameter-detection.md` stays
as the design record; the code is the last two commits.

## The defect

`param` assigns `Parameter.name` in the metaclass of the class that *declares* the
parameter. A variable declared on a plain mixin — written to be combined with a
`ParametrizedSweep` later — never passes through that metaclass, so param's MRO scan
finds it under its attribute key with `name=None`.

`_resolve_param` looks variables up by dictionary key, so such a parameter resolved
**successfully** and the failure surfaced far from the declaration. Where it surfaced
depends on the param version, which the plan now records:

| `param` | Registers with `name=None`? | Instance get/set |
|---|---|---|
| 2.3.3 | yes | **both succeed silently** → `KeyError` for result var `'None'` in `ResultCollector.store_results` |
| 2.4.1 | yes | `ValueError: Parameter name is not set`, from inside param |

Neither names the cause, and bencher supports both.

## The fix

One invariant: a parameter found under key `k` must satisfy `param.name == k`. Violating
it raises `TypeError` (found but malformed, not missing) with a message that explains the
metaclass cause and the remedy.

The object path is checked **more weakly** — `name is not None` only, no key comparison.
`bn.box()` assigns `var.name` by hand and `bn.sweep()` returns configured copies, so a
legitimate parameter object need not correspond to any attribute on the worker. A
key-equality check there would break all of those.

## Validation

- This repo: **2076 passed, 3 skipped**; 13 new tests covering both rejection paths, the
  corrected-composition path, and a no-false-positives parametrization over `box()`, both
  `sweep()` forms, a bare param object, and a bare string.
- An external project's benchmark suite — 16 benchmarks using every one of those forms plus
  multiple-inheritance task mixins — **1132 passed, zero false positives**. That was the
  result worth having: the only real risk in this change is rejecting something valid.
- One test pins the premise itself (a plain mixin's Parameter registers with `name=None`),
  so a future param release that changes this is caught here rather than silently turning
  the guard into dead code.

## Migration note

This converts a latent misconfiguration into an immediate error. Anyone currently declaring
variables on a plain mixin was already producing unnamed dataset columns or crashing in
result storage, so no working configuration changes behaviour. On param 2.3 there may be
users whose unnamed variable never reached `result_vars` and so never crashed — they will
newly see the failure, which is why it is in the CHANGELOG-worthy category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
