### PR TITLE
feat: compose Rerun recording results

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -128,7 +128,11 @@ except ModuleNotFoundError:
     pass
 
 try:
-    from .results.composable_container.composable_container_rerun import ComposableContainerRerun
+    from .results.composable_container.composable_container_rerun import (
+        ComposableContainerRerun,
+        RerunRecording,
+        RerunViewKind,
+    )
 except ModuleNotFoundError:
     pass
 

--- a/bencher/example/generated/rerun/example_rerun_composable_down.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_down.py
@@ -6,7 +6,14 @@ import bencher as bn
 
 
 class RerunComposition(bn.ParametrizedSweep):
-    """Create two recordings and combine them into one Rerun result."""
+    """Record two step responses over time and combine them into one result.
+
+    Each recording animates a second-order system tracking a unit step: the
+    plant marker sweeps left to right as it settles, the trace grows behind it,
+    and the output is logged as a scalar.  Both recordings span the same
+    ``time_s`` range, which is what makes the composition modes differ — see
+    the description below.
+    """
 
     out_rerun = bn.ResultRerun(width=900, height=520)
 
@@ -15,34 +22,40 @@ class RerunComposition(bn.ParametrizedSweep):
             compose_method=bn.ComposeType.down,
             name="Down composition",
         )
+        # (label, damping ratio, colour) — the reference settles cleanly, the
+        # candidate is under-damped and rings.
         scenes = [
-            ("Reference", [-0.65, 0.0], [230, 80, 80]),
-            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+            ("Reference", 0.9, [230, 80, 80]),
+            ("Candidate", 0.35, [70, 120, 235]),
         ]
-        for index, (label, center, color) in enumerate(scenes):
+        n_steps, dt, omega_n = 80, 0.025, 8.0
+
+        for index, (label, zeta, color) in enumerate(scenes):
             recording = rr.RecordingStream(
                 f"bencher_composable_down_{index}",
                 make_default=False,
             )
-            recording.log(
-                "scene/box",
-                rr.Boxes2D(
-                    centers=[center],
-                    half_sizes=[[0.5, 0.35]],
-                    colors=[color],
-                    labels=[label],
-                ),
-                static=True,
-            )
-            recording.log(
-                "scene/landmarks",
-                rr.Points2D(
-                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
-                    colors=[color],
-                    radii=0.08,
-                ),
-                static=True,
-            )
+            y, dy, trace = 0.0, 0.0, []
+            for step in range(n_steps):
+                # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+                ddy = omega_n**2 * (1.0 - y) - 2 * zeta * omega_n * dy
+                dy += ddy * dt
+                y += dy * dt
+                trace.append([step * dt, y])
+
+                recording.set_time("time_s", duration=step * dt)
+                recording.log(
+                    "scene/plant",
+                    rr.Boxes2D(
+                        centers=[[step * dt, y]],
+                        half_sizes=[[0.03, 0.05]],
+                        colors=[color],
+                        labels=[label],
+                    ),
+                )
+                recording.log("scene/trace", rr.LineStrips2D([trace], colors=[color]))
+                recording.log("metrics/output", rr.Scalars(y))
+
             composed.append(bn.capture_rerun_rrd(recording), label=label)
 
         # ResultRerun recognizes the compositor and materializes one combined
@@ -56,11 +69,13 @@ def example_rerun_composable_down(run_cfg: bn.BenchRunCfg | None = None) -> bn.B
     bench.plot_sweep(
         input_vars=[],
         result_vars=["out_rerun"],
-        description="Two independent ``.rrd`` recordings are assigned directly to a "
-        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
-        "their chunks into one recording, and creates a native Rerun ``down`` layout.",
-        post_description="``right`` and ``down`` create horizontal and vertical views; "
-        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+        description="Two independent ``.rrd`` recordings, each animating a step response "
+        "over a ``time_s`` timeline, are assigned directly to a ``ComposableContainerRerun``. "
+        "Bencher namespaces their entity paths, combines their chunks into one recording, "
+        "and generates a native Rerun Blueprint. ``down`` stacks the per-recording views vertically, both driven by the same timeline, so the two responses animate together.",
+        post_description="``right`` and ``down`` place each recording in its own view on a "
+        "shared timeline; ``overlay`` draws them in one view at the same times; ``sequence`` "
+        "offsets the timelines so the recordings play back to back.",
     )
 
     return bench

--- a/bencher/example/generated/rerun/example_rerun_composable_down.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_down.py
@@ -1,0 +1,70 @@
+"""Auto-generated example: Rerun Composition — Down."""
+
+import rerun as rr
+
+import bencher as bn
+
+
+class RerunComposition(bn.ParametrizedSweep):
+    """Create two recordings and combine them into one Rerun result."""
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        composed = bn.ComposableContainerRerun(
+            compose_method=bn.ComposeType.down,
+            name="Down composition",
+        )
+        scenes = [
+            ("Reference", [-0.65, 0.0], [230, 80, 80]),
+            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+        ]
+        for index, (label, center, color) in enumerate(scenes):
+            recording = rr.RecordingStream(
+                f"bencher_composable_down_{index}",
+                make_default=False,
+            )
+            recording.log(
+                "scene/box",
+                rr.Boxes2D(
+                    centers=[center],
+                    half_sizes=[[0.5, 0.35]],
+                    colors=[color],
+                    labels=[label],
+                ),
+                static=True,
+            )
+            recording.log(
+                "scene/landmarks",
+                rr.Points2D(
+                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
+                    colors=[color],
+                    radii=0.08,
+                ),
+                static=True,
+            )
+            composed.append(bn.capture_rerun_rrd(recording), label=label)
+
+        # ResultRerun recognizes the compositor and materializes one combined
+        # path-backed .rrd before the result enters Bencher's cache.
+        self.out_rerun = composed
+
+
+def example_rerun_composable_down(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Composition — Down."""
+    bench = RerunComposition().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[],
+        result_vars=["out_rerun"],
+        description="Two independent ``.rrd`` recordings are assigned directly to a "
+        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
+        "their chunks into one recording, and creates a native Rerun ``down`` layout.",
+        post_description="``right`` and ``down`` create horizontal and vertical views; "
+        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_composable_down)

--- a/bencher/example/generated/rerun/example_rerun_composable_overlay.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_overlay.py
@@ -1,0 +1,70 @@
+"""Auto-generated example: Rerun Composition — Overlay."""
+
+import rerun as rr
+
+import bencher as bn
+
+
+class RerunComposition(bn.ParametrizedSweep):
+    """Create two recordings and combine them into one Rerun result."""
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        composed = bn.ComposableContainerRerun(
+            compose_method=bn.ComposeType.overlay,
+            name="Overlay composition",
+        )
+        scenes = [
+            ("Reference", [-0.65, 0.0], [230, 80, 80]),
+            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+        ]
+        for index, (label, center, color) in enumerate(scenes):
+            recording = rr.RecordingStream(
+                f"bencher_composable_overlay_{index}",
+                make_default=False,
+            )
+            recording.log(
+                "scene/box",
+                rr.Boxes2D(
+                    centers=[center],
+                    half_sizes=[[0.5, 0.35]],
+                    colors=[color],
+                    labels=[label],
+                ),
+                static=True,
+            )
+            recording.log(
+                "scene/landmarks",
+                rr.Points2D(
+                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
+                    colors=[color],
+                    radii=0.08,
+                ),
+                static=True,
+            )
+            composed.append(bn.capture_rerun_rrd(recording), label=label)
+
+        # ResultRerun recognizes the compositor and materializes one combined
+        # path-backed .rrd before the result enters Bencher's cache.
+        self.out_rerun = composed
+
+
+def example_rerun_composable_overlay(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Composition — Overlay."""
+    bench = RerunComposition().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[],
+        result_vars=["out_rerun"],
+        description="Two independent ``.rrd`` recordings are assigned directly to a "
+        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
+        "their chunks into one recording, and creates a native Rerun ``overlay`` layout.",
+        post_description="``right`` and ``down`` create horizontal and vertical views; "
+        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_composable_overlay)

--- a/bencher/example/generated/rerun/example_rerun_composable_overlay.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_overlay.py
@@ -6,7 +6,14 @@ import bencher as bn
 
 
 class RerunComposition(bn.ParametrizedSweep):
-    """Create two recordings and combine them into one Rerun result."""
+    """Record two step responses over time and combine them into one result.
+
+    Each recording animates a second-order system tracking a unit step: the
+    plant marker sweeps left to right as it settles, the trace grows behind it,
+    and the output is logged as a scalar.  Both recordings span the same
+    ``time_s`` range, which is what makes the composition modes differ — see
+    the description below.
+    """
 
     out_rerun = bn.ResultRerun(width=900, height=520)
 
@@ -15,34 +22,40 @@ class RerunComposition(bn.ParametrizedSweep):
             compose_method=bn.ComposeType.overlay,
             name="Overlay composition",
         )
+        # (label, damping ratio, colour) — the reference settles cleanly, the
+        # candidate is under-damped and rings.
         scenes = [
-            ("Reference", [-0.65, 0.0], [230, 80, 80]),
-            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+            ("Reference", 0.9, [230, 80, 80]),
+            ("Candidate", 0.35, [70, 120, 235]),
         ]
-        for index, (label, center, color) in enumerate(scenes):
+        n_steps, dt, omega_n = 80, 0.025, 8.0
+
+        for index, (label, zeta, color) in enumerate(scenes):
             recording = rr.RecordingStream(
                 f"bencher_composable_overlay_{index}",
                 make_default=False,
             )
-            recording.log(
-                "scene/box",
-                rr.Boxes2D(
-                    centers=[center],
-                    half_sizes=[[0.5, 0.35]],
-                    colors=[color],
-                    labels=[label],
-                ),
-                static=True,
-            )
-            recording.log(
-                "scene/landmarks",
-                rr.Points2D(
-                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
-                    colors=[color],
-                    radii=0.08,
-                ),
-                static=True,
-            )
+            y, dy, trace = 0.0, 0.0, []
+            for step in range(n_steps):
+                # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+                ddy = omega_n**2 * (1.0 - y) - 2 * zeta * omega_n * dy
+                dy += ddy * dt
+                y += dy * dt
+                trace.append([step * dt, y])
+
+                recording.set_time("time_s", duration=step * dt)
+                recording.log(
+                    "scene/plant",
+                    rr.Boxes2D(
+                        centers=[[step * dt, y]],
+                        half_sizes=[[0.03, 0.05]],
+                        colors=[color],
+                        labels=[label],
+                    ),
+                )
+                recording.log("scene/trace", rr.LineStrips2D([trace], colors=[color]))
+                recording.log("metrics/output", rr.Scalars(y))
+
             composed.append(bn.capture_rerun_rrd(recording), label=label)
 
         # ResultRerun recognizes the compositor and materializes one combined
@@ -56,11 +69,13 @@ def example_rerun_composable_overlay(run_cfg: bn.BenchRunCfg | None = None) -> b
     bench.plot_sweep(
         input_vars=[],
         result_vars=["out_rerun"],
-        description="Two independent ``.rrd`` recordings are assigned directly to a "
-        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
-        "their chunks into one recording, and creates a native Rerun ``overlay`` layout.",
-        post_description="``right`` and ``down`` create horizontal and vertical views; "
-        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+        description="Two independent ``.rrd`` recordings, each animating a step response "
+        "over a ``time_s`` timeline, are assigned directly to a ``ComposableContainerRerun``. "
+        "Bencher namespaces their entity paths, combines their chunks into one recording, "
+        "and generates a native Rerun Blueprint. ``overlay`` puts both recordings in one shared view at their original times, so the two responses are drawn on top of each other for direct comparison.",
+        post_description="``right`` and ``down`` place each recording in its own view on a "
+        "shared timeline; ``overlay`` draws them in one view at the same times; ``sequence`` "
+        "offsets the timelines so the recordings play back to back.",
     )
 
     return bench

