### PR TITLE
refactor: remove ResultVolume, which was declarable but not usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`ResultVolume` is gone.** It was declarable but not usable: exported from
+  `bencher/__init__.py` and listed in `ALL_RESULT_TYPES`/`RESULT_KIND_ORDER`, but absent
+  from every registry that decides how a sample is *stored*. Putting one in `result_vars`
+  raised `KeyError: No variable named '<name>'` in `precompute_result_arrays` — the type
+  got no data variable, yet the collector indexed one anyway — and had it survived that,
+  the store loop's `else` raised `TypeError: Unsupported result type`. Since no working
+  code could have used it, removal is only nominally an API break. Note that
+  `VolumeResult` (`bencher/results/volume_result.py`), the 3-float-input volume *plot*, is
+  unrelated and unaffected — it renders `ResultFloat`.
+
+  A new `TestEveryResultTypeIsStorable` pins the invariant that made this a trap:
+  membership in `ALL_RESULT_TYPES` now implies the collector has a branch to store the
+  type, and that `result_kind` classifies it as something other than `"unknown"`.
+  `ResultHmap` is the one exemption, collected out-of-band via `result_hmaps`.
+
 ### Changed
 - **`DataSetResult` now renders `ResultDataSet` results only.** It previously claimed every
   pane-type result, which made `bench.add(bn.DataSetResult)` / `plot_list=["dataset"]` a

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -107,7 +107,6 @@ from .variables.results import (
     ResultVar,
     ResultVec,
     ResultVideo,
-    ResultVolume,
     curve,
 )
 from .variables.sweep_base import SUBSAMPLING_DIVISIONS_SAMPLES, hash_sha1

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -473,21 +473,6 @@ class ResultDataSet(param.Parameter):
         return _hash_slots(self)
 
 
