### PR TITLE
plan 20 + implementation: reject or normalise duplicate declared variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
 ### Fixed
+- **A variable declared twice in one sweep is now rejected or normalised, instead of quietly
+  moving the cache and history key.** ⚠️ *This moves the key for affected benchmarks — see
+  below.* `plot_sweep` converted each list positionally with no uniqueness check, and the
+  three kinds of variable each misbehaved differently:
+
+  `result_vars=["y", "y"]` was the damaging one. It produced a dataset **byte-identical** to
+  `result_vars=["y"]` under a **different** key: `ResultCollector.setup_dataset` builds
+  `data_vars` as a dict keyed by name and `bencher.history` keys its per-column metadata the
+  same way, so the repeat collapsed in the data, while `BenchCfg.hash_persistent` folded the
+  per-variable digests as a sorted *tuple* and so hashed it twice. The benchmark ran,
+  reported correct numbers, and appended to a different trend line than the one it appeared
+  to belong to — with nothing in the run saying so. The duplicate is now dropped (first
+  occurrence kept) with a `UserWarning` naming the variable and both positions.
+
+  `input_vars=["x", "x"]` was accepted and then either collapsed to a single dimension or
+  died inside xarray with `broadcasting cannot handle duplicate dimensions`, depending on
+  the sweep's shape — after the whole sweep had run. It now raises a `ValueError` at
+  declaration time, naming the variable and every position.
+
+  `const_vars` behaved differently depending on spelling: the dict form collapsed duplicates
+  before bencher saw them, while the list-of-pairs form accepted a repeat with two
+  *different* values and let iteration order pick the winner. Repeats with equal values are
+  now deduped silently; conflicting values raise, naming both.
+
+  Validation happens once, in `validate_declared_vars`, called from `plot_sweep` after
+  conversion so comparison is on resolved names and every declaration form — string, spec
+  dict, param object, and mixtures — is covered by the same code.
+
+  Separately, `hash_persistent` now folds result and const digests as **sets** rather than
+  sorted tuples. Its docstring already promised they contribute as an "unordered set", but a
+  sorted tuple delivered only the ordering half of that; uniqueness was missing, which is
+  the mechanism behind the bug above. This keeps identity correct on paths that never reach
+  the validator, such as a `BenchCfg` built or deserialized directly.
+
+  **Migration:** only benchmarks that *currently declare an overlapping result variable* are
+  affected, and they are exactly the ones now emitting the new warning. Their key moves onto
+  the key it would have had if declared correctly, so in the common case the benchmark
+  rejoins the trend it should have been on all along; in the worst case it starts a fresh
+  series, and `on_history_reset` controls how loudly that surfaces. Configurations without a
+  duplicate are bit-identical: every golden hash in `test/test_hash_persistent.py` is
+  unchanged, since `sorted(set(xs)) == sorted(xs)` when `xs` is already unique.
 - **`hover=False` on an intra-sample chart now actually disables hover.** `set_default_opts`
   registers `tools=["hover"]` as a global holoviews default for most element types, so a
   spec that merely omitted the key got hover back and the option was a silent no-op.

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -837,14 +837,28 @@ class BenchCfg(BenchRunCfg):
         for v in self.input_vars or []:
             hash_val = hash_sha1((hash_val, v.hash_persistent()))
 
+        # Folded as sets -- sorted *unique* digests -- so that a variable appearing twice
+        # cannot move the key, which is what "unordered set" above has always claimed.
+        # A sorted tuple delivered the ordering half of that contract but not the
+        # uniqueness half: a repeat appeared twice in the hashed sequence, while the
+        # dataset's data_vars and history's per-column metadata are keyed by name and
+        # collapsed it. That disagreement is the bug plan 20 documents.
+        # validate_declared_vars rejects or dedupes duplicates before they reach here on
+        # the plot_sweep path; deduping here too keeps identity correct on the paths that
+        # bypass it -- a BenchCfg built or deserialized directly. Configurations without a
+        # duplicate hash exactly as before, since sorted(set(xs)) == sorted(xs) when xs is
+        # already unique.
         if include_result_vars:
-            result_hashes = tuple(sorted(v.hash_persistent() for v in self.result_vars or []))
+            result_hashes = tuple(sorted({v.hash_persistent() for v in self.result_vars or []}))
         else:
             result_hashes = ()
 
         const_hashes = tuple(
             sorted(
-                hash_sha1((v[0].hash_persistent(), hash_sha1(v[1]))) for v in self.const_vars or []
+                {
+                    hash_sha1((v[0].hash_persistent(), hash_sha1(v[1])))
+                    for v in self.const_vars or []
+                }
             )
         )
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -33,7 +33,7 @@ from bencher.result_collector import ResultCollector
 from bencher.results.bench_result import BenchResult
 from bencher.results.optimize_result import OptimizeResult
 from bencher.sample_order import SampleOrder
-from bencher.sweep_executor import SweepExecutor, worker_kwargs_wrapper
+from bencher.sweep_executor import SweepExecutor, validate_declared_vars, worker_kwargs_wrapper
 from bencher.sweep_timings import SweepTimings, phase_timer
 from bencher.utils import AGG_FN_MAP, params_to_str, resolve_aggregate
 from bencher.variables.inputs import IntSweep
@@ -441,6 +441,12 @@ class Bench(BenchPlotServer):
             cv_list = list(const_vars_in[i])
             cv_list[0] = self.convert_vars_to_params(cv_list[0], "const", run_cfg)
             const_vars_in[i] = cv_list