--- a/bencher/example/generated/rerun/example_rerun_composable_right.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_right.py
@@ -6,7 +6,14 @@ import bencher as bn
 
 
 class RerunComposition(bn.ParametrizedSweep):
-    """Create two recordings and combine them into one Rerun result."""
+    """Record two step responses over time and combine them into one result.
+
+    Each recording animates a second-order system tracking a unit step: the
+    plant marker sweeps left to right as it settles, the trace grows behind it,
+    and the output is logged as a scalar.  Both recordings span the same
+    ``time_s`` range, which is what makes the composition modes differ — see
+    the description below.
+    """
 
     out_rerun = bn.ResultRerun(width=900, height=520)
 
@@ -15,34 +22,40 @@ class RerunComposition(bn.ParametrizedSweep):
             compose_method=bn.ComposeType.right,
             name="Right composition",
         )
+        # (label, damping ratio, colour) — the reference settles cleanly, the
+        # candidate is under-damped and rings.
         scenes = [
-            ("Reference", [-0.65, 0.0], [230, 80, 80]),
-            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+            ("Reference", 0.9, [230, 80, 80]),
+            ("Candidate", 0.35, [70, 120, 235]),
         ]
-        for index, (label, center, color) in enumerate(scenes):
+        n_steps, dt, omega_n = 80, 0.025, 8.0
+
+        for index, (label, zeta, color) in enumerate(scenes):
             recording = rr.RecordingStream(
                 f"bencher_composable_right_{index}",
                 make_default=False,
             )
-            recording.log(
-                "scene/box",
-                rr.Boxes2D(
-                    centers=[center],
-                    half_sizes=[[0.5, 0.35]],
-                    colors=[color],
-                    labels=[label],
-                ),
-                static=True,
-            )
-            recording.log(
-                "scene/landmarks",
-                rr.Points2D(
-                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
-                    colors=[color],
-                    radii=0.08,
-                ),
-                static=True,
-            )
+            y, dy, trace = 0.0, 0.0, []
+            for step in range(n_steps):
+                # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+                ddy = omega_n**2 * (1.0 - y) - 2 * zeta * omega_n * dy
+                dy += ddy * dt
+                y += dy * dt
+                trace.append([step * dt, y])
+
+                recording.set_time("time_s", duration=step * dt)
+                recording.log(
+                    "scene/plant",
+                    rr.Boxes2D(
+                        centers=[[step * dt, y]],
+                        half_sizes=[[0.03, 0.05]],
+                        colors=[color],
+                        labels=[label],
+                    ),
+                )
+                recording.log("scene/trace", rr.LineStrips2D([trace], colors=[color]))
+                recording.log("metrics/output", rr.Scalars(y))
+
             composed.append(bn.capture_rerun_rrd(recording), label=label)
 
         # ResultRerun recognizes the compositor and materializes one combined
@@ -56,11 +69,13 @@ def example_rerun_composable_right(run_cfg: bn.BenchRunCfg | None = None) -> bn.
     bench.plot_sweep(
         input_vars=[],
         result_vars=["out_rerun"],
-        description="Two independent ``.rrd`` recordings are assigned directly to a "
-        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
-        "their chunks into one recording, and creates a native Rerun ``right`` layout.",
-        post_description="``right`` and ``down`` create horizontal and vertical views; "
-        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+        description="Two independent ``.rrd`` recordings, each animating a step response "
+        "over a ``time_s`` timeline, are assigned directly to a ``ComposableContainerRerun``. "
+        "Bencher namespaces their entity paths, combines their chunks into one recording, "
+        "and generates a native Rerun Blueprint. ``right`` gives each recording its own view side by side, both driven by the same timeline, so the two responses animate together.",
+        post_description="``right`` and ``down`` place each recording in its own view on a "
+        "shared timeline; ``overlay`` draws them in one view at the same times; ``sequence`` "
+        "offsets the timelines so the recordings play back to back.",
     )
 
     return bench

--- a/bencher/example/generated/rerun/example_rerun_composable_right.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_right.py
@@ -1,0 +1,70 @@
+"""Auto-generated example: Rerun Composition — Right."""
+
+import rerun as rr
+
+import bencher as bn
+
+
+class RerunComposition(bn.ParametrizedSweep):
+    """Create two recordings and combine them into one Rerun result."""
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        composed = bn.ComposableContainerRerun(
+            compose_method=bn.ComposeType.right,
+            name="Right composition",
+        )
+        scenes = [
+            ("Reference", [-0.65, 0.0], [230, 80, 80]),
+            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+        ]
+        for index, (label, center, color) in enumerate(scenes):
+            recording = rr.RecordingStream(
+                f"bencher_composable_right_{index}",
+                make_default=False,
+            )
+            recording.log(
+                "scene/box",
+                rr.Boxes2D(
+                    centers=[center],
+                    half_sizes=[[0.5, 0.35]],
+                    colors=[color],
+                    labels=[label],
+                ),
+                static=True,
+            )
+            recording.log(
+                "scene/landmarks",
+                rr.Points2D(
+                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
+                    colors=[color],
+                    radii=0.08,
+                ),
+                static=True,
+            )
+            composed.append(bn.capture_rerun_rrd(recording), label=label)
+
+        # ResultRerun recognizes the compositor and materializes one combined
+        # path-backed .rrd before the result enters Bencher's cache.
+        self.out_rerun = composed
+
+
+def example_rerun_composable_right(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Composition — Right."""
+    bench = RerunComposition().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[],
+        result_vars=["out_rerun"],
+        description="Two independent ``.rrd`` recordings are assigned directly to a "
+        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
+        "their chunks into one recording, and creates a native Rerun ``right`` layout.",
+        post_description="``right`` and ``down`` create horizontal and vertical views; "
+        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_composable_right)

--- a/bencher/example/generated/rerun/example_rerun_composable_sequence.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_sequence.py
@@ -1,0 +1,70 @@
+"""Auto-generated example: Rerun Composition — Sequence."""
+
+import rerun as rr
+
+import bencher as bn
+
+
+class RerunComposition(bn.ParametrizedSweep):
+    """Create two recordings and combine them into one Rerun result."""
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        composed = bn.ComposableContainerRerun(
+            compose_method=bn.ComposeType.sequence,
+            name="Sequence composition",
+        )
+        scenes = [
+            ("Reference", [-0.65, 0.0], [230, 80, 80]),
+            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+        ]
+        for index, (label, center, color) in enumerate(scenes):
+            recording = rr.RecordingStream(
+                f"bencher_composable_sequence_{index}",
+                make_default=False,
+            )
+            recording.log(
+                "scene/box",
+                rr.Boxes2D(
+                    centers=[center],
+                    half_sizes=[[0.5, 0.35]],
+                    colors=[color],
+                    labels=[label],
+                ),
+                static=True,
+            )
+            recording.log(
+                "scene/landmarks",
+                rr.Points2D(
+                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
+                    colors=[color],
+                    radii=0.08,
+                ),
+                static=True,
+            )
+            composed.append(bn.capture_rerun_rrd(recording), label=label)
+
+        # ResultRerun recognizes the compositor and materializes one combined
+        # path-backed .rrd before the result enters Bencher's cache.
+        self.out_rerun = composed
+
+
+def example_rerun_composable_sequence(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Composition — Sequence."""
+    bench = RerunComposition().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=[],
+        result_vars=["out_rerun"],
+        description="Two independent ``.rrd`` recordings are assigned directly to a "
+        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
+        "their chunks into one recording, and creates a native Rerun ``sequence`` layout.",
+        post_description="``right`` and ``down`` create horizontal and vertical views; "
+        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_composable_sequence)

--- a/bencher/example/generated/rerun/example_rerun_composable_sequence.py
+++ b/bencher/example/generated/rerun/example_rerun_composable_sequence.py
@@ -6,7 +6,14 @@ import bencher as bn
 
 
 class RerunComposition(bn.ParametrizedSweep):
-    """Create two recordings and combine them into one Rerun result."""
+    """Record two step responses over time and combine them into one result.
+
+    Each recording animates a second-order system tracking a unit step: the
+    plant marker sweeps left to right as it settles, the trace grows behind it,
+    and the output is logged as a scalar.  Both recordings span the same
+    ``time_s`` range, which is what makes the composition modes differ — see
+    the description below.
+    """
 
     out_rerun = bn.ResultRerun(width=900, height=520)
 
@@ -15,34 +22,40 @@ class RerunComposition(bn.ParametrizedSweep):
             compose_method=bn.ComposeType.sequence,
             name="Sequence composition",
         )
+        # (label, damping ratio, colour) — the reference settles cleanly, the
+        # candidate is under-damped and rings.
         scenes = [
-            ("Reference", [-0.65, 0.0], [230, 80, 80]),
-            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+            ("Reference", 0.9, [230, 80, 80]),
+            ("Candidate", 0.35, [70, 120, 235]),
         ]
-        for index, (label, center, color) in enumerate(scenes):
+        n_steps, dt, omega_n = 80, 0.025, 8.0
+
+        for index, (label, zeta, color) in enumerate(scenes):
             recording = rr.RecordingStream(
                 f"bencher_composable_sequence_{index}",
                 make_default=False,
             )
-            recording.log(
-                "scene/box",
-                rr.Boxes2D(
-                    centers=[center],
-                    half_sizes=[[0.5, 0.35]],
-                    colors=[color],
-                    labels=[label],
-                ),
-                static=True,
-            )
-            recording.log(
-                "scene/landmarks",
-                rr.Points2D(
-                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
-                    colors=[color],
-                    radii=0.08,
-                ),
-                static=True,
-            )
+            y, dy, trace = 0.0, 0.0, []
+            for step in range(n_steps):
+                # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+                ddy = omega_n**2 * (1.0 - y) - 2 * zeta * omega_n * dy
+                dy += ddy * dt
+                y += dy * dt
+                trace.append([step * dt, y])
+
+                recording.set_time("time_s", duration=step * dt)
+                recording.log(
+                    "scene/plant",
+                    rr.Boxes2D(
+                        centers=[[step * dt, y]],
+                        half_sizes=[[0.03, 0.05]],
+                        colors=[color],
+                        labels=[label],
+                    ),
+                )
+                recording.log("scene/trace", rr.LineStrips2D([trace], colors=[color]))
+                recording.log("metrics/output", rr.Scalars(y))
+
             composed.append(bn.capture_rerun_rrd(recording), label=label)
 
         # ResultRerun recognizes the compositor and materializes one combined
@@ -56,11 +69,13 @@ def example_rerun_composable_sequence(run_cfg: bn.BenchRunCfg | None = None) -> 
     bench.plot_sweep(
         input_vars=[],
         result_vars=["out_rerun"],
-        description="Two independent ``.rrd`` recordings are assigned directly to a "
-        "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
-        "their chunks into one recording, and creates a native Rerun ``sequence`` layout.",
-        post_description="``right`` and ``down`` create horizontal and vertical views; "
-        "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+        description="Two independent ``.rrd`` recordings, each animating a step response "
+        "over a ``time_s`` timeline, are assigned directly to a ``ComposableContainerRerun``. "
+        "Bencher namespaces their entity paths, combines their chunks into one recording, "
+        "and generates a native Rerun Blueprint. ``sequence`` splices the recordings end to end: the second recording's ``time_s`` values are offset to start where the first one ends, and each recording is cleared as the next begins.  Scrubbing or playing the single shared view therefore runs the reference response first, then the candidate.",
+        post_description="``right`` and ``down`` place each recording in its own view on a "
+        "shared timeline; ``overlay`` draws them in one view at the same times; ``sequence`` "
+        "offsets the timelines so the recordings play back to back.",
     )
 
     return bench

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -1,9 +1,10 @@
 """Meta-generator: Rerun visualization integration examples.
 
-Generates three rerun examples:
+Generates rerun examples for:
 - capture_window: basic rerun capture in a single sweep
 - regression: 0 input vars, 3 over-time snapshots with regression on the 3rd
 - sweep: 1 input var (damping_ratio), single sweep, no over_time
+- composable_{right,down,sequence,overlay}: combine two complete recordings
 """
 
 import bencher as bn
