### PR TITLE
plan 15 + implementation: stable benchmark series identity

### DIFF
--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -749,6 +749,19 @@ class BenchCfg(BenchRunCfg):
         doc="Use tags to group different benchmarks together. By default benchmarks are considered distinct from each other and are identified by the hash of their name and inputs, constants and results and tag, but you can optionally change the hash value to only depend on the tag.  This way you can have multiple unrelated benchmarks share values with each other based only on the tag value.",
     )
 
+    series_id: str = param.String(
+        None,
+        allow_None=True,
+        doc="Names the over_time *trend* this benchmark appends to, independently of "
+        "what identifies its configuration. tag partitions storage; series_id names "
+        "the trend. Deliberately NOT part of hash_persistent: two benchmarks with the "
+        "same name, tag, inputs and consts stay one cache entry whatever their "
+        "series_id, and folding it in would re-key every existing cache and history "
+        "on upgrade. Declare it to keep a trend across a rename of the worker class "
+        "or a change of cache tag; leave it unset and the series is bench_name:tag, "
+        "exactly as before.",
+    )
+
     hash_value: str = param.String(
         "",
         doc="store the hash value of the config to avoid having to hash multiple times",
@@ -860,6 +873,13 @@ class BenchCfg(BenchRunCfg):
         from bencher.identity import identity_of
 
         return identity_of(self, run_cfg)
+
+    @property
+    def series(self) -> str:
+        """The series this run appends to: the declared ``series_id`` or the default."""
+        from bencher.history import default_series_id
+
+        return self.series_id or default_series_id(self.bench_name, self.tag)
 
     def inputs_as_str(self) -> list[str]:
         """Get a list of input variable names.

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -279,6 +279,7 @@ class Bench(BenchPlotServer):
         post_description: str | None = None,
         pass_repeat: bool = False,
         tag: str = "",
+        series_id: str | None = None,
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
@@ -528,6 +529,7 @@ class Bench(BenchPlotServer):
             title=title,
             pass_repeat=pass_repeat,
             tag=run_cfg.run_tag + tag,
+            series_id=series_id,
             plot_callbacks=plot_callbacks,
             agg_over_dims=agg_over_dims,
             agg_fn=agg_fn,
@@ -742,6 +744,7 @@ class Bench(BenchPlotServer):
                         bench_cfg.result_vars,
                         on_history_reset=run_cfg.on_history_reset,
                         bench_name=bench_cfg.bench_name,
+                        series_id=bench_cfg.series,
                         tag=bench_cfg.tag,
                         config_summary=history_config_summary(bench_cfg),
                     )
@@ -874,6 +877,7 @@ class Bench(BenchPlotServer):
         on_history_reset: str = "warn",
         bench_name: str | None = None,
         tag: str | None = None,
+        series_id: str | None = None,
         config_summary: dict | None = None,
     ) -> xr.Dataset:
         """Load, reconcile, and persist historical benchmark data from cache."""
@@ -886,6 +890,7 @@ class Bench(BenchPlotServer):
             on_history_reset=on_history_reset,
             bench_name=bench_name,
             tag=tag,
+            series_id=series_id,
             config_summary=config_summary,
         )
 

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -74,8 +74,8 @@ class HistoryResetError(Exception):
 class HistoryEvent:
     """One schema-affecting event detected while loading over_time history."""
 
-    kind: str  # full_reset | column_born | column_dormant | column_retired |
-    #            column_resumed | history_discarded
+    kind: str  # full_reset | history_renamed | column_born | column_dormant |
+    #            column_retired | column_resumed | history_discarded
     detail: str
     column: str | None = None
 
@@ -177,9 +177,34 @@ def diff_summaries(old: dict | None, new: dict | None) -> list[str]:
     return lines
 
 
-def last_seen_key(bench_name: str, tag: str | None) -> str:
-    """History-cache key of the last-seen index entry for one benchmark."""
-    return f"__history_last_seen__:{bench_name}:{tag}"
+def default_series_id(bench_name: str, tag: str | None) -> str:
+    """The series a benchmark belongs to when it does not declare one.
+
+    Byte-identical to the pre-``series_id`` index key, so nothing moves on
+    upgrade for a caller who declares nothing.
+    """
+    return f"{bench_name}:{tag}"
+
+
+def last_seen_key(series_id: str) -> str:
+    """History-cache key of the last-seen index entry for one *series*.
+
+    Keyed on the series rather than on ``(bench_name, tag)`` because those two
+    are themselves inputs to the history key: an index keyed on them moves
+    together with the key it exists to watch, so a rename -- the most common way
+    a key moves -- missed on both sides and silently orphaned the trend.
+    """
+    return f"__history_last_seen__:{series_id}"
+
+
+def legacy_last_seen_key(bench_name: str, tag: str | None) -> str:
+    """The pre-``series_id`` index key, read-only, for one upgrade.
+
+    Identical to ``last_seen_key(default_series_id(bench_name, tag))``, so it only
+    ever differs for a benchmark that declares a ``series_id``. Kept as its own
+    function so the fallback lookup is explicit and easy to delete.
+    """
+    return last_seen_key(default_series_id(bench_name, tag))
 
 
 def current_time_value(dataset: xr.Dataset) -> Any:

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -47,7 +47,6 @@ EXCLUDED_FIELDS = (
     "series_id (names the trend, not the configuration)",
     "aggregate / agg_fn",
     "sample_order",
-    "catch / fail_on_sample_error",
     "plot_callbacks / auto_plot",
 )
 

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -44,8 +44,10 @@ IDENTITY_FIELDS = (
 EXCLUDED_FIELDS = (
     "title",
     "description / post_description",
+    "series_id (names the trend, not the configuration)",
     "aggregate / agg_fn",
     "sample_order",
+    "catch / fail_on_sample_error",
     "plot_callbacks / auto_plot",
 )
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from contextlib import suppress
 from datetime import datetime
 from itertools import product
 from typing import Any
@@ -26,9 +27,11 @@ from bencher.history import (
     column_meta,
     current_time_value,
     data_var_columns,
+    default_series_id,
     diff_summaries,
     incompatible_reason,
     last_seen_key,
+    legacy_last_seen_key,
     project,
     reconcile,
 )
@@ -425,6 +428,90 @@ class ResultCollector:
         logger.info(f"saving benchmark: {bench_res.bench_cfg.bench_name}")
         c[bench_res.bench_cfg.bench_name] = bench_cfg_hashes
 
+    def _read_last_seen(
+        self, cache: Cache, series_id: str, bench_name: str | None, tag: str | None
+    ) -> dict | None:
+        """The last-seen index entry for *series_id*, falling back to the legacy key.
+
+        Ordered: the series key first, then the pre-``series_id`` ``(bench_name,
+        tag)`` key, so the first run after upgrade finds its predecessor. A legacy
+        hit needs no explicit migration -- this run's write lands under the new key
+        at the end of ``load_history_cache``. The two keys are the *same string*
+        unless a ``series_id`` was declared, so the fallback only does work where it
+        has to.
+        """
+        entry = cache.get(last_seen_key(series_id))
+        if entry is not None or bench_name is None:
+            return entry
+        return cache.get(legacy_last_seen_key(bench_name, tag))
+
+    def _adopt_or_report_reset(
+        self,
+        cache: Cache,
+        bench_cfg_hash: str,
+        *,
+        series_id: str,
+        bench_name: str | None,
+        tag: str | None,
+        config_summary: dict | None,
+        events: list[HistoryEvent],
+    ) -> dict | None:
+        """Classify a history-key miss under a known series: adopt, or report a reset.
+
+        A key can move for two very different reasons, and until the series was
+        named independently of the key there was no way to tell them apart. The
+        stored ``config_summary`` decides:
+
+        * **identical** -- the declaration did not change, so only ``bench_name``
+          or ``tag`` moved: a pure rename. The stored record is re-keyed to the new
+          hash and a non-lossy ``history_renamed`` event is emitted. Safe precisely
+          because the summary covers every field that shapes the dataset -- same
+          dimensions, same coordinates, same columns -- and the record is *moved*,
+          never concatenated with an incompatible one.
+        * **differs** -- a genuinely different experiment, which is the existing
+          ``full_reset`` with its diff.
+
+        Returns the adopted record, or None to continue as a fresh series.
+        """
+        last = self._read_last_seen(cache, series_id, bench_name, tag)
+        if not last or last.get("key") == bench_cfg_hash:
+            return None
+
+        old_key = last.get("key")
+        diff = diff_summaries(last.get("summary"), config_summary)
+        stored_summary = last.get("summary")
+        renamed = (
+            stored_summary is not None
+            and config_summary is not None
+            and stored_summary == config_summary
+        )
+        if renamed:
+            adopted = self._load_history_record(cache, old_key) if old_key else None
+            if adopted is not None:
+                events.append(
+                    HistoryEvent(
+                        "history_renamed",
+                        f"over_time history adopted for series '{series_id}': the "
+                        f"history key moved from {old_key} to {bench_cfg_hash} with an "
+                        f"unchanged declaration (benchmark '{bench_name}', tag "
+                        f"'{tag}'), so the existing "
+                        f"{last.get('events', '?')} events were carried over",
+                    )
+                )
+                with suppress(KeyError, OSError):
+                    del cache[old_key]
+                return adopted
+
+        detail = (
+            f"over_time history reset for benchmark '{bench_name}' "
+            f"(tag '{tag}'): the history key changed"
+            + (": " + "; ".join(diff) if diff else "")
+            + f"; {last.get('events', '?')} historical events are "
+            f"orphaned under the old key"
+        )
+        events.append(HistoryEvent("full_reset", detail))
+        return None
+
     def _load_history_record(self, cache: Cache, bench_cfg_hash: str) -> dict | None:
         """Fetch and normalize one history record, or None when absent/unreadable.
 
@@ -470,6 +557,7 @@ class ResultCollector:
         on_history_reset: str = "warn",
         bench_name: str | None = None,
         tag: str | None = None,
+        series_id: str | None = None,
         config_summary: dict | None = None,
     ) -> xr.Dataset:
         """Load, reconcile, and persist historical benchmark data.
@@ -494,9 +582,13 @@ class ResultCollector:
                 None, column reconciliation and projection are skipped entirely.
             on_history_reset (str): Policy for loss-y schema events — "warn",
                 "error" (raise HistoryResetError before persisting), or "ignore".
-            bench_name (str | None): Benchmark name for the last-seen index; enables
-                full-reset detection when the history key moves.
-            tag (str | None): Benchmark tag for the last-seen index.
+            bench_name (str | None): Benchmark name, used in event messages and as
+                half of the legacy index key read during the one-release upgrade.
+            tag (str | None): Benchmark tag, same two uses as bench_name.
+            series_id (str | None): The series this run appends to
+                (``BenchCfg.series``). Keys the last-seen index, which is what lets
+                a pure rename be adopted rather than silently orphaned. When None
+                the index is not consulted and no reset is detected.
             config_summary (dict | None): ``bencher.history.config_summary`` of the
                 current config, stored in the last-seen index and diffed on resets.
 
@@ -505,6 +597,12 @@ class ResultCollector:
                 historical plus current data, projected onto the current columns.
         """
         c = self.get_history_cache()