-class ResultVolume(param.Parameter):
-    __slots__ = ["units", "obj", "max_time_events"]
-    _hash_exclude = ("obj", "max_time_events")
-
-    def __init__(self, obj=None, default=None, units="container", max_time_events=None, **params):
-        super().__init__(default=default, **params)
-        self.units = units
-        self.obj = obj
-        self.max_time_events = max_time_events
-
-    def hash_persistent(self) -> str:
-        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
-        return _hash_slots(self)
-
-
 PANEL_TYPES = (
     ResultPath,
     ResultImage,
@@ -526,7 +511,6 @@ ALL_RESULT_TYPES = (
     ResultRerun,
     ResultDataSet,
     ResultReference,
-    ResultVolume,
 )
 
 # Most-derived first: kind classification takes the first isinstance match
@@ -544,7 +528,6 @@ RESULT_KIND_ORDER = (
     (ResultContainer, "container"),
     (ResultHmap, "hmap"),
     (ResultReference, "reference"),
-    (ResultVolume, "volume"),
 )
 
 
@@ -585,8 +568,8 @@ _OBJECT_MISSING_TYPES = (
     ResultRerun,
 )
 # Single-column result types that get a data variable in the dataset. ResultVec
-# is handled separately (it expands to one column per element); ResultHmap and
-# ResultVolume are stored out-of-band and intentionally get no data variable.
+# is handled separately (it expands to one column per element); ResultHmap is
+# stored out-of-band and intentionally gets no data variable.
 DATA_VAR_RESULT_TYPES = SCALAR_RESULT_TYPES + _REFERENCE_MISSING_TYPES + _OBJECT_MISSING_TYPES
 
 
@@ -596,7 +579,7 @@ def result_missing_fill(rv) -> tuple[Any, type]:
         return -1, int
     if isinstance(rv, _OBJECT_MISSING_TYPES):
         return "NAN", object
-    # ResultFloat / ResultBool / ResultVec / ResultVolume and any future numeric.
+    # ResultFloat / ResultBool / ResultVec and any future numeric.
     return float("nan"), float
 
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -239,7 +239,6 @@ Result types declare what a benchmark function returns:
 - `ResultString` — a string result
 - `ResultDataSet` — any picklable Python payload per sample, optionally with a
   `container=` callback that renders it without coupling storage to its data type
-- `ResultVolume` — volume data
 
 Bencher distinguishes inputs from results by type: anything that is a subclass of a result type
 is an output; everything else is an input. This split drives the entire downstream pipeline.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,6 +1,12 @@
 version: 7
 platforms:
-- name: linux-64
+- name: p1
+  subdir: linux-64
+  virtual-packages:
+  - __glibc=2.31
+  - __unix=0=0
+  - __linux=4.18
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -9,7 +15,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -40,7 +46,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -181,7 +187,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -212,7 +218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -362,7 +368,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -393,7 +399,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
@@ -536,7 +542,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -568,7 +574,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
@@ -709,7 +715,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -741,7 +747,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -882,7 +888,7 @@ environments:
     indexes:
     - https://pypi.org/simple
     packages:
-      linux-64:
+      p1:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
@@ -913,7 +919,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl
@@ -1607,7 +1613,7 @@ packages:
   run_exports: {}
   size: 27468597
   timestamp: 1767671008593
-- pypi: .
+- pypi: ./
   name: holobench
   requires_dist:
   - holoviews>=1.15,<=1.23.1
@@ -1618,7 +1624,7 @@ packages:
   - diskcache>=5.6,<=5.6.3
   - optuna>=3.2,<=4.9.0
   - xarray>=2023.7,<=2026.4.0
-  - plotly>=5.15,<=6.8.0
+  - plotly>=5.15,<=6.9.0
   - pandas>=2.0,<=3.0.3
   - strenum>=0.4.0,<=0.4.15
   - scikit-learn>=1.2,<=1.9.0
@@ -1633,12 +1639,12 @@ packages:
   - pylint>=3.2.5,<=4.0.6 ; extra == 'test'
   - pytest-cov>=4.1,<=7.1.0 ; extra == 'test'
   - pytest>=7.4,<=9.1.1 ; extra == 'test'
-  - hypothesis>=6.104.2,<=6.156.1 ; extra == 'test'
+  - hypothesis>=6.104.2,<=6.163.0 ; extra == 'test'
   - ruff>=0.5.0,<=0.16.0 ; extra == 'test'
   - sphinxcontrib-mermaid>=1.0,<3.0 ; extra == 'test'
-  - coverage>=7.5.4,<=7.15.0 ; extra == 'test'
+  - coverage>=7.5.4,<=7.15.2 ; extra == 'test'
   - prek>=0.2.28,<0.5.0 ; extra == 'test'
-  - ty>=0.0.13,<=0.0.56 ; extra == 'test'
+  - ty>=0.0.13,<=0.0.64 ; extra == 'test'
   - sphinx>=7.0,<=9.1.0 ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   - sphinxcontrib-napoleon ; extra == 'docs'
@@ -1647,8 +1653,8 @@ packages:
   - sphinx-copybutton ; extra == 'docs'
   - playwright ; extra == 'docs'
   - pillow ; extra == 'docs'
-  - rerun-sdk>=0.32.0,<=0.34.0 ; extra == 'rerun'
-  - rerun-notebook>=0.32.0,<=0.34.0 ; extra == 'rerun'
+  - rerun-sdk>=0.32.0,<=0.35.0 ; extra == 'rerun'
+  - rerun-notebook>=0.32.0,<=0.35.0 ; extra == 'rerun'
   requires_python: '>=3.10,<3.14'
 - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -38,7 +38,6 @@ from bencher.variables.results import (
     ResultString,
     ResultVec,
     ResultVideo,
-    ResultVolume,
 )
 
 
@@ -169,7 +168,6 @@ class TestHashPersistentDifferentiation:
             (ResultContainer, "container", "custom"),
             (ResultReference, "container", "custom"),
             (ResultDataSet, "dataset", "custom"),
-            (ResultVolume, "container", "custom"),
         ],
         ids=lambda x: x.__name__ if isinstance(x, type) else x,
     )
@@ -276,7 +274,6 @@ class TestBenchCfgHashStability:
             cfg.result_vars = [
                 ResultReference(obj=obj_payload, doc="ref"),
                 ResultDataSet(obj=obj_payload, doc="ds"),
-                ResultVolume(obj=obj_payload, doc="vol"),
             ]
             cfg.const_vars = []
             return cfg

--- a/test/test_result_missing.py
+++ b/test/test_result_missing.py
@@ -14,7 +14,9 @@ import numpy as np
 
 from bencher.result_collector import _sentinel_for_result_var
 from bencher.variables.results import (
+    ALL_RESULT_TYPES,
     DATA_VAR_RESULT_TYPES,
+    XARRAY_MULTIDIM_RESULT_TYPES,
     ResultBool,
     ResultContainer,
     ResultDataSet,
@@ -27,14 +29,19 @@ from bencher.variables.results import (
     ResultString,
     ResultVec,
     ResultVideo,
-    ResultVolume,
     result_is_missing,
+    result_kind,
     result_missing_fill,
 )
 
 
+def _instantiate(cls):
+    """A default instance of *cls*; ResultVec needs an explicit size."""
+    return cls(size=2) if cls is ResultVec else cls()
+
+
 def _nan_backed_vars():
-    return [ResultFloat(), ResultBool(), ResultVec(size=2), ResultVolume()]
+    return [ResultFloat(), ResultBool(), ResultVec(size=2)]
 
 
 def _reference_backed_vars():
@@ -92,11 +99,51 @@ class TestDataVarResultTypes(unittest.TestCase):
         self.assertIsInstance(ResultBool(), DATA_VAR_RESULT_TYPES)
 
     def test_out_of_band_and_multi_column_types_excluded(self):
-        # ResultVec expands to one column per element; ResultHmap and
-        # ResultVolume are stored out-of-band — none get a single data var.
+        # ResultVec expands to one column per element; ResultHmap is stored
+        # out-of-band — neither gets a single data var.
         self.assertNotIsInstance(ResultVec(size=2), DATA_VAR_RESULT_TYPES)
         self.assertNotIsInstance(ResultHmap(), DATA_VAR_RESULT_TYPES)
-        self.assertNotIsInstance(ResultVolume(), DATA_VAR_RESULT_TYPES)
+
+
+class TestEveryResultTypeIsStorable(unittest.TestCase):
+    """No result type may be declarable but unstorable.
+
+    ``ResultVolume`` used to be exactly that: exported and listed in
+    ``ALL_RESULT_TYPES``/``RESULT_KIND_ORDER``, but absent from every registry
+    that decides how a sample is *stored*. Putting one in ``result_vars`` died in
+    ``precompute_result_arrays`` with ``KeyError: No variable named ...`` — the
+    type had no data variable, yet the collector indexed one anyway. It was
+    deleted rather than wired up.
+
+    This pins the invariant that made it a trap: membership in
+    ``ALL_RESULT_TYPES`` implies the collector's store loop has a branch for the
+    type. That loop dispatches on ``XARRAY_MULTIDIM_RESULT_TYPES``,
+    ``ResultDataSet``, ``ResultReference`` and ``ResultVec``, and raises
+    ``TypeError`` otherwise; ``ResultHmap`` is the one legitimate exception,
+    collected separately via ``bench_res.result_hmaps``.
+    """
+
+    STORABLE = XARRAY_MULTIDIM_RESULT_TYPES + (ResultDataSet, ResultReference, ResultVec)
+
+    def test_all_result_types_have_a_collector_branch(self):
+        for cls in ALL_RESULT_TYPES:
+            if cls is ResultHmap:
+                continue
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(
+                    issubclass(cls, self.STORABLE),
+                    f"{cls.__name__} is in ALL_RESULT_TYPES but the collector has no "
+                    f"branch to store it, so declaring one raises at sweep time. "
+                    f"Either wire it into a storage registry or drop it from "
+                    f"ALL_RESULT_TYPES.",
+                )
+
+    def test_result_kind_covers_all_result_types(self):
+        # A type absent from RESULT_KIND_ORDER classifies as "unknown", which
+        # silently degrades plot selection rather than failing.
+        for cls in ALL_RESULT_TYPES:
+            with self.subTest(cls=cls.__name__):
+                self.assertNotEqual(result_kind(_instantiate(cls)), "unknown")
 
 
 class TestResultIsMissing(unittest.TestCase):


### PR DESCRIPTION
Branches off `main`, independent of #994.

## The type never worked

`ResultVolume` was exported from `bencher/__init__.py` and listed in `ALL_RESULT_TYPES` and `RESULT_KIND_ORDER` — but absent from every registry that decides how a sample is actually *stored*: `XARRAY_MULTIDIM_RESULT_TYPES`, `DATA_VAR_RESULT_TYPES`, `_OBJECT_MISSING_TYPES`, `_REFERENCE_MISSING_TYPES`, `PANEL_TYPES`.

So declaring one crashed:

```
KeyError: "No variable named 'vol'. Variables on the dataset include ['f', 'x', 'repeat']"
  bencher/result_collector.py:306 in precompute_result_arrays
```

`setup_dataset` skipped it (not in `DATA_VAR_RESULT_TYPES`), then the collector indexed `ds[rv.name]` anyway. Had it survived that, the store loop's `else` would have raised `TypeError: Unsupported result type: ResultVolume`.

Since no working code could have used it, removal is only nominally an API break.

**`VolumeResult` is unrelated and unaffected.** The 3-float-input volume plot in `bencher/results/volume_result.py` renders `ResultFloat` and has nothing to do with this type — the name collision is the only connection.

## Why delete rather than wire up

It came in with `to_volume` (686e076, pre-src-layout) as a stub that was never finished, and there is no use case to validate an implementation against. `ResultReference` already covers "arbitrary out-of-band object with a declared renderer", which is what a working `ResultVolume` would have been.

## Regression guard

The real defect is that the storage/render/missing-fill/kind axes are six hand-maintained tuples correlated only by convention, so a half-wired type fails at `plot_sweep` instead of at import. `TestEveryResultTypeIsStorable` pins the two invariants that were violated:

- membership in `ALL_RESULT_TYPES` implies the collector's store loop has a branch for the type (verified to reject a freshly-added dead type, and to require `ResultHmap`'s exemption — it is collected out-of-band via `result_hmaps`);
- `result_kind` classifies every member as something other than `"unknown"`, which would silently degrade plot selection rather than fail.

Deriving those registries from per-type trait declarations, so the invariant holds by construction, is the follow-up.

## Tests

`pixi run ci` clean (ruff + pylint 10.00/10); 2058 passed, 3 skipped. Also green under `pixi run test-split`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the unused ResultVolume result type and add safeguards to ensure all declared result types are storable and correctly classified.

New Features:
- Add TestEveryResultTypeIsStorable to enforce that every type in ALL_RESULT_TYPES has a storage branch and a non-"unknown" result_kind.

Bug Fixes:
- Prevent configuration that declares a result type without a corresponding storage path from failing at sweep time with unclear KeyErrors or TypeErrors.

Enhancements:
- Tighten invariants around result type registries by asserting consistency between ALL_RESULT_TYPES, storage dispatch, and result_kind classification.

Documentation:
- Update concepts documentation to drop ResultVolume from the list of supported result types.
- Document the removal and behavior guarantees for result types in the changelog.

Tests:
- Extend result missing tests to cover all result types and validate that result_kind is defined for each.
- Update hash persistence tests and configurations to remove references to the deleted ResultVolume type.

Chores:
- Remove ResultVolume from core result type definitions, exports, registries, and related comments.