@@ -15,6 +16,10 @@ RERUN_EXAMPLES = [
     "capture_window",
     "regression",
     "sweep",
+    "composable_right",
+    "composable_down",
+    "composable_sequence",
+    "composable_overlay",
 ]
 
 
@@ -30,6 +35,8 @@ class MetaRerun(MetaGeneratorBase):
             self._generate_regression()
         elif self.example == "sweep":
             self._generate_sweep()
+        elif self.example.startswith("composable_"):
+            self._generate_composable(self.example.removeprefix("composable_"))
 
     def _generate_capture_window(self):
         """Capture a rerun viewer window as a Panel widget inside a sweep."""
@@ -144,6 +151,75 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             run_kwargs={"subsampling_divisions": 3},
+        )
+
+    def _generate_composable(self, compose: str):
+        """Combine complete recordings with a native Rerun Blueprint layout."""
+        imports = "import rerun as rr\n\nimport bencher as bn"
+        class_code = f'''
+class RerunComposition(bn.ParametrizedSweep):
+    """Create two recordings and combine them into one Rerun result."""
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        composed = bn.ComposableContainerRerun(
+            compose_method=bn.ComposeType.{compose},
+            name="{compose.title()} composition",
+        )
+        scenes = [
+            ("Reference", [-0.65, 0.0], [230, 80, 80]),
+            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+        ]
+        for index, (label, center, color) in enumerate(scenes):
+            recording = rr.RecordingStream(
+                f"bencher_composable_{compose}_{{index}}",
+                make_default=False,
+            )
+            recording.log(
+                "scene/box",
+                rr.Boxes2D(
+                    centers=[center],
+                    half_sizes=[[0.5, 0.35]],
+                    colors=[color],
+                    labels=[label],
+                ),
+                static=True,
+            )
+            recording.log(
+                "scene/landmarks",
+                rr.Points2D(
+                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
+                    colors=[color],
+                    radii=0.08,
+                ),
+                static=True,
+            )
+            composed.append(bn.capture_rerun_rrd(recording), label=label)
+
+        # ResultRerun recognizes the compositor and materializes one combined
+        # path-backed .rrd before the result enters Bencher's cache.
+        self.out_rerun = composed'''
+        body = f"""\
+bench = RerunComposition().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=[],
+    result_vars=["out_rerun"],
+    description="Two independent ``.rrd`` recordings are assigned directly to a "
+    "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
+    "their chunks into one recording, and creates a native Rerun ``{compose}`` layout.",
+    post_description="``right`` and ``down`` create horizontal and vertical views; "
+    "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+)
+"""
+        self.generate_example(
+            title=f"Rerun Composition — {compose.title()}",
+            output_dir=OUTPUT_DIR,
+            filename=f"example_rerun_composable_{compose}",
+            function_name=f"example_rerun_composable_{compose}",
+            imports=imports,
+            body=body,
+            class_code=class_code,
         )
 
 

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -4,7 +4,8 @@ Generates rerun examples for:
 - capture_window: basic rerun capture in a single sweep
 - regression: 0 input vars, 3 over-time snapshots with regression on the 3rd
 - sweep: 1 input var (damping_ratio), single sweep, no over_time