+        # An explicit series_id wins; otherwise the series is bench_name:tag, which
+        # is what the index was keyed on before series_id existed. Deriving it here
+        # rather than requiring it keeps every existing caller's reset detection.
+        series = series_id or (
+            default_series_id(bench_name, tag) if bench_name is not None else None
+        )
         current_cols = data_var_columns(result_vars)
         events: list[HistoryEvent] = []
         merged = dataset
@@ -517,20 +615,18 @@ class ResultCollector:
         else:
             logger.info(f"checking historical key: {bench_cfg_hash}")
             record = self._load_history_record(c, bench_cfg_hash)
+            if record is None and series is not None:
+                record = self._adopt_or_report_reset(
+                    c,
+                    bench_cfg_hash,
+                    series_id=series,
+                    bench_name=bench_name,
+                    tag=tag,
+                    config_summary=config_summary,
+                    events=events,
+                )
             if record is None:
                 logger.info("did not detect any historical data")
-                if bench_name is not None:
-                    last = c.get(last_seen_key(bench_name, tag))
-                    if last and last.get("key") != bench_cfg_hash:
-                        diff = diff_summaries(last.get("summary"), config_summary)
-                        detail = (
-                            f"over_time history reset for benchmark '{bench_name}' "
-                            f"(tag '{tag}'): the history key changed"
-                            + (": " + "; ".join(diff) if diff else "")
-                            + f"; {last.get('events', '?')} historical events are "
-                            f"orphaned under the old key"
-                        )
-                        events.append(HistoryEvent("full_reset", detail))
             else:
                 logger.info("loading historical data from cache")
                 ds_old = record["dataset"]