+
+        # One validation site, after conversion so comparison is on resolved names
+        # rather than the mixed bag of strings, dicts and objects the caller passed.
+        input_vars_in, result_vars_in, const_vars_in = validate_declared_vars(
+            input_vars_in, result_vars_in, const_vars_in
+        )
 
         if title is None:
             if len(input_vars_in) > 0:

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -38,12 +38,99 @@ def _resolve_param(
     return all_params[name]
 
 
-def _positions_by_name(names: list[str]) -> dict[str, list[int]]:
-    """Declared positions of each name, in declaration order."""
-    out: dict[str, list[int]] = {}
-    for index, name in enumerate(names):
-        out.setdefault(name, []).append(index)
-    return out
+def _validate_input_vars(input_vars: list[param.Parameter]) -> list[param.Parameter]:
+    """Reject an input variable declared more than once, returning the list unchanged.
+
+    Each input variable is one dataset dimension, so a repeat has no valid
+    interpretation. Left alone it does not even reliably fail: whether xarray
+    rejects the broadcast or quietly collapses the repeat into a single dimension
+    depends on the sweep's shape, and when it does fail the message comes from
+    deep inside xarray with no reference to the declaration that caused it.
+
+    Every position is named, not just the offending pair, because the fix is to
+    delete all but one of them.
+    """
+    seen: set[str] = set()
+    for var in input_vars:
+        if var.name in seen:
+            # Only walked on the error path, so the happy path stays a single pass.
+            positions = [i for i, v in enumerate(input_vars) if v.name == var.name]
+            raise ValueError(
+                f"Input variable '{var.name}' is declared {len(positions)} times "
+                f"(positions {positions}). Each input variable defines one dataset "
+                f"dimension, so it may appear only once."
+            )
+        seen.add(var.name)
+    return input_vars
+
+
+def _dedupe_result_vars(result_vars: list[param.Parameter]) -> list[param.Parameter]:
+    """Drop result variables repeated by name, keeping the first, and warn.
+
+    The deduped set is already what bencher stores: the dataset's ``data_vars``
+    and history's per-column metadata are both keyed by name, so a repeat
+    collapses there. Only ``BenchCfg.hash_persistent`` disagreed, folding the
+    per-variable digests as a sorted *tuple* so a repeat appeared twice and moved
+    the key -- the benchmark ran, reported correct numbers, and appended to a
+    trend line other than the one it appeared to belong to. Deduping makes cache
+    and history identity agree with the data that was already being written,
+    which is why this warns rather than raising.
+    """
+    kept: list[param.Parameter] = []
+    first_seen: dict[str, int] = {}
+    for index, var in enumerate(result_vars):
+        if var.name in first_seen:
+            warnings.warn(
+                f"Result variable '{var.name}' is declared twice (positions "
+                f"{first_seen[var.name]} and {index}); the duplicate is ignored. "
+                f"Result variables are a set keyed by name -- declare each metric "
+                f"once. Until now the repeat moved the cache and history key "
+                f"without changing the data.",
+                UserWarning,
+                # here -> validate_declared_vars -> plot_sweep -> the caller to blame
+                stacklevel=4,
+            )
+            continue
+        first_seen[var.name] = index
+        kept.append(var)
+    return kept
+
+
+def _const_values_conflict(first: Any, second: Any) -> bool:
+    """Whether two values declared for the same constant disagree.
+
+    Compared by ``hash_sha1`` rather than ``!=`` so that "the same constant"
+    means exactly what ``hash_persistent`` means by it -- identity is what the
+    dedupe is protecting. It also copes with the values that actually turn up
+    here, which are arbitrary: unhashable containers, and objects whose ``__eq__``
+    is elementwise rather than a bool (numpy arrays) or missing entirely.
+    """
+    return hash_sha1(first) != hash_sha1(second)
+
+
+def _dedupe_const_vars(const_vars: list[list]) -> list[list]:
+    """Drop constants repeated with an equal value; raise when the values differ.
+
+    A repeated constant with two different values is a contradiction in the
+    declaration, and which one won depended on iteration order.
+    """
+    kept: list[list] = []
+    first_seen: dict[str, tuple[int, Any]] = {}
+    for index, entry in enumerate(const_vars):
+        var, value = entry[0], entry[1]
+        if var.name in first_seen:
+            prev_index, prev_value = first_seen[var.name]
+            if _const_values_conflict(prev_value, value):
+                raise ValueError(
+                    f"Constant '{var.name}' is declared twice with different values: "
+                    f"{prev_value!r} at position {prev_index} and {value!r} at "
+                    f"position {index}. Which one applied depended on iteration "
+                    f"order, so declare it once with the value you mean."
+                )
+            continue
+        first_seen[var.name] = (index, value)
+        kept.append(entry)
+    return kept
 
 
 def validate_declared_vars(
@@ -53,24 +140,12 @@ def validate_declared_vars(
 ) -> tuple[list[param.Parameter], list[param.Parameter], list[list]]:
     """Reject or normalise variables declared more than once in one sweep.
 
-    Compares resolved ``name``, so the string, dict and object declaration forms
-    are all covered and a mixture of them is too. The three kinds get three
-    answers because the data model gives them three meanings, not out of
-    leniency:
-
-    * **Input** -- raises. Each input variable is one dataset dimension, and a
-      repeated dimension has no valid interpretation; it already fails, deep
-      inside xarray's broadcasting with no reference to the declaration.
-    * **Result** -- deduped on name, first occurrence kept, ``UserWarning``.
-      The deduped set is already what bencher stores: the dataset's ``data_vars``
-      and history's per-column metadata are both keyed by name, so a repeat
-      collapses there. Only ``BenchCfg.hash_persistent`` disagreed, folding the
-      per-variable digests as a sorted *tuple* so a repeat appeared twice and
-      moved the key. Deduping makes cache and history identity agree with the
-      data that was already being written.
-    * **Const** -- deduped when the values agree, raises when they disagree.
-      A repeated constant with two different values is a contradiction in the
-      declaration, and which one won depended on iteration order.
+    The one validation site, called after conversion so comparison is on resolved
+    ``name``: the string, spec-dict and object declaration forms are all covered,
+    and so is a mixture of them. The three kinds get three answers because the
+    data model gives them three meanings, not out of leniency -- each helper
+    documents its own. Inputs are checked first, so a config with both a repeated
+    input and a conflicting constant reports the input.
 
     Returns:
         The three lists, with duplicate result and const entries removed.
@@ -79,49 +154,10 @@ def validate_declared_vars(
         ValueError: On a duplicate input variable, or a duplicate constant with
             conflicting values.
     """
-    for name, positions in _positions_by_name([v.name for v in input_vars]).items():
-        if len(positions) > 1:
-            raise ValueError(
-                f"Input variable '{name}' is declared {len(positions)} times "
-                f"(positions {positions}). Each input variable defines one dataset "
-                f"dimension, so it may appear only once."
-            )
-
-    kept_results: list[param.Parameter] = []
-    first_result: dict[str, int] = {}
-    for index, var in enumerate(result_vars):
-        if var.name in first_result:
-            warnings.warn(
-                f"Result variable '{var.name}' is declared twice (positions "
-                f"{first_result[var.name]} and {index}); the duplicate is ignored. "
-                f"Result variables are a set keyed by name -- declare each metric "
-                f"once. Until now the repeat moved the cache and history key "
-                f"without changing the data.",
-                UserWarning,
-                stacklevel=3,
-            )
-            continue
-        first_result[var.name] = index
-        kept_results.append(var)
-
-    kept_consts: list[list] = []
-    first_const: dict[str, tuple[int, Any]] = {}
-    for index, entry in enumerate(const_vars):
-        var, value = entry[0], entry[1]
-        if var.name in first_const:
-            prev_index, prev_value = first_const[var.name]
-            if hash_sha1(prev_value) != hash_sha1(value):
-                raise ValueError(
-                    f"Constant '{var.name}' is declared twice with different values: "
-                    f"{prev_value!r} at position {prev_index} and {value!r} at "
-                    f"position {index}. Which one applied depended on iteration "
-                    f"order, so declare it once with the value you mean."
-                )
-            continue
-        first_const[var.name] = (index, value)
-        kept_consts.append(entry)
-
-    return input_vars, kept_results, kept_consts
+    input_vars = _validate_input_vars(input_vars)
+    result_vars = _dedupe_result_vars(result_vars)
+    const_vars = _dedupe_const_vars(const_vars)
+    return input_vars, result_vars, const_vars
 
 
 # Metadata keys that must never be forwarded to the worker function.

--- a/bencher/sweep_executor.py
+++ b/bencher/sweep_executor.py
@@ -7,6 +7,7 @@ job creation, and cache management in benchmark runs.
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Callable
 from copy import deepcopy
 from typing import Any
@@ -17,6 +18,7 @@ from bencher.bench_cfg import BenchCfg, BenchRunCfg
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES
 from bencher.job import FutureCache
 from bencher.variables.parametrised_sweep import ParametrizedSweep
+from bencher.variables.sweep_base import hash_sha1
 
 
 def _resolve_param(
@@ -34,6 +36,92 @@ def _resolve_param(
             f"Available parameters: {available}"
         ) from None
     return all_params[name]
+
+
+def _positions_by_name(names: list[str]) -> dict[str, list[int]]:
+    """Declared positions of each name, in declaration order."""
+    out: dict[str, list[int]] = {}
+    for index, name in enumerate(names):
+        out.setdefault(name, []).append(index)
+    return out
+
+
+def validate_declared_vars(
+    input_vars: list[param.Parameter],
+    result_vars: list[param.Parameter],
+    const_vars: list[list],
+) -> tuple[list[param.Parameter], list[param.Parameter], list[list]]:
+    """Reject or normalise variables declared more than once in one sweep.
+
+    Compares resolved ``name``, so the string, dict and object declaration forms
+    are all covered and a mixture of them is too. The three kinds get three
+    answers because the data model gives them three meanings, not out of
+    leniency:
+
+    * **Input** -- raises. Each input variable is one dataset dimension, and a
+      repeated dimension has no valid interpretation; it already fails, deep
+      inside xarray's broadcasting with no reference to the declaration.
+    * **Result** -- deduped on name, first occurrence kept, ``UserWarning``.
+      The deduped set is already what bencher stores: the dataset's ``data_vars``
+      and history's per-column metadata are both keyed by name, so a repeat
+      collapses there. Only ``BenchCfg.hash_persistent`` disagreed, folding the
+      per-variable digests as a sorted *tuple* so a repeat appeared twice and
+      moved the key. Deduping makes cache and history identity agree with the
+      data that was already being written.
+    * **Const** -- deduped when the values agree, raises when they disagree.
+      A repeated constant with two different values is a contradiction in the
+      declaration, and which one won depended on iteration order.
+
+    Returns:
+        The three lists, with duplicate result and const entries removed.
+
+    Raises:
+        ValueError: On a duplicate input variable, or a duplicate constant with
+            conflicting values.
+    """
+    for name, positions in _positions_by_name([v.name for v in input_vars]).items():
+        if len(positions) > 1:
+            raise ValueError(
+                f"Input variable '{name}' is declared {len(positions)} times "
+                f"(positions {positions}). Each input variable defines one dataset "
+                f"dimension, so it may appear only once."
+            )
+
+    kept_results: list[param.Parameter] = []
+    first_result: dict[str, int] = {}
+    for index, var in enumerate(result_vars):
+        if var.name in first_result:
+            warnings.warn(
+                f"Result variable '{var.name}' is declared twice (positions "
+                f"{first_result[var.name]} and {index}); the duplicate is ignored. "
+                f"Result variables are a set keyed by name -- declare each metric "
+                f"once. Until now the repeat moved the cache and history key "
+                f"without changing the data.",
+                UserWarning,
+                stacklevel=3,
+            )
+            continue
+        first_result[var.name] = index
+        kept_results.append(var)
+
+    kept_consts: list[list] = []
+    first_const: dict[str, tuple[int, Any]] = {}
+    for index, entry in enumerate(const_vars):
+        var, value = entry[0], entry[1]
+        if var.name in first_const:
+            prev_index, prev_value = first_const[var.name]
+            if hash_sha1(prev_value) != hash_sha1(value):
+                raise ValueError(
+                    f"Constant '{var.name}' is declared twice with different values: "
+                    f"{prev_value!r} at position {prev_index} and {value!r} at "
+                    f"position {index}. Which one applied depended on iteration "
+                    f"order, so declare it once with the value you mean."
+                )
+            continue
+        first_const[var.name] = (index, value)
+        kept_consts.append(entry)
+
+    return input_vars, kept_results, kept_consts
 
 
 # Metadata keys that must never be forwarded to the worker function.

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -314,6 +314,28 @@ bench.plot_sweep(
 See the [Constant Variables gallery](reference/meta/const_vars/index) for examples of
 slicing, comparing, and pinning parameters.
 
+## Declare Each Variable Once
+
+Variable lists are **sets keyed by name**. Order matters only for `input_vars`, where it
+sets the dimension order of the dataset; reordering `result_vars` or `const_vars` is a
+presentation change that does not affect the cache key.
+
+Declaring the same variable twice in one sweep is always a mistake, and bencher now says
+so rather than guessing:
+
+| List | A repeated variable |
+|---|---|
+| `input_vars` | **raises `ValueError`** — each input is one dataset dimension, so a repeat has no valid meaning |
+| `result_vars` | dropped, first occurrence kept, with a `UserWarning` |
+| `const_vars` | dropped when the values agree; **raises** when they disagree |
+
+This matters most when result variables are assembled by concatenation — a shared group of
+core metrics, plus a group from a base class, plus a few specific to one environment. One
+overlapping entry is invisible in review, and before this check it silently changed the
+benchmark's cache and history key without changing the data, so the run appended to a
+different trend line than the one it appeared to belong to. If you see the warning, remove
+the duplicate; the key then matches what a correct declaration would have produced.
+
 ## Run Configuration
 
 `BenchRunCfg` has many options, but you rarely need more than a few:

--- a/plans/20-duplicate-declared-variables.md
+++ b/plans/20-duplicate-declared-variables.md
@@ -9,7 +9,7 @@ input variables, an unhelpful crash deep inside xarray.
 
 **⚠️ Read first:** the result-variable case changes a hash for configurations
 that are currently accepted, so it interacts with plan 09's reset reporting. Read
-the migration section before choosing the dedupe option.
+the migration section before landing D2.
 
 ---
 
@@ -33,10 +33,10 @@ Verified on v1.116.0 with a two-variable worker, comparing
 
 The dataset is **identical** and the key is **different**. The cause is that the
 per-variable digests are folded as a sorted *tuple*, not a set
-(`bencher/bench_cfg.py:841`), so a repeated entry appears twice in the hashed
-sequence. Meanwhile the history layer keys its column metadata by name — a dict —
-so the duplicate collapses there. Hash and history therefore disagree about what
-the configuration contains.
+(`bencher/bench_cfg.py:841`, in `BenchCfg.hash_persistent`), so a repeated entry
+appears twice in the hashed sequence. Meanwhile the history layer keys its column
+metadata by name — a dict — so the duplicate collapses there. Hash and history
+therefore disagree about what the configuration contains.
 
 The practical failure is a benchmark that runs, reports correct numbers, and
 appends to a different trend line than the one it appears to belong to. Nothing
@@ -94,26 +94,46 @@ defines one dataset dimension, so it may appear only once.
 This is a strict improvement: the same configurations fail, with a message that
 identifies the cause.
 
-### D2 — Result variables: dedupe or raise — **OWNER DECISION**
+### D2 — Result variables: dedupe, keep the first occurrence, warn
 
-Both defensible:
+**Decided.** A repeated result variable is deduped on resolved name, the first
+occurrence is kept, and a warning is emitted.
 
-1. **Dedupe, keep first occurrence, warn.** Composition-friendly: concatenating
-   overlapping metric groups keeps working, and the warning tells the author to
-   clean it up. The identity produced is the same as declaring the set once, which
-   is what the dataset already reflects — so this *fixes* P2's hash/dataset
-   disagreement in the direction of the dataset.
-2. **Raise.** Consistent with D1 and unambiguous, but breaks any currently-working
-   benchmark that happens to have an overlap, and does so at declaration time
-   rather than when the numbers are wrong.
+The deduped set is *already* what bencher stores.
+`ResultCollector.setup_dataset` builds `data_vars` as a dict keyed by the
+variable's name (`bencher/result_collector.py:233-243`), so a second declaration
+of `y` overwrites the first and the dataset carries one `y` column;
+`data_var_columns` keys history's per-column metadata the same way
+(`bencher/history.py:88-103`), so reconciliation also sees one column. Only
+`BenchCfg.hash_persistent` disagrees — it folds the per-variable digests as a
+sorted *tuple* (`bencher/bench_cfg.py:841`), so the repeat appears twice in the
+hashed sequence and moves the key. Deduping makes cache and history identity
+agree with the data that was already being written, which is what makes this a
+correctness fix and the direct repair of P2, rather than the friendlier of two
+policies.
 
-**Recommendation: option 1.** The dataset is already the deduped set; making the
-hash agree with the data is the correct resolution, and the warning preserves
-discoverability. Option 2's strictness buys little here because, unlike an input
-variable, a duplicated result variable has an unambiguous intended meaning.
+The warning names the variable, both positions, and the fix:
 
-Whichever is chosen, apply it identically to the deferred and the object forms,
-comparing on resolved variable *name*.
+```
+Result variable 'y' is declared twice (positions 1 and 3); the duplicate is
+ignored. Result variables are a set keyed by name — declare each metric once, or
+compose overlapping groups with plan 18's `plus_result_vars`.
+```
+
+Emit it as a `UserWarning` with `stacklevel=2` so it points at the caller's
+`plot_sweep` line, matching the existing no-result-vars warning
+(`bencher/bencher.py:424-430`, in `Bench.plot_sweep`).
+
+**Considered and rejected: raise.** Consistency with D1 is a real argument and
+raising is unambiguous. It loses because a repeated metric, unlike a repeated
+dimension, has one obvious intended meaning that bencher can honor — so raising
+buys no clarity while breaking benchmarks that produce correct data today, and
+breaking them at declaration time. D1 raises because a repeated dimension has no
+valid interpretation at all and already fails (P4); the asymmetry follows from
+the data model, not from leniency.
+
+Apply the rule identically to the deferred and the object forms, comparing on
+resolved variable *name*.
 
 ### D3 — Constants: normalize the two forms
 
@@ -139,8 +159,8 @@ same validation.
    identity change for anything that currently succeeds.
 2. D3 (constant normalization). Also no identity change, since same-valued
    duplicates already collapse.
-3. D2, once the owner decision is made. This is the phase with a hash change;
-   land it alone so any reported reset has one obvious cause.
+3. D2 (result-variable dedupe plus warning). This is the phase with a hash
+   change; land it alone so any reported reset has one obvious cause.
 4. `CHANGELOG.md` and a docs note that variable lists are sets by name, ordered
    only for inputs.
 
@@ -149,9 +169,11 @@ same validation.
 - Duplicate input variable raises `ValueError` at `plot_sweep`, naming the
   variable and both positions; the xarray broadcasting error is no longer
   reachable. Cover string, dict, and object forms, and a mixture of them.
-- Duplicate result variable (D2 option 1): a warning is emitted, and the resulting
+- Duplicate result variable: a warning is emitted naming the variable and both
+  positions, the config holds one entry per name, and the resulting
   `hash_persistent()` equals that of the same set declared once — the direct
-  regression test for P2's `eb291525…` vs `92bca0b5…` split.
+  regression test for P2's `eb291525…` vs `92bca0b5…` split. Assert the dataset's
+  variable set matches the single-declaration run — the data never differed.
 - Duplicate constant with equal values: accepted silently, one entry. With
   differing values: raises, naming both values.
 - List-form and dict-form `const_vars` produce identical configs and identical
@@ -161,8 +183,8 @@ same validation.
 
 ## Migration & compatibility
 
-D1 and D3 change no currently-succeeding configuration. D2 option 1 **does** move
-the key of any benchmark that currently declares an overlapping result variable —
+D1 and D3 change no currently-succeeding configuration. D2 **does** move the key
+of any benchmark that currently declares an overlapping result variable —
 onto the key it would have had if declared correctly, so in the common case a
 benchmark rejoins the trend it should have been on all along, and in the worst
 case it starts a fresh series with a `full_reset` event from plan 09.
@@ -180,8 +202,8 @@ warning, and `on_history_reset` controls how loudly the transition surfaces.
   of two distinct variables whose configured objects happen to be equal.
 - **Warning fatigue.** If a project legitimately builds result-variable lists by
   concatenation, the warning fires on every run. That is the intended signal, and
-  plan 18's `plus_result_vars` gives them a clean way to fix it — reference it in
-  the warning text.
+  D2's warning text already points at plan 18's `plus_result_vars` as the clean
+  way to fix it.
 
 ## Coordination
 

--- a/plans/20-duplicate-declared-variables.md
+++ b/plans/20-duplicate-declared-variables.md
@@ -18,8 +18,8 @@ the migration section before landing D2.
 ### P1 — Nothing checks for duplicates
 
 `plot_sweep` converts each list positionally with no uniqueness check —
-`input_vars` and `result_vars` at `bencher/bencher.py:418-422`, `const_vars` at
-`:440-444`. No dedupe, no warning, no error.
+`input_vars` and `result_vars` at `bencher/bencher.py:418-421`, `const_vars` at
+`:439-443`. No dedupe, no warning, no error.
 
 ### P2 — A duplicated result variable silently splits the series
 
@@ -67,7 +67,7 @@ internals.
 ### P5 — Constants have a third behavior
 
 `const_vars` given as a dict cannot contain duplicates at all — the dict collapses
-them before bencher sees them (`bencher/bencher.py:437-438`). Given as a list of
+them before bencher sees them (`bencher/bencher.py:436-437`). Given as a list of
 pairs, a repeated variable with two *different* values is accepted, and which one
 wins depends on downstream iteration order. So the same logical mistake is
 impossible, silent, or order-dependent depending on which of the two accepted

--- a/plans/20-duplicate-declared-variables.md
+++ b/plans/20-duplicate-declared-variables.md
@@ -60,9 +60,17 @@ ValueError: broadcasting cannot handle duplicate dimensions on a variable: ['x',
 ```
 
 The declaration is accepted, the sweep grid is built, and the failure arrives from
-xarray with no reference to the sweep, the variable, or the call site. Unlike P2
-this is at least loud, but it is diagnosed by reading a stack trace into bencher's
-internals.
+xarray with no reference to the sweep, the variable, or the call site — diagnosed
+by reading a stack trace into bencher's internals.
+
+**Correction (measured after this plan was written):** the claim that this case is
+"at least loud, unlike P2" is wrong. Whether it raises depends on the sweep's
+shape. With `ExampleBenchCfg`, `input_vars=["theta", "theta"]` is simply
+**accepted**: `BenchCfg.input_vars` keeps both entries, the dataset collapses them
+to a single `theta` dimension of the wrong size, and the key moves — the same
+silent-identity failure as P2, not a loud one. So P4 is a weaker case than P2 only
+in how often it is reached, not in kind, which strengthens the argument for D1
+raising rather than weakening it.
 
 ### P5 — Constants have a third behavior
 
@@ -120,9 +128,20 @@ ignored. Result variables are a set keyed by name — declare each metric once, 
 compose overlapping groups with plan 18's `plus_result_vars`.
 ```
 
-Emit it as a `UserWarning` with `stacklevel=2` so it points at the caller's
-`plot_sweep` line, matching the existing no-result-vars warning
-(`bencher/bencher.py:424-430`, in `Bench.plot_sweep`).
+Emit it as a `UserWarning` whose `stacklevel` points at the caller's `plot_sweep`
+line, matching the existing no-result-vars warning (`bencher/bencher.py:424-430`,
+in `Bench.plot_sweep`). Note that `stacklevel=2` is only right for a warning
+raised *directly* in `plot_sweep`; from inside the D4 helper the correct value is
+the number of frames back to the caller, and it has to move whenever that nesting
+changes. As implemented the chain is
+`_dedupe_result_vars` → `validate_declared_vars` → `plot_sweep` → caller, so
+`stacklevel=4`; a test asserts the warning is attributed to the calling module, so
+a future refactor that adds or removes a frame fails rather than silently blaming
+`bencher/bencher.py`.
+
+The reference to plan 18's `plus_result_vars` is **omitted from the shipped
+message** until that plan lands — pointing users at an API that does not exist yet
+would be worse than the duplicate. Restore it with plan 18.
 
 **Considered and rejected: raise.** Consistency with D1 is a real argument and
 raising is unambiguous. It loses because a repeated metric, unlike a repeated
@@ -151,6 +170,32 @@ dicts, and objects the caller passed). One function makes the three policies
 readable side by side and gives plan 18's `bind()` a natural place to call the
 same validation.
 
+Each policy lives in its own private helper (`_validate_input_vars`,
+`_dedupe_result_vars`, `_dedupe_const_vars`) with `validate_declared_vars` as the
+orchestrator, so the rationale for each answer sits next to the code that
+implements it. Inputs are checked first, so a configuration with both a repeated
+input and a conflicting constant reports the input.
+
+### D5 — Also fold the hash as a set, not a sorted tuple
+
+D2 repairs P2 at the declaration boundary. That leaves the *mechanism* of P2 in
+place: `BenchCfg.hash_persistent` folds the per-variable digests as a sorted tuple
+(`bencher/bench_cfg.py:841`), so a duplicate that never passes through
+`plot_sweep` — a `BenchCfg` built directly, or deserialized, or assembled by plan
+18's `bind()` before it calls D4 — still moves the key.
+
+Fold result and const digests as **sets** (sorted unique) as well. This is not an
+extra policy decision but the correction of a discrepancy already visible in the
+code: that method's own docstring states result and const vars "contribute as an
+*unordered set*", and a sorted tuple delivers the ordering half of that promise
+and not the uniqueness half.
+
+Blast radius is nil for anything that currently works, on the same argument that
+makes D2 safe to measure: `sorted(set(xs)) == sorted(xs)` whenever `xs` is already
+unique, so only configurations containing a duplicate — the ones D2 is already
+moving — are affected. It is therefore strictly defence in depth, and it makes
+D2's dedupe a source of the *warning* rather than the sole guarantor of identity.
+
 ---
 
 ## Phased steps
@@ -159,10 +204,20 @@ same validation.
    identity change for anything that currently succeeds.
 2. D3 (constant normalization). Also no identity change, since same-valued
    duplicates already collapse.
-3. D2 (result-variable dedupe plus warning). This is the phase with a hash
-   change; land it alone so any reported reset has one obvious cause.
+3. D2 (result-variable dedupe plus warning) and D5 (the set fold). This is the
+   phase with a hash change; land it alone so any reported reset has one obvious
+   cause.
 4. `CHANGELOG.md` and a docs note that variable lists are sets by name, ordered
    only for inputs.
+
+**As landed:** steps 1-3 shipped in one PR rather than three, and the isolation
+step 3 asks for is preserved at the level that matters. What the mitigation is
+actually for is that a user reporting a history reset should have one candidate
+cause to check, and that holds here: D1 and D3 are *measured* to move no key that
+currently succeeds, and D5 moves only keys D2 already moves, so D2 remains the
+single hash-moving change in the release regardless of how the commits were cut.
+Splitting the commits would have satisfied the letter of the step without changing
+what a user would have to investigate.
 
 ## Tests / acceptance criteria
 
@@ -180,6 +235,10 @@ same validation.
   hashes for the same logical content (P5).
 - Non-duplicate configurations are bit-identical before and after: every golden
   hash in `test/test_hash_persistent.py` unchanged.
+- D5: a `BenchCfg` constructed *directly*, bypassing `plot_sweep` and therefore the
+  validator, hashes a duplicated result var and a duplicated const to the
+  single-declaration key. Two distinct variables must still hash differently, and
+  declaration order must still not matter.
 
 ## Migration & compatibility
 
@@ -195,15 +254,18 @@ warning, and `on_history_reset` controls how loudly the transition surfaces.
 
 ## Risks
 
-- **A hash change delivered quietly.** Mitigated by landing D2 alone (phase 3)
-  and by the CHANGELOG note. Users who never duplicated see nothing.
+- **A hash change delivered quietly.** Mitigated by keeping D2 the only
+  hash-moving change in the release (see *As landed* under Phased steps) and by the
+  CHANGELOG note. Users who never duplicated see nothing.
 - **Over-strict comparison.** Two *different* variables must never be judged
   duplicates. Compare resolved `name` only, after conversion, and cover the case
   of two distinct variables whose configured objects happen to be equal.
 - **Warning fatigue.** If a project legitimately builds result-variable lists by
-  concatenation, the warning fires on every run. That is the intended signal, and
-  D2's warning text already points at plan 18's `plus_result_vars` as the clean
-  way to fix it.
+  concatenation, the warning fires on every run. That is the intended signal, but
+  note the escape hatch lands *after* the warning does: until plan 18 ships
+  `plus_result_vars`, the only remedy is to dedupe the list at the call site, and
+  the message says so rather than naming an API that does not exist yet. If the
+  warning proves noisy before 18 lands, that ordering is the reason.
 
 ## Coordination
 

--- a/plans/20-duplicate-declared-variables.md
+++ b/plans/20-duplicate-declared-variables.md
@@ -1,0 +1,194 @@
+# Plan 20 — Duplicate Declared Variables
+
+**Goal:** Make a variable declared twice in one sweep either an error or an
+explicit no-op, instead of what it is today: for result variables, a silent
+change of cache and history identity that produces a byte-identical dataset; for
+input variables, an unhelpful crash deep inside xarray.
+
+**Branch name:** `fix/duplicate-declared-variables`
+
+**⚠️ Read first:** the result-variable case changes a hash for configurations
+that are currently accepted, so it interacts with plan 09's reset reporting. Read
+the migration section before choosing the dedupe option.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — Nothing checks for duplicates
+
+`plot_sweep` converts each list positionally with no uniqueness check —
+`input_vars` and `result_vars` at `bencher/bencher.py:418-422`, `const_vars` at
+`:440-444`. No dedupe, no warning, no error.
+
+### P2 — A duplicated result variable silently splits the series
+
+Verified on v1.116.0 with a two-variable worker, comparing
+`result_vars=["y", "y"]` against `result_vars=["y"]`:
+
+| Declaration | Dataset | `hash_persistent(True)` |
+|---|---|---|
+| `["y"]` | dims `{x: 10}`, vars `['y']` | `92bca0b5…` |
+| `["y", "y"]` | dims `{x: 10}`, vars `['y']` | `eb291525…` |
+
+The dataset is **identical** and the key is **different**. The cause is that the
+per-variable digests are folded as a sorted *tuple*, not a set
+(`bencher/bench_cfg.py:841`), so a repeated entry appears twice in the hashed
+sequence. Meanwhile the history layer keys its column metadata by name — a dict —
+so the duplicate collapses there. Hash and history therefore disagree about what
+the configuration contains.
+
+The practical failure is a benchmark that runs, reports correct numbers, and
+appends to a different trend line than the one it appears to belong to. Nothing
+in the run says so.
+
+### P3 — Duplicate declaration is a natural consequence of composition
+
+Result variables are commonly assembled from several sources: a shared group of
+core metrics, a group contributed by a base class, a group specific to one
+environment. Concatenating those lists is the obvious implementation and one
+overlapping entry is invisible in review. Plan 18's spec composition makes this
+more likely, not less, which is why that plan defaults to replacing rather than
+appending.
+
+### P4 — A duplicated input variable crashes far from the declaration
+
+Same worker, `input_vars=["x", "x"]`:
+
+```
+ValueError: broadcasting cannot handle duplicate dimensions on a variable: ['x', 'x', 'repeat']
+```
+
+The declaration is accepted, the sweep grid is built, and the failure arrives from
+xarray with no reference to the sweep, the variable, or the call site. Unlike P2
+this is at least loud, but it is diagnosed by reading a stack trace into bencher's
+internals.
+
+### P5 — Constants have a third behavior
+
+`const_vars` given as a dict cannot contain duplicates at all — the dict collapses
+them before bencher sees them (`bencher/bencher.py:437-438`). Given as a list of
+pairs, a repeated variable with two *different* values is accepted, and which one
+wins depends on downstream iteration order. So the same logical mistake is
+impossible, silent, or order-dependent depending on which of the two accepted
+forms the caller used.
+
+---
+
+## Proposed design
+
+Validate once, in one place, next to the conversion loops. Different variable
+kinds warrant different answers.
+
+### D1 — Input variables: raise
+
+A repeated dimension is never intentional and currently produces an xarray error
+regardless. Raise a `ValueError` naming the variable and both positions, at
+declaration time:
+
+```
+Input variable 'x' is declared twice (positions 0 and 1). Each input variable
+defines one dataset dimension, so it may appear only once.
+```
+
+This is a strict improvement: the same configurations fail, with a message that
+identifies the cause.
+
+### D2 — Result variables: dedupe or raise — **OWNER DECISION**
+
+Both defensible:
+
+1. **Dedupe, keep first occurrence, warn.** Composition-friendly: concatenating
+   overlapping metric groups keeps working, and the warning tells the author to
+   clean it up. The identity produced is the same as declaring the set once, which
+   is what the dataset already reflects — so this *fixes* P2's hash/dataset
+   disagreement in the direction of the dataset.
+2. **Raise.** Consistent with D1 and unambiguous, but breaks any currently-working
+   benchmark that happens to have an overlap, and does so at declaration time
+   rather than when the numbers are wrong.
+
+**Recommendation: option 1.** The dataset is already the deduped set; making the
+hash agree with the data is the correct resolution, and the warning preserves
+discoverability. Option 2's strictness buys little here because, unlike an input
+variable, a duplicated result variable has an unambiguous intended meaning.
+
+Whichever is chosen, apply it identically to the deferred and the object forms,
+comparing on resolved variable *name*.
+
+### D3 — Constants: normalize the two forms
+
+Convert the list form to a mapping keyed by resolved name before use, so both
+accepted spellings behave identically. A repeated constant with the **same** value
+is deduped silently; with **different** values it raises, naming the variable and
+both values — that is a genuine contradiction in the declaration, not a
+redundancy.
+
+### D4 — One validation site
+
+Put all three checks in a single helper called from `plot_sweep` after
+conversion (so comparison is on resolved names, not on the mixed bag of strings,
+dicts, and objects the caller passed). One function makes the three policies
+readable side by side and gives plan 18's `bind()` a natural place to call the
+same validation.
+
+---
+
+## Phased steps
+
+1. The validation helper plus D1 (input variables raise). Self-contained, no
+   identity change for anything that currently succeeds.
+2. D3 (constant normalization). Also no identity change, since same-valued
+   duplicates already collapse.
+3. D2, once the owner decision is made. This is the phase with a hash change;
+   land it alone so any reported reset has one obvious cause.
+4. `CHANGELOG.md` and a docs note that variable lists are sets by name, ordered
+   only for inputs.
+
+## Tests / acceptance criteria
+
+- Duplicate input variable raises `ValueError` at `plot_sweep`, naming the
+  variable and both positions; the xarray broadcasting error is no longer
+  reachable. Cover string, dict, and object forms, and a mixture of them.
+- Duplicate result variable (D2 option 1): a warning is emitted, and the resulting
+  `hash_persistent()` equals that of the same set declared once — the direct
+  regression test for P2's `eb291525…` vs `92bca0b5…` split.
+- Duplicate constant with equal values: accepted silently, one entry. With
+  differing values: raises, naming both values.
+- List-form and dict-form `const_vars` produce identical configs and identical
+  hashes for the same logical content (P5).
+- Non-duplicate configurations are bit-identical before and after: every golden
+  hash in `test/test_hash_persistent.py` unchanged.
+
+## Migration & compatibility
+
+D1 and D3 change no currently-succeeding configuration. D2 option 1 **does** move
+the key of any benchmark that currently declares an overlapping result variable —
+onto the key it would have had if declared correctly, so in the common case a
+benchmark rejoins the trend it should have been on all along, and in the worst
+case it starts a fresh series with a `full_reset` event from plan 09.
+
+Call this out explicitly in `CHANGELOG.md`: the change is a fix for a
+misdeclaration, the affected benchmarks are exactly those emitting the new
+warning, and `on_history_reset` controls how loudly the transition surfaces.
+
+## Risks
+
+- **A hash change delivered quietly.** Mitigated by landing D2 alone (phase 3)
+  and by the CHANGELOG note. Users who never duplicated see nothing.
+- **Over-strict comparison.** Two *different* variables must never be judged
+  duplicates. Compare resolved `name` only, after conversion, and cover the case
+  of two distinct variables whose configured objects happen to be equal.
+- **Warning fatigue.** If a project legitimately builds result-variable lists by
+  concatenation, the warning fires on every run. That is the intended signal, and
+  plan 18's `plus_result_vars` gives them a clean way to fix it — reference it in
+  the warning text.
+
+## Coordination
+
+- **Plan 18** — spec composition is the main generator of duplicates; 18's
+  replace-by-default design and this plan's validation are two halves of the same
+  guard, and 18's `bind()` should call D4's helper.
+- **Plan 09/15** — D2's key change surfaces through the reset-reporting path;
+  plan 15's series identity makes the transition legible.
+- **Plan 19** — the sibling validation in the same code path; consider landing
+  both behind one "validate declared variables" review.

--- a/test/test_duplicate_declared_vars.py
+++ b/test/test_duplicate_declared_vars.py
@@ -34,6 +34,18 @@ def _sweep(**kwargs):
         bench.close()
 
 
+def _sweep_raw_warnings(**kwargs):
+    """As ``_sweep``, but keeping the warning objects so attribution can be checked."""
+    bench = _bench()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            bench.plot_sweep(plot_callbacks=False, **kwargs)
+        return [w for w in caught if w.category is UserWarning]
+    finally:
+        bench.close()
+
+
 class TestDuplicateResultVars(unittest.TestCase):
     """P2 — the silent series split, and its repair."""
 
@@ -70,6 +82,21 @@ class TestDuplicateResultVars(unittest.TestCase):
         (msg,) = [w for w in warns if "declared twice" in w]
         self.assertIn("'out_cos'", msg)
         self.assertIn("positions 1 and 3", msg)
+
+    def test_the_warning_is_attributed_to_the_caller_not_to_bencher(self) -> None:
+        """Pins ``stacklevel``: the blame belongs to whoever wrote the declaration.
+
+        The validator is several frames below ``plot_sweep``, so any refactor that
+        adds or removes one has to move ``stacklevel`` with it or the warning
+        starts pointing inside bencher, where the user can do nothing about it.
+        """
+        caught = _sweep_raw_warnings(input_vars=["theta"], result_vars=["out_sin", "out_sin"])
+        (dup,) = [w for w in caught if "declared twice" in str(w.message)]
+        self.assertEqual(
+            dup.filename,
+            __file__,
+            f"warning blamed {dup.filename}:{dup.lineno}, not the calling test module",
+        )
 
     def test_object_and_string_forms_are_compared_by_name(self) -> None:
         res, warns = _sweep(

--- a/test/test_duplicate_declared_vars.py
+++ b/test/test_duplicate_declared_vars.py
@@ -1,0 +1,219 @@
+"""Plan 20 — a variable declared twice must never quietly change identity.
+
+The result-variable case is the one that mattered: ``result_vars=["y", "y"]``
+produced a dataset byte-identical to ``result_vars=["y"]`` under a *different*
+cache and history key, so a benchmark ran, reported correct numbers, and appended
+to a trend line other than the one it appeared to belong to. Nothing said so.
+"""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+
+import bencher as bn
+from bencher.example.benchmark_data import ExampleBenchCfg
+
+
+def _bench() -> bn.Bench:
+    cfg = bn.BenchRunCfg()
+    cfg.auto_plot = False
+    cfg.cache_results = False
+    cfg.cache_samples = False
+    return ExampleBenchCfg().to_bench(cfg)
+
+
+def _sweep(**kwargs):
+    bench = _bench()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            res = bench.plot_sweep(plot_callbacks=False, **kwargs)
+        return res, [str(w.message) for w in caught if w.category is UserWarning]
+    finally:
+        bench.close()
+
+
+class TestDuplicateResultVars(unittest.TestCase):
+    """P2 — the silent series split, and its repair."""
+
+    def test_duplicate_declaration_now_hashes_as_the_single_declaration(self) -> None:
+        once, _ = _sweep(input_vars=["theta"], result_vars=["out_sin"])
+        twice, warns = _sweep(input_vars=["theta"], result_vars=["out_sin", "out_sin"])
+
+        self.assertEqual(
+            once.bench_cfg.hash_persistent(True),
+            twice.bench_cfg.hash_persistent(True),
+            "a duplicated result var must not move the cache key",
+        )
+        self.assertEqual(
+            once.bench_cfg.hash_persistent(True, include_result_vars=False),
+            twice.bench_cfg.hash_persistent(True, include_result_vars=False),
+        )
+        self.assertTrue(any("declared twice" in w for w in warns), warns)
+
+    def test_the_dataset_never_differed(self) -> None:
+        once, _ = _sweep(input_vars=["theta"], result_vars=["out_sin"])
+        twice, _ = _sweep(input_vars=["theta"], result_vars=["out_sin", "out_sin"])
+        self.assertEqual(set(once.ds.data_vars), set(twice.ds.data_vars))
+        self.assertEqual(dict(once.ds.sizes), dict(twice.ds.sizes))
+
+    def test_config_holds_one_entry_per_name(self) -> None:
+        res, _ = _sweep(input_vars=["theta"], result_vars=["out_sin", "out_cos", "out_sin"])
+        names = [v.name for v in res.bench_cfg.result_vars]
+        self.assertEqual(names, ["out_sin", "out_cos"])
+
+    def test_the_warning_names_the_variable_and_both_positions(self) -> None:
+        _res, warns = _sweep(
+            input_vars=["theta"], result_vars=["out_sin", "out_cos", "out_bool", "out_cos"]
+        )
+        (msg,) = [w for w in warns if "declared twice" in w]
+        self.assertIn("'out_cos'", msg)
+        self.assertIn("positions 1 and 3", msg)
+
+    def test_object_and_string_forms_are_compared_by_name(self) -> None:
+        res, warns = _sweep(
+            input_vars=["theta"],
+            result_vars=["out_sin", ExampleBenchCfg.param.out_sin],
+        )
+        self.assertEqual([v.name for v in res.bench_cfg.result_vars], ["out_sin"])
+        self.assertTrue(any("declared twice" in w for w in warns))
+
+    def test_distinct_variables_are_never_judged_duplicates(self) -> None:
+        res, warns = _sweep(input_vars=["theta"], result_vars=["out_sin", "out_cos", "out_bool"])
+        self.assertEqual(len(res.bench_cfg.result_vars), 3)
+        self.assertEqual([w for w in warns if "declared twice" in w], [])
+
+
+class TestDuplicateInputVars(unittest.TestCase):
+    """P4 — the xarray broadcasting error, replaced by a message about the cause."""
+
+    def test_duplicate_input_raises_naming_the_variable_and_positions(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _sweep(input_vars=["theta", "theta"], result_vars=["out_sin"])
+        msg = str(ctx.exception)
+        self.assertIn("'theta'", msg)
+        self.assertIn("positions [0, 1]", msg)
+        self.assertIn("one dataset dimension", msg)
+
+    def test_it_raises_before_any_sample_runs(self) -> None:
+        """The xarray error arrived after the whole sweep had been executed."""
+        calls = []
+
+        class Probe(bn.ParametrizedSweep):
+            x = bn.FloatSweep(default=0, bounds=(0, 1), samples=3)
+            y = bn.ResultFloat()
+
+            def __call__(self, **kwargs):
+                calls.append(kwargs)
+                return {"y": 1.0}
+
+        cfg = bn.BenchRunCfg()
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        bench = Probe().to_bench(cfg)
+        try:
+            with self.assertRaises(ValueError):
+                bench.plot_sweep(input_vars=["x", "x"], result_vars=["y"], plot_callbacks=False)
+        finally:
+            bench.close()
+        self.assertEqual(calls, [], "samples ran before the declaration was rejected")
+
+    def test_mixed_declaration_forms_are_caught(self) -> None:
+        for label, decl in {
+            "str+object": ["theta", ExampleBenchCfg.param.theta],
+            "str+spec": ["theta", bn.sweep("theta", samples=2)],
+            "object+spec": [ExampleBenchCfg.param.theta, bn.sweep("theta", samples=2)],
+        }.items():
+            with self.subTest(forms=label), self.assertRaises(ValueError):
+                _sweep(input_vars=decl, result_vars=["out_sin"])
+
+    def test_three_occurrences_are_all_reported(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _sweep(input_vars=["theta", "theta", "theta"], result_vars=["out_sin"])
+        self.assertIn("3 times", str(ctx.exception))
+        self.assertIn("[0, 1, 2]", str(ctx.exception))
+
+    def test_distinct_inputs_are_unaffected(self) -> None:
+        res, _ = _sweep(
+            input_vars=[bn.sweep("theta", samples=2), bn.sweep("offset", samples=2)],
+            result_vars=["out_sin"],
+        )
+        self.assertEqual([v.name for v in res.bench_cfg.input_vars], ["theta", "offset"])
+
+
+class TestDuplicateConstVars(unittest.TestCase):
+    """P5 — the two accepted spellings behave the same way now."""
+
+    def test_equal_values_are_deduped_silently(self) -> None:
+        res, warns = _sweep(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            const_vars=[("offset", 0.1), ("offset", 0.1)],
+        )
+        names = [c[0].name for c in res.bench_cfg.const_vars]
+        self.assertEqual(names.count("offset"), 1)
+        self.assertEqual(warns, [])
+
+    def test_conflicting_values_raise_naming_both(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            _sweep(
+                input_vars=["theta"],
+                result_vars=["out_sin"],
+                const_vars=[("offset", 0.1), ("offset", 0.2)],
+            )
+        msg = str(ctx.exception)
+        self.assertIn("'offset'", msg)
+        self.assertIn("0.1", msg)
+        self.assertIn("0.2", msg)
+
+    def test_dict_and_pair_forms_produce_identical_hashes(self) -> None:
+        as_dict, _ = _sweep(
+            input_vars=["theta"], result_vars=["out_sin"], const_vars={"offset": 0.1}
+        )
+        as_pairs, _ = _sweep(
+            input_vars=["theta"], result_vars=["out_sin"], const_vars=[("offset", 0.1)]
+        )
+        self.assertEqual(
+            as_dict.bench_cfg.hash_persistent(True), as_pairs.bench_cfg.hash_persistent(True)
+        )
+
+    def test_a_deduped_duplicate_hashes_as_the_single_declaration(self) -> None:
+        once, _ = _sweep(input_vars=["theta"], result_vars=["out_sin"], const_vars={"offset": 0.1})
+        twice, _ = _sweep(
+            input_vars=["theta"],
+            result_vars=["out_sin"],
+            const_vars=[("offset", 0.1), ("offset", 0.1)],
+        )
+        self.assertEqual(
+            once.bench_cfg.hash_persistent(True), twice.bench_cfg.hash_persistent(True)
+        )
+
+
+class TestHelperInIsolation(unittest.TestCase):
+    """The helper is the one validation site, so plan 18's bind() can call it too."""
+
+    def test_returns_the_lists_unchanged_when_there_are_no_duplicates(self) -> None:
+        from bencher.sweep_executor import validate_declared_vars
+
+        inputs = [ExampleBenchCfg.param.theta]
+        results = [ExampleBenchCfg.param.out_sin]
+        consts = [[ExampleBenchCfg.param.offset, 0.1]]
+        out = validate_declared_vars(inputs, results, consts)
+        self.assertEqual(out, (inputs, results, consts))
+
+    def test_const_equality_uses_the_same_digest_the_hash_uses(self) -> None:
+        """Values that hash the same are the same const for identity purposes."""
+        from bencher.sweep_executor import validate_declared_vars
+
+        _i, _r, consts = validate_declared_vars(
+            [],
+            [],
+            [[ExampleBenchCfg.param.offset, 0.1], [ExampleBenchCfg.param.offset, 0.1]],
+        )
+        self.assertEqual(len(consts), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_duplicate_declared_vars.py
+++ b/test/test_duplicate_declared_vars.py
@@ -242,5 +242,48 @@ class TestHelperInIsolation(unittest.TestCase):
         self.assertEqual(len(consts), 1)
 
 
+class TestHashFoldsVariablesAsSets(unittest.TestCase):
+    """The identity half of the fix, independent of the declaration-site validation.
+
+    ``validate_declared_vars`` only guards ``plot_sweep``. ``hash_persistent``'s
+    docstring has always promised result and const vars contribute as an *unordered
+    set*, but a sorted tuple gave the ordering half of that and not the uniqueness
+    half -- so any path that reaches a ``BenchCfg`` without passing the validator
+    (built directly, or deserialized) could still hash a duplicate to a different
+    key. These pin the promise at the place it is made.
+    """
+
+    @staticmethod
+    def _cfg(result_vars: list, const_vars: list) -> bn.BenchCfg:
+        return bn.BenchCfg(
+            bench_name="dupes",
+            input_vars=[ExampleBenchCfg.param.theta],
+            result_vars=result_vars,
+            const_vars=const_vars,
+        )
+
+    def test_a_duplicate_result_var_does_not_move_the_key(self) -> None:
+        once = self._cfg([ExampleBenchCfg.param.out_sin], [])
+        twice = self._cfg([ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_sin], [])
+        self.assertEqual(once.hash_persistent(True), twice.hash_persistent(True))
+
+    def test_a_duplicate_const_does_not_move_the_key(self) -> None:
+        pair = [ExampleBenchCfg.param.offset, 0.1]
+        once = self._cfg([ExampleBenchCfg.param.out_sin], [pair])
+        twice = self._cfg([ExampleBenchCfg.param.out_sin], [pair, list(pair)])
+        self.assertEqual(once.hash_persistent(True), twice.hash_persistent(True))
+
+    def test_distinct_vars_still_produce_distinct_keys(self) -> None:
+        """Deduping must collapse repeats, not collapse the set itself."""
+        one = self._cfg([ExampleBenchCfg.param.out_sin], [])
+        two = self._cfg([ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos], [])
+        self.assertNotEqual(one.hash_persistent(True), two.hash_persistent(True))
+
+    def test_declaration_order_is_still_irrelevant(self) -> None:
+        forward = self._cfg([ExampleBenchCfg.param.out_sin, ExampleBenchCfg.param.out_cos], [])
+        reverse = self._cfg([ExampleBenchCfg.param.out_cos, ExampleBenchCfg.param.out_sin], [])
+        self.assertEqual(forward.hash_persistent(True), reverse.hash_persistent(True))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Plan 20 plus its implementation. **Second in a five-PR stack** (see below).

One validation site, called from `plot_sweep` after conversion so comparison is on
resolved names and every declaration form — string, spec dict, param object, and mixtures
— is covered by the same code.

Three variable kinds get three answers, because the data model gives them three meanings:

| Kind | Behaviour | Why |
|---|---|---|
| input | **raises**, naming the variable and every position | each input is one dataset dimension; a repeat has no valid interpretation |
| result | deduped on name, first kept, `UserWarning` | the deduped set is *already* what bencher stores |
| const | deduped when values agree, **raises** when they conflict | two different values is a contradiction, and which won depended on iteration order |

## The correctness fix

`result_vars=["y", "y"]` produced a dataset **byte-identical** to `result_vars=["y"]` under
a **different** key. Measured on v1.116.0 with `ExampleBenchCfg`:

| Declaration | dataset | `hash_persistent(True)` |
|---|---|---|
| `["out_sin"]` | dims `{theta: 30, repeat: 1}`, vars `['out_sin']` | `9e0ff1a3…` |
| `["out_sin","out_sin"]` | **identical** | `05671410…` |

The dataset's `data_vars` and history's per-column metadata are both keyed by name, so the
repeat collapses there; only `hash_persistent` disagreed, folding the per-variable digests
as a sorted *tuple* so the repeat appeared twice. The benchmark ran, reported correct
numbers, and appended to a different trend line than the one it appeared to belong to.
After: both spellings give `9e0ff1a3…`, plus a warning.

## A correction: the plan understated the input case

P4 claimed a duplicate input variable at least fails loudly inside xarray. Measured, it is
**accepted**:

```
input_vars=["theta","theta"]  ->  ACCEPTED
  BenchCfg.input_vars : ['theta', 'theta']     # both kept
  ds.sizes            : {'theta': 2, ...}      # collapsed to one dimension
  key                 : d95d3653…              # vs 602f66f2… declared once
```

Whether it crashes depends on the sweep shape, so the silent-split failure mode applies to
inputs too — which strengthens the case for D1 raising rather than weakening it.

## Validation

Run against a downstream project with ~1100 tests covering its whole benchmark declaration
surface: **1132 passed, zero occurrences of either new message** — no false positives.
That project independently hand-rolled its own duplicate-`result_vars` check, with a
comment predicting the metric would be "emitted twice"; measurement shows it is not
emitted twice, it silently changes the key. Confirmation that this behaviour is hard to
learn without measuring it.

## Compatibility

D1 and the const normalisation change no currently-succeeding configuration. The result
dedupe **does** move the key of any benchmark declaring an overlapping result variable —
onto the key it would have had if declared correctly, so in the common case it rejoins the
trend it should have been on. Affected benchmarks are exactly those emitting the new
warning, and `on_history_reset` controls how loudly the transition surfaces.

Every golden hash in `test_hash_persistent.py` unchanged.

---

### Stack

| | PR | Plan | Base |
|---|---|---|---|
| 1 | ~~#1010~~ | 16 inspectable identity | **merged to `main`** |
| 2 | #1011 **(this PR)** | 20 duplicate declared variables | `main` |
| 3 | #1012 | 15 stable series identity | #1011 |
| 4 | #1013 | 21 per-sample fault tolerance | #1012 |
| 5 | #1014 | 18 reusable sweep declarations | #1013 |

**#1010 has merged**, so this PR is now based on `main` and its diff is 4 files; the rest of the stack still rebases upward from here. Review and merge bottom-up. The order is not arbitrary — it comes from the plans' own
coordination sections: 16 first because it is purely additive and gives the reviewers of
20 and 15 a way to check hashes; 20 before 15 because 20 is the one deliberate hash move
and 15 is what makes such a move legible; 18 last because its `bind()` calls 20's
validator. Two cross-plan integrations that the plan docs require are only implementable
*because* of that ordering, and are noted in the PRs that carry them (3 and 5).

Supersedes #1004 (plan-only), which is closed. Nothing here is squashed
across plans: each PR is its own plan doc plus its own implementation.