-- composable_{right,down,sequence,overlay}: combine two complete recordings
+- composable_{right,down,sequence,overlay}: combine two complete recordings, each
+  animated over a ``time_s`` timeline so the composition modes are distinguishable
 """
 
 import bencher as bn
@@ -21,6 +22,21 @@ RERUN_EXAMPLES = [
     "composable_sequence",
     "composable_overlay",
 ]
+
+# What each composition mode does to the two recordings, appended to the
+# generated example's description.
+COMPOSE_DESCRIPTIONS = {
+    "right": "``right`` gives each recording its own view side by side, both driven "
+    "by the same timeline, so the two responses animate together.",
+    "down": "``down`` stacks the per-recording views vertically, both driven by the "
+    "same timeline, so the two responses animate together.",
+    "sequence": "``sequence`` splices the recordings end to end: the second "
+    "recording's ``time_s`` values are offset to start where the first one ends, and "
+    "each recording is cleared as the next begins.  Scrubbing or playing the single "
+    "shared view therefore runs the reference response first, then the candidate.",
+    "overlay": "``overlay`` puts both recordings in one shared view at their original "
+    "times, so the two responses are drawn on top of each other for direct comparison.",
+}
 
 
 class MetaRerun(MetaGeneratorBase):
@@ -158,7 +174,14 @@ bench.plot_sweep(
         imports = "import rerun as rr\n\nimport bencher as bn"
         class_code = f'''
 class RerunComposition(bn.ParametrizedSweep):
-    """Create two recordings and combine them into one Rerun result."""
+    """Record two step responses over time and combine them into one result.
+
+    Each recording animates a second-order system tracking a unit step: the
+    plant marker sweeps left to right as it settles, the trace grows behind it,
+    and the output is logged as a scalar.  Both recordings span the same
+    ``time_s`` range, which is what makes the composition modes differ — see
+    the description below.
+    """
 
     out_rerun = bn.ResultRerun(width=900, height=520)
 
@@ -167,34 +190,40 @@ class RerunComposition(bn.ParametrizedSweep):
             compose_method=bn.ComposeType.{compose},
             name="{compose.title()} composition",
         )
+        # (label, damping ratio, colour) — the reference settles cleanly, the
+        # candidate is under-damped and rings.
         scenes = [
-            ("Reference", [-0.65, 0.0], [230, 80, 80]),
-            ("Candidate", [0.65, 0.0], [70, 120, 235]),
+            ("Reference", 0.9, [230, 80, 80]),
+            ("Candidate", 0.35, [70, 120, 235]),
         ]
-        for index, (label, center, color) in enumerate(scenes):
+        n_steps, dt, omega_n = 80, 0.025, 8.0
+
+        for index, (label, zeta, color) in enumerate(scenes):
             recording = rr.RecordingStream(
                 f"bencher_composable_{compose}_{{index}}",
                 make_default=False,
             )
-            recording.log(
-                "scene/box",
-                rr.Boxes2D(
-                    centers=[center],
-                    half_sizes=[[0.5, 0.35]],
-                    colors=[color],
-                    labels=[label],
-                ),
-                static=True,
-            )
-            recording.log(
-                "scene/landmarks",
-                rr.Points2D(
-                    [[center[0] - 0.25, -0.55], [center[0] + 0.25, 0.55]],
-                    colors=[color],
-                    radii=0.08,
-                ),
-                static=True,
-            )
+            y, dy, trace = 0.0, 0.0, []
+            for step in range(n_steps):
+                # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+                ddy = omega_n**2 * (1.0 - y) - 2 * zeta * omega_n * dy
+                dy += ddy * dt
+                y += dy * dt
+                trace.append([step * dt, y])
+
+                recording.set_time("time_s", duration=step * dt)
+                recording.log(
+                    "scene/plant",
+                    rr.Boxes2D(
+                        centers=[[step * dt, y]],
+                        half_sizes=[[0.03, 0.05]],
+                        colors=[color],
+                        labels=[label],
+                    ),
+                )
+                recording.log("scene/trace", rr.LineStrips2D([trace], colors=[color]))
+                recording.log("metrics/output", rr.Scalars(y))
+
             composed.append(bn.capture_rerun_rrd(recording), label=label)
 
         # ResultRerun recognizes the compositor and materializes one combined
@@ -205,11 +234,13 @@ bench = RerunComposition().to_bench(run_cfg)
 bench.plot_sweep(
     input_vars=[],
     result_vars=["out_rerun"],
-    description="Two independent ``.rrd`` recordings are assigned directly to a "
-    "``ComposableContainerRerun``. Bencher namespaces their entity paths, combines "
-    "their chunks into one recording, and creates a native Rerun ``{compose}`` layout.",
-    post_description="``right`` and ``down`` create horizontal and vertical views; "
-    "``sequence`` creates tabs; ``overlay`` places compatible entities in one shared view.",
+    description="Two independent ``.rrd`` recordings, each animating a step response "
+    "over a ``time_s`` timeline, are assigned directly to a ``ComposableContainerRerun``. "
+    "Bencher namespaces their entity paths, combines their chunks into one recording, "
+    "and generates a native Rerun Blueprint. {COMPOSE_DESCRIPTIONS[compose]}",
+    post_description="``right`` and ``down`` place each recording in its own view on a "
+    "shared timeline; ``overlay`` draws them in one view at the same times; ``sequence`` "
+    "offsets the timelines so the recordings play back to back.",
 )
 """
         self.generate_example(

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -141,6 +141,18 @@ def _set_result_value(
         set_xarray_multidim(bench_res.ds[name], idx, value)
 
 
+def _materialize_result_value(rv, value):
+    """Convert deferred result artifacts into their cacheable stored representation."""
+    if isinstance(rv, ResultRerun):
+        from bencher.results.composable_container.composable_container_rerun import (
+            ComposableContainerRerun,
+        )
+
+        if isinstance(value, ComposableContainerRerun):
+            return value.render()
+    return value
+
+
 class ResultCollector:
     """Manages benchmark result collection, storage, and caching.
 
@@ -352,6 +364,7 @@ class ResultCollector:
                         f"Make sure your benchmark() method sets "
                         f"self.{rv.name}."
                     ) from None
+                result_value = _materialize_result_value(rv, result_value)
                 if bench_run_cfg.print_bench_results:
                     logger.info(f"{rv.name}: {result_value}")
 

--- a/bencher/results/composable_container/__init__.py
+++ b/bencher/results/composable_container/__init__.py
@@ -9,6 +9,11 @@ from bencher.results.composable_container.composable_container_dataframe import 
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
 )
+from bencher.results.composable_container.composable_container_rerun import (
+    ComposableContainerRerun,
+    RerunRecording,
+    RerunViewKind,
+)
 from bencher.results.composable_container.composable_container_video import (
     ComposableContainerVideo,
     RenderCfg,

--- a/bencher/results/composable_container/composable_container_rerun.py
+++ b/bencher/results/composable_container/composable_container_rerun.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -108,12 +107,44 @@ _VIEW_NAMES = {
     RerunViewKind.state_timeline: "State timeline",
 }
 
+# ``rerun.blueprint`` is imported lazily, so the view classes are referenced by
+# attribute name rather than by value.
+_VIEW_CLASS_NAMES = {
+    RerunViewKind.spatial_2d: "Spatial2DView",
+    RerunViewKind.spatial_3d: "Spatial3DView",
+    RerunViewKind.time_series: "TimeSeriesView",
+    RerunViewKind.bar_chart: "BarChartView",
+    RerunViewKind.tensor: "TensorView",
+    RerunViewKind.text_document: "TextDocumentView",
+    RerunViewKind.text_log: "TextLogView",
+    RerunViewKind.map: "MapView",
+    RerunViewKind.graph: "GraphView",
+    RerunViewKind.state_timeline: "StateTimelineView",
+}
 
-def _infer_chunk_view_kinds(chunk) -> set[RerunViewKind]:
+_LAYOUT_CLASS_NAMES = {
+    ComposeType.right: "Horizontal",
+    ComposeType.down: "Vertical",
+}
+
+# Gap inserted between spliced recordings so consecutive items never share an index.
+_SPLICE_GAP_NS = 1
+
+
+def _index_fields(batch) -> list:
+    """Return the timeline (index) fields of a chunk record batch."""
+    return [
+        arrow_field
+        for arrow_field in batch.schema
+        if (arrow_field.metadata or {}).get(b"rerun:kind") == b"index"
+    ]
+
+
+def _batch_view_kinds(batch) -> set[RerunViewKind]:
+    """Infer which Blueprint view types can display the archetypes in a chunk."""
     kinds = set()
-    for arrow_field in chunk.to_record_batch().schema:
-        metadata = arrow_field.metadata or {}
-        archetype = metadata.get(b"rerun:archetype")
+    for arrow_field in batch.schema:
+        archetype = (arrow_field.metadata or {}).get(b"rerun:archetype")
         if archetype is None:
             continue
         archetype_name = archetype.decode().rsplit(".", maxsplit=1)[-1]
@@ -123,49 +154,120 @@ def _infer_chunk_view_kinds(chunk) -> set[RerunViewKind]:
     return kinds
 
 
-def _ordered_view_kinds(kinds: Iterable[RerunViewKind]) -> list[RerunViewKind]:
-    selected = set(kinds)
-    return [kind for kind in RerunViewKind if kind in selected]
+def _index_values(batch, name: str):
+    """Return one timeline column as a numpy int64 array of raw index units."""
+    import pyarrow as pa
+
+    column = batch.column(batch.schema.get_field_index(name))
+    return column.cast(pa.int64()).to_numpy(zero_copy_only=False)
 
 
-def _namespace_chunk(chunk, *, prefix: str, kinds: set[RerunViewKind]):
-    kinds.update(_infer_chunk_view_kinds(chunk))
-    source_path = str(chunk.entity_path).lstrip("/")
-    return chunk.with_entity_path(f"{prefix}/{source_path}")
+def _batch_time_bounds(batch) -> dict[str, tuple[int, int]]:
+    """Return ``{timeline_name: (first, last)}`` in raw index units for one chunk."""
+    bounds = {}
+    for arrow_field in _index_fields(batch):
+        values = _index_values(batch, arrow_field.name)
+        bounds[arrow_field.name] = (int(values.min()), int(values.max()))
+    return bounds
 
 
-def _blueprint_view(rrb, kind: RerunViewKind, *, origin: str, name: str):
-    view_classes = {
-        RerunViewKind.spatial_2d: rrb.Spatial2DView,
-        RerunViewKind.spatial_3d: rrb.Spatial3DView,
-        RerunViewKind.time_series: rrb.TimeSeriesView,
-        RerunViewKind.bar_chart: rrb.BarChartView,
-        RerunViewKind.tensor: rrb.TensorView,
-        RerunViewKind.text_document: rrb.TextDocumentView,
-        RerunViewKind.text_log: rrb.TextLogView,
-        RerunViewKind.map: rrb.MapView,
-        RerunViewKind.graph: rrb.GraphView,
-        RerunViewKind.state_timeline: rrb.StateTimelineView,
-    }
-    return view_classes[kind](origin=origin, name=name)
+def _shifted_chunks(chunk, offsets: dict[str, int]) -> list:
+    """Return ``chunk`` with each timeline column advanced by ``offsets[timeline]``."""
+    import pyarrow as pa
+    from rerun.experimental import Chunk
+
+    batch = chunk.to_record_batch()
+    columns = list(batch.columns)
+    shifted_any = False
+    for arrow_field in _index_fields(batch):
+        offset = offsets.get(arrow_field.name, 0)
+        if offset == 0:
+            continue
+        position = batch.schema.get_field_index(arrow_field.name)
+        shifted = _index_values(batch, arrow_field.name) + offset
+        columns[position] = pa.array(shifted).cast(batch.column(position).type)
+        shifted_any = True
+    if not shifted_any:
+        return [chunk]
+    return Chunk.from_record_batch(pa.RecordBatch.from_arrays(columns, schema=batch.schema))
 
 
-def _blueprint_views(rrb, kinds: Iterable[RerunViewKind], *, origin: str, label: str):
-    ordered = _ordered_view_kinds(kinds)
-    if not ordered:
-        ordered = [RerunViewKind.spatial_2d]
-    views = [
-        _blueprint_view(
-            rrb,
-            kind,
-            origin=origin,
-            name=label if len(ordered) == 1 else f"{label} — {_VIEW_NAMES[kind]}",
-        )
-        for kind in ordered
-    ]
-    if len(views) == 1:
-        return views[0]
-    return rrb.Vertical(*views, name=label)
+@dataclass
+class _ComposedItem:
+    """One source recording, re-rooted under ``prefix``, with its layout metadata."""
+
+    prefix: str
+    label: str
+    chunks: list = field(default_factory=list)
+    view_kinds: set[RerunViewKind] = field(default_factory=set)
+    time_bounds: dict[str, tuple[int, int]] = field(default_factory=dict)
+    time_types: dict[str, Any] = field(default_factory=dict)
+
+    def add(self, chunk) -> None:
+        """Record a chunk and fold its archetypes and time range into the metadata."""
+        self.chunks.append(chunk)
+        batch = chunk.to_record_batch()
+        self.view_kinds.update(_batch_view_kinds(batch))
+        for arrow_field in _index_fields(batch):
+            self.time_types[arrow_field.name] = arrow_field.type
+        for name, (first, last) in _batch_time_bounds(batch).items():
+            existing = self.time_bounds.get(name, (first, last))
+            self.time_bounds[name] = (min(existing[0], first), max(existing[1], last))
+
+
+def _read_item(path: str | Path, *, prefix: str, label: str) -> _ComposedItem:
+    """Decode one ``.rrd`` file, re-rooting every entity path under ``prefix``."""
+    from rerun.experimental import RrdReader
+
+    reader = RrdReader(path)
+    stores = reader.recordings()
+    if not stores:
+        raise ValueError(f"RRD contains no recording stores: {path}")
+
+    item = _ComposedItem(prefix=prefix, label=label)
+    for store in stores:
+        for chunk in reader.stream(store=store):
+            source_path = str(chunk.entity_path).lstrip("/")
+            item.add(chunk.with_entity_path(f"{prefix}/{source_path}"))
+    return item
+
+
+def _splice_offsets(items: list[_ComposedItem]) -> list[dict[str, int]]:
+    """Offset each item's timelines so it starts after the previous item ends.
+
+    Timelines are spliced independently by name: an item that does not use a
+    timeline neither consumes nor advances it.  The first user of a timeline
+    keeps its original values.
+    """
+    offsets: list[dict[str, int]] = []
+    timeline_ends: dict[str, int] = {}
+    for item in items:
+        item_offsets = {}
+        for name, (first, last) in item.time_bounds.items():
+            previous_end = timeline_ends.get(name)
+            offset = 0 if previous_end is None else previous_end - first + _SPLICE_GAP_NS
+            item_offsets[name] = offset
+            timeline_ends[name] = last + offset
+        offsets.append(item_offsets)
+    return offsets
+
+
+def _set_recording_time(recording, timeline: str, time_type, value: int) -> None:
+    """Set ``timeline`` to a raw index ``value``, matching the column's time type.
+
+    ``value`` is in nanoseconds for duration and timestamp timelines, so numpy
+    types are used to keep nanosecond precision (``timedelta`` would round to
+    microseconds).
+    """
+    import numpy as np
+    import pyarrow as pa
+
+    if pa.types.is_timestamp(time_type):
+        recording.set_time(timeline, timestamp=np.datetime64(value, "ns"))
+    elif pa.types.is_duration(time_type):
+        recording.set_time(timeline, duration=np.timedelta64(value, "ns"))
+    else:
+        recording.set_time(timeline, sequence=value)
 
 
 @dataclass(kw_only=True)
@@ -178,8 +280,9 @@ class ComposableContainerRerun(ComposableContainerBase):
 
     - ``right`` -> ``rrb.Horizontal``
     - ``down`` -> ``rrb.Vertical``
-    - ``sequence`` -> ``rrb.Tabs``
-    - ``overlay`` -> shared views rooted at ``/``
+    - ``overlay`` -> shared views rooted at ``/``, all items playing together
+    - ``sequence`` -> shared views rooted at ``/``, items spliced end to end in
+      time so scrubbing the timeline plays them one after the other
 
     View types are inferred from Rerun archetype metadata. Pass ``view_kinds`` to
     :meth:`append` when a recording needs an explicit override.
@@ -190,6 +293,24 @@ class ComposableContainerRerun(ComposableContainerBase):
     name: str | None = None
     application_id: str = "bencher/composed"
 
+    @staticmethod
+    def _to_recording(
+        obj: str | Path | RerunRecording,
+        *,
+        label: str | None,
+        view_kinds: Iterable[RerunViewKind | str] | None,
+    ) -> RerunRecording:
+        if isinstance(obj, RerunRecording):
+            if label is not None or view_kinds is not None:
+                raise ValueError(
+                    "label and view_kinds must be set on RerunRecording or append(), not both"
+                )
+            return obj
+        kinds = (
+            tuple(RerunViewKind(kind) for kind in view_kinds) if view_kinds is not None else None
+        )
+        return RerunRecording(path=obj, label=label, view_kinds=kinds)
+
     def append(
         self,
         obj: str | Path | RerunRecording,
@@ -198,20 +319,12 @@ class ComposableContainerRerun(ComposableContainerBase):
         view_kinds: Iterable[RerunViewKind | str] | None = None,
     ) -> None:
         """Append an RRD path or a recording value with optional view metadata."""
-        if isinstance(obj, RerunRecording):
-            if label is not None or view_kinds is not None:
-                raise ValueError(
-                    "label and view_kinds must be set on RerunRecording or append(), not both"
-                )
-            item = obj
-        else:
-            kinds = (
-                tuple(RerunViewKind(kind) for kind in view_kinds)
-                if view_kinds is not None
-                else None
-            )
-            item = RerunRecording(path=obj, label=label, view_kinds=kinds)
-        self.container.append(item)
+        self.container.append(self._to_recording(obj, label=label, view_kinds=view_kinds))
+
+    @property
+    def _shares_one_view(self) -> bool:
+        """Whether every item is displayed in the same view rooted at ``/``."""
+        return self.compose_method in (ComposeType.overlay, ComposeType.sequence)
 
     def _output_file(self) -> Path:
         if self.output_path is not None:
@@ -225,38 +338,76 @@ class ComposableContainerRerun(ComposableContainerBase):
 
         return Path(gen_rerun_data_path("composed"))
 
-    def _build_blueprint(self, rrb, item_kinds: list[set[RerunViewKind]]):
-        if self.compose_method == ComposeType.overlay:
-            all_kinds = set().union(*item_kinds)
-            return _blueprint_views(
+    def _views(self, rrb, kinds: Iterable[RerunViewKind], *, origin: str, label: str):
+        """Build the view (or vertical stack of views) that displays one origin."""
+        selected = set(kinds)
+        ordered = [kind for kind in RerunViewKind if kind in selected] or [RerunViewKind.spatial_2d]
+        views = [
+            getattr(rrb, _VIEW_CLASS_NAMES[kind])(
+                origin=origin,
+                name=label if len(ordered) == 1 else f"{label} — {_VIEW_NAMES[kind]}",
+            )
+            for kind in ordered
+        ]
+        if len(views) == 1:
+            return views[0]
+        return rrb.Vertical(*views, name=label)
+
+    def _layout(self, rrb, items: list[_ComposedItem]):
+        """Map the compose method onto a Blueprint layout of per-item views."""
+        if self._shares_one_view:
+            return self._views(
                 rrb,
-                all_kinds,
+                set().union(*(item.view_kinds for item in items)),
                 origin="/",
-                label=self.name or "Overlay",
+                label=self.name or self.compose_method.title(),
             )
 
-        layouts = []
-        for index, (item, kinds) in enumerate(zip(self.container, item_kinds)):
-            layouts.append(
-                _blueprint_views(
-                    rrb,
-                    kinds,
-                    origin=f"/item_{index}",
-                    label=item.label or f"Item {index + 1}",
+        views = [
+            self._views(rrb, item.view_kinds, origin=item.prefix, label=item.label)
+            for item in items
+        ]
+        if len(views) == 1:
+            return views[0]
+        layout_class = _LAYOUT_CLASS_NAMES.get(self.compose_method)
+        if layout_class is None:
+            raise RuntimeError(f"Unsupported Rerun compose type: {self.compose_method}")
+        return getattr(rrb, layout_class)(*views, name=self.name)
+
+    def _read_items(self) -> list[_ComposedItem]:
+        items = []
+        for index, entry in enumerate(self.container):
+            item = _read_item(
+                entry.path,
+                prefix=f"/item_{index}",
+                label=entry.label or f"Item {index + 1}",
+            )
+            if entry.view_kinds:
+                item.view_kinds = set(entry.view_kinds)
+            items.append(item)
+        return items
+
+    def _send_spliced(self, recording, items: list[_ComposedItem]) -> None:
+        """Send items end to end in time, clearing each one as the next begins."""
+        import rerun as rr
+
+        offsets = _splice_offsets(items)
+        for index, (item, item_offsets) in enumerate(zip(items, offsets)):
+            for chunk in item.chunks:
+                recording.send_chunks(_shifted_chunks(chunk, item_offsets))
+            if index == len(items) - 1 or not item.time_bounds:
+                continue
+            # Rerun queries are latest-at, so without an explicit clear the final
+            # frame of this item would linger underneath the following item.
+            for timeline, (_, last) in item.time_bounds.items():
+                _set_recording_time(
+                    recording,
+                    timeline,
+                    item.time_types[timeline],
+                    last + item_offsets.get(timeline, 0) + _SPLICE_GAP_NS,
                 )
-            )
-
-        if len(layouts) == 1:
-            return layouts[0]
-        match self.compose_method:
-            case ComposeType.right:
-                return rrb.Horizontal(*layouts, name=self.name)
-            case ComposeType.down:
-                return rrb.Vertical(*layouts, name=self.name)
-            case ComposeType.sequence:
-                return rrb.Tabs(*layouts, name=self.name)
-            case _:
-                raise RuntimeError(f"Unsupported Rerun compose type: {self.compose_method}")
+            recording.log(item.prefix, rr.Clear(recursive=True))
+            recording.reset_time()
 
     def render(self, **_kwargs: Any) -> str:
         """Materialize the composition as one path-backed ``.rrd`` artifact."""
@@ -267,41 +418,31 @@ class ComposableContainerRerun(ComposableContainerBase):
         if missing:
             raise FileNotFoundError(f"Rerun recording does not exist: {missing[0]}")
 
+        output = self._output_file()
+
         import rerun as rr
         import rerun.blueprint as rrb
-        from rerun.experimental import RrdReader
 
+        items = self._read_items()
         recording = rr.RecordingStream(
             self.application_id,
             make_default=False,
             make_thread_default=False,
         )
-        item_kinds: list[set[RerunViewKind]] = []
 
-        for index, item in enumerate(self.container):
-            inferred_kinds: set[RerunViewKind] = set()
-            reader = RrdReader(item.path)
-            stores = reader.recordings()
-            if not stores:
-                raise ValueError(f"RRD contains no recording stores: {item.path}")
-
-            namespace_chunk = partial(
-                _namespace_chunk,
-                prefix=f"/item_{index}",
-                kinds=inferred_kinds,
-            )
-            for store in stores:
-                recording.send_chunks(reader.stream(store=store).map(namespace_chunk))
-            item_kinds.append(set(item.view_kinds or inferred_kinds))
+        if self.compose_method == ComposeType.sequence:
+            self._send_spliced(recording, items)
+        else:
+            for item in items:
+                recording.send_chunks(item.chunks)
 
         blueprint = rrb.Blueprint(
-            self._build_blueprint(rrb, item_kinds),
+            self._layout(rrb, items),
             auto_layout=False,
             auto_views=False,
             collapse_panels=True,
         )
         recording.send_blueprint(blueprint, make_active=True, make_default=True)
 
-        output = self._output_file()
         output.write_bytes(recording.memory_recording().drain_as_bytes())
         return str(output)

--- a/bencher/results/composable_container/composable_container_rerun.py
+++ b/bencher/results/composable_container/composable_container_rerun.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
+from functools import partial
+from pathlib import Path
 from typing import Any
+
+from strenum import StrEnum
 
 from bencher.results.composable_container.composable_container_base import (
     ComposableContainerBase,
@@ -9,36 +14,294 @@ from bencher.results.composable_container.composable_container_base import (
 )
 
 
+class RerunViewKind(StrEnum):
+    """Rerun Blueprint view types supported by recording composition."""
+
+    spatial_2d = "spatial_2d"
+    spatial_3d = "spatial_3d"
+    time_series = "time_series"
+    bar_chart = "bar_chart"
+    tensor = "tensor"
+    text_document = "text_document"
+    text_log = "text_log"
+    map = "map"
+    graph = "graph"
+    state_timeline = "state_timeline"
+
+
+@dataclass(frozen=True)
+class RerunRecording:
+    """One recording and its presentation metadata inside a composition."""
+
+    path: str | Path
+    label: str | None = None
+    view_kinds: tuple[RerunViewKind, ...] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", Path(self.path))
+        if self.view_kinds is not None:
+            object.__setattr__(
+                self,
+                "view_kinds",
+                tuple(RerunViewKind(kind) for kind in self.view_kinds),
+            )
+
+
+_ARCHETYPE_VIEW_KINDS = {
+    # Spatial 2D
+    "Arrows2D": RerunViewKind.spatial_2d,
+    "Boxes2D": RerunViewKind.spatial_2d,
+    "DepthImage": RerunViewKind.spatial_2d,
+    "Ellipses2D": RerunViewKind.spatial_2d,
+    "EncodedDepthImage": RerunViewKind.spatial_2d,
+    "EncodedImage": RerunViewKind.spatial_2d,
+    "Image": RerunViewKind.spatial_2d,
+    "LineStrips2D": RerunViewKind.spatial_2d,
+    "Pinhole": RerunViewKind.spatial_2d,
+    "Points2D": RerunViewKind.spatial_2d,
+    "SegmentationImage": RerunViewKind.spatial_2d,
+    "VideoFrameReference": RerunViewKind.spatial_2d,
+    "VideoStream": RerunViewKind.spatial_2d,
+    # Spatial 3D
+    "Arrows3D": RerunViewKind.spatial_3d,
+    "Asset3D": RerunViewKind.spatial_3d,
+    "Boxes3D": RerunViewKind.spatial_3d,
+    "Capsules3D": RerunViewKind.spatial_3d,
+    "CoordinateFrame": RerunViewKind.spatial_3d,
+    "Cylinders3D": RerunViewKind.spatial_3d,
+    "Ellipsoids3D": RerunViewKind.spatial_3d,
+    "GridMap": RerunViewKind.spatial_3d,
+    "InstancePoses3D": RerunViewKind.spatial_3d,
+    "LineStrips3D": RerunViewKind.spatial_3d,
+    "Mesh3D": RerunViewKind.spatial_3d,
+    "Points3D": RerunViewKind.spatial_3d,
+    "Transform3D": RerunViewKind.spatial_3d,
+    "TransformAxes3D": RerunViewKind.spatial_3d,
+    "ViewCoordinates": RerunViewKind.spatial_3d,
+    "VoxelGridMap": RerunViewKind.spatial_3d,
+    # Non-spatial views
+    "BarChart": RerunViewKind.bar_chart,
+    "GraphEdges": RerunViewKind.graph,
+    "GraphNodes": RerunViewKind.graph,
+    "GeoLineStrings": RerunViewKind.map,
+    "GeoPoints": RerunViewKind.map,
+    "Scalars": RerunViewKind.time_series,
+    "SeriesLines": RerunViewKind.time_series,
+    "SeriesPoints": RerunViewKind.time_series,
+    "StateChange": RerunViewKind.state_timeline,
+    "StateConfiguration": RerunViewKind.state_timeline,
+    "Tensor": RerunViewKind.tensor,
+    "TextDocument": RerunViewKind.text_document,
+    "TextLog": RerunViewKind.text_log,
+}
+
+_VIEW_NAMES = {
+    RerunViewKind.spatial_2d: "2D",
+    RerunViewKind.spatial_3d: "3D",
+    RerunViewKind.time_series: "Time series",
+    RerunViewKind.bar_chart: "Bar chart",
+    RerunViewKind.tensor: "Tensor",
+    RerunViewKind.text_document: "Document",
+    RerunViewKind.text_log: "Log",
+    RerunViewKind.map: "Map",
+    RerunViewKind.graph: "Graph",
+    RerunViewKind.state_timeline: "State timeline",
+}
+
+
+def _infer_chunk_view_kinds(chunk) -> set[RerunViewKind]:
+    kinds = set()
+    for arrow_field in chunk.to_record_batch().schema:
+        metadata = arrow_field.metadata or {}
+        archetype = metadata.get(b"rerun:archetype")
+        if archetype is None:
+            continue
+        archetype_name = archetype.decode().rsplit(".", maxsplit=1)[-1]
+        kind = _ARCHETYPE_VIEW_KINDS.get(archetype_name)
+        if kind is not None:
+            kinds.add(kind)
+    return kinds
+
+
+def _ordered_view_kinds(kinds: Iterable[RerunViewKind]) -> list[RerunViewKind]:
+    selected = set(kinds)
+    return [kind for kind in RerunViewKind if kind in selected]
+
+
+def _namespace_chunk(chunk, *, prefix: str, kinds: set[RerunViewKind]):
+    kinds.update(_infer_chunk_view_kinds(chunk))
+    source_path = str(chunk.entity_path).lstrip("/")
+    return chunk.with_entity_path(f"{prefix}/{source_path}")
+
+
+def _blueprint_view(rrb, kind: RerunViewKind, *, origin: str, name: str):
+    view_classes = {
+        RerunViewKind.spatial_2d: rrb.Spatial2DView,
+        RerunViewKind.spatial_3d: rrb.Spatial3DView,
+        RerunViewKind.time_series: rrb.TimeSeriesView,
+        RerunViewKind.bar_chart: rrb.BarChartView,
+        RerunViewKind.tensor: rrb.TensorView,
+        RerunViewKind.text_document: rrb.TextDocumentView,
+        RerunViewKind.text_log: rrb.TextLogView,
+        RerunViewKind.map: rrb.MapView,
+        RerunViewKind.graph: rrb.GraphView,
+        RerunViewKind.state_timeline: rrb.StateTimelineView,
+    }
+    return view_classes[kind](origin=origin, name=name)
+
+
+def _blueprint_views(rrb, kinds: Iterable[RerunViewKind], *, origin: str, label: str):
+    ordered = _ordered_view_kinds(kinds)
+    if not ordered:
+        ordered = [RerunViewKind.spatial_2d]
+    views = [
+        _blueprint_view(
+            rrb,
+            kind,
+            origin=origin,
+            name=label if len(ordered) == 1 else f"{label} — {_VIEW_NAMES[kind]}",
+        )
+        for kind in ordered
+    ]
+    if len(views) == 1:
+        return views[0]
+    return rrb.Vertical(*views, name=label)
+
+
 @dataclass(kw_only=True)
 class ComposableContainerRerun(ComposableContainerBase):
-    """Composable container that maps ComposeType to rerun blueprint containers.
+    """Combine complete Rerun recordings into one recording and Blueprint.
 
-    - ``right``    -> ``rrb.Horizontal`` (side by side)
-    - ``down``     -> ``rrb.Vertical`` (stacked)
-    - ``sequence`` -> ``rrb.Vertical`` (stacked; timeline semantics not yet implemented)
-    - ``overlay``  -> ``rrb.Vertical`` (stacked; same-entity-path overlay not yet implemented)
+    Input entity paths are namespaced under ``/item_N`` before being forwarded
+    into a new recording. The generated Blueprint maps Bencher composition onto
+    Rerun as follows:
+
+    - ``right`` -> ``rrb.Horizontal``
+    - ``down`` -> ``rrb.Vertical``
+    - ``sequence`` -> ``rrb.Tabs``
+    - ``overlay`` -> shared views rooted at ``/``
+
+    View types are inferred from Rerun archetype metadata. Pass ``view_kinds`` to
+    :meth:`append` when a recording needs an explicit override.
     """
 
-    container: list[Any] = field(default_factory=list)
+    container: list[RerunRecording] = field(default_factory=list)
+    output_path: str | Path | None = None
+    name: str | None = None
+    application_id: str = "bencher/composed"
 
-    def render(self):
-        """Return a rerun blueprint container matching the compose method."""
-        import rerun.blueprint as rrb
+    def append(
+        self,
+        obj: str | Path | RerunRecording,
+        *,
+        label: str | None = None,
+        view_kinds: Iterable[RerunViewKind | str] | None = None,
+    ) -> None:
+        """Append an RRD path or a recording value with optional view metadata."""
+        if isinstance(obj, RerunRecording):
+            if label is not None or view_kinds is not None:
+                raise ValueError(
+                    "label and view_kinds must be set on RerunRecording or append(), not both"
+                )
+            item = obj
+        else:
+            kinds = (
+                tuple(RerunViewKind(kind) for kind in view_kinds)
+                if view_kinds is not None
+                else None
+            )
+            item = RerunRecording(path=obj, label=label, view_kinds=kinds)
+        self.container.append(item)
 
-        items = self.container
-        if not items:
-            return rrb.Vertical()
+    def _output_file(self) -> Path:
+        if self.output_path is not None:
+            output = Path(self.output_path)
+            if output.suffix.lower() != ".rrd":
+                raise ValueError("Rerun composition output_path must end in .rrd")
+            output.parent.mkdir(parents=True, exist_ok=True)
+            return output
 
+        from bencher.utils import gen_rerun_data_path
+
+        return Path(gen_rerun_data_path("composed"))
+
+    def _build_blueprint(self, rrb, item_kinds: list[set[RerunViewKind]]):
+        if self.compose_method == ComposeType.overlay:
+            all_kinds = set().union(*item_kinds)
+            return _blueprint_views(
+                rrb,
+                all_kinds,
+                origin="/",
+                label=self.name or "Overlay",
+            )
+
+        layouts = []
+        for index, (item, kinds) in enumerate(zip(self.container, item_kinds)):
+            layouts.append(
+                _blueprint_views(
+                    rrb,
+                    kinds,
+                    origin=f"/item_{index}",
+                    label=item.label or f"Item {index + 1}",
+                )
+            )
+
+        if len(layouts) == 1:
+            return layouts[0]
         match self.compose_method:
             case ComposeType.right:
-                return rrb.Horizontal(*items)
+                return rrb.Horizontal(*layouts, name=self.name)
             case ComposeType.down:
-                return rrb.Vertical(*items)
+                return rrb.Vertical(*layouts, name=self.name)
             case ComposeType.sequence:
-                # Temporal sequence: items share the same view, differentiated by timeline
-                return rrb.Vertical(*items)
-            case ComposeType.overlay:
-                # Overlay: items logged to the same entity path in the same view
-                return rrb.Vertical(*items)
+                return rrb.Tabs(*layouts, name=self.name)
             case _:
-                return rrb.Vertical(*items)
+                raise RuntimeError(f"Unsupported Rerun compose type: {self.compose_method}")
+
+    def render(self, **_kwargs: Any) -> str:
+        """Materialize the composition as one path-backed ``.rrd`` artifact."""
+        if not self.container:
+            raise ValueError("Cannot render an empty ComposableContainerRerun")
+
+        missing = [Path(item.path) for item in self.container if not Path(item.path).is_file()]
+        if missing:
+            raise FileNotFoundError(f"Rerun recording does not exist: {missing[0]}")
+
+        import rerun as rr
+        import rerun.blueprint as rrb
+        from rerun.experimental import RrdReader
+
+        recording = rr.RecordingStream(
+            self.application_id,
+            make_default=False,
+            make_thread_default=False,
+        )
+        item_kinds: list[set[RerunViewKind]] = []
+
+        for index, item in enumerate(self.container):
+            inferred_kinds: set[RerunViewKind] = set()
+            reader = RrdReader(item.path)
+            stores = reader.recordings()
+            if not stores:
+                raise ValueError(f"RRD contains no recording stores: {item.path}")
+
+            namespace_chunk = partial(
+                _namespace_chunk,
+                prefix=f"/item_{index}",
+                kinds=inferred_kinds,
+            )
+            for store in stores:
+                recording.send_chunks(reader.stream(store=store).map(namespace_chunk))
+            item_kinds.append(set(item.view_kinds or inferred_kinds))
+
+        blueprint = rrb.Blueprint(
+            self._build_blueprint(rrb, item_kinds),
+            auto_layout=False,
+            auto_views=False,
+            collapse_panels=True,
+        )
+        recording.send_blueprint(blueprint, make_active=True, make_default=True)
+
+        output = self._output_file()
+        output.write_bytes(recording.memory_recording().drain_as_bytes())
+        return str(output)

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -356,7 +356,9 @@ class ResultRerun(ResultContainer):
 
     Stores a path to an .rrd file (like ResultContainer) but carries viewer
     sizing metadata and provides a dedicated ``to_container()`` that renders
-    the file with the rerun web viewer.
+    the file with the rerun web viewer. A ``ComposableContainerRerun`` can also
+    be assigned directly; result collection materializes it to one .rrd file
+    before caching.
 
     Usage in a ParametrizedSweep::
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -310,9 +310,12 @@ supports four composition methods:
 
 Different backends implement these operations: `ComposableContainerPanel` uses Panel's `Row`
 and `Column` widgets for interactive dashboards, `ComposableContainerVideo` uses `moviepy` for
-video compositing, and `ComposableContainerDataset` uses `xr.concat` for data merging.
+video compositing, `ComposableContainerDataset` uses `xr.concat` for data merging, and
+`ComposableContainerRerun` namespaces and merges complete Rerun recordings while generating
+native Horizontal, Vertical, Tabs, or shared-view Blueprints.
 See the [Composable Containers gallery](reference/meta/composable_containers/index) for
-interactive examples of each backend and composition mode.
+interactive examples of each backend and composition mode, and the
+[Rerun Integration gallery](reference/meta/rerun/index) for recording composition.
 
 ## Automatic Plot Selection
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -312,7 +312,9 @@ Different backends implement these operations: `ComposableContainerPanel` uses P
 and `Column` widgets for interactive dashboards, `ComposableContainerVideo` uses `moviepy` for
 video compositing, `ComposableContainerDataset` uses `xr.concat` for data merging, and
 `ComposableContainerRerun` namespaces and merges complete Rerun recordings while generating
-native Horizontal, Vertical, Tabs, or shared-view Blueprints.
+a native Blueprint: Horizontal (`right`) and Vertical (`down`) give each recording its own
+view on a shared timeline, `overlay` draws them all in one view at their original times, and
+`sequence` splices their timelines end to end so one view plays them back to back.
 See the [Composable Containers gallery](reference/meta/composable_containers/index) for
 interactive examples of each backend and composition mode, and the
 [Rerun Integration gallery](reference/meta/rerun/index) for recording composition.

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -230,7 +230,11 @@ self.scene = combined
 ```
 
 The four composition methods map to horizontal views (`right`), vertical views
-(`down`), tabs (`sequence`), and compatible entities in shared views (`overlay`).
+(`down`), one shared view showing every recording at its original times
+(`overlay`), and one shared view whose timelines are spliced end to end so the
+recordings play one after the other (`sequence`). `sequence` needs recordings with
+data on a timeline — it offsets each recording's index values to start where the
+previous one ended, and clears each recording as the next begins.
 View types are inferred from recorded archetypes; pass `view_kinds=` to `append()`
 to override inference. See the
 [Rerun Integration gallery](reference/meta/rerun/index) for complete examples.

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -128,6 +128,7 @@ demo.
 | `bn.ResultVideo()` | Videos | `self.vid = video_writer.write()` |
 | `bn.ResultPath()` | Downloadable file outputs | `self.artifact = "/path/to/file"` |
 | `bn.ResultContainer()` | Embeddable HTML/panel content | `self.widget = pane` |
+| `bn.ResultRerun()` | Rerun recording or composition | `self.scene = path_or_compositor` |
 | `bn.ResultVec(size=3)` | Fixed-size vector results (x, y, z) | `self.position = [1.0, 2.0, 3.0]` |
 | `bn.ResultDataSet()` | Any picklable data payload per sample | `self.data = bn.ResultDataSet(payload)` |
 
@@ -215,6 +216,24 @@ For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
 See the [ResultImage gallery](reference/meta/result_types/result_image/index) and
 [ResultVideo gallery](reference/meta/result_types/result_video/index) for working examples.
+
+For Rerun recordings, assign the path returned by `bn.capture_rerun_rrd()` to a
+`bn.ResultRerun`. To combine complete recordings, assign a
+`bn.ComposableContainerRerun` directly; Bencher materializes it into one namespaced
+recording and native Rerun Blueprint before caching:
+
+```python
+combined = bn.ComposableContainerRerun(compose_method=bn.ComposeType.right)
+combined.append(reference_rrd, label="Reference")
+combined.append(candidate_rrd, label="Candidate")
+self.scene = combined
+```
+
+The four composition methods map to horizontal views (`right`), vertical views
+(`down`), tabs (`sequence`), and compatible entities in shared views (`overlay`).
+View types are inferred from recorded archetypes; pass `view_kinds=` to `append()`
+to override inference. See the
+[Rerun Integration gallery](reference/meta/rerun/index) for complete examples.
 
 ## Running a Sweep
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,6 +1,12 @@
 version: 7
 platforms:
-- name: linux-64
+- name: p1
+  subdir: linux-64
+  virtual-packages:
+  - __glibc=2.31
+  - __unix=0=0
+  - __linux=4.18
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -9,7 +15,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -40,20 +46,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -101,6 +105,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
@@ -137,6 +142,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
@@ -181,7 +187,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -212,7 +218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -220,13 +226,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -277,6 +281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/75/f2/6b7627dfe7b4e418e295e254bb15c3a6455f11f8c0ad0d43113f678049c3/sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/85/749bd22d1a68db7291c89e2ebca53f4306c3f205853cf31e9de279034c3c/sphinxcontrib_jquery-4.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
@@ -317,6 +322,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
@@ -362,7 +368,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -393,19 +399,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -453,6 +457,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
@@ -491,6 +496,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -536,7 +542,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -568,7 +574,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
@@ -578,13 +584,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/43/a81f20050a3115b57d62c8e781446949512eac36690dc384ccea65ff4cc1/fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -633,6 +637,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
@@ -667,6 +672,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
@@ -709,7 +715,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -741,7 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -749,13 +755,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -803,6 +807,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/81/f642ac08104049383076f83480ed412c9626e068769a1c34873c595bec0e/psygnal-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
@@ -837,6 +842,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
@@ -882,7 +888,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -913,20 +919,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
@@ -974,6 +978,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
@@ -1010,6 +1015,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
@@ -1607,7 +1613,7 @@ packages:
   run_exports: {}
   size: 27468597
   timestamp: 1767671008593
-- pypi: .
+- pypi: ./
   name: holobench
   requires_dist:
   - holoviews>=1.15,<=1.23.1
@@ -1618,7 +1624,7 @@ packages:
   - diskcache>=5.6,<=5.6.3
   - optuna>=3.2,<=4.9.0
   - xarray>=2023.7,<=2026.4.0
-  - plotly>=5.15,<=6.8.0
+  - plotly>=5.15,<=6.9.0
   - pandas>=2.0,<=3.0.3
   - strenum>=0.4.0,<=0.4.15
   - scikit-learn>=1.2,<=1.9.0
@@ -1633,12 +1639,12 @@ packages:
   - pylint>=3.2.5,<=4.0.6 ; extra == 'test'
   - pytest-cov>=4.1,<=7.1.0 ; extra == 'test'
   - pytest>=7.4,<=9.1.1 ; extra == 'test'
-  - hypothesis>=6.104.2,<=6.156.1 ; extra == 'test'
+  - hypothesis>=6.104.2,<=6.163.0 ; extra == 'test'
   - ruff>=0.5.0,<=0.16.0 ; extra == 'test'
   - sphinxcontrib-mermaid>=1.0,<3.0 ; extra == 'test'
-  - coverage>=7.5.4,<=7.15.0 ; extra == 'test'
+  - coverage>=7.5.4,<=7.15.2 ; extra == 'test'
   - prek>=0.2.28,<0.5.0 ; extra == 'test'
-  - ty>=0.0.13,<=0.0.56 ; extra == 'test'
+  - ty>=0.0.13,<=0.0.64 ; extra == 'test'
   - sphinx>=7.0,<=9.1.0 ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   - sphinxcontrib-napoleon ; extra == 'docs'
@@ -1647,8 +1653,8 @@ packages:
   - sphinx-copybutton ; extra == 'docs'
   - playwright ; extra == 'docs'
   - pillow ; extra == 'docs'
-  - rerun-sdk>=0.32.0,<=0.34.0 ; extra == 'rerun'
-  - rerun-notebook>=0.32.0,<=0.34.0 ; extra == 'rerun'
+  - rerun-sdk>=0.32.0,<=0.35.0 ; extra == 'rerun'
+  - rerun-notebook>=0.32.0,<=0.35.0 ; extra == 'rerun'
   requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek
@@ -1847,47 +1853,6 @@ packages:
   sha256: 1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a
   requires_dist:
   - click>=5.0 ; extra == 'cli'
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/0e/10/dda8cbcc4fc82eeff6cbf84042f7979f329fd768a010c47d5f11e855fb9b/rerun_sdk-0.34.0-cp310-abi3-manylinux_2_28_x86_64.whl
-  name: rerun-sdk
-  version: 0.34.0
-  sha256: 75b87269a839aa2e3aeb0b1fbfb06c7f1e86d833fc63b92dd1935964476987e5
-  requires_dist:
-  - attrs>=23.1.0
-  - numpy>=2
-  - pillow>=8.0.0
-  - psutil>=7.0
-  - pyarrow>=18.0.0
-  - typing-extensions>=4.5
-  - av>=14.2.0 ; extra == 'tests'
-  - inline-snapshot==0.31.1 ; extra == 'tests'
-  - opencv-python>4.6 ; extra == 'tests'
-  - pandas>=2 ; extra == 'tests'
-  - polars==1.36.1 ; extra == 'tests'
-  - pytest==9.0.3 ; extra == 'tests'
-  - semver>=3.0,<3.1 ; extra == 'tests'
-  - syrupy==5.0.0 ; extra == 'tests'
-  - tomli==2.0.1 ; extra == 'tests'
-  - torch>=2.5 ; extra == 'tests'
-  - torchvision ; extra == 'tests'
-  - datafusion==53.0.0 ; extra == 'tests'
-  - rerun-notebook==0.34.0 ; extra == 'notebook'
-  - datafusion==53.0.0 ; extra == 'datafusion'
-  - pandas>=2 ; extra == 'datafusion'
-  - datafusion==53.0.0 ; extra == 'dataplatform'
-  - pandas>=2 ; extra == 'dataplatform'
-  - datafusion==53.0.0 ; extra == 'catalog'
-  - pandas>=2 ; extra == 'catalog'
-  - torch>=2.5 ; extra == 'dataloader'
-  - torchvision ; extra == 'dataloader'
-  - av ; extra == 'dataloader'
-  - pillow>=8.0.0 ; extra == 'dataloader'
-  - opentelemetry-api ; extra == 'tracing'
-  - opentelemetry-sdk ; extra == 'tracing'
-  - opentelemetry-exporter-otlp-proto-grpc ; extra == 'tracing'
-  - datafusion==53.0.0 ; extra == 'all'
-  - pandas>=2 ; extra == 'all'
-  - rerun-notebook==0.34.0 ; extra == 'all'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
   name: pyparsing
@@ -2155,18 +2120,6 @@ packages:
   - pytest-rerunfailures<16.0 ; extra == 'tests'
   - pytest-xdist ; extra == 'tests'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/1a/01/11311714987ec75e80d45127c8b22d606fa39e854291beb9fcde60403e13/rerun_notebook-0.34.0-py2.py3-none-any.whl
-  name: rerun-notebook
-  version: 0.34.0
-  sha256: cd684e96cfeed60fa9bf693920644e952fc9a768f6b3a5a1add97bcdcf77bd5c
-  requires_dist:
-  - anywidget
-  - ipykernel<7.0.0
-  - jupyter-ui-poll
-  - hatch ; extra == 'dev'
-  - jupyterlab ; extra == 'dev'
-  - watchfiles ; extra == 'dev'
-  - pytest>=8.0 ; extra == 'test'
 - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
   name: colorcet
   version: 3.2.1
@@ -3579,6 +3532,18 @@ packages:
   - psutil ; extra == 'test'
   - setuptools ; extra == 'test'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
+  name: rerun-notebook
+  version: 0.35.0
+  sha256: 3cc847cffad3077c883a0f3483f76dfe4b6ae291d9ea136b098765a7bd1d70e2
+  requires_dist:
+  - anywidget
+  - ipykernel!=7.0.*
+  - jupyter-ui-poll
+  - hatch ; extra == 'dev'
+  - jupyterlab ; extra == 'dev'
+  - watchfiles ; extra == 'dev'
+  - pytest>=8.0 ; extra == 'test'
 - pypi: https://files.pythonhosted.org/packages/79/81/f642ac08104049383076f83480ed412c9626e068769a1c34873c595bec0e/psygnal-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: psygnal
   version: 0.15.1
@@ -4451,6 +4416,47 @@ packages:
   requires_dist:
   - typing-extensions>=4 ; python_full_version < '3.11'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
+  name: rerun-sdk
+  version: 0.35.0
+  sha256: 9297dd2a856ffd241d78ab70df05a9a5fc1355456949a3ac0fdae32344c6cc5f
+  requires_dist:
+  - attrs>=23.1.0
+  - numpy>=2
+  - pillow>=8.0.0
+  - psutil>=7.0
+  - pyarrow>=18.0.0
+  - typing-extensions>=4.5
+  - datafusion==53.0.0 ; extra == 'all'
+  - pandas>=2 ; extra == 'all'
+  - rerun-notebook==0.35.0 ; extra == 'all'
+  - datafusion==53.0.0 ; extra == 'catalog'
+  - pandas>=2 ; extra == 'catalog'
+  - datafusion==53.0.0 ; extra == 'datafusion'
+  - pandas>=2 ; extra == 'datafusion'
+  - torch>=2.5 ; extra == 'dataloader'
+  - torchvision ; extra == 'dataloader'
+  - av ; extra == 'dataloader'
+  - pillow>=8.0.0 ; extra == 'dataloader'
+  - datafusion==53.0.0 ; extra == 'dataplatform'
+  - pandas>=2 ; extra == 'dataplatform'
+  - rerun-notebook==0.35.0 ; extra == 'notebook'
+  - av>=14.2.0 ; extra == 'tests'
+  - inline-snapshot==0.31.1 ; extra == 'tests'
+  - opencv-python>4.6 ; extra == 'tests'
+  - pandas>=2 ; extra == 'tests'
+  - polars==1.36.1 ; extra == 'tests'
+  - pytest==9.0.3 ; extra == 'tests'
+  - semver>=3.0,<3.1 ; extra == 'tests'
+  - syrupy==5.0.0 ; extra == 'tests'
+  - tomli==2.0.1 ; extra == 'tests'
+  - torch>=2.5 ; extra == 'tests'
+  - torchvision ; extra == 'tests'
+  - datafusion==53.0.0 ; extra == 'tests'
+  - opentelemetry-api ; extra == 'tracing'
+  - opentelemetry-sdk ; extra == 'tracing'
+  - opentelemetry-exporter-otlp-proto-grpc ; extra == 'tracing'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b1/c4/2a6fe5111a01005fc7af3878259ce17684fabb8852815eda6225620f3c59/pyzmq-27.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
   name: pyzmq
   version: 27.1.0

--- a/test/test_composable_container_rerun.py
+++ b/test/test_composable_container_rerun.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+
+import pytest
+import rerun as rr
+from rerun.experimental import RrdReader
+
+import bencher as bn
+from bencher.result_collector import _materialize_result_value
+from bencher.results.composable_container.composable_container_base import ComposeType
+from bencher.results.composable_container.composable_container_rerun import (
+    ComposableContainerRerun,
+    RerunRecording,
+    RerunViewKind,
+)
+from bencher.variables.results import ResultRerun
+
+
+def _write_recording(tmp_path: Path, name: str, *archetypes) -> Path:
+    recording = rr.RecordingStream(name, make_default=False)
+    for entity_path, archetype in archetypes:
+        recording.log(entity_path, archetype)
+    path = tmp_path / f"{name}.rrd"
+    path.write_bytes(recording.memory_recording().drain_as_bytes())
+    return path
+
+
+def _recording_entity_paths(path: str | Path) -> set[str]:
+    reader = RrdReader(path)
+    assert len(reader.recordings()) == 1
+    return {str(chunk.entity_path) for chunk in reader.stream(store=reader.recordings()[0])}
+
+
+def _blueprint_column_values(path: str | Path, column_name: str) -> list:
+    reader = RrdReader(path)
+    assert len(reader.blueprints()) == 1
+    values = []
+    for chunk in reader.stream(store=reader.blueprints()[0]):
+        batch = chunk.to_record_batch()
+        if column_name in batch.schema.names:
+            values.extend(batch.column(batch.schema.get_field_index(column_name)).to_pylist())
+    return values
+
+
+@pytest.mark.parametrize(
+    ("compose_method", "expected_container_kind"),
+    [
+        (ComposeType.right, 2),
+        (ComposeType.down, 3),
+        (ComposeType.sequence, 1),
+    ],
+)
+def test_composes_recordings_with_blueprint_layout(
+    tmp_path, compose_method, expected_container_kind
+):
+    left = _write_recording(tmp_path, "left", ("points", rr.Points2D([[0, 0]])))
+    right = _write_recording(tmp_path, "right", ("points", rr.Points2D([[1, 1]])))
+    output = tmp_path / f"{compose_method}.rrd"
+
+    container = ComposableContainerRerun(
+        compose_method=compose_method,
+        output_path=output,
+        name=f"{compose_method} composition",
+    )
+    container.append(left, label="Left")
+    container.append(right, label="Right")
+
+    assert container.render() == str(output)
+    assert output.is_file()
+    assert {"/item_0/points", "/item_1/points"} <= _recording_entity_paths(output)
+    origins = _blueprint_column_values(output, "ViewBlueprint:space_origin")
+    assert {value[0] for value in origins} == {"/item_0", "/item_1"}
+    container_kinds = _blueprint_column_values(output, "ContainerBlueprint:container_kind")
+    assert [expected_container_kind] in container_kinds
+
+
+def test_overlay_uses_one_shared_view(tmp_path):
+    first = _write_recording(tmp_path, "first", ("points", rr.Points2D([[0, 0]])))
+    second = _write_recording(tmp_path, "second", ("boxes", rr.Boxes2D(half_sizes=[[1, 1]])))
+    output = tmp_path / "overlay.rrd"
+
+    container = ComposableContainerRerun(
+        compose_method=ComposeType.overlay,
+        output_path=output,
+    )
+    container.append(first)
+    container.append(second)
+    container.render()
+
+    assert {"/item_0/points", "/item_1/boxes"} <= _recording_entity_paths(output)
+    assert _blueprint_column_values(output, "ViewBlueprint:space_origin") == [["/"]]
+    assert _blueprint_column_values(output, "ViewBlueprint:class_identifier") == [["2D"]]
+
+
+def test_infers_multiple_view_kinds(tmp_path):
+    source = _write_recording(
+        tmp_path,
+        "mixed",
+        ("scene/points", rr.Points3D([[0, 0, 0]])),
+        ("metrics/loss", rr.Scalars(0.5)),
+    )
+    output = tmp_path / "mixed-output.rrd"
+
+    container = ComposableContainerRerun(output_path=output)
+    container.append(source, label="Mixed")
+    container.render()
+
+    identifiers = _blueprint_column_values(output, "ViewBlueprint:class_identifier")
+    assert {value[0] for value in identifiers} == {"3D", "TimeSeries"}
+
+
+def test_view_kind_can_be_overridden(tmp_path):
+    source = _write_recording(tmp_path, "source", ("points", rr.Points2D([[0, 0]])))
+    output = tmp_path / "override.rrd"
+
+    container = ComposableContainerRerun(output_path=output)
+    container.append(source, view_kinds=[RerunViewKind.spatial_3d])
+    container.render()
+
+    assert _blueprint_column_values(output, "ViewBlueprint:class_identifier") == [["3D"]]
+
+
+def test_accepts_recording_value_object(tmp_path):
+    source = _write_recording(tmp_path, "source", ("points", rr.Points2D([[0, 0]])))
+    output = tmp_path / "value-object.rrd"
+    item = RerunRecording(source, label="Source", view_kinds=(RerunViewKind.spatial_2d,))
+
+    container = ComposableContainerRerun(output_path=output)
+    container.append(item)
+
+    assert Path(container.render()).is_file()
+
+
+def test_empty_container_is_rejected(tmp_path):
+    container = ComposableContainerRerun(output_path=tmp_path / "empty.rrd")
+
+    with pytest.raises(ValueError, match="empty"):
+        container.render()
+
+
+def test_missing_recording_is_rejected(tmp_path):
+    container = ComposableContainerRerun(output_path=tmp_path / "output.rrd")
+    container.append(tmp_path / "missing.rrd")
+
+    with pytest.raises(FileNotFoundError, match="missing.rrd"):
+        container.render()
+
+
+def test_result_rerun_materializes_composable_container(tmp_path):
+    source = _write_recording(tmp_path, "source", ("points", rr.Points2D([[0, 0]])))
+    output = tmp_path / "materialized.rrd"
+    container = ComposableContainerRerun(output_path=output)
+    container.append(source)
+
+    result = _materialize_result_value(ResultRerun(), container)
+
+    assert result == str(output)
+    assert output.is_file()
+
+
+def test_public_api_exports_rerun_composition_types():
+    assert bn.ComposableContainerRerun is ComposableContainerRerun
+    assert bn.RerunRecording is RerunRecording
+    assert bn.RerunViewKind is RerunViewKind

--- a/test/test_composable_container_rerun.py
+++ b/test/test_composable_container_rerun.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 import rerun as rr
+from rerun.blueprint.components import ContainerKind
 from rerun.experimental import RrdReader
 
 import bencher as bn
@@ -11,6 +12,7 @@ from bencher.results.composable_container.composable_container_rerun import (
     ComposableContainerRerun,
     RerunRecording,
     RerunViewKind,
+    _batch_time_bounds,
 )
 from bencher.variables.results import ResultRerun
 
@@ -22,6 +24,34 @@ def _write_recording(tmp_path: Path, name: str, *archetypes) -> Path:
     path = tmp_path / f"{name}.rrd"
     path.write_bytes(recording.memory_recording().drain_as_bytes())
     return path
+
+
+def _write_temporal_recording(tmp_path: Path, name: str, *, steps: int = 4) -> Path:
+    """Write a recording that spans ``steps`` ticks of a ``frame`` sequence timeline."""
+    recording = rr.RecordingStream(name, make_default=False)
+    for step in range(steps):
+        recording.set_time("frame", sequence=step)
+        recording.log("points", rr.Points2D([[step, step]]))
+    path = tmp_path / f"{name}.rrd"
+    path.write_bytes(recording.memory_recording().drain_as_bytes())
+    return path
+
+
+def _recording_time_bounds(path: str | Path, timeline: str) -> dict[str, tuple[int, int]]:
+    """Return ``{entity_path: (first, last)}`` on ``timeline`` for a composed recording."""
+    reader = RrdReader(path)
+    bounds = {}
+    for chunk in reader.stream(store=reader.recordings()[0]):
+        chunk_bounds = _batch_time_bounds(chunk.to_record_batch()).get(timeline)
+        if chunk_bounds is None:
+            continue
+        entity_path = str(chunk.entity_path)
+        existing = bounds.get(entity_path, chunk_bounds)
+        bounds[entity_path] = (
+            min(existing[0], chunk_bounds[0]),
+            max(existing[1], chunk_bounds[1]),
+        )
+    return bounds
 
 
 def _recording_entity_paths(path: str | Path) -> set[str]:
@@ -41,12 +71,20 @@ def _blueprint_column_values(path: str | Path, column_name: str) -> list:
     return values
 
 
+def _container_kinds(path: str | Path) -> set[str]:
+    """Return the Blueprint container kinds by name (``Horizontal``, ``Vertical``, …)."""
+    return {
+        ContainerKind(value).name
+        for values in _blueprint_column_values(path, "ContainerBlueprint:container_kind")
+        for value in values
+    }
+
+
 @pytest.mark.parametrize(
     ("compose_method", "expected_container_kind"),
     [
-        (ComposeType.right, 2),
-        (ComposeType.down, 3),
-        (ComposeType.sequence, 1),
+        (ComposeType.right, "Horizontal"),
+        (ComposeType.down, "Vertical"),
     ],
 )
 def test_composes_recordings_with_blueprint_layout(
@@ -69,8 +107,51 @@ def test_composes_recordings_with_blueprint_layout(
     assert {"/item_0/points", "/item_1/points"} <= _recording_entity_paths(output)
     origins = _blueprint_column_values(output, "ViewBlueprint:space_origin")
     assert {value[0] for value in origins} == {"/item_0", "/item_1"}
-    container_kinds = _blueprint_column_values(output, "ContainerBlueprint:container_kind")
-    assert [expected_container_kind] in container_kinds
+    assert expected_container_kind in _container_kinds(output)
+
+
+def test_sequence_splices_recordings_end_to_end(tmp_path):
+    first = _write_temporal_recording(tmp_path, "first", steps=4)
+    second = _write_temporal_recording(tmp_path, "second", steps=3)
+    output = tmp_path / "sequence.rrd"
+
+    container = ComposableContainerRerun(
+        compose_method=ComposeType.sequence,
+        output_path=output,
+        name="Sequence composition",
+    )
+    container.append(first, label="First")
+    container.append(second, label="Second")
+    container.render()
+
+    bounds = _recording_time_bounds(output, "frame")
+    # The first recording keeps its own times; the second starts after it ends.
+    assert bounds["/item_0/points"] == (0, 3)
+    assert bounds["/item_1/points"] == (4, 6)
+    # Every item but the last is cleared so it does not linger under the next one.
+    assert bounds["/item_0"] == (4, 4)
+    assert "/item_1" not in bounds
+    # One shared view, so playing the timeline runs the items back to back.
+    assert _blueprint_column_values(output, "ViewBlueprint:space_origin") == [["/"]]
+
+
+def test_sequence_preserves_original_times_under_overlay(tmp_path):
+    """``overlay`` is the same layout as ``sequence`` but leaves the times alone."""
+    first = _write_temporal_recording(tmp_path, "first", steps=4)
+    second = _write_temporal_recording(tmp_path, "second", steps=3)
+    output = tmp_path / "overlay-times.rrd"
+
+    container = ComposableContainerRerun(
+        compose_method=ComposeType.overlay,
+        output_path=output,
+    )
+    container.append(first)
+    container.append(second)
+    container.render()
+
+    bounds = _recording_time_bounds(output, "frame")
+    assert bounds["/item_0/points"] == (0, 3)
+    assert bounds["/item_1/points"] == (0, 2)
 
 
 def test_overlay_uses_one_shared_view(tmp_path):
@@ -143,6 +224,23 @@ def test_missing_recording_is_rejected(tmp_path):
 
     with pytest.raises(FileNotFoundError, match="missing.rrd"):
         container.render()
+
+
+def test_output_path_must_be_an_rrd(tmp_path):
+    source = _write_recording(tmp_path, "source", ("points", rr.Points2D([[0, 0]])))
+    container = ComposableContainerRerun(output_path=tmp_path / "output.mp4")
+    container.append(source)
+
+    with pytest.raises(ValueError, match="must end in .rrd"):
+        container.render()
+
+
+def test_append_rejects_duplicate_metadata(tmp_path):
+    item = RerunRecording(tmp_path / "source.rrd", label="Source")
+    container = ComposableContainerRerun()
+
+    with pytest.raises(ValueError, match="not both"):
+        container.append(item, label="Other")
 
 
 def test_result_rerun_materializes_composable_container(tmp_path):


### PR DESCRIPTION
## Summary

- turn ComposableContainerRerun into a path-backed compositor that merges complete RRD recordings into one cacheable ResultRerun artifact
- namespace input entity paths, infer Blueprint view types from archetype metadata, and support explicit view overrides
- map right/down/sequence/overlay to Horizontal, Vertical, Tabs, and shared-view Rerun Blueprints
- expose the Rerun composition API and materialize deferred compositions during result collection
- add four generated Rerun gallery examples plus user documentation
- update the lockfile to Rerun SDK and notebook 0.35.0

## TDD and validation

- added focused tests for recording merge, layouts, overlay, view inference and override, validation, materialization, and public exports
- pixi run --locked pytest -q test/test_composable_container_rerun.py test/test_generated_examples.py -k composable_container_rerun\ or\ rerun_composable (15 passed)
- pixi run --locked ci (2078 passed, 3 skipped; 89% coverage)
- pixi run --locked generate-docs (167 generated examples)
- pixi run --locked -e docs docs-quick (HTML build succeeded; repository has 351 existing Sphinx warnings)

## Summary by Sourcery

Introduce path-backed Rerun recording composition that merges multiple .rrd recordings into a single cacheable ResultRerun artifact with native Blueprint layouts.

New Features:
- Add RerunRecording and RerunViewKind types to describe individual recordings and supported Blueprint view kinds.
- Implement ComposableContainerRerun as a compositor that namespaces and merges full Rerun recordings into one output .rrd with Horizontal, Vertical, Tabs, or shared-view layouts.
- Allow ResultRerun to accept a ComposableContainerRerun directly and automatically materialize it into a stored .rrd during result collection.
- Generate four new Rerun gallery examples demonstrating right, down, sequence, and overlay compositions.

Enhancements:
- Infer Rerun Blueprint view types from archetype metadata with optional explicit overrides when composing recordings.
- Extend meta-example generation and public API exports to include Rerun composition types and their usage.
- Clarify documentation for ResultRerun and composable containers, including Rerun-specific composition behavior and gallery references.

Build:
- Update the lockfile to the latest Rerun SDK and notebook versions required for the new composition functionality.

Documentation:
- Update user-facing docs to describe ResultRerun usage, ComposableContainerRerun-based Rerun composition modes, and link to the Rerun Integration gallery.

Tests:
- Add focused tests covering Rerun recording merging, layout mapping, overlay behavior, view kind inference and overrides, error handling, materialization, and public API exports.