@@ -582,8 +678,8 @@ class ResultCollector:
             "columns": columns_meta,
             "retired": retired,
         }
-        if bench_name is not None:
-            c[last_seen_key(bench_name, tag)] = {
+        if series is not None:
+            c[last_seen_key(series)] = {
                 "key": bench_cfg_hash,
                 "summary": config_summary,
                 "events": int(merged.sizes.get("over_time", 0)),

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -588,7 +588,9 @@ class ResultCollector:
             series_id (str | None): The series this run appends to
                 (``BenchCfg.series``). Keys the last-seen index, which is what lets
                 a pure rename be adopted rather than silently orphaned. When None
-                the index is not consulted and no reset is detected.
+                the series falls back to ``bench_name:tag``, so the index is still
+                consulted and reset detection is unchanged for callers that declare
+                nothing; the index is skipped only when ``bench_name`` is None too.
             config_summary (dict | None): ``bencher.history.config_summary`` of the
                 current config, stored in the last-seen index and diffed on resets.
 

--- a/plans/15-benchmark-series-identity.md
+++ b/plans/15-benchmark-series-identity.md
@@ -1,0 +1,211 @@
+# Plan 15 — Stable Benchmark Series Identity
+
+**Goal:** Let a benchmark's `over_time` history survive renames, and make every
+identity change either *adopted* or *reported* — never silently orphaned. Today
+the reset detector added in plan 09 is keyed on the two fields whose change is
+the most common cause of a reset, so it cannot see them move.
+
+**Branch name:** `feat/benchmark-series-identity`
+
+**⚠️ Read first:** plans 09 and 14 (both implemented in v1.116.0) define the
+history key and the reconciliation model this builds on. The new field must not
+enter `hash_persistent()` (`bencher/bench_cfg.py:785`) — it identifies a
+*series*, not a configuration, and folding it in would re-key every existing
+cache and history on upgrade.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — The reset detector is keyed on the fields it exists to detect
+
+Plan 09 shipped a last-seen index so a moved history key is reported rather
+than silently starting a new trend. On a history-cache miss the loader looks up
+the previous entry, compares keys, and emits a `full_reset` event naming the
+diff (`bencher/result_collector.py:508-520`), which `apply_policy` then warns
+or raises on (`bencher/result_collector.py:546`, `bencher/history.py:405`).
+
+That index is keyed by `last_seen_key(bench_name, tag)`
+(`bencher/history.py:180`), and both of those are themselves inputs to the
+history key (`bencher/bench_cfg.py:831` folds `bench_name`, `:834` folds
+`tag`). So the detector splits cleanly in two:
+
+| What changed | Index entry | Detected? |
+|---|---|---|
+| `input_vars`, `const_vars`, `repeats` | stays put | **yes** — `full_reset` with a diff |
+| `bench_name` or `tag` | **moves with the key** | **no** — miss on both, silent orphan |
+
+A rename is the *most likely* way a key moves in practice, and it is precisely
+the case that produces no event: the lookup at
+`bencher/result_collector.py:510` misses, so the code takes the "first run ever"
+path and writes a fresh index entry under the new name.
+
+### P2 — `bench_name` defaults to a Python class name, and it is hashed
+
+When a sweep is turned into a bench without an explicit name, the name falls
+back to the worker's class name (`bencher/factories.py:39-42`, reached from
+`ParametrizedSweep.to_bench` at `bencher/variables/parametrised_sweep.py:246`).
+That value is then folded into the persistent hash
+(`bencher/bench_cfg.py:831`).
+
+The consequence is that ordinary refactors silently reset history: renaming the
+worker class, extracting a shared base and running it under two thin
+subclasses, or generating worker classes programmatically all change the
+identity of a benchmark whose measurements did not change at all. Plan 13's D3
+recognizes exactly this hazard for `__name__`-derived *tags* and deliberately
+gates auto-tagging on the decorator so undecorated benchmarks are not re-keyed;
+the same hazard already exists, ungated, for `bench_name`.
+
+### P3 — `tag` carries two unrelated jobs
+
+`tag` is the sample-cache isolation knob — the effective cache tag is
+`run_cfg.run_tag + tag`, composed at `bencher/bencher.py:524` and again on the
+`optimize()` path at `bencher/bencher.py:1224` — *and* part of series
+identity. So a change made for cache-partitioning reasons resets the trend, and
+there is no way to express "different cache partition, same series" or "same
+partition, deliberately new series".
+
+### P4 — There is no way to say "this is the same benchmark as before"
+
+Because identity is derived entirely from incidental facts (a class name, a
+cache tag), an author who *intends* continuity across a refactor has no way to
+declare it, and an author who intends a fresh start has no way to declare that
+either. Both are expressed by accident, and neither is visible in review.
+
+---
+
+## Proposed design
+
+One new author-controlled field, used as the index key and nothing else.
+
+### D1 — `series_id` on the sweep declaration
+
+`plot_sweep()` gains `series_id: str | None = None`
+(`bencher/bencher.py:271-288`), stored on `BenchCfg` and defaulting to
+`f"{bench_name}:{tag}"` — byte-identical to today's index key, so nothing moves
+on upgrade.
+
+- It **must not** reach `hash_persistent()` (`bencher/bench_cfg.py:785`). That
+  method folds an explicit tuple of fields rather than scanning the class, so
+  exclusion means simply not adding it — and unlike the sweep-variable classes
+  there is no slot-coverage test to catch a mistake here, which is why phase 1
+  lands a golden-hash guard before anything else. Two benchmarks with the same
+  inputs, consts, name, and tag stay one cache entry whatever their
+  `series_id`; the field decides only *which trend line this run appends to*.
+- The last-seen index key becomes `last_seen_key(series_id)`
+  (`bencher/history.py:180`), with the legacy two-argument form retained for one
+  release as a read fallback (see D4).
+- `series_id` is also a natural member of plan 13's declaration bundle, so it
+  can be declared once per benchmark rather than at each call site.
+
+### D2 — Adopt history across a pure rename
+
+With a stable `series_id`, a moved key can be classified instead of guessed at.
+The index entry already stores a `config_summary` — inputs, consts, results,
+repeats (`bencher/history.py:135-152`) — so on a cache miss under a known
+`series_id`:
+
+| Stored summary vs current | Classification | Action |
+|---|---|---|
+| identical | pure rename (`bench_name`/`tag` moved) | **adopt**: re-key the stored record to the new hash, emit `history_renamed` |
+| differs | genuine new experiment | **reset**: today's `full_reset` event, with the existing diff |
+
+Adoption is safe exactly when the summary matches, because the summary covers
+every field that shapes the dataset: same dimensions, same coordinates, same
+columns. The record is moved, not merged — no concatenation of incompatible
+datasets, which is the failure class plan 14 was written to avoid.
+
+`history_renamed` is a new `HistoryEvent` kind. It is **informational**, not
+loss-y: `apply_policy` (`bencher/history.py:405`) should log it at INFO and not
+raise even under `on_history_reset="error"`, because nothing was lost. Only the
+reset branch stays fatal under that policy.
+
+### D3 — Separate cache partition from series
+
+Once `series_id` exists, a caller who changes `tag` purely to isolate a cache
+partition keeps `series_id` fixed and keeps the trend. Document the pairing
+explicitly at both fields: **`tag` partitions storage, `series_id` names the
+trend.** No behavior change for callers who set neither.
+
+### D4 — Upgrade path
+
+The first run after upgrade must find its predecessor. Order the lookup:
+
+1. `last_seen_key(series_id)` — the new form.
+2. `last_seen_key(bench_name, tag)` — the legacy form, read-only.
+
+A hit on (2) is migrated by writing (1) and is not reported as an event. Drop
+the fallback after one minor release, noted in `CHANGELOG.md`.
+
+---
+
+## Phased steps
+
+Each phase is independently shippable and leaves the suite green.
+
+1. **Add the field, keep the behavior.** `series_id` on `plot_sweep`/`BenchCfg`,
+   defaulted to `f"{bench_name}:{tag}"`, added to `_hash_exclude`, with a
+   `test_hash_persistent.py` case proving the golden hashes are unmoved
+   (`test/test_hash_persistent.py:774-801`).
+2. **Re-key the index.** Index on `series_id` with the legacy read fallback
+   (D4). No new events yet; existing `full_reset` detection must behave
+   identically for unchanged benchmarks.
+3. **Add adoption.** The summary comparison, the `history_renamed` event, the
+   record move, and the INFO-level policy handling.
+4. **Documentation.** The `tag`-vs-`series_id` split at both fields, in the
+   caching docs, and a `CHANGELOG.md` entry stating that renaming a worker class
+   no longer resets history when `series_id` is declared.
+5. *(Optional, after plan 13)* accept `series_id` in the declaration bundle.
+
+---
+
+## Tests / acceptance criteria
+
+- Golden hashes in `test/test_hash_persistent.py` are unchanged by phase 1.
+- Two runs differing only in `bench_name`, same `series_id`: second run adopts,
+  history length grows by one, a `history_renamed` event is emitted, and
+  `on_history_reset="error"` does **not** raise.
+- Same, differing only in `tag`: same outcome.
+- Two runs differing in `input_vars` under one `series_id`: `full_reset` with
+  the existing diff text; `on_history_reset="error"` raises and the stored
+  record is left untouched (the pre-persist guarantee from plan 14).
+- A run whose index entry exists only under the legacy key migrates silently
+  and reports no event.
+- `series_id` never reaches the hash: a new case alongside
+  `test_title_change_does_not_affect_golden_hash`
+  (`test/test_hash_persistent.py:796`) asserting that two configs differing only
+  in `series_id` share both the cache key and the history key.
+
+## Migration & compatibility
+
+Fully backward compatible. Callers who set nothing get today's identity, today's
+detection, and one extra INFO line's worth of behavior change (renames that were
+previously silent orphans become silent *adoptions* only if they also happen to
+share a default `series_id` — which they do not, so unchanged callers see no
+difference at all). The stored record layout gains no new required field;
+`HISTORY_FORMAT` (`bencher/history.py:59`) needs a bump only if the record
+itself grows `bench_name`/`tag` provenance, which D2 requires — do it in phase 3
+with the reconciliation loader tolerating a missing field.
+
+## Risks
+
+- **Adoption of the wrong record.** Mitigated by requiring an exact
+  `config_summary` match; a mismatch falls through to today's reset path.
+  A hand-copied `series_id` shared by two genuinely different benchmarks would
+  produce a reset on every alternating run, which is noisy but not corrupting.
+- **`series_id` drifting into the hash.** A single misplaced line would re-key
+  every user's cache. The `_hash_exclude` contract test is the guard, and phase 1
+  exists specifically to land that guard before any behavior changes.
+- **Scope creep into A4.** This plan touches only the last-seen index and the
+  record's identity fields; storage layout stays A4's business.
+
+## Coordination
+
+- **Plan 09** introduced the last-seen index; this closes the hole in it.
+- **Plan 14** owns the reconciliation model — adoption must not bypass it.
+- **Plan 13** D1/D3: `series_id` belongs in the declaration bundle, and D3's
+  gating of `__name__`-derived tags shares this plan's reasoning.
+- **Plan 16** exposes identity as an inspectable value; the two are independent
+  but land better together (16 makes this plan's behavior assertable).
+- **A4** may relocate the index; keep the key derivation in one function
+  (`bencher/history.py:180`) so it moves as a unit.

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -23,6 +23,7 @@ from bencher.history import (
     column_identity,
     data_var_columns,
     last_seen_key,
+    legacy_last_seen_key,
 )
 from bencher.regression import detect_regressions
 from bencher.result_collector import ResultCollector
@@ -399,7 +400,7 @@ class TestResetPolicy(ReconcilerBase):
         rv_a, rv_b = _result_float("a"), _result_float("b")
         self.load(["a", "b"], 1, [rv_a, rv_b])
         cache = self.collector.get_history_cache()
-        ls_key = last_seen_key(self.kwargs["bench_name"], self.kwargs["tag"])
+        ls_key = legacy_last_seen_key(self.kwargs["bench_name"], self.kwargs["tag"])
         record_before = cache[self.key]
         last_before = cache.get(ls_key)
         with self.assertRaises(HistoryResetError):
@@ -427,10 +428,18 @@ class TestResetPolicy(ReconcilerBase):
             self.load(["a"], 2, [rv_a], on_history_reset="ignore")
 
     def test_full_reset_reported_via_last_seen_index(self):
+        """A key move with a *changed* declaration is still a reported reset.
+
+        The declaration has to actually change: a key that moves while the stored
+        config summary is *unchanged* is a rename, and is adopted instead (see
+        TestSeriesIdentity). This harness passes config_summary explicitly, so the
+        changed declaration is expressed there.
+        """
         self.load(["a"], 1, [_result_float("a")])
-        self.key = f"history-{uuid.uuid4()}"  # input/const change = new key
+        self.key = f"history-{uuid.uuid4()}"
+        changed = {**self.kwargs["config_summary"], "inputs": [("x", "FloatSweep", "ul")]}
         with self.assertLogs("bencher.history", level=logging.WARNING) as logs:
-            self.load(["a"], 2, [_result_float("a")])
+            self.load(["a"], 2, [_result_float("a")], config_summary=changed)
         self.assertTrue(any("orphaned under the old key" in line for line in logs.output))
 
     def test_born_column_is_not_lossy(self):

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -22,7 +22,6 @@ from bencher.history import (
     HistoryResetError,
     column_identity,
     data_var_columns,
-    last_seen_key,
     legacy_last_seen_key,
 )
 from bencher.regression import detect_regressions

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -554,6 +554,24 @@ class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
             _real_run(**decl, sample_order=bn.SampleOrder.REVERSED),
         )
 
