### PR TITLE
plan 16 + implementation: inspectable, pinnable benchmark identity

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -35,6 +35,15 @@ from .bench_runner import BenchRunner
 from .bencher import Bench, BenchCfg, BenchRunCfg
 from .example.benchmark_data import ExampleBenchCfg
 from .file_server import run_file_server
+from .identity import (
+    EXCLUDED_FIELDS,
+    IDENTITY_FIELDS,
+    SweepIdentity,
+    config_summary,
+    diff_identities,
+    identity_of,
+    sweep_identity,
+)
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -855,7 +855,8 @@ class BenchCfg(BenchRunCfg):
 
         *run_cfg* replays the merge :meth:`bencher.bencher.Bench.run_sweep`
         performs before hashing; pass it for a config that has not been run, whose
-        ``repeats`` and ``over_time`` are still the class defaults.
+        ``repeats`` and ``over_time`` are still the class defaults. The replay runs
+        against a copy, so asking for an identity never reconfigures *self*.
         """
         from bencher.identity import identity_of
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -850,6 +850,17 @@ class BenchCfg(BenchRunCfg):
 
         return hash_sha1((hash_val, result_hashes, const_hashes))
 
+    def identity(self, run_cfg: "BenchRunCfg | None" = None) -> "SweepIdentity":
+        """This config's cache/history/sample keys as an inspectable value.
+
+        *run_cfg* replays the merge :meth:`bencher.bencher.Bench.run_sweep`
+        performs before hashing; pass it for a config that has not been run, whose
+        ``repeats`` and ``over_time`` are still the class defaults.
+        """
+        from bencher.identity import identity_of
+
+        return identity_of(self, run_cfg)
+
     def inputs_as_str(self) -> list[str]:
         """Get a list of input variable names.
 

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -6,7 +6,7 @@ import warnings
 from copy import deepcopy
 from datetime import datetime
 from enum import auto
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import panel as pn
 import param
@@ -19,6 +19,10 @@ from bencher.results.laxtex_result import to_latex
 from bencher.variables.results import OptDir
 from bencher.variables.sweep_base import SUBSAMPLING_DIVISIONS_SAMPLES, describe_variable, hash_sha1
 from bencher.variables.time import TimeEvent, TimeSnapshot
+
+if TYPE_CHECKING:
+    # Runtime import would be circular: identity imports this module.
+    from bencher.identity import SweepIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -850,7 +854,7 @@ class BenchCfg(BenchRunCfg):
 
         return hash_sha1((hash_val, result_hashes, const_hashes))
 
-    def identity(self, run_cfg: "BenchRunCfg | None" = None) -> "SweepIdentity":
+    def identity(self, run_cfg: BenchRunCfg | None = None) -> SweepIdentity:
         """This config's cache/history/sample keys as an inspectable value.
 
         *run_cfg* replays the merge :meth:`bencher.bencher.Bench.run_sweep`

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -111,6 +111,12 @@ class Bench(BenchPlotServer):
         self._executor = SweepExecutor(cache_size=self.cache_size)
         self._collector = ResultCollector(cache_size=self.cache_size)
 
+        # The worker manager owns this state; these mirror it for backward
+        # compatibility and are refreshed by _expose_worker_attrs().
+        self.worker: Callable | None = None
+        self.worker_class_instance: ParametrizedSweep | None = None
+        self.worker_input_cfg: ParametrizedSweep | None = None
+
         # Set worker using the manager
         self.set_worker(worker, worker_input_cfg)
 
@@ -198,10 +204,30 @@ class Bench(BenchPlotServer):
             RuntimeError: If worker is a class type instead of an instance.
         """
         self._worker_mgr.set_worker(worker, worker_input_cfg)
-        # Expose worker attributes for backward compatibility
+        self._expose_worker_attrs()
+
+    def _expose_worker_attrs(self) -> None:
+        """Mirror the worker manager's state onto self, for backward compatibility."""
         self.worker = self._worker_mgr.worker
         self.worker_class_instance = self._worker_mgr.worker_class_instance
         self.worker_input_cfg = self._worker_mgr.worker_input_cfg
+
+    def set_worker_class(self, worker_class: type[ParametrizedSweep]) -> None:
+        """Attach a worker class for declaration only, without a callable worker.
+
+        Delegates to :meth:`bencher.worker_manager.WorkerManager.set_worker_class`,
+        whose docstring explains why a class is enough to declare and hash a sweep but
+        not to run one. Used by :func:`bencher.identity.sweep_identity`.
+
+        Args:
+            worker_class: A ParametrizedSweep subclass. Never instantiated, never
+                called.
+
+        Raises:
+            RuntimeError: If given an instance rather than a class.
+        """
+        self._worker_mgr.set_worker_class(worker_class)
+        self._expose_worker_attrs()
 
     def sweep_sequential(
         self,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -114,7 +114,8 @@ class Bench(BenchPlotServer):
         # The worker manager owns this state; these mirror it for backward
         # compatibility and are refreshed by _expose_worker_attrs().
         self.worker: Callable | None = None
-        self.worker_class_instance: ParametrizedSweep | None = None
+        # A *class* when attached via set_worker_class for declaration only.
+        self.worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None = None
         self.worker_input_cfg: ParametrizedSweep | None = None
 
         # Set worker using the manager

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -121,6 +121,11 @@ def diff_identities(
 def _attach_worker(bench: Any, worker: Any) -> None:
     """Make *worker* available for by-name variable resolution, without calling it.
 
+    An **instance** goes through the real :meth:`bencher.bencher.Bench.set_worker`,
+    so identity is set up by the same code path as
+    :func:`bencher.factories.create_bench` and cannot drift from it as
+    ``set_worker``'s invariants change.
+
     A **class** is accepted and never instantiated. Everything the declaration path
     needs from a worker is class-level -- ``param.objects()`` plus the
     ``get_inputs_only`` / ``get_input_defaults`` / ``get_results_only``
@@ -131,12 +136,19 @@ def _attach_worker(bench: Any, worker: Any) -> None:
     check it before running.
 
     ``Bench.set_worker`` rejects a class on purpose, because a class cannot be
-    *called*; identity never calls one, so it is attached directly instead.
+    *called*; identity never calls one, so a class is attached directly instead.
+    The only state that bypass skips is the callable ``bench.worker`` itself, which
+    the ``dry_run`` declaration path never reaches -- and the equivalence tests in
+    ``test/test_identity.py`` pin every declaration form against a real
+    ``to_bench()`` run, so a divergence between the two setups fails there.
     """
     if worker is None:
         return
+    if not isinstance(worker, type):
+        bench.set_worker(worker)
+        return
     bench.worker_class_instance = worker
-    bench._worker_mgr.worker_class_instance = worker  # noqa: SLF001
+    bench._worker_mgr.worker_class_instance = worker
 
 
 def sweep_identity(
@@ -237,10 +249,17 @@ def identity_of(bench_cfg: BenchCfg, run_cfg: BenchRunCfg | None = None) -> Swee
     required for a config that has not been through a run -- ``repeats`` and
     ``over_time`` live on the run config and reach ``BenchCfg`` only through that
     merge.
+
+    *bench_cfg* is never mutated: the merge runs against a copy. Asking a config
+    what its keys are is a query, and :class:`BenchCfg` subclasses
+    :class:`BenchRunCfg`, so merging in place would write every run-side field
+    (``repeats``, ``cache_results``, ``dry_run``, ...) onto a config the caller
+    still holds and may run again.
     """
     from bencher.bencher import Bench
 
     if run_cfg is not None:
+        bench_cfg = deepcopy(bench_cfg)
         values, _missing, _constant = Bench.filter_overridable_params(bench_cfg, run_cfg)
         with param.parameterized.discard_events(bench_cfg):
             bench_cfg.param.update(values)

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -1,0 +1,268 @@
+"""Inspectable, pinnable benchmark identity.
+
+``BenchCfg.hash_persistent`` is the single source of truth for a benchmark's cache
+and over_time history keys, but it lives on a config object that ``plot_sweep``
+assembles part-way through its own body, so the only way to learn a declaration's
+keys used to be to run the benchmark. Downstream projects that want to protect a
+long-lived trend from an accidental reset therefore transcribe the hashing rule
+into an assertion about "the fields that make up the key" -- an assertion that
+keeps passing after the rule changes.
+
+:func:`sweep_identity` closes that gap without adding a second implementation of
+the rule: it drives the real :meth:`bencher.bencher.Bench.plot_sweep` in dry-run
+mode, applies the same ``run_cfg`` -> ``BenchCfg`` merge that
+:meth:`bencher.bencher.Bench.run_sweep` applies, and calls the same
+``hash_persistent``. Anything that changes the keys changes them here too, by
+construction.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+import param
+
+from bencher.bench_cfg import BenchCfg, BenchRunCfg
+from bencher.history import config_summary, diff_summaries
+
+# Fields folded into hash_persistent, and the ones deliberately left out.  Stated
+# here for explain(), which is the whole point of the plan: when a key moves, a
+# user needs to be told what could have moved it without reading the hashing code.
+IDENTITY_FIELDS = (
+    "CACHE_VERSION",
+    "bench_name",
+    "over_time",
+    "repeats",
+    "tag",
+    "input_vars (in list order)",
+    "result_vars (as an unordered set; cache_key only)",
+    "const_vars (as an unordered set)",
+)
+
+EXCLUDED_FIELDS = (
+    "title",
+    "description / post_description",
+    "aggregate / agg_fn",
+    "sample_order",
+    "plot_callbacks / auto_plot",
+)
+
+
+@dataclass(frozen=True)
+class SweepIdentity:
+    """The keys a sweep declaration resolves to, as a value.
+
+    Immutable, picklable, ``json.dumps(asdict(...))``-able, and usable as a dict
+    key: every compared field is a string, an int or a bool.
+
+    ``summary`` is excluded from equality and hashing (``compare=False``). It is
+    derived explanatory data -- the same payload the reset warning is built from
+    -- not part of the identity, and a dict field would otherwise make the
+    dataclass unhashable.
+    """
+
+    cache_key: str
+    history_key: str
+    sample_key: str
+    bench_name: str
+    tag: str
+    repeats: int
+    over_time: bool
+    summary: dict = field(default_factory=dict, compare=False, repr=False)
+
+    def explain(self) -> str:
+        """Human-readable rendering of the keys and what did or did not contribute.
+
+        A pinned key is a *within-version* guard against accidental drift, not a
+        cross-version guarantee: ``CACHE_VERSION`` is folded in deliberately, so a
+        version bump legitimately moves every key.
+        """
+        lines = [
+            f"bench_name: {self.bench_name}",
+            f"tag:        {self.tag!r}",
+            f"repeats:    {self.repeats}",
+            f"over_time:  {self.over_time}",
+            "",
+            f"cache_key   (result cache):    {self.cache_key}",
+            f"history_key (over_time trend): {self.history_key}",
+            f"sample_key  (sample cache):    {self.sample_key}",
+            "",
+            "contributing fields:",
+        ]
+        lines += [f"  - {f}" for f in IDENTITY_FIELDS]
+        lines.append("excluded on purpose (changing these never moves a key):")
+        lines += [f"  - {f}" for f in EXCLUDED_FIELDS]
+        if self.summary:
+            lines.append("")
+            lines.append("resolved declaration:")
+            for kind in ("inputs", "consts", "results"):
+                for row in self.summary.get(kind, []):
+                    lines.append(f"  {kind[:-1]:6} {row}")
+        return "\n".join(lines)
+
+
+def diff_identities(
+    old: SweepIdentity | dict | None, new: SweepIdentity | dict | None
+) -> list[str]:
+    """Lines describing how *new*'s declaration differs from *old*'s.
+
+    Accepts either :class:`SweepIdentity` values or the raw ``config_summary``
+    dicts stored in the last-seen index, so the same helper serves a live
+    comparison and a comparison against history.
+    """
+    return diff_summaries(
+        old.summary if isinstance(old, SweepIdentity) else old,
+        new.summary if isinstance(new, SweepIdentity) else new,
+    )
+
+
+def _attach_worker(bench: Any, worker: Any) -> None:
+    """Make *worker* available for by-name variable resolution, without calling it.
+
+    A **class** is accepted and never instantiated. Everything the declaration path
+    needs from a worker is class-level -- ``param.objects()`` plus the
+    ``get_inputs_only`` / ``get_input_defaults`` / ``get_results_only``
+    classmethods -- and a worker whose ``__init__`` demands live resources (an
+    open device, a running simulator, an attached robot) cannot be constructed
+    just to be asked what its parameters are. Requiring an instance would put
+    identity out of reach of exactly the expensive benchmarks that most need to
+    check it before running.
+
+    ``Bench.set_worker`` rejects a class on purpose, because a class cannot be
+    *called*; identity never calls one, so it is attached directly instead.
+    """
+    if worker is None:
+        return
+    bench.worker_class_instance = worker
+    bench._worker_mgr.worker_class_instance = worker  # noqa: SLF001
+
+
+def sweep_identity(
+    *,
+    worker: Any = None,
+    bench_name: str | None = None,
+    input_vars: list | dict | None = None,
+    result_vars: list | None = None,
+    const_vars: list | dict | None = None,
+    tag: str = "",
+    title: str | None = None,
+    description: str | None = None,
+    post_description: str | None = None,
+    run_cfg: BenchRunCfg | None = None,
+    repeats: int | None = None,
+    over_time: bool | None = None,
+) -> SweepIdentity:
+    """The keys *this declaration* would produce, without running the benchmark.
+
+    Accepts the declarative arguments of :meth:`bencher.bencher.Bench.plot_sweep`
+    with the same spellings, so ``sweep_identity(worker=W, **kwargs)`` and
+    ``bench.plot_sweep(**kwargs)`` describe the same sweep.
+
+    ``run_cfg`` is **not** optional in the way it looks. ``subsampling_divisions``
+    (default 0 on a bare :class:`BenchRunCfg`, but commonly set) and
+    ``samples_per_var`` reshape every input variable before it is hashed, and
+    ``run_tag`` is prefixed to ``tag``; a run driven with a different one has a
+    different identity. Pass the same ``run_cfg`` the real run uses, or pass
+    ``repeats`` / ``over_time`` for the common case where those are the only
+    run-side fields that matter.
+
+    Args:
+        worker: The ``ParametrizedSweep`` subclass **or** instance the variables are
+            declared on. Required whenever any variable is given as a string or a
+            :func:`bencher.sweep` spec dict, because resolution needs the declaring
+            class. Also supplies the default ``bench_name``. A class is never
+            instantiated -- see :func:`_attach_worker` -- so a worker whose
+            construction needs live resources can still be asked for its identity.
+        bench_name: Overrides the name, which is otherwise the worker's class name
+            -- matching :func:`bencher.factories.create_bench`. ``bench_name`` is
+            hashed, so this is the field a rename moves.
+        repeats: Convenience override of ``run_cfg.repeats``.
+        over_time: Convenience override of ``run_cfg.over_time``.
+
+    Returns:
+        SweepIdentity: The three keys plus the resolved declaration summary.
+
+    Raises:
+        TypeError: If neither *worker* nor *bench_name* is given, or if a
+            by-name variable is used with no worker (raised by the existing
+            resolution guard, which lists the available parameters).
+    """
+    from bencher.bencher import Bench
+
+    if bench_name is None:
+        if worker is None:
+            raise TypeError(
+                "sweep_identity() needs a bench_name or a worker to take one from: "
+                "bench_name is hashed, so it cannot be defaulted arbitrarily."
+            )
+        # Matches create_bench, which takes the name from the worker's class.
+        bench_name = worker.__name__ if isinstance(worker, type) else type(worker).__name__
+
+    cfg = BenchRunCfg() if run_cfg is None else deepcopy(run_cfg)
+    if repeats is not None:
+        cfg.repeats = repeats
+    if over_time is not None:
+        cfg.over_time = over_time
+    # Stop plot_sweep before it executes a single sample or opens a cache; none of
+    # these three fields is hashed, so forcing them cannot change the answer.
+    cfg.dry_run = True
+    cfg.auto_plot = False
+
+    bench = Bench(bench_name, None)
+    _attach_worker(bench, worker)
+    try:
+        res = bench.plot_sweep(
+            title=title,
+            input_vars=input_vars,
+            result_vars=result_vars,
+            const_vars=const_vars,
+            description=description,
+            post_description=post_description,
+            tag=tag,
+            run_cfg=cfg,
+            plot_callbacks=False,
+        )
+        return identity_of(res.bench_cfg, cfg)
+    finally:
+        bench.close()
+
+
+def identity_of(bench_cfg: BenchCfg, run_cfg: BenchRunCfg | None = None) -> SweepIdentity:
+    """The identity of a config that already exists.
+
+    *run_cfg* replays the ``run_cfg`` -> ``BenchCfg`` merge that
+    :meth:`bencher.bencher.Bench.run_sweep` performs before hashing, and is
+    required for a config that has not been through a run -- ``repeats`` and
+    ``over_time`` live on the run config and reach ``BenchCfg`` only through that
+    merge.
+    """
+    from bencher.bencher import Bench
+
+    if run_cfg is not None:
+        values, _missing, _constant = Bench.filter_overridable_params(bench_cfg, run_cfg)
+        with param.parameterized.discard_events(bench_cfg):
+            bench_cfg.param.update(values)
+
+    return SweepIdentity(
+        cache_key=bench_cfg.hash_persistent(True),
+        history_key=bench_cfg.hash_persistent(True, include_result_vars=False),
+        sample_key=bench_cfg.hash_persistent(False),
+        bench_name=str(bench_cfg.bench_name),
+        tag=str(bench_cfg.tag),
+        repeats=int(bench_cfg.repeats),
+        over_time=bool(bench_cfg.over_time),
+        summary=config_summary(bench_cfg),
+    )
+
+
+__all__ = [
+    "EXCLUDED_FIELDS",
+    "IDENTITY_FIELDS",
+    "SweepIdentity",
+    "config_summary",
+    "diff_identities",
+    "identity_of",
+    "sweep_identity",
+]

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -126,29 +126,24 @@ def _attach_worker(bench: Any, worker: Any) -> None:
     :func:`bencher.factories.create_bench` and cannot drift from it as
     ``set_worker``'s invariants change.
 
-    A **class** is accepted and never instantiated. Everything the declaration path
-    needs from a worker is class-level -- ``param.objects()`` plus the
-    ``get_inputs_only`` / ``get_input_defaults`` / ``get_results_only``
-    classmethods -- and a worker whose ``__init__`` demands live resources (an
-    open device, a running simulator, an attached robot) cannot be constructed
-    just to be asked what its parameters are. Requiring an instance would put
-    identity out of reach of exactly the expensive benchmarks that most need to
-    check it before running.
+    A **class** goes through :meth:`bencher.bencher.Bench.set_worker_class`, which
+    owns the declaration-only contract: a class is never instantiated and never
+    called, and ``bench.worker`` is deliberately left unset so an attempt to sample
+    raises instead of calling a class object. ``set_worker`` rejects a class on
+    purpose, because a class cannot be *called* -- and identity never calls one, so
+    the two methods split that case between them rather than identity writing the
+    manager's attributes itself.
 
-    ``Bench.set_worker`` rejects a class on purpose, because a class cannot be
-    *called*; identity never calls one, so a class is attached directly instead.
-    The only state that bypass skips is the callable ``bench.worker`` itself, which
-    the ``dry_run`` declaration path never reaches -- and the equivalence tests in
-    ``test/test_identity.py`` pin every declaration form against a real
-    ``to_bench()`` run, so a divergence between the two setups fails there.
+    The equivalence tests in ``test/test_identity.py`` pin every declaration form
+    against a real ``to_bench()`` run, so any divergence between the two setups
+    fails there rather than showing up as a wrong key.
     """
     if worker is None:
         return
-    if not isinstance(worker, type):
+    if isinstance(worker, type):
+        bench.set_worker_class(worker)
+    else:
         bench.set_worker(worker)
-        return
-    bench.worker_class_instance = worker
-    bench._worker_mgr.worker_class_instance = worker
 
 
 def sweep_identity(

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -101,6 +101,17 @@ class BenchResult(
         # DataSetResult.__init__(self.bench_cfg)
         self.timings = None  # Populated by Bench.run_sweep() with SweepTimings
 
+    @property
+    def identity(self) -> "SweepIdentity":
+        """The keys this result was stored under, as an inspectable value.
+
+        The config has already been through ``run_sweep``'s run_cfg merge, so no
+        run config is needed here.
+        """
+        from bencher.identity import identity_of
+
+        return identity_of(self.bench_cfg)
+
     @classmethod
     def from_existing(cls, original: BenchResult) -> BenchResult:
         new_instance = cls(original.bench_cfg)

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import panel as pn
 from param import Parameter
@@ -53,6 +53,11 @@ from bencher.results.video_summary import VideoSummaryResult
 from bencher.results.volume_result import VolumeResult
 from bencher.utils import listify, resolve_aggregate
 
+if TYPE_CHECKING:
+    # Runtime import would be circular: identity imports bench_cfg, which this
+    # module's own import chain pulls in.
+    from bencher.identity import SweepIdentity
+
 logger = logging.getLogger(__name__)
 
 
@@ -102,7 +107,7 @@ class BenchResult(
         self.timings = None  # Populated by Bench.run_sweep() with SweepTimings
 
     @property
-    def identity(self) -> "SweepIdentity":
+    def identity(self) -> SweepIdentity:
         """The keys this result was stored under, as an inspectable value.
 
         The config has already been through ``run_sweep``'s run_cfg merge, so no

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -117,6 +117,40 @@ class WorkerManager:
             logger.info(f"setting worker {worker}")
         self.worker_input_cfg = worker_input_cfg
 
+    def set_worker_class(self, worker_class: type[ParametrizedSweep]) -> None:
+        """Attach a worker *class* for declaration only, leaving ``worker`` unset.
+
+        Everything the declaration path needs from a worker is class-level --
+        ``param.objects()`` plus the ``get_inputs_only`` / ``get_input_defaults`` /
+        ``get_results_only`` classmethods -- so a class is enough to resolve variables
+        by name, describe a sweep and hash it. What a class cannot do is be *called*,
+        which is why :meth:`set_worker` rejects one; ``worker`` is deliberately left
+        ``None`` here so any attempt to sample raises rather than silently calling a
+        class object.
+
+        This exists for :func:`bencher.identity.sweep_identity`, which answers "what
+        keys would this declaration produce" without running anything. Requiring an
+        instance would put that out of reach of a worker whose ``__init__`` demands
+        live resources -- an open device, a running simulator, an attached robot --
+        which is exactly the expensive benchmark whose keys are worth checking before
+        committing to a run.
+
+        Args:
+            worker_class: A ParametrizedSweep subclass. Never instantiated, never
+                called.
+
+        Raises:
+            RuntimeError: If given an instance rather than a class -- the mirror of
+                ``set_worker``'s complaint, so neither method silently accepts what
+                the other is for.
+        """
+        if not isinstance(worker_class, type):
+            raise RuntimeError(  # noqa: TRY004
+                "This should be a class, not a class instance. Use set_worker() for an instance."
+            )
+        self.worker_class_instance = worker_class
+        logger.info(f"setting worker class {worker_class} for declaration only")
+
     def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
         """Retrieve the result variables from the worker class instance.
 

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -64,7 +64,8 @@ class WorkerManager:
     def __init__(self) -> None:
         """Initialize a new WorkerManager."""
         self.worker: Callable | None = None
-        self.worker_class_instance: ParametrizedSweep | None = None
+        # A *class* when attached via set_worker_class for declaration only.
+        self.worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None = None
         self.worker_input_cfg: ParametrizedSweep | None = None
 
     def set_worker(

--- a/plans/16-inspectable-benchmark-identity.md
+++ b/plans/16-inspectable-benchmark-identity.md
@@ -1,0 +1,172 @@
+# Plan 16 — Inspectable, Pinnable Benchmark Identity
+
+**Goal:** Make a benchmark's identity a value a caller can compute, print, and
+pin in a test *without running the benchmark*. Today identity exists only as a
+private method on a `BenchCfg` that `plot_sweep()` builds internally, so the only
+way to protect a long-lived trend from an accidental reset is to reimplement the
+hashing rule downstream — against a rule that has already changed twice.
+
+**Branch name:** `feat/sweep-identity-api`
+
+**⚠️ Read first:** this plan is purely additive — one new pure function and two
+accessors, all delegating to the existing `hash_persistent()`. It must not change
+any hash. The golden hashes at `test/test_hash_persistent.py:774-801` are the
+acceptance gate.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — Identity is only reachable through a live run
+
+`BenchCfg.hash_persistent(include_repeats, include_result_vars)`
+(`bencher/bench_cfg.py:785`) is a method on a config object that
+`plot_sweep()` assembles from converted variables partway through its own body
+(`bencher/bencher.py:519`). There is no way to ask "what cache key and history
+key will this declaration produce?" before committing to a run — and for an
+expensive benchmark, running it is exactly what you are trying to avoid when
+checking that a refactor preserved identity.
+
+### P2 — The contributing set is documented, not exposed
+
+Which fields participate is stated in a docstring and a comment block
+(`bencher/bench_cfg.py:795-827`): `bench_name`, `over_time`, `repeats`, `tag`,
+`input_vars` in list order, `const_vars` and `result_vars` as sorted sets, with
+`CACHE_VERSION` folded in and `title` deliberately excluded. That rule has
+changed twice in recent history — `CACHE_VERSION` reached 5, and
+`include_result_vars=False` was introduced for the history key by plans 09/14.
+
+Anything downstream that protects a trend by asserting on "the fields that make
+up the key" is therefore asserting on a *transcription* of the rule, which drifts
+silently the next time the rule changes. The assertion keeps passing while the
+thing it was protecting has moved.
+
+### P3 — Golden-hash coverage exists, but only inward
+
+`test/test_hash_persistent.py` pins golden hashes for bencher's own fixtures
+(`:774` with repeats, `:783` without, `:789` for the history key) and asserts the
+determinism contract. That is the right pattern, and there is no public entry
+point that lets a user apply it to their own benchmarks.
+
+### P4 — The reset diff payload is private
+
+`history.config_summary(bench_cfg)` already computes a compact, readable identity
+summary — inputs, consts, results, repeats (`bencher/history.py:135-152`) — and
+`diff_summaries` already renders a human-readable delta between two of them
+(`bencher/history.py:155-177`). Both are exactly what a caller wants when a key
+moves unexpectedly, and neither is exported.
+
+---
+
+## Proposed design
+
+One pure function, one accessor, one export. No new hashing code.
+
+### D1 — `bn.sweep_identity(...)`
+
+New public function (module `bencher/identity.py`, keeping `bencher.py` from
+growing — see plans 07/08):
+
+```python
+ident = bn.sweep_identity(
+    bench_name="MyWorker",
+    tag="nightly",
+    input_vars=[...],          # same forms plot_sweep accepts
+    result_vars=[...],
+    const_vars={...},
+    repeats=1,
+    over_time=True,
+    worker=MyWorker,           # needed to resolve string/dict specs
+)
+ident.cache_key      # hash_persistent(True)
+ident.history_key    # hash_persistent(True, include_result_vars=False)
+ident.summary        # config_summary(...)
+```
+
+- Returns a frozen dataclass `SweepIdentity`.
+- Implemented by building a `BenchCfg` through the *same* conversion path
+  `plot_sweep` uses (`Bench.convert_vars_to_params`,
+  `bencher/bencher.py:822`) and calling `hash_persistent()` — so there is
+  exactly one implementation of the rule and it cannot drift from the runtime.
+- `worker` is required whenever any variable is given as a string or a
+  `bn.sweep()` dict, because resolution needs the declaring class
+  (`bencher/sweep_executor.py:122-127` already raises a clear error otherwise).
+
+### D2 — `BenchCfg.identity()` and `BenchResult.identity`
+
+The same `SweepIdentity` from a config that already exists, so a completed run
+can report what it actually used. This is the accessor that makes plan 15's
+behavior assertable, and it costs nothing: `identity()` is a two-line wrapper.
+
+### D3 — Export the summary and diff helpers
+
+`bn.config_summary(bench_cfg)` and `bn.diff_identities(old, new) -> list[str]`,
+re-exporting `bencher/history.py:135` and `:155`. These are already the payload
+the reset warning is built from; exporting them lets a caller print the same
+explanation on demand rather than waiting for a warning that may never come.
+
+### D4 — `Bench.explain_identity() -> str`
+
+A human-readable rendering: the two keys, the fields that contributed, and the
+fields deliberately excluded (`title`, and per plan 15, `series_id`). This
+follows the precedent of A2's `explain_selection()` — when a derived value
+surprises a user, a method that explains it beats reading the hashing code.
+
+---
+
+## Phased steps
+
+1. `bencher/identity.py` with `SweepIdentity` and `sweep_identity()`, delegating
+   to the existing conversion + hashing path. Export from `bencher/__init__.py`.
+2. `BenchCfg.identity()` and the `BenchResult` accessor (D2).
+3. Export `config_summary` / `diff_identities` (D3).
+4. `explain_identity()` (D4).
+5. Docs: a short "protecting a long-lived trend" section in the caching docs
+   showing the golden-key test pattern, plus a `CHANGELOG.md` entry.
+
+Phases 1–4 are independent; do 1 first since the rest reference `SweepIdentity`.
+
+## Tests / acceptance criteria
+
+- **Equivalence, the central test:** for a matrix of declarations (bounded and
+  explicit sweeps, string and object variables, consts as dict and as list,
+  `over_time` on and off, several repeat counts), `sweep_identity(...)` returns
+  keys byte-identical to those of a real `plot_sweep()` run with the same
+  arguments. Property-based coverage here is worth more than any number of
+  hand-written cases, and the existing hypothesis tests in this file are the
+  pattern to follow.
+- Every golden hash in `test/test_hash_persistent.py` is unchanged.
+- `sweep_identity` with a string variable and no `worker` raises the existing
+  clear error rather than a `None` dereference.
+- `history_key` ignores `result_vars` and `cache_key` does not — the plan 09/14
+  contract, asserted through the new surface.
+- `explain_identity()` names `title` as excluded (a regression guard for the
+  deliberate exclusion at `bencher/bench_cfg.py:822`).
+
+## Migration & compatibility
+
+Purely additive. No existing signature changes, no hash changes, no cache
+invalidation. `hash_persistent()` stays where it is and keeps its current
+semantics; this plan only gives it a public, documented front door.
+
+## Risks
+
+- **A second implementation of the rule.** The whole value of the plan
+  evaporates if `sweep_identity` reimplements hashing instead of delegating. The
+  equivalence test is the guard, and it must cover every argument form
+  `plot_sweep` accepts, not just the common one.
+- **Encouraging users to depend on hash stability across versions.** They
+  cannot: `CACHE_VERSION` is folded in deliberately
+  (`bencher/bench_cfg.py:824-827`). Document that a pinned key is a
+  *within-version* guard against accidental drift, and that a `CACHE_VERSION`
+  bump legitimately moves every key.
+
+## Coordination
+
+- **Plan 15** — this makes 15's adoption/reset behavior directly assertable;
+  15 adds `series_id` to what `explain_identity()` must report as excluded.
+- **Plans 09/14** own the rule this exposes; any change there must update the
+  equivalence matrix rather than the transcription (there is none).
+- **A3/A4** — a frozen identity value object is the natural key type for A4's
+  storage interface; keep `SweepIdentity` free of live objects so it stays
+  serializable.

--- a/plans/16-inspectable-benchmark-identity.md
+++ b/plans/16-inspectable-benchmark-identity.md
@@ -10,8 +10,11 @@ hashing rule downstream — against a rule that has already changed twice.
 
 **⚠️ Read first:** this plan is purely additive — one new pure function and two
 accessors, all delegating to the existing `hash_persistent()`. It must not change
-any hash. The golden hashes at `test/test_hash_persistent.py:774-801` are the
-acceptance gate.
+any hash. The golden hashes in `TestGoldenBenchCfgHash`
+(`test/test_hash_persistent.py:774-801`) are the acceptance gate. Every line
+number in this document is pinned to `main` @ `7dad0cd4` (v1.116.0); the symbol
+named beside each one is the durable reference — grep the symbol if the line has
+moved.
 
 ---
 
@@ -21,20 +24,22 @@ acceptance gate.
 
 `BenchCfg.hash_persistent(include_repeats, include_result_vars)`
 (`bencher/bench_cfg.py:785`) is a method on a config object that
-`plot_sweep()` assembles from converted variables partway through its own body
-(`bencher/bencher.py:519`). There is no way to ask "what cache key and history
-key will this declaration produce?" before committing to a run — and for an
-expensive benchmark, running it is exactly what you are trying to avoid when
-checking that a refactor preserved identity.
+`Bench.plot_sweep` assembles from converted variables partway through its own
+body (the `BenchCfg(...)` construction, `bencher/bencher.py:514-530`). There is
+no way to ask "what cache key and history key will this declaration produce?"
+before committing to a run — and for an expensive benchmark, running it is
+exactly what you are trying to avoid when checking that a refactor preserved
+identity.
 
 ### P2 — The contributing set is documented, not exposed
 
-Which fields participate is stated in a docstring and a comment block
-(`bencher/bench_cfg.py:795-827`): `bench_name`, `over_time`, `repeats`, `tag`,
-`input_vars` in list order, `const_vars` and `result_vars` as sorted sets, with
-`CACHE_VERSION` folded in and `title` deliberately excluded. That rule has
-changed twice in recent history — `CACHE_VERSION` reached 5, and
-`include_result_vars=False` was introduced for the history key by plans 09/14.
+Which fields participate is stated in `BenchCfg.hash_persistent`'s docstring and
+its `title`/`CACHE_VERSION` comment block (`bencher/bench_cfg.py:793-827`):
+`bench_name`, `over_time`, `repeats`, `tag`, `input_vars` in list order,
+`const_vars` and `result_vars` as sorted sets, with `CACHE_VERSION` folded in and
+`title` deliberately excluded. That rule has changed twice in recent history —
+`CACHE_VERSION` reached 5, and `include_result_vars=False` was introduced for the
+history key by plans 09/14.
 
 Anything downstream that protects a trend by asserting on "the fields that make
 up the key" is therefore asserting on a *transcription* of the rule, which drifts
@@ -43,10 +48,12 @@ thing it was protecting has moved.
 
 ### P3 — Golden-hash coverage exists, but only inward
 
-`test/test_hash_persistent.py` pins golden hashes for bencher's own fixtures
-(`:774` with repeats, `:783` without, `:789` for the history key) and asserts the
-determinism contract. That is the right pattern, and there is no public entry
-point that lets a user apply it to their own benchmarks.
+`TestGoldenBenchCfgHash` pins golden hashes for bencher's own fixtures —
+`test_golden_hash_with_repeats` (`test/test_hash_persistent.py:774`),
+`test_golden_hash_without_repeats` (`:783`), `test_golden_hash_history_key`
+(`:789`) — and asserts the determinism contract. That is the right pattern, and
+there is no public entry point that lets a user apply it to their own
+benchmarks.
 
 ### P4 — The reset diff payload is private
 
@@ -86,11 +93,24 @@ ident.summary        # config_summary(...)
 - Returns a frozen dataclass `SweepIdentity`.
 - Implemented by building a `BenchCfg` through the *same* conversion path
   `plot_sweep` uses (`Bench.convert_vars_to_params`,
-  `bencher/bencher.py:822`) and calling `hash_persistent()` — so there is
+  `bencher/bencher.py:821`) and calling `hash_persistent()` — so there is
   exactly one implementation of the rule and it cannot drift from the runtime.
 - `worker` is required whenever any variable is given as a string or a
   `bn.sweep()` dict, because resolution needs the declaring class
-  (`bencher/sweep_executor.py:122-127` already raises a clear error otherwise).
+  (`SweepExecutor.convert_vars_to_params`'s string/dict guard,
+  `bencher/sweep_executor.py:122-126`, already raises a clear error otherwise).
+
+`SweepIdentity` is a value, not a handle. Its fields are primitives and immutable
+containers only — `str`, `int`, `bool`, `tuple`, nested frozen dataclasses — and
+never a callable, a `param` object, or a live worker instance. `cache_key` and
+`history_key` are hex digest strings; `summary` is the plain dict
+`config_summary` already returns. An identity must survive `pickle` unchanged and
+serialize through `json.dumps(asdict(ident))` with no custom encoder, and its
+equality and hashing are value-based, so it works as a dict key and compares
+equal across processes. This is a constraint rather than a preference because A4
+wants an identity *as* a storage key, and a key carrying a live object cannot
+cross a process boundary or a cache: the worker belongs in `sweep_identity`'s
+arguments, never in its return value.
 
 ### D2 — `BenchCfg.identity()` and `BenchResult.identity`
 
@@ -101,8 +121,9 @@ behavior assertable, and it costs nothing: `identity()` is a two-line wrapper.
 ### D3 — Export the summary and diff helpers
 
 `bn.config_summary(bench_cfg)` and `bn.diff_identities(old, new) -> list[str]`,
-re-exporting `bencher/history.py:135` and `:155`. These are already the payload
-the reset warning is built from; exporting them lets a caller print the same
+re-exporting `history.config_summary` (`bencher/history.py:135`) and
+`history.diff_summaries` (`:155`). These are already the payload the reset
+warning is built from; exporting them lets a caller print the same
 explanation on demand rather than waiting for a warning that may never come.
 
 ### D4 — `Bench.explain_identity() -> str`
@@ -141,7 +162,12 @@ Phases 1–4 are independent; do 1 first since the rest reference `SweepIdentity
 - `history_key` ignores `result_vars` and `cache_key` does not — the plan 09/14
   contract, asserted through the new surface.
 - `explain_identity()` names `title` as excluded (a regression guard for the
-  deliberate exclusion at `bencher/bench_cfg.py:822`).
+  exclusion documented in `hash_persistent`'s `title` NOTE comment,
+  `bencher/bench_cfg.py:820-823`).
+- A `SweepIdentity` round-trips through `pickle` unchanged, and through
+  `json.dumps(asdict(ident))` with no custom encoder — tuple-to-list is the only
+  normalization the JSON form may introduce. Two identities built from the same
+  declaration compare equal, hash equal, and address the same dict entry.
 
 ## Migration & compatibility
 
@@ -156,10 +182,10 @@ semantics; this plan only gives it a public, documented front door.
   equivalence test is the guard, and it must cover every argument form
   `plot_sweep` accepts, not just the common one.
 - **Encouraging users to depend on hash stability across versions.** They
-  cannot: `CACHE_VERSION` is folded in deliberately
-  (`bencher/bench_cfg.py:824-827`). Document that a pinned key is a
-  *within-version* guard against accidental drift, and that a `CACHE_VERSION`
-  bump legitimately moves every key.
+  cannot: `CACHE_VERSION` is folded in deliberately as the first element of
+  `hash_persistent`'s hash tuple (`bencher/bench_cfg.py:825-830`). Document that
+  a pinned key is a *within-version* guard against accidental drift, and that a
+  `CACHE_VERSION` bump legitimately moves every key.
 
 ## Coordination
 
@@ -168,5 +194,5 @@ semantics; this plan only gives it a public, documented front door.
 - **Plans 09/14** own the rule this exposes; any change there must update the
   equivalence matrix rather than the transcription (there is none).
 - **A3/A4** — a frozen identity value object is the natural key type for A4's
-  storage interface; keep `SweepIdentity` free of live objects so it stays
-  serializable.
+  storage interface; D1's serialization constraints exist for exactly that, and
+  A4 should key on `SweepIdentity` rather than reconstruct a key from its parts.

--- a/plans/16-inspectable-benchmark-identity.md
+++ b/plans/16-inspectable-benchmark-identity.md
@@ -164,6 +164,15 @@ Phases 1–4 are independent; do 1 first since the rest reference `SweepIdentity
 - `explain_identity()` names `title` as excluded (a regression guard for the
   exclusion documented in `hash_persistent`'s `title` NOTE comment,
   `bencher/bench_cfg.py:820-823`).
+- Every field the explanation names as contributing or as excluded is checked
+  *behaviourally* — change it, assert a key moves or does not — and the checks are
+  asserted to cover the lists exactly, so extending either list without a check
+  fails. The explanation is prose about a rule defined elsewhere, which is the same
+  transcription hazard listed under Risks; only a behavioural check retires it.
+- Asking for an identity never mutates what it was asked about. `BenchCfg`
+  subclasses `BenchRunCfg`, so replaying `run_sweep`'s merge in place would write
+  every run-side field (`repeats`, `cache_results`, `dry_run`, ...) onto a config
+  the caller still holds — a query that silently reconfigures the next run.
 - A `SweepIdentity` round-trips through `pickle` unchanged, and through
   `json.dumps(asdict(ident))` with no custom encoder — tuple-to-list is the only
   normalization the JSON form may introduce. Two identities built from the same

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -15,8 +15,10 @@ import math
 import pickle
 import unittest
 from dataclasses import asdict
+from unittest import mock
 
 import bencher as bn
+from bencher.bench_cfg import BenchCfg
 from bencher.example.benchmark_data import ExampleBenchCfg
 
 
@@ -170,6 +172,43 @@ class TestKeySemantics(unittest.TestCase):
         )
         self.assertEqual(ident.tag, "a_b")
 
+    def test_explicit_repeats_and_over_time_win_over_the_run_cfg(self) -> None:
+        """The keyword overrides are documented as overrides, so pin the precedence."""
+        run_cfg = bn.BenchRunCfg(repeats=1, over_time=False)
+        overridden = self._ident(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            run_cfg=run_cfg,
+            repeats=3,
+            over_time=True,
+        )
+        self.assertEqual(overridden.repeats, 3)
+        self.assertTrue(overridden.over_time)
+        # ...and the override reaches the keys, not just the reported fields.
+        from_run_cfg = self._ident(input_vars=["theta"], result_vars=["out_sin"], run_cfg=run_cfg)
+        self.assertNotEqual(overridden.history_key, from_run_cfg.history_key)
+        self.assertEqual(
+            overridden.history_key,
+            self._ident(
+                input_vars=["theta"],
+                result_vars=["out_sin"],
+                run_cfg=bn.BenchRunCfg(repeats=3, over_time=True),
+            ).history_key,
+        )
+
+    def test_the_run_cfg_passed_in_is_not_mutated_by_the_overrides(self) -> None:
+        run_cfg = bn.BenchRunCfg(repeats=1, over_time=False)
+        self._ident(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            run_cfg=run_cfg,
+            repeats=9,
+            over_time=True,
+        )
+        self.assertEqual(run_cfg.repeats, 1)
+        self.assertFalse(run_cfg.over_time)
+        self.assertFalse(run_cfg.dry_run)
+
     def test_input_var_order_matters_but_result_var_order_does_not(self) -> None:
         ab = self._ident(input_vars=["theta", "offset"], result_vars=["out_sin", "out_cos"])
         ba = self._ident(input_vars=["offset", "theta"], result_vars=["out_cos", "out_sin"])
@@ -289,6 +328,29 @@ class TestConfigAccessors(unittest.TestCase):
         finally:
             bench.close()
 
+    def test_asking_for_an_identity_does_not_reconfigure_the_config(self) -> None:
+        """BenchCfg subclasses BenchRunCfg, so an in-place merge would rewrite every
+        run-side field (repeats, cache_results, dry_run, ...) of a config the caller
+        still holds -- turning a query into a silent reconfiguration of the next run."""
+        cfg = bn.BenchRunCfg()
+        cfg.auto_plot = False
+        cfg.dry_run = True
+        bench = ExampleBenchCfg().to_bench(cfg)
+        try:
+            res = bench.plot_sweep(
+                input_vars=["theta"], result_vars=["out_sin"], plot_callbacks=False
+            )
+            merged = [k for k in bn.BenchRunCfg.param if k in res.bench_cfg.param]
+            before = {k: getattr(res.bench_cfg, k) for k in merged}
+            ident = res.bench_cfg.identity(
+                bn.BenchRunCfg(repeats=7, over_time=True, cache_results=True)
+            )
+            self.assertEqual(ident.repeats, 7)
+            self.assertTrue(ident.over_time)
+            self.assertEqual(before, {k: getattr(res.bench_cfg, k) for k in merged})
+        finally:
+            bench.close()
+
     def test_identity_of_an_unrun_config_needs_the_run_cfg(self) -> None:
         """repeats/over_time reach BenchCfg only through run_sweep's merge."""
         run_cfg = bn.BenchRunCfg(repeats=5)
@@ -360,6 +422,173 @@ class TestNoRuntimeCost(unittest.TestCase):
         )
         self.assertTrue(ident.cache_key)
         self.assertNotEqual(ident.cache_key, ident.history_key)
+
+
+def _dry_identity(run_cfg: bn.BenchRunCfg | None = None, **plot_sweep_kwargs) -> bn.SweepIdentity:
+    """Identity of a declaration made through a real ``plot_sweep``, without sampling.
+
+    Reaches the ``plot_sweep`` keywords ``sweep_identity`` deliberately does not
+    expose -- ``aggregate``, ``agg_fn``, ``plot_callbacks`` -- which land on
+    ``BenchCfg`` and so are the ones worth proving *inert*.
+    """
+    cfg = bn.BenchRunCfg() if run_cfg is None else run_cfg.deep()
+    cfg.dry_run = True
+    cfg.auto_plot = False
+    bench = ExampleBenchCfg().to_bench(cfg)
+    try:
+        return bn.identity_of(bench.plot_sweep(run_cfg=cfg, **plot_sweep_kwargs).bench_cfg, cfg)
+    finally:
+        bench.close()
+
+
+_GUARD_BASE = {
+    "input_vars": ["theta"],
+    "result_vars": ["out_sin"],
+    "const_vars": {"offset": 0.1},
+}
+
+
+class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
+    """``IDENTITY_FIELDS`` / ``EXCLUDED_FIELDS`` are prose about code that lives elsewhere.
+
+    ``explain()`` is only worth reading if those two lists are true of
+    ``BenchCfg.hash_persistent``, and a hand-kept description of a hashing rule
+    defined somewhere else is exactly the transcription this API exists to delete --
+    so each entry is checked behaviourally, by changing that field and asserting a key
+    does or does not move. The coverage map is asserted to name every entry, so
+    extending either list without a matching check fails here rather than silently
+    documenting something untrue.
+    """
+
+    def _ident(self, **kwargs) -> bn.SweepIdentity:
+        return bn.sweep_identity(worker=ExampleBenchCfg, **{**_GUARD_BASE, **kwargs})
+
+    def _assert_keys_move(self, a: bn.SweepIdentity, b: bn.SweepIdentity) -> None:
+        self.assertNotEqual(a.cache_key, b.cache_key, "cache_key")
+        self.assertNotEqual(a.history_key, b.history_key, "history_key")
+
+    def _assert_no_key_moves(self, a: bn.SweepIdentity, b: bn.SweepIdentity) -> None:
+        self.assertEqual(a.cache_key, b.cache_key, "cache_key")
+        self.assertEqual(a.history_key, b.history_key, "history_key")
+        self.assertEqual(a.sample_key, b.sample_key, "sample_key")
+
+    # --- contributing fields -------------------------------------------------
+
+    def check_cache_version(self) -> None:
+        """A version bump is meant to invalidate every key at once."""
+        base = self._ident()
+        with mock.patch("bencher.bench_cfg.CACHE_VERSION", 10_000):
+            bumped = self._ident()
+        self._assert_keys_move(base, bumped)
+        self.assertNotEqual(base.sample_key, bumped.sample_key)
+
+    def check_bench_name(self) -> None:
+        self._assert_keys_move(self._ident(), self._ident(bench_name="Renamed"))
+
+    def check_over_time(self) -> None:
+        self._assert_keys_move(self._ident(), self._ident(over_time=True))
+
+    def check_repeats(self) -> None:
+        base, more = self._ident(), self._ident(repeats=3)
+        self._assert_keys_move(base, more)
+        # ...but not the sample key, which is hashed with include_repeats=False so a
+        # single sample stays reusable across repeat counts.
+        self.assertEqual(base.sample_key, more.sample_key)
+
+    def check_tag(self) -> None:
+        self._assert_keys_move(self._ident(), self._ident(tag="nightly"))
+
+    def check_input_vars(self) -> None:
+        """In list order: the order fixes the dimension layout of the result arrays."""
+        two = {"input_vars": ["theta", "offset"], "const_vars": {}}
+        self._assert_keys_move(
+            self._ident(**two), self._ident(input_vars=["offset", "theta"], const_vars={})
+        )
+        self._assert_keys_move(self._ident(**two), self._ident(input_vars=["theta"], const_vars={}))
+
+    def check_result_vars(self) -> None:
+        """An unordered set, and in the cache key only."""
+        one = self._ident()
+        two = self._ident(result_vars=["out_sin", "out_cos"])
+        self.assertNotEqual(one.cache_key, two.cache_key)
+        self.assertEqual(one.history_key, two.history_key)
+        self.assertEqual(two.cache_key, self._ident(result_vars=["out_cos", "out_sin"]).cache_key)
+
+    def check_const_vars(self) -> None:
+        """An unordered set: const order only reaches the title string."""
+        self._assert_keys_move(self._ident(), self._ident(const_vars={"offset": 0.2}))
+        pair = [(ExampleBenchCfg.param.offset, 0.1), (ExampleBenchCfg.param.noisy, True)]
+        self.assertEqual(
+            self._ident(const_vars=pair).cache_key,
+            self._ident(const_vars=list(reversed(pair))).cache_key,
+        )
+
+    # --- fields excluded on purpose ------------------------------------------
+
+    def check_title(self) -> None:
+        self._assert_no_key_moves(self._ident(), self._ident(title="Something else entirely"))
+
+    def check_descriptions(self) -> None:
+        self._assert_no_key_moves(self._ident(), self._ident(description="d", post_description="p"))
+
+    def check_aggregation(self) -> None:
+        """``agg_over_dims``/``agg_fn`` land on BenchCfg, and must stay inert there."""
+        self._assert_no_key_moves(
+            _dry_identity(input_vars=["theta", "offset"], result_vars=["out_sin"]),
+            _dry_identity(
+                input_vars=["theta", "offset"],
+                result_vars=["out_sin"],
+                aggregate=True,
+                agg_fn="max",
+            ),
+        )
+
+    def check_sample_order(self) -> None:
+        """Sampling traversal only -- it never reaches BenchCfg at all."""
+        self.assertNotIn("sample_order", BenchCfg.param)
+        decl = {"input_vars": [bn.sweep("theta", samples=2)], "result_vars": ["out_sin"]}
+        self._assert_no_key_moves(
+            _real_run(**decl, sample_order=bn.SampleOrder.INORDER),
+            _real_run(**decl, sample_order=bn.SampleOrder.REVERSED),
+        )
+
+    def check_plotting(self) -> None:
+        """``plot_callbacks`` is stored on BenchCfg; ``auto_plot`` is merged onto it."""
+        decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
+        self._assert_no_key_moves(
+            _dry_identity(**decl, plot_callbacks=False),
+            _dry_identity(**decl, plot_callbacks=True),
+        )
+        self._assert_no_key_moves(
+            _dry_identity(**decl, plot_callbacks=False),
+            _dry_identity(bn.BenchRunCfg(auto_plot=True), **decl, plot_callbacks=False),
+        )
+
+    def _checks(self) -> dict:
+        return {
+            "CACHE_VERSION": self.check_cache_version,
+            "bench_name": self.check_bench_name,
+            "over_time": self.check_over_time,
+            "repeats": self.check_repeats,
+            "tag": self.check_tag,
+            "input_vars (in list order)": self.check_input_vars,
+            "result_vars (as an unordered set; cache_key only)": self.check_result_vars,
+            "const_vars (as an unordered set)": self.check_const_vars,
+            "title": self.check_title,
+            "description / post_description": self.check_descriptions,
+            "aggregate / agg_fn": self.check_aggregation,
+            "sample_order": self.check_sample_order,
+            "plot_callbacks / auto_plot": self.check_plotting,
+        }
+
+    def test_every_documented_field_has_a_check(self) -> None:
+        """Adding a field to either list without a check fails here."""
+        self.assertEqual(set(self._checks()), set(bn.IDENTITY_FIELDS) | set(bn.EXCLUDED_FIELDS))
+
+    def test_each_documented_field_behaves_as_documented(self) -> None:
+        for field_name, check in self._checks().items():
+            with self.subTest(field=field_name):
+                check()
 
 
 class TestMathImportedForRealism(unittest.TestCase):

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -392,7 +392,9 @@ class TestNoRuntimeCost(unittest.TestCase):
             x = bn.FloatSweep(default=0, bounds=(0, 1), samples=3)
             y = bn.ResultFloat()
 
-            def __init__(self, **params):
+            # Never reaching super().__init__ is the whole point: this class cannot be
+            # constructed at all, so identity must not try.
+            def __init__(self, **params):  # pylint: disable=super-init-not-called
                 raise RuntimeError("requires an active sampling context")
 
         ident = bn.sweep_identity(worker=NeedsHardware, input_vars=["x"], result_vars=["y"])

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -1,0 +1,378 @@
+"""Plan 16 — ``bn.sweep_identity`` must agree with a real run, byte for byte.
+
+The whole value of a public identity API is that it cannot drift from the runtime,
+so the central test here is equivalence against an actual ``plot_sweep``, over
+every declaration form ``plot_sweep`` accepts. A test that only pinned
+``sweep_identity`` against itself would pass forever while the hashing rule moved
+underneath it -- which is exactly the failure mode of the downstream
+transcriptions this API exists to replace.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import pickle
+import unittest
+from dataclasses import asdict
+
+import bencher as bn
+from bencher.example.benchmark_data import ExampleBenchCfg
+
+
+def _real_run(run_cfg: bn.BenchRunCfg | None = None, **kwargs) -> bn.SweepIdentity:
+    """Actually run the sweep and report the identity it was stored under."""
+    cfg = run_cfg if run_cfg is not None else bn.BenchRunCfg()
+    cfg.auto_plot = False
+    cfg.cache_results = False
+    cfg.cache_samples = False
+    bench = ExampleBenchCfg().to_bench(cfg)
+    try:
+        return bench.plot_sweep(plot_callbacks=False, **kwargs).identity
+    finally:
+        bench.close()
+
+
+DECLARATIONS = {
+    "param_object": dict(
+        input_vars=[ExampleBenchCfg.param.theta],
+        result_vars=[ExampleBenchCfg.param.out_sin],
+    ),
+    "by_name": dict(input_vars=["theta"], result_vars=["out_sin"]),
+    "sweep_spec_bounds": dict(
+        input_vars=[bn.sweep("theta", bounds=(0, 1), samples=3)],
+        result_vars=["out_sin"],
+    ),
+    "sweep_spec_values": dict(
+        input_vars=[bn.sweep("theta", [0.0, 0.5, 1.0])],
+        result_vars=["out_sin"],
+    ),
+    "two_inputs": dict(
+        input_vars=[bn.sweep("theta", samples=2), bn.sweep("offset", samples=2)],
+        result_vars=["out_sin", "out_cos"],
+    ),
+    "consts_as_dict": dict(
+        input_vars=[bn.sweep("theta", samples=2)],
+        result_vars=["out_sin"],
+        const_vars={"offset": 0.1},
+    ),
+    "consts_as_pairs": dict(
+        input_vars=[bn.sweep("theta", samples=2)],
+        result_vars=["out_sin"],
+        const_vars=[(ExampleBenchCfg.param.offset, 0.1)],
+    ),
+    "tagged": dict(
+        input_vars=[bn.sweep("theta", samples=2)],
+        result_vars=["out_sin"],
+        tag="nightly",
+    ),
+    "no_inputs": dict(input_vars=[], result_vars=["out_sin"], const_vars={"theta": 0.5}),
+}
+
+RUN_CFGS = {
+    "default": dict(),
+    "over_time": dict(over_time=True),
+    "repeats_3": dict(repeats=3),
+    "subsampling_2": dict(subsampling_divisions=2),
+    "subsampling_4_over_time": dict(subsampling_divisions=4, over_time=True, repeats=2),
+    "samples_per_var": dict(samples_per_var=4),
+    "run_tag": dict(run_tag="rt"),
+}
+
+
+class TestEquivalence(unittest.TestCase):
+    """sweep_identity(...) == the identity of an actual run of the same sweep."""
+
+    def _check(self, decl: dict, run_kwargs: dict) -> None:
+        predicted = bn.sweep_identity(
+            worker=ExampleBenchCfg, run_cfg=bn.BenchRunCfg(**run_kwargs), **decl
+        )
+        actual = _real_run(bn.BenchRunCfg(**run_kwargs), **decl)
+        self.assertEqual(predicted.cache_key, actual.cache_key, "cache_key")
+        self.assertEqual(predicted.history_key, actual.history_key, "history_key")
+        self.assertEqual(predicted.sample_key, actual.sample_key, "sample_key")
+        self.assertEqual(predicted.bench_name, actual.bench_name)
+        self.assertEqual(predicted.tag, actual.tag)
+        self.assertEqual(predicted.repeats, actual.repeats)
+        self.assertEqual(predicted.over_time, actual.over_time)
+        self.assertEqual(predicted.summary, actual.summary)
+        self.assertEqual(predicted, actual)
+
+    def test_every_declaration_form_default_run(self) -> None:
+        for name, decl in DECLARATIONS.items():
+            with self.subTest(declaration=name):
+                self._check(decl, {})
+
+    def test_every_run_cfg_shape(self) -> None:
+        decl = DECLARATIONS["sweep_spec_bounds"]
+        for name, run_kwargs in RUN_CFGS.items():
+            with self.subTest(run_cfg=name):
+                self._check(decl, run_kwargs)
+
+    def test_auto_discovered_vars(self) -> None:
+        """input_vars=None auto-discovers; the prediction must discover the same."""
+        self._check(dict(result_vars=["out_sin"], const_vars={}), dict(subsampling_divisions=2))
+
+
+class TestKeySemantics(unittest.TestCase):
+    def _ident(self, **kwargs) -> bn.SweepIdentity:
+        return bn.sweep_identity(worker=ExampleBenchCfg, **kwargs)
+
+    def test_history_key_ignores_result_vars_and_cache_key_does_not(self) -> None:
+        """The plan 09/14 contract, asserted through the new surface."""
+        one = self._ident(input_vars=["theta"], result_vars=["out_sin"])
+        two = self._ident(input_vars=["theta"], result_vars=["out_sin", "out_cos"])
+        self.assertEqual(one.history_key, two.history_key)
+        self.assertNotEqual(one.cache_key, two.cache_key)
+
+    def test_title_and_description_do_not_move_any_key(self) -> None:
+        base = self._ident(input_vars=["theta"], result_vars=["out_sin"])
+        titled = self._ident(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            title="Something else entirely",
+            description="d",
+            post_description="p",
+        )
+        self.assertEqual(base.cache_key, titled.cache_key)
+        self.assertEqual(base.history_key, titled.history_key)
+
+    def test_bench_name_moves_every_key(self) -> None:
+        """The rename case: identical declaration, different name, different series."""
+        a = self._ident(bench_name="Alpha", input_vars=["theta"], result_vars=["out_sin"])
+        b = self._ident(bench_name="Beta", input_vars=["theta"], result_vars=["out_sin"])
+        self.assertNotEqual(a.history_key, b.history_key)
+        self.assertNotEqual(a.cache_key, b.cache_key)
+
+    def test_bench_name_defaults_to_the_worker_class_name(self) -> None:
+        """Matches create_bench, so a prediction and a to_bench() run agree."""
+        ident = self._ident(input_vars=["theta"], result_vars=["out_sin"])
+        self.assertEqual(ident.bench_name, "ExampleBenchCfg")
+
+    def test_subsampling_divisions_moves_the_key(self) -> None:
+        """Input vars are reshaped before hashing, so the run config is part of identity."""
+        keys = {
+            n: self._ident(
+                input_vars=["theta"],
+                result_vars=["out_sin"],
+                run_cfg=bn.BenchRunCfg(subsampling_divisions=n),
+            ).history_key
+            for n in (0, 2, 4)
+        }
+        self.assertEqual(len(set(keys.values())), 3, keys)
+
+    def test_run_tag_is_prefixed_to_tag(self) -> None:
+        ident = self._ident(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            tag="b",
+            run_cfg=bn.BenchRunCfg(run_tag="a_"),
+        )
+        self.assertEqual(ident.tag, "a_b")
+
+    def test_input_var_order_matters_but_result_var_order_does_not(self) -> None:
+        ab = self._ident(input_vars=["theta", "offset"], result_vars=["out_sin", "out_cos"])
+        ba = self._ident(input_vars=["offset", "theta"], result_vars=["out_cos", "out_sin"])
+        self.assertNotEqual(ab.history_key, ba.history_key)
+        reordered_results = self._ident(
+            input_vars=["theta", "offset"], result_vars=["out_cos", "out_sin"]
+        )
+        self.assertEqual(ab.cache_key, reordered_results.cache_key)
+
+
+class TestValueSemantics(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ident = bn.sweep_identity(
+            worker=ExampleBenchCfg, input_vars=["theta"], result_vars=["out_sin"]
+        )
+
+    def test_frozen(self) -> None:
+        with self.assertRaises(Exception):
+            self.ident.cache_key = "x"
+
+    def test_pickle_round_trip_is_unchanged(self) -> None:
+        again = pickle.loads(pickle.dumps(self.ident))
+        self.assertEqual(again, self.ident)
+        self.assertEqual(again.cache_key, self.ident.cache_key)
+        self.assertEqual(again.summary, self.ident.summary)
+
+    def test_json_round_trip_needs_no_custom_encoder(self) -> None:
+        blob = json.dumps(asdict(self.ident))
+        back = json.loads(blob)
+        self.assertEqual(back["cache_key"], self.ident.cache_key)
+        self.assertEqual(back["history_key"], self.ident.history_key)
+
+    def test_usable_as_a_dict_key(self) -> None:
+        twin = bn.sweep_identity(
+            worker=ExampleBenchCfg, input_vars=["theta"], result_vars=["out_sin"]
+        )
+        self.assertEqual({self.ident: 1, twin: 2}, {self.ident: 2})
+
+    def test_summary_is_excluded_from_equality(self) -> None:
+        """It is derived explanation, and a dict field would break hashing."""
+        from dataclasses import fields
+
+        (summary_field,) = [f for f in fields(bn.SweepIdentity) if f.name == "summary"]
+        self.assertFalse(summary_field.compare)
+        self.assertIsInstance(hash(self.ident), int)
+
+
+class TestErrors(unittest.TestCase):
+    def test_by_name_variable_without_a_worker_raises_the_existing_error(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            bn.sweep_identity(bench_name="X", input_vars=["theta"], result_vars=["out_sin"])
+        self.assertIn("without a worker class instance", str(ctx.exception))
+
+    def test_no_worker_and_no_bench_name_raises(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            bn.sweep_identity(input_vars=[], result_vars=[])
+        self.assertIn("bench_name", str(ctx.exception))
+
+    def test_unknown_variable_name_lists_available_parameters(self) -> None:
+        with self.assertRaises(KeyError) as ctx:
+            bn.sweep_identity(worker=ExampleBenchCfg, input_vars=["nope"], result_vars=["out_sin"])
+        self.assertIn("Available parameters", str(ctx.exception))
+
+
+class TestExplain(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ident = bn.sweep_identity(
+            worker=ExampleBenchCfg,
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            const_vars={"offset": 0.2},
+            tag="nightly",
+        )
+
+    def test_names_title_as_excluded(self) -> None:
+        """Regression guard for the exclusion documented in hash_persistent."""
+        text = self.ident.explain()
+        excluded = text.split("excluded on purpose")[1]
+        self.assertIn("title", excluded)
+
+    def test_reports_both_keys_and_the_contributing_fields(self) -> None:
+        text = self.ident.explain()
+        self.assertIn(self.ident.cache_key, text)
+        self.assertIn(self.ident.history_key, text)
+        for expected in ("bench_name", "tag", "repeats", "over_time", "input_vars"):
+            self.assertIn(expected, text)
+
+    def test_diff_identities_names_what_moved(self) -> None:
+        other = bn.sweep_identity(
+            worker=ExampleBenchCfg,
+            input_vars=["theta", "offset"],
+            result_vars=["out_sin"],
+            tag="nightly",
+        )
+        lines = bn.diff_identities(self.ident, other)
+        self.assertTrue(any("inputs changed" in line for line in lines), lines)
+
+    def test_diff_identities_accepts_raw_summaries(self) -> None:
+        """The stored last-seen index holds dicts, not SweepIdentity values."""
+        lines = bn.diff_identities(self.ident.summary, self.ident.summary)
+        self.assertEqual(lines, [])
+
+
+class TestConfigAccessors(unittest.TestCase):
+    def test_bench_cfg_identity_matches_the_result_identity(self) -> None:
+        cfg = bn.BenchRunCfg(subsampling_divisions=2, repeats=2)
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        bench = ExampleBenchCfg().to_bench(cfg)
+        try:
+            res = bench.plot_sweep(
+                input_vars=["theta"], result_vars=["out_sin"], plot_callbacks=False
+            )
+            self.assertEqual(res.bench_cfg.identity(), res.identity)
+            self.assertEqual(res.identity.repeats, 2)
+        finally:
+            bench.close()
+
+    def test_identity_of_an_unrun_config_needs_the_run_cfg(self) -> None:
+        """repeats/over_time reach BenchCfg only through run_sweep's merge."""
+        run_cfg = bn.BenchRunCfg(repeats=5)
+        ident = bn.sweep_identity(
+            worker=ExampleBenchCfg,
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            run_cfg=run_cfg,
+        )
+        self.assertEqual(ident.repeats, 5)
+
+
+class TestNoRuntimeCost(unittest.TestCase):
+    def test_the_worker_is_never_called(self) -> None:
+        calls = []
+
+        class Probe(bn.ParametrizedSweep):
+            x = bn.FloatSweep(default=0, bounds=(0, 1), samples=3)
+            y = bn.ResultFloat()
+
+            def __call__(self, **kwargs):
+                calls.append(kwargs)
+                return {"y": 1.0}
+
+        ident = bn.sweep_identity(worker=Probe, input_vars=["x"], result_vars=["y"])
+        self.assertEqual(calls, [])
+        self.assertTrue(ident.cache_key)
+
+    def test_a_worker_class_is_never_instantiated(self) -> None:
+        """The case that makes identity reachable for an expensive benchmark.
+
+        A worker that needs live resources -- an attached robot, a running
+        simulator, an open device -- cannot be constructed just to be asked what
+        its parameters are, and requiring an instance would put identity out of
+        reach of exactly the benchmarks whose runs are worth checking first.
+        """
+
+        class NeedsHardware(bn.ParametrizedSweep):
+            x = bn.FloatSweep(default=0, bounds=(0, 1), samples=3)
+            y = bn.ResultFloat()
+
+            def __init__(self, **params):
+                raise RuntimeError("requires an active sampling context")
+
+        ident = bn.sweep_identity(worker=NeedsHardware, input_vars=["x"], result_vars=["y"])
+        self.assertTrue(ident.history_key)
+        self.assertEqual(ident.bench_name, "NeedsHardware")
+
+    def test_a_class_and_an_instance_agree(self) -> None:
+        by_class = bn.sweep_identity(
+            worker=ExampleBenchCfg, input_vars=["theta"], result_vars=["out_sin"]
+        )
+        by_instance = bn.sweep_identity(
+            worker=ExampleBenchCfg(), input_vars=["theta"], result_vars=["out_sin"]
+        )
+        self.assertEqual(by_class, by_instance)
+
+    def test_auto_discovery_works_from_a_class(self) -> None:
+        """get_inputs_only / get_input_defaults / get_results_only are classmethods."""
+        by_class = bn.sweep_identity(worker=ExampleBenchCfg)
+        by_instance = bn.sweep_identity(worker=ExampleBenchCfg())
+        self.assertEqual(by_class, by_instance)
+        self.assertTrue(by_class.summary["inputs"])
+        self.assertTrue(by_class.summary["results"])
+
+    def test_a_zero_length_declaration_still_produces_keys(self) -> None:
+        ident = bn.sweep_identity(
+            worker=ExampleBenchCfg, input_vars=[], result_vars=["out_sin"], const_vars={}
+        )
+        self.assertTrue(ident.cache_key)
+        self.assertNotEqual(ident.cache_key, ident.history_key)
+
+
+class TestMathImportedForRealism(unittest.TestCase):
+    """theta's bounds are [0, pi]; a values= declaration inside them is realistic."""
+
+    def test_explicit_values_within_bounds(self) -> None:
+        ident = bn.sweep_identity(
+            worker=ExampleBenchCfg,
+            input_vars=[bn.sweep("theta", [0.0, math.pi / 2, math.pi])],
+            result_vars=["out_sin"],
+        )
+        self.assertTrue(ident.history_key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -14,7 +14,7 @@ import json
 import math
 import pickle
 import unittest
-from dataclasses import asdict
+from dataclasses import FrozenInstanceError, asdict
 from unittest import mock
 
 import bencher as bn
@@ -36,49 +36,49 @@ def _real_run(run_cfg: bn.BenchRunCfg | None = None, **kwargs) -> bn.SweepIdenti
 
 
 DECLARATIONS = {
-    "param_object": dict(
-        input_vars=[ExampleBenchCfg.param.theta],
-        result_vars=[ExampleBenchCfg.param.out_sin],
-    ),
-    "by_name": dict(input_vars=["theta"], result_vars=["out_sin"]),
-    "sweep_spec_bounds": dict(
-        input_vars=[bn.sweep("theta", bounds=(0, 1), samples=3)],
-        result_vars=["out_sin"],
-    ),
-    "sweep_spec_values": dict(
-        input_vars=[bn.sweep("theta", [0.0, 0.5, 1.0])],
-        result_vars=["out_sin"],
-    ),
-    "two_inputs": dict(
-        input_vars=[bn.sweep("theta", samples=2), bn.sweep("offset", samples=2)],
-        result_vars=["out_sin", "out_cos"],
-    ),
-    "consts_as_dict": dict(
-        input_vars=[bn.sweep("theta", samples=2)],
-        result_vars=["out_sin"],
-        const_vars={"offset": 0.1},
-    ),
-    "consts_as_pairs": dict(
-        input_vars=[bn.sweep("theta", samples=2)],
-        result_vars=["out_sin"],
-        const_vars=[(ExampleBenchCfg.param.offset, 0.1)],
-    ),
-    "tagged": dict(
-        input_vars=[bn.sweep("theta", samples=2)],
-        result_vars=["out_sin"],
-        tag="nightly",
-    ),
-    "no_inputs": dict(input_vars=[], result_vars=["out_sin"], const_vars={"theta": 0.5}),
+    "param_object": {
+        "input_vars": [ExampleBenchCfg.param.theta],
+        "result_vars": [ExampleBenchCfg.param.out_sin],
+    },
+    "by_name": {"input_vars": ["theta"], "result_vars": ["out_sin"]},
+    "sweep_spec_bounds": {
+        "input_vars": [bn.sweep("theta", bounds=(0, 1), samples=3)],
+        "result_vars": ["out_sin"],
+    },
+    "sweep_spec_values": {
+        "input_vars": [bn.sweep("theta", [0.0, 0.5, 1.0])],
+        "result_vars": ["out_sin"],
+    },
+    "two_inputs": {
+        "input_vars": [bn.sweep("theta", samples=2), bn.sweep("offset", samples=2)],
+        "result_vars": ["out_sin", "out_cos"],
+    },
+    "consts_as_dict": {
+        "input_vars": [bn.sweep("theta", samples=2)],
+        "result_vars": ["out_sin"],
+        "const_vars": {"offset": 0.1},
+    },
+    "consts_as_pairs": {
+        "input_vars": [bn.sweep("theta", samples=2)],
+        "result_vars": ["out_sin"],
+        "const_vars": [(ExampleBenchCfg.param.offset, 0.1)],
+    },
+    "tagged": {
+        "input_vars": [bn.sweep("theta", samples=2)],
+        "result_vars": ["out_sin"],
+        "tag": "nightly",
+    },
+    "no_inputs": {"input_vars": [], "result_vars": ["out_sin"], "const_vars": {"theta": 0.5}},
 }
 
 RUN_CFGS = {
-    "default": dict(),
-    "over_time": dict(over_time=True),
-    "repeats_3": dict(repeats=3),
-    "subsampling_2": dict(subsampling_divisions=2),
-    "subsampling_4_over_time": dict(subsampling_divisions=4, over_time=True, repeats=2),
-    "samples_per_var": dict(samples_per_var=4),
-    "run_tag": dict(run_tag="rt"),
+    "default": {},
+    "over_time": {"over_time": True},
+    "repeats_3": {"repeats": 3},
+    "subsampling_2": {"subsampling_divisions": 2},
+    "subsampling_4_over_time": {"subsampling_divisions": 4, "over_time": True, "repeats": 2},
+    "samples_per_var": {"samples_per_var": 4},
+    "run_tag": {"run_tag": "rt"},
 }
 
 
@@ -113,7 +113,7 @@ class TestEquivalence(unittest.TestCase):
 
     def test_auto_discovered_vars(self) -> None:
         """input_vars=None auto-discovers; the prediction must discover the same."""
-        self._check(dict(result_vars=["out_sin"], const_vars={}), dict(subsampling_divisions=2))
+        self._check({"result_vars": ["out_sin"], "const_vars": {}}, {"subsampling_divisions": 2})
 
 
 class TestKeySemantics(unittest.TestCase):
@@ -226,7 +226,7 @@ class TestValueSemantics(unittest.TestCase):
         )
 
     def test_frozen(self) -> None:
-        with self.assertRaises(Exception):
+        with self.assertRaises(FrozenInstanceError):
             self.ident.cache_key = "x"
 
     def test_pickle_round_trip_is_unchanged(self) -> None:

--- a/test/test_worker_manager.py
+++ b/test/test_worker_manager.py
@@ -48,6 +48,23 @@ class TestWorkerManager(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.manager.set_worker(ExampleBenchCfg)  # Class, not instance
 
+    def test_set_worker_class_attaches_the_class_without_a_callable_worker(self):
+        """The declaration-only path used by sweep_identity.
+
+        ``worker`` stays None on purpose: a class cannot be called, so leaving it unset
+        makes an attempt to sample fail loudly rather than call a class object.
+        """
+        self.manager.set_worker_class(ExampleBenchCfg)
+        self.assertIs(self.manager.worker_class_instance, ExampleBenchCfg)
+        self.assertIsNone(self.manager.worker)
+        # A class is enough to answer what the declaration is made of.
+        self.assertIn("out_sin", self.manager.get_result_vars(as_str=True))
+
+    def test_set_worker_class_rejects_an_instance(self):
+        """The mirror of set_worker's complaint, so neither silently takes the other's."""
+        with self.assertRaises(RuntimeError):
+            self.manager.set_worker_class(ExampleBenchCfg())
+
     def test_get_result_vars_as_str(self):
         """Test getting result var names as strings."""
         self.manager.set_worker(ExampleBenchCfg())


### PR DESCRIPTION
Plan 16 plus its implementation. **First in a five-PR stack** (see below).

`BenchCfg.hash_persistent` is the single source of truth for a benchmark's cache and
over_time history keys, but it lives on a config object `plot_sweep` assembles part-way
through its own body — so the only way to learn a declaration's keys was to run the
benchmark. Downstream projects that want to protect a long-lived trend therefore
transcribe the hashing rule into an assertion about "the fields that make up the key",
and that assertion keeps passing after the rule changes.

## What this adds

- `bn.sweep_identity(...) -> SweepIdentity` — `cache_key`, `history_key`, `sample_key`,
  plus the resolved declaration summary, without running anything.
- `BenchCfg.identity()` and `BenchResult.identity`.
- `bn.config_summary` / `bn.diff_identities`, re-exported from `bencher.history`.
- `SweepIdentity.explain()` — the keys, the contributing fields, and the fields
  deliberately excluded.

**There is deliberately no second implementation of the hashing rule.** `sweep_identity`
drives the real `plot_sweep` in dry-run mode, replays the `run_cfg` → `BenchCfg` merge
that `run_sweep` performs, and calls the same `hash_persistent`. The central test asserts
equivalence against an *actual run* over 9 declaration forms × 7 run-config shapes.

## Two corrections to the plan, both found by implementing it

**A worker class is accepted and never instantiated.** The plan's D1 took a worker
instance. Real workers cannot always be constructed — the downstream this was audited
against raises `RuntimeError("requires an active sampling context")` from `__init__`.
Everything the declaration path needs is class-level (`param.objects()` plus the
`get_inputs_only` / `get_input_defaults` / `get_results_only` classmethods), so requiring
an instance would put identity out of reach of exactly the expensive benchmarks that most
need to check it before running.

**`run_cfg` is part of identity, and D1 omitted it.** `subsampling_divisions` and
`samples_per_var` reshape every input variable *before* it is hashed, and `run_tag` is
prefixed to `tag`. Measured — subsampling 0/2/4:

| Declaration form | distinct history keys |
|---|---|
| `["theta"]` | **3** |
| `bn.sweep("theta", bounds=(0,1), samples=5)` | **3** |
| `bn.sweep("theta", [0.0, 0.25, 0.5, 0.75, 1.0])` | **1** |

The explicit-`values` form is subsampling-immune, because `with_sample_values` pins the
values and `with_subsampling_divisions` maps them to themselves. A declared `samples` on
an input var is also *overwritten* by subsampling, so it never reaches the key at all.

## Validation

`sweep_identity` was pointed at a real downstream project's 16 (benchmark, environment)
cells to check what its hand-written history-key guard actually covers:

| Mutation | history keys moved | that project's guard still green |
|---|---|---|
| `repeats` 1 → 3 | **16/16** | 16/16 |
| `subsampling_divisions` → 3 | **4/4 swept cells** | 4/4 |
| control: tag renamed | 16/16 | 0/16 — caught |

A golden `history_key` assertion catches every key that moved. That is the use case.

## Compatibility

Purely additive. No signature changes, no hash changes, no cache invalidation — all 7
golden hashes in `test_hash_persistent.py` unchanged.

Caveat worth stating: `Bench.__init__` calls `ensure_cache_version()`, so
`sweep_identity` touches the cache-version file. It executes no samples and opens no
sample cache.

---

### Stack

| | PR | Plan | Base |
|---|---|---|---|
| 1 | #1010 | 16 inspectable identity | `main` |
| 2 | #1011 | 20 duplicate declared variables | #1010 |
| 3 | #1012 | 15 stable series identity | #1011 |
| 4 | #1013 | 21 per-sample fault tolerance | #1012 |
| 5 | #1014 | 18 reusable sweep declarations | #1013 |

Review and merge bottom-up. The order is not arbitrary — it comes from the plans' own
coordination sections: 16 first because it is purely additive and gives the reviewers of
20 and 15 a way to check hashes; 20 before 15 because 20 is the one deliberate hash move
and 15 is what makes such a move legible; 18 last because its `bind()` calls 20's
validator. Two cross-plan integrations that the plan docs require are only implementable
*because* of that ordering, and are noted in the PRs that carry them (3 and 5).

Supersedes #1000 (plan-only), which is closed. Nothing here is squashed
across plans: each PR is its own plan doc plus its own implementation.
