### PR TITLE
docs: index plans 15-21

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -34,11 +34,24 @@ without additional context. **Read the whole plan before starting it.**
 | 12 | [Portable artifact paths & cache config](12-portable-artifact-paths-and-cache-config.md) | Low | Small–Medium | Precursor to A3/A4 |
 | 13 | [Benchmark declaration bundle & run defaults](13-benchmark-declaration-and-run-defaults.md) | Low | Medium | Coordinate with 09 |
 | 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.116.0) |
+| 15 | [Stable benchmark series identity](15-benchmark-series-identity.md) | Medium | Medium | Yes — closes a hole in 09 |
+| 16 | [Inspectable, pinnable benchmark identity](16-inspectable-benchmark-identity.md) | Low | Small | Anytime; pairs with 15 |
+| 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | Yes — quick win |
+| 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | Coordinate with 13 |
+| 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | Yes — quick win |
+| 20 | [Duplicate declared variables](20-duplicate-declared-variables.md) | Low–Med | Small | With 19 |
+| 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | After 10 |
 
 Plans 01–03 are quick wins (01 is done). Plan 02's headline owner decision — the
 Plotly-vs-plugin-system direction for PRs #830/#932 — was resolved plugin-first on
 2026-07-01 (see the A1 addendum); its remaining steps are still live and the other
 `OWNER DECISION` markers still apply.
+
+Plans 15–21 came out of an audit of how a large external project drives bencher,
+and of the workarounds it had accumulated. Three of them (17, 19, 20) are small
+correctness fixes worth doing first; 15 and 16 concern benchmark *identity* and
+build directly on the landed 09/14; 18 complements 13's declaration bundle; 21
+extends `optimize()`'s existing `catch=` to the sweep path.
 
 ## Architecture plans (`plans/architecture/`)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -15,6 +15,13 @@ without additional context. **Read the whole plan before starting it.**
 5. The PyPI package name is **`holobench`** (intentional — `bencher` was taken).
    The import name is `bencher`. Do NOT "fix" this mismatch.
 6. If a step fails in a way the plan doesn't cover, stop and report rather than improvising.
+7. **Cite code as `file:line` and name the symbol there.** The symbol is the durable
+   reference; the line number is a convenience pinned to the commit the plan was written
+   against, so it goes stale — confirm each citation against the current tree before relying
+   on it. If a plan's evidence no longer matches the code, say so in the PR rather than
+   silently working around it: a moved line is harmless, but a claim that no longer holds may
+   invalidate the plan's reasoning. When writing a plan, state the commit or version its
+   citations were taken against.
 
 ## Plan index and recommended order
 
@@ -48,10 +55,11 @@ Plotly-vs-plugin-system direction for PRs #830/#932 — was resolved plugin-firs
 `OWNER DECISION` markers still apply.
 
 Plans 15–21 came out of an audit of how a large external project drives bencher,
-and of the workarounds it had accumulated. Three of them (17, 19, 20) are small
-correctness fixes worth doing first; 15 and 16 concern benchmark *identity* and
-build directly on the landed 09/14; 18 complements 13's declaration bundle; 21
-extends `optimize()`'s existing `catch=` to the sweep path.
+and of the workarounds it had accumulated; all seven cite code as of `main` @
+`7dad0cd4` (v1.116.0). Three of them (17, 19, 20) are small correctness fixes
+worth doing first; 15 and 16 concern benchmark *identity* and build directly on
+the landed 09/14; 18 complements 13's declaration bundle; 21 extends
+`optimize()`'s existing `catch=` to the sweep path.
 
 ## Architecture plans (`plans/architecture/`)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -41,13 +41,13 @@ without additional context. **Read the whole plan before starting it.**
 | 12 | [Portable artifact paths & cache config](12-portable-artifact-paths-and-cache-config.md) | Low | Small–Medium | Precursor to A3/A4 |
 | 13 | [Benchmark declaration bundle & run defaults](13-benchmark-declaration-and-run-defaults.md) | Low | Medium | Coordinate with 09 |
 | 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.116.0) |
-| 15 | [Stable benchmark series identity](15-benchmark-series-identity.md) | Medium | Medium | Yes — closes a hole in 09 |
-| 16 | [Inspectable, pinnable benchmark identity](16-inspectable-benchmark-identity.md) | Low | Small | Anytime; pairs with 15 |
+| 15 | [Stable benchmark series identity](15-benchmark-series-identity.md) | Medium | Medium | **Implemented** in #1012 (stack 3/5) |
+| 16 | [Inspectable, pinnable benchmark identity](16-inspectable-benchmark-identity.md) | Low | Small | **Implemented** in #1010 (stack 1/5) |
 | 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | **Implemented** in the plan PR |
-| 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | Coordinate with 13 |
+| 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | **Implemented** in #1014 (stack 5/5) |
 | 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | **Implemented** in the plan PR |
-| 20 | [Duplicate declared variables](20-duplicate-declared-variables.md) | Low–Med | Small | With 19 |
-| 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | After 10 |
+| 20 | [Duplicate declared variables](20-duplicate-declared-variables.md) | Low–Med | Small | **Implemented** in #1011 (stack 2/5) |
+| 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | **Implemented** in #1013 (stack 4/5) |
 
 Plans 01–03 are quick wins (01 is done). Plan 02's headline owner decision — the
 Plotly-vs-plugin-system direction for PRs #830/#932 — was resolved plugin-first on

--- a/plans/README.md
+++ b/plans/README.md
@@ -43,11 +43,11 @@ without additional context. **Read the whole plan before starting it.**
 | 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.116.0) |
 | 15 | [Stable benchmark series identity](15-benchmark-series-identity.md) | Medium | Medium | **Implemented** in #1012 (stack 3/5) |
 | 16 | [Inspectable, pinnable benchmark identity](16-inspectable-benchmark-identity.md) | Low | Small | **Implemented** in #1010 (stack 1/5) |
-| 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | **Implemented** in the plan PR |
-| 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | **Implemented** in #1014 (stack 5/5) |
-| 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | **Implemented** in the plan PR |
+| 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | **Implemented** in #1001 |
+| 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | **Implemented** (phase 1) in #1014; phase 2 deferred to A5 §6 |
+| 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | **Implemented** in #1003 |
 | 20 | [Duplicate declared variables](20-duplicate-declared-variables.md) | Low–Med | Small | **Implemented** in #1011 (stack 2/5) |
-| 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | **Implemented** in #1013 (stack 4/5) |
+| 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | **Implemented** in #1013; `catch` lives on `BenchRunCfg` only (amended per A5 R1) |
 
 Plans 01–03 are quick wins (01 is done). Plan 02's headline owner decision — the
 Plotly-vs-plugin-system direction for PRs #830/#932 — was resolved plugin-first on

--- a/plans/README.md
+++ b/plans/README.md
@@ -43,9 +43,9 @@ without additional context. **Read the whole plan before starting it.**
 | 14 | [Schema-evolving over_time history](14-history-schema-reconciliation.md) | — | — | **Implemented** (design record, v1.116.0) |
 | 15 | [Stable benchmark series identity](15-benchmark-series-identity.md) | Medium | Medium | Yes — closes a hole in 09 |
 | 16 | [Inspectable, pinnable benchmark identity](16-inspectable-benchmark-identity.md) | Low | Small | Anytime; pairs with 15 |
-| 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | Yes — quick win |
+| 17 | [Single-point sweep ranges](17-single-point-sweep-ranges.md) | Low | Small | **Implemented** in the plan PR |
 | 18 | [Reusable sweep declarations](18-reusable-sweep-declarations.md) | Low–Med | Medium | Coordinate with 13 |
-| 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | Yes — quick win |
+| 19 | [Reject unnamed parameters](19-unnamed-parameter-detection.md) | Low | Small | **Implemented** in the plan PR |
 | 20 | [Duplicate declared variables](20-duplicate-declared-variables.md) | Low–Med | Small | With 19 |
 | 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | After 10 |
 


### PR DESCRIPTION
Adds the `plans/README.md` index rows for plans 15–21, plus one paragraph on where
that group came from.

Kept as a separate PR on purpose: it is the only one of the eight that touches
`plans/README.md`, so the seven plan PRs cannot conflict with each other. **Merge
this one last** — its links point at files the other seven add.

| PR | Plan |
|---|---|
| #999 | 15 — Stable benchmark series identity |
| #1000 | 16 — Inspectable, pinnable benchmark identity |
| #1001 | 17 — Single-point sweep ranges |
| #1002 | 18 — Reusable sweep declarations |
| #1003 | 19 — Reject unnamed parameters at resolution time |
| #1004 | 20 — Duplicate declared variables |
| #1005 | 21 — Per-sample fault tolerance in sweeps |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Extend plans/README.md with table entries and brief contextual description for plans 15–21.