+    def check_series_id(self) -> None:
+        """The pairing this list exists to state: tag partitions storage, series_id names the trend.
+
+        ``series_id`` reaches ``BenchCfg`` and is deliberately kept out of
+        ``hash_persistent`` -- naming a trend must never move the keys whose
+        movement the trend exists to survive. ``tag`` is checked to move, one
+        entry above, so the two halves are pinned against each other.
+        """
+        decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
+        self._assert_no_key_moves(
+            _dry_identity(**decl),
+            _dry_identity(**decl, series_id="latency"),
+        )
+        self._assert_no_key_moves(
+            _dry_identity(**decl, series_id="latency"),
+            _dry_identity(**decl, series_id="throughput"),
+        )
+
     def check_plotting(self) -> None:
         """``plot_callbacks`` is stored on BenchCfg; ``auto_plot`` is merged onto it."""
         decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
@@ -580,6 +598,7 @@ class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
             "description / post_description": self.check_descriptions,
             "aggregate / agg_fn": self.check_aggregation,
             "sample_order": self.check_sample_order,
+            "series_id (names the trend, not the configuration)": self.check_series_id,
             "plot_callbacks / auto_plot": self.check_plotting,
         }
 

--- a/test/test_series_identity.py
+++ b/test/test_series_identity.py
@@ -1,0 +1,356 @@
+"""Plan 15 — a benchmark's trend must survive a rename, or say that it didn't.
+
+The reset detector added by plan 09 was keyed on ``(bench_name, tag)`` — the two
+fields whose change is the most common cause of a moved history key. The index
+entry therefore moved together with the key it existed to watch, so a rename
+missed on both sides and took the "first run ever" path: a silently orphaned
+trend, no event, nothing to notice.
+
+``series_id`` names the trend independently of what identifies the configuration,
+which is what makes the two reasons a key can move distinguishable at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+import uuid
+
+import numpy as np
+import xarray as xr
+
+import bencher as bn
+from bencher.history import (
+    HistoryResetError,
+    default_series_id,
+    last_seen_key,
+    legacy_last_seen_key,
+)
+from bencher.result_collector import ResultCollector
+from bencher.variables.results import ResultFloat
+
+
+def _result_float(name: str) -> ResultFloat:
+    rv = ResultFloat()
+    rv.name = name
+    return rv
+
+
+def _run_ds(name: str, value: float, t: int) -> xr.Dataset:
+    return xr.Dataset(
+        {name: (("repeat", "over_time"), np.array([[value]], dtype=float))},
+        coords={"repeat": [0], "over_time": [np.datetime64(f"2024-01-0{t}")]},
+    )
+
+
+class SeriesBase(unittest.TestCase):
+    """Drives the collector directly against a throwaway cachedir."""
+
+    def setUp(self) -> None:
+        self._old_cwd = os.getcwd()
+        self._tmp = tempfile.mkdtemp()
+        os.chdir(self._tmp)
+        self.collector = ResultCollector()
+        self.summary = {"inputs": [], "consts": [], "results": [], "repeats": 1}
+
+    def tearDown(self) -> None:
+        self.collector.close_caches()
+        os.chdir(self._old_cwd)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def load(self, key, t, *, bench_name, tag="t", series_id=None, summary=None, policy="warn"):
+        rv = _result_float("a")
+        return self.collector.load_history_cache(
+            _run_ds("a", float(t), t),
+            key,
+            False,
+            None,
+            [rv],
+            on_history_reset=policy,
+            bench_name=bench_name,
+            tag=tag,
+            series_id=series_id,
+            config_summary=self.summary if summary is None else summary,
+        )
+
+
+class TestDefaultsAreUnchanged(unittest.TestCase):
+    """Phase 1's contract: declaring nothing changes nothing."""
+
+    def test_series_defaults_to_bench_name_and_tag(self) -> None:
+        cfg = bn.BenchCfg(bench_name="B", tag="t")
+        self.assertIsNone(cfg.series_id)
+        self.assertEqual(cfg.series, "B:t")
+        self.assertEqual(cfg.series, default_series_id("B", "t"))
+
+    def test_the_default_index_key_is_byte_identical_to_the_legacy_one(self) -> None:
+        """Nothing moves on upgrade for a caller who declares no series_id."""
+        self.assertEqual(last_seen_key(default_series_id("B", "t")), legacy_last_seen_key("B", "t"))
+
+    def test_a_declared_series_id_replaces_the_default(self) -> None:
+        cfg = bn.BenchCfg(bench_name="B", tag="t", series_id="latency")
+        self.assertEqual(cfg.series, "latency")
+
+    def test_explain_identity_names_series_id_as_excluded(self) -> None:
+        """The pairing users need told: tag partitions storage, series_id names the
+        trend. A field that is deliberately outside the hash is only useful if the
+        surface that explains identity says so."""
+        from bencher.example.benchmark_data import ExampleBenchCfg
+
+        ident = bn.sweep_identity(
+            worker=ExampleBenchCfg, input_vars=["theta"], result_vars=["out_sin"]
+        )
+        excluded = ident.explain().split("excluded on purpose")[1]
+        self.assertIn("series_id", excluded)
+
+    def test_series_id_never_reaches_the_hash(self) -> None:
+        """It identifies a series, not a configuration; folding it in would re-key
+        every existing cache and history on upgrade."""
+        plain = bn.BenchCfg(bench_name="B", tag="t")
+        declared = bn.BenchCfg(bench_name="B", tag="t", series_id="anything")
+        other = bn.BenchCfg(bench_name="B", tag="t", series_id="something-else")
+        for include_results in (True, False):
+            self.assertEqual(
+                plain.hash_persistent(True, include_results),
+                declared.hash_persistent(True, include_results),
+            )
+            self.assertEqual(
+                declared.hash_persistent(True, include_results),
+                other.hash_persistent(True, include_results),
+            )
+        self.assertEqual(plain.hash_persistent(False), declared.hash_persistent(False))
+
+
+class TestRenameIsAdopted(SeriesBase):
+    """D2 — a key that moves with an unchanged declaration is a rename."""
+
+    def _first_run(self, series_id):
+        key_a = f"history-{uuid.uuid4()}"
+        self.load(key_a, 1, bench_name="OldName", series_id=series_id)
+        return key_a
+
+    def test_a_renamed_bench_keeps_its_history(self) -> None:
+        series = "latency"
+        self._first_run(series)
+        key_b = f"history-{uuid.uuid4()}"
+        served = self.load(key_b, 2, bench_name="NewName", series_id=series)
+        self.assertEqual(served.sizes["over_time"], 2, "history was not carried over")
+        self.assertEqual(list(served["a"].values[0]), [1.0, 2.0])
+
+    def test_a_changed_tag_keeps_its_history(self) -> None:
+        """D3 — tag partitions storage; series_id names the trend."""
+        series = "latency"
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="B", tag="t1", series_id=series)
+        served = self.load(f"history-{uuid.uuid4()}", 2, bench_name="B", tag="t2", series_id=series)
+        self.assertEqual(served.sizes["over_time"], 2)
+
+    def test_adoption_is_informational_not_lossy(self) -> None:
+        """Nothing was lost, so on_history_reset='error' must not raise."""
+        series = "latency"
+        self._first_run(series)
+        served = self.load(
+            f"history-{uuid.uuid4()}", 2, bench_name="NewName", series_id=series, policy="error"
+        )
+        self.assertEqual(served.sizes["over_time"], 2)
+
+    def test_adoption_logs_at_info_naming_both_keys(self) -> None:
+        series = "latency"
+        key_a = self._first_run(series)
+        with self.assertLogs("bencher.history", level=logging.INFO) as logs:
+            self.load(f"history-{uuid.uuid4()}", 2, bench_name="NewName", series_id=series)
+        adopted = [line for line in logs.output if "adopted" in line]
+        self.assertTrue(adopted, logs.output)
+        self.assertTrue(any(key_a in line for line in adopted))
+
+    def test_no_warning_is_emitted_for_a_rename(self) -> None:
+        series = "latency"
+        self._first_run(series)
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            self.load(f"history-{uuid.uuid4()}", 2, bench_name="NewName", series_id=series)
+
+    def test_the_old_record_is_moved_not_duplicated(self) -> None:
+        series = "latency"
+        key_a = self._first_run(series)
+        key_b = f"history-{uuid.uuid4()}"
+        self.load(key_b, 2, bench_name="NewName", series_id=series)
+        cache = self.collector.get_history_cache()
+        self.assertNotIn(key_a, cache, "the adopted record was left behind under the old key")
+        self.assertIn(key_b, cache)
+
+    def test_three_consecutive_renames_keep_one_series(self) -> None:
+        series = "latency"
+        served = None
+        for i, name in enumerate(("A", "B", "C", "D"), start=1):
+            served = self.load(f"history-{uuid.uuid4()}", i, bench_name=name, series_id=series)
+        self.assertEqual(served.sizes["over_time"], 4)
+        self.assertEqual(list(served["a"].values[0]), [1.0, 2.0, 3.0, 4.0])
+
+
+class TestGenuineChangeStillResets(SeriesBase):
+    """The other half of D2: a changed declaration is not a rename."""
+
+    def test_a_changed_declaration_reports_a_full_reset(self) -> None:
+        series = "latency"
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="B", series_id=series)
+        changed = {**self.summary, "inputs": [("x", "FloatSweep", "ul")]}
+        with self.assertLogs("bencher.history", level=logging.WARNING) as logs:
+            served = self.load(
+                f"history-{uuid.uuid4()}", 2, bench_name="B", series_id=series, summary=changed
+            )
+        self.assertTrue(any("orphaned under the old key" in line for line in logs.output))
+        self.assertTrue(any("inputs changed" in line for line in logs.output))
+        self.assertEqual(served.sizes["over_time"], 1, "a reset must start a fresh series")
+
+    def test_error_policy_still_raises_on_a_genuine_reset(self) -> None:
+        series = "latency"
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="B", series_id=series)
+        changed = {**self.summary, "repeats": 3}
+        with self.assertRaises(HistoryResetError):
+            self.load(
+                f"history-{uuid.uuid4()}",
+                2,
+                bench_name="B",
+                series_id=series,
+                summary=changed,
+                policy="error",
+            )
+
+    def test_a_reset_leaves_the_stored_record_untouched(self) -> None:
+        """Plan 14's pre-persist guarantee: an erroring run advances nothing."""
+        series = "latency"
+        key_a = f"history-{uuid.uuid4()}"
+        self.load(key_a, 1, bench_name="B", series_id=series)
+        cache = self.collector.get_history_cache()
+        before = cache[key_a]["dataset"].copy(deep=True)
+        index_before = cache.get(last_seen_key(series))
+        with self.assertRaises(HistoryResetError):
+            self.load(
+                f"history-{uuid.uuid4()}",
+                2,
+                bench_name="B",
+                series_id=series,
+                summary={**self.summary, "repeats": 9},
+                policy="error",
+            )
+        xr.testing.assert_identical(before, cache[key_a]["dataset"])
+        self.assertEqual(index_before, cache.get(last_seen_key(series)))
+
+    def test_different_series_ids_do_not_see_each_other(self) -> None:
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="B", series_id="one")
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            served = self.load(f"history-{uuid.uuid4()}", 2, bench_name="B", series_id="two")
+        self.assertEqual(served.sizes["over_time"], 1)
+
+
+class TestUpgradePath(SeriesBase):
+    """D4 — the first run after upgrade must find its predecessor."""
+
+    def test_a_legacy_index_entry_is_found_and_migrated(self) -> None:
+        key_a = f"history-{uuid.uuid4()}"
+        # A run from before series_id existed: the index lands under the legacy key,
+        # which for an undeclared series is the same string.
+        self.load(key_a, 1, bench_name="B", tag="t")
+        cache = self.collector.get_history_cache()
+        self.assertIn(legacy_last_seen_key("B", "t"), cache)
+
+        # Now the same benchmark declares a series_id for the first time. Its index
+        # entry does not exist under the new key yet.
+        self.assertNotIn(last_seen_key("latency"), cache)
+        served = self.load(key_a, 2, bench_name="B", tag="t", series_id="latency")
+        self.assertEqual(served.sizes["over_time"], 2)
+        self.assertIn(last_seen_key("latency"), cache, "the index was not migrated")
+
+    def test_declare_the_series_before_renaming_then_the_rename_is_adopted(self) -> None:
+        """The supported sequence, and the reason the order matters.
+
+        Declaring ``series_id`` writes the index under the series key while the old
+        ``bench_name`` is still in force; the rename then finds it. Doing both in
+        one run cannot work — see the next test — so this ordering is the migration
+        procedure, not an implementation detail.
+        """
+        key_a = f"history-{uuid.uuid4()}"
+        self.load(key_a, 1, bench_name="OldName", tag="t", series_id="latency")
+        served = self.load(
+            f"history-{uuid.uuid4()}", 2, bench_name="NewName", tag="t", series_id="latency"
+        )
+        self.assertEqual(served.sizes["over_time"], 2)
+
+    def test_renaming_and_declaring_in_one_run_cannot_find_the_old_entry(self) -> None:
+        """The limit of the legacy fallback, pinned so it is not mistaken for a bug.
+
+        The fallback key is ``(bench_name, tag)`` of the *current* run, and
+        bench_name is precisely what moved, so the pre-series_id entry — written
+        under the old name — is unreachable. Recovering it would need the old
+        identity, which nothing records. Declare the series first (previous test).
+        """
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="OldName", tag="t")
+        served = self.load(
+            f"history-{uuid.uuid4()}", 2, bench_name="NewName", tag="t", series_id="latency"
+        )
+        self.assertEqual(served.sizes["over_time"], 1)
+
+    def test_a_rename_without_a_declared_series_id_is_still_undetectable(self) -> None:
+        """The honest limit of the design.
+
+        Without a declared series_id the series *is* bench_name:tag, so a rename
+        moves the index with the key exactly as before. This is the case series_id
+        exists to let a user opt out of -- it cannot be fixed by default without
+        guessing which of two benchmarks is the continuation of a third.
+        """
+        self.load(f"history-{uuid.uuid4()}", 1, bench_name="OldName", tag="t")
+        with self.assertNoLogs("bencher.history", level=logging.WARNING):
+            served = self.load(f"history-{uuid.uuid4()}", 2, bench_name="NewName", tag="t")
+        self.assertEqual(served.sizes["over_time"], 1)
+
+
+class TestPlotSweepSurface(unittest.TestCase):
+    """The field is reachable from the public declaration surface."""
+
+    def test_plot_sweep_accepts_series_id_and_stores_it(self) -> None:
+        from bencher.example.benchmark_data import ExampleBenchCfg
+
+        cfg = bn.BenchRunCfg()
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        bench = ExampleBenchCfg().to_bench(cfg)
+        try:
+            res = bench.plot_sweep(
+                input_vars=["theta"],
+                result_vars=["out_sin"],
+                series_id="latency",
+                plot_callbacks=False,
+            )
+        finally:
+            bench.close()
+        self.assertEqual(res.bench_cfg.series_id, "latency")
+        self.assertEqual(res.bench_cfg.series, "latency")
+
+    def test_series_id_does_not_move_the_run_key(self) -> None:
+        from bencher.example.benchmark_data import ExampleBenchCfg
+
+        keys = []
+        for series_id in (None, "latency"):
+            cfg = bn.BenchRunCfg()
+            cfg.auto_plot = False
+            cfg.cache_results = False
+            cfg.cache_samples = False
+            bench = ExampleBenchCfg().to_bench(cfg)
+            try:
+                res = bench.plot_sweep(
+                    input_vars=["theta"],
+                    result_vars=["out_sin"],
+                    series_id=series_id,
+                    plot_callbacks=False,
+                )
+                keys.append(res.bench_cfg.hash_persistent(True))
+            finally:
+                bench.close()
+        self.assertEqual(keys[0], keys[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_series_identity.py
+++ b/test/test_series_identity.py
@@ -263,6 +263,15 @@ class TestUpgradePath(SeriesBase):
         self.assertEqual(served.sizes["over_time"], 2)
         self.assertIn(last_seen_key("latency"), cache, "the index was not migrated")
 
+        # From here the legacy entry is read-only: it still records the pre-upgrade
+        # run while only the series key advances. It is left in place rather than
+        # deleted -- an undeclared run under the same name still reads that string
+        # as its own series key -- so "read-only" is the contract to pin, and a
+        # regression that wrote both would leave two live indices for one trend.
+        self.load(key_a, 3, bench_name="B", tag="t", series_id="latency")
+        self.assertEqual(cache[legacy_last_seen_key("B", "t")]["events"], 1)
+        self.assertEqual(cache[last_seen_key("latency")]["events"], 3)
+
     def test_declare_the_series_before_renaming_then_the_rename_is_adopted(self) -> None:
         """The supported sequence, and the reason the order matters.
 


### PR DESCRIPTION
Plan 15 plus its implementation (phases 1–3). **Third in a five-PR stack** (see below).

Plan 09's reset detector was keyed by `last_seen_key(bench_name, tag)` — and both of those
are themselves inputs to the history key. The index entry therefore moved together with
the key it existed to watch, so the most common way a key moves in practice produced no
event at all:

| What changed | index entry | detected? |
|---|---|---|
| `input_vars`, `const_vars`, `repeats` | stays put | yes — `full_reset` with a diff |
| `bench_name` or `tag` | **moves with the key** | **no** — miss on both, silent orphan |

## What this adds

`series_id` on `plot_sweep`/`BenchCfg`, defaulting to `f"{bench_name}:{tag}"` — **byte-
identical to the previous index key**, so nothing moves on upgrade for anyone who declares
nothing. It never reaches `hash_persistent`: it names a *trend*, not a configuration.
**`tag` partitions storage; `series_id` names the trend.**

On a key miss under a known series, the stored `config_summary` classifies what happened:

- **unchanged** → a pure rename. The record is re-keyed and a `history_renamed` event is
  emitted. That event needed no policy work: `HistoryEvent.lossy` is membership in
  `_LOSSY_KINDS`, so a new kind is automatically informational — INFO, never raising even
  under `on_history_reset="error"`. Nothing was lost.
- **differs** → the existing `full_reset` with its diff, still fatal under that policy.

Adoption is safe exactly when the summary matches, because the summary covers every field
that shapes the dataset. The record is **moved, not merged** — no concatenation of
incompatible datasets, which is the failure class plan 14 exists to avoid.

## Cross-plan wire, only possible at this stack position

Sitting on plan 16, this also closes the gap both plans call for and neither could
implement alone: `series_id` now appears in `SweepIdentity.explain()`'s excluded list, so
the surface that explains identity states the storage-vs-trend pairing.

## Validation

Measured end-to-end against a real downstream benchmark declaration through the real
history cache:

| Scenario | history length after 2 runs | events |
|---|---|---|
| rename, no `series_id` | 1 — orphaned | **none** |
| rename, `series_id` declared | **2** | INFO, naming both keys |
| control: changed declaration, same name | 1 | WARNING reset |

Downstream suite: 1132 passed.

## ⚠️ Two existing tests change

Both in `test_history_reconciliation.py`, and both because their fixture now describes a
different case:

- `test_error_policy_raises_before_persisting` called `last_seen_key` with two positional
  arguments. It now uses `legacy_last_seen_key`, which is that exact key and exists for
  the one-release upgrade fallback.
- `test_full_reset_reported_via_last_seen_index` moved the history key while leaving
  `config_summary` untouched — which is now the **rename** signature. Its own comment said
  "input/const change", so the fixture now expresses that change in the `config_summary`
  it passes.

## A limit of D4, found by implementing it and pinned as a test

Renaming **and** declaring `series_id` in the same run cannot find the legacy index entry,
because the fallback key is `(bench_name, tag)` of the *current* run and `bench_name` is
what just moved. Recovering it would need the old identity, which nothing records. The
procedure is: declare the series first, rename in a later run.

Not included: phase 4's docs beyond the field docstrings, and phase 5 (plan 13's
declaration bundle), which needs plan 13.

---

### Stack

| | PR | Plan | Base |
|---|---|---|---|
| 1 | #1010 | 16 inspectable identity | `main` |
| 2 | #1011 | 20 duplicate declared variables | #1010 |
| 3 | #1012 | 15 stable series identity | #1011 |
| 4 | #1013 | 21 per-sample fault tolerance | #1012 |
| 5 | #1014 | 18 reusable sweep declarations | #1013 |

Review and merge bottom-up. The order is not arbitrary — it comes from the plans' own
coordination sections: 16 first because it is purely additive and gives the reviewers of
20 and 15 a way to check hashes; 20 before 15 because 20 is the one deliberate hash move
and 15 is what makes such a move legible; 18 last because its `bind()` calls 20's
validator. Two cross-plan integrations that the plan docs require are only implementable
*because* of that ordering, and are noted in the PRs that carry them (3 and 5).

Supersedes #999 (plan-only), which is closed. Nothing here is squashed
across plans: each PR is its own plan doc plus its own implementation.
