### PR TITLE
plan 21 + implementation: per-sample fault tolerance in sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-sample fault tolerance on the sweep path: `catch=` and `fail_on_sample_error`.**
+  `Bench.optimize(catch=...)` has had this knob since #962, so the same benchmark was
+  fault-tolerant when driven by Optuna and all-or-nothing when swept. `catch` is available on
+  `BenchRunCfg` (so `bn.run(catch=...)` works) and as a `plot_sweep` argument; a bare
+  exception type is accepted and wrapped. A caught sample leaves the missing-value sentinel
+  at its coordinate — `setup_dataset` already fills every result variable, so the dataset
+  shape is unchanged and reductions skip it — is logged at WARNING with its inputs, and
+  writes **nothing** to the sample cache, so a transient flake cannot become a permanent
+  cached failure. Default `()` is fail-fast, exactly as before, and tolerating a failure
+  moves no cache key.
+
+  `fail_on_sample_error: bool | float` is the other half, and the two are a pair rather than
+  independent knobs: `catch` alone turns real breakage into a green run over an all-sentinel
+  dataset. `True` fails the run if any sample was caught; a float in (0, 1] fails when the
+  failed *fraction* reaches it, measured over samples the run actually **executed** — a cache
+  hit never reached the worker, so counting it would make one threshold mean different things
+  on a cold and a warm cache. The raise happens after the dataset and report are assembled,
+  so the partial results survive it, and only for a run that actually sampled: on a
+  benchmark-result cache hit the loaded result carries a *previous* run's counts, which are
+  not this run's errors. Both knobs are validated before sampling starts, so a typo'd
+  threshold costs milliseconds rather than a whole sweep.
+
+  Inspect failures via `BenchResult.failed_samples` (a `SampleFailure` per caught sample:
+  job id, inputs, exception repr, traceback), `n_failed`, and `failed_fraction`.
+
 ### Removed
 - **`ResultVolume` is gone.** It was declarable but not usable: exported from
   `bencher/__init__.py` and listed in `ALL_RESULT_TYPES`/`RESULT_KIND_ORDER`, but absent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Per-sample fault tolerance on the sweep path: `catch=` and `fail_on_sample_error`.**
   `Bench.optimize(catch=...)` has had this knob since #962, so the same benchmark was
-  fault-tolerant when driven by Optuna and all-or-nothing when swept. `catch` is available on
-  `BenchRunCfg` (so `bn.run(catch=...)` works) and as a `plot_sweep` argument; a bare
-  exception type is accepted and wrapped. A caught sample leaves the missing-value sentinel
+  fault-tolerant when driven by Optuna and all-or-nothing when swept. `catch` lives on
+  `BenchRunCfg` (so `bn.run(catch=...)` works, and it reaches `plot_sweep` via `run_cfg` —
+  its one home); a bare exception type is accepted and wrapped. A caught sample leaves the missing-value sentinel
   at its coordinate — `setup_dataset` already fills every result variable, so the dataset
   shape is unchanged and reductions skip it — is logged at WARNING with its inputs, and
   writes **nothing** to the sample cache, so a transient flake cannot become a permanent

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -32,7 +32,7 @@ from bencher.results.volume_result import VolumeResult
 from .bench_cfg import ShowMode
 from .bench_plot_server import BenchPlotServer
 from .bench_runner import BenchRunner
-from .bencher import Bench, BenchCfg, BenchRunCfg
+from .bencher import Bench, BenchCfg, BenchRunCfg, SampleErrorPolicyError
 from .example.benchmark_data import ExampleBenchCfg
 from .file_server import run_file_server
 from .identity import (
@@ -44,6 +44,7 @@ from .identity import (
     identity_of,
     sweep_identity,
 )
+from .job import SampleFailure
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -183,6 +183,29 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     repeats: int = param.Integer(1, doc="The number of times to sample the inputs")
 
+    catch: tuple = param.Parameter(
+        (),
+        doc="Exception types a single sample may raise without aborting the sweep. "
+        "Default () keeps today's fail-fast behaviour. Spelled exactly as on "
+        "Bench.optimize(catch=...), which has had this knob since #962. A caught "
+        "sample leaves the missing-value sentinel at its coordinate, is logged at "
+        "WARNING, and is recorded in BenchResult.failed_samples; nothing is written "
+        "to the sample cache for it, so a transient flake cannot become permanent. "
+        "Use with fail_on_sample_error -- they are a pair, not independent knobs: "
+        "catch alone turns real breakage into a green run over an all-sentinel "
+        "dataset.",
+    )
+
+    fail_on_sample_error: bool | float = param.Parameter(
+        False,
+        doc="Fail the run after the fact if samples were caught. True raises when "
+        "any sample failed; a float in (0, 1] raises when the failed *fraction* "
+        "reaches it, so a flake is tolerated but a run made of flakes is not. The "
+        "raise happens after the dataset and report are assembled, so the partial "
+        "results survive it -- losing the artifact would defeat catching in the "
+        "first place.",
+    )
+
     subsampling_divisions: int = param.Integer(
         default=0,
         bounds=[0, 12],

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -183,7 +183,7 @@ class BenchRunCfg(BenchPlotSrvCfg):
 
     repeats: int = param.Integer(1, doc="The number of times to sample the inputs")
 
-    catch: tuple = param.Parameter(
+    catch: tuple[type[BaseException], ...] = param.Parameter(
         (),
         doc="Exception types a single sample may raise without aborting the sweep. "
         "Default () keeps today's fail-fast behaviour. Spelled exactly as on "
@@ -191,21 +191,31 @@ class BenchRunCfg(BenchPlotSrvCfg):
         "sample leaves the missing-value sentinel at its coordinate, is logged at "
         "WARNING, and is recorded in BenchResult.failed_samples; nothing is written "
         "to the sample cache for it, so a transient flake cannot become permanent. "
-        "Use with fail_on_sample_error -- they are a pair, not independent knobs: "
-        "catch alone turns real breakage into a green run over an all-sentinel "
-        "dataset.",
+        "A bare exception type is accepted and wrapped, so catch=RuntimeError and "
+        "catch=(RuntimeError,) are the same; anything that is not an exception type "
+        "raises TypeError at the start of the run rather than from inside the "
+        "sampling loop. Use with fail_on_sample_error -- they are a pair, not "
+        "independent "
+        "knobs: catch alone turns real breakage into a green run over an "
+        "all-sentinel dataset.",
     )
 
     fail_on_sample_error: bool | float = param.Parameter(
         False,
         doc="Fail the run after the fact if samples were caught. True raises when "
         "any sample failed; a float in (0, 1] raises when the failed *fraction* "
-        "reaches it, so a flake is tolerated but a run made of flakes is not. A "
-        "truthy integer is rejected rather than guessed at: 1 could mean True or "
-        "100%, so write True or 1.0. Falsy values (False, 0, 0.0) mean off. The "
+        "reaches it, so a flake is tolerated but a run made of flakes is not. The "
+        "fraction is over samples this run *executed*, not over every coordinate: "
+        "a cache hit never reached the worker and so could not have failed, and "
+        "counting it would make one threshold mean different things on a cold and a "
+        "warm cache. A truthy integer is rejected rather than guessed at: 1 could "
+        "mean True or 100%, so write True or 1.0. Falsy values (False, 0, 0.0) mean "
+        "off; out-of-range thresholds are rejected before sampling starts. The "
         "raise happens after the dataset and report are assembled, so the partial "
         "results survive it -- losing the artifact would defeat catching in the "
-        "first place.",
+        "first place. It fires only for a run that actually sampled: on a "
+        "benchmark-result cache hit the loaded result carries a previous run's "
+        "failure counts, which are not this run's errors (read n_failed for that).",
     )
 
     subsampling_divisions: int = param.Integer(

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -200,7 +200,9 @@ class BenchRunCfg(BenchPlotSrvCfg):
         False,
         doc="Fail the run after the fact if samples were caught. True raises when "
         "any sample failed; a float in (0, 1] raises when the failed *fraction* "
-        "reaches it, so a flake is tolerated but a run made of flakes is not. The "
+        "reaches it, so a flake is tolerated but a run made of flakes is not. A "
+        "truthy integer is rejected rather than guessed at: 1 could mean True or "
+        "100%, so write True or 1.0. Falsy values (False, 0, 0.0) mean off. The "
         "raise happens after the dataset and report are assembled, so the partial "
         "results survive it -- losing the artifact would defeat catching in the "
         "first place.",

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -26,7 +26,7 @@ from bencher.bench_plot_server import BenchPlotServer
 from bencher.bench_report import BenchReport
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES, ensure_cache_version
 from bencher.history import config_summary as history_config_summary
-from bencher.job import Executors, FutureCache, Job, JobFuture
+from bencher.job import Executors, FutureCache, Job, JobFuture, normalize_catch
 from bencher.optuna_conversions import sweep_var_to_optuna_dist, sweep_var_to_suggest
 from bencher.regression import RegressionError, detect_regressions
 from bencher.result_collector import ResultCollector
@@ -74,6 +74,42 @@ class SampleErrorPolicyError(Exception):
     """
 
 
+def validate_sample_error_policy(policy: bool | float) -> float | None:
+    """Validate ``fail_on_sample_error`` and return its threshold, if it has one.
+
+    Returns ``None`` for the two policies that are not a fraction: off (falsy) and
+    ``True`` (fail on any failure). Called both from ``plot_sweep``, so a typo'd
+    threshold costs milliseconds rather than a whole sweep, and from
+    :func:`_enforce_sample_error_policy`, so the enforcement stays self-contained
+    for callers that reach it directly.
+    """
+    if not policy:  # False, None, 0, 0.0 -- the policy is simply off
+        return None
+    if policy is True:
+        return None
+    # bool is a subclass of int, so a bare 1 is truthy, is *not* True, and would
+    # otherwise silently become the 1.0 threshold -- "raise only if every sample
+    # failed", the near-opposite of the "raise if any failed" the caller almost
+    # certainly meant by writing 1. Both readings are defensible, which is why
+    # this refuses to pick one. Floats are unambiguous and stay allowed, so
+    # 1.0 still means 100%.
+    if isinstance(policy, int):
+        # ValueError, not the TypeError ruff's TRY004 suggests: int is inside this
+        # field's bool | float contract, so the type is fine and the *value* is what
+        # cannot be resolved to one meaning.
+        raise ValueError(  # noqa: TRY004
+            "fail_on_sample_error must be True/False or a float in (0, 1]; got the "
+            f"integer {policy!r}, which is ambiguous -- use True to fail on any "
+            f"failed sample, or {float(policy)!r} to fail at that failed fraction"
+        )
+    threshold = float(policy)
+    if not 0.0 < threshold <= 1.0:
+        raise ValueError(
+            f"fail_on_sample_error must be True/False or a float in (0, 1], got {policy!r}"
+        )
+    return threshold
+
+
 def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -> None:
     """Fail the run if ``fail_on_sample_error`` says the failures are the story.
 
@@ -81,33 +117,18 @@ def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -
     fraction reaches it, which is what lets a project tolerate a flake and still
     fail a run made of flakes. This is the half of plan 21 that makes ``catch=``
     safe to use unattended.
+
+    Only called for a run that actually sampled: on a benchmark-result cache hit
+    the loaded result carries the *previous* run's failure counts, and failing the
+    current run on them would raise for a run whose worker never executed -- see
+    ``run_sweep``.
     """
-    if not policy:  # False, None, 0, 0.0 -- the policy is simply off
-        return
     # The threshold is validated before the "did anything fail?" early return.
     # Checking it afterwards means a typo'd threshold is inert on every clean run
     # and only surfaces once a sample happens to fail -- reporting a *config*
     # error at the one moment the caller is trying to read a *sample* failure.
-    threshold = None
-    if policy is not True:
-        # bool is a subclass of int, so a bare 1 is truthy, is *not* True, and would
-        # otherwise silently become the 1.0 threshold -- "raise only if every sample
-        # failed", the near-opposite of the "raise if any failed" the caller almost
-        # certainly meant by writing 1. Both readings are defensible, which is why
-        # this refuses to pick one. Floats are unambiguous and stay allowed, so
-        # 1.0 still means 100%.
-        if isinstance(policy, int):
-            raise ValueError(
-                "fail_on_sample_error must be True/False or a float in (0, 1]; got the "
-                f"integer {policy!r}, which is ambiguous -- use True to fail on any "
-                f"failed sample, or {float(policy)!r} to fail at that failed fraction"
-            )
-        threshold = float(policy)
-        if not 0.0 < threshold <= 1.0:
-            raise ValueError(
-                f"fail_on_sample_error must be True/False or a float in (0, 1], got {policy!r}"
-            )
-    if not bench_res.n_failed:
+    threshold = validate_sample_error_policy(policy)
+    if not policy or not bench_res.n_failed:
         return
     n, frac = bench_res.n_failed, bench_res.failed_fraction
     if policy is True:
@@ -116,7 +137,7 @@ def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -
         )
     if frac >= threshold:
         raise SampleErrorPolicyError(
-            f"{n} sample(s) failed ({frac:.0%} of those attempted), which meets "
+            f"{n} sample(s) failed ({frac:.0%} of those executed), which meets "
             f"fail_on_sample_error={threshold}"
         )
 
@@ -363,7 +384,7 @@ class Bench(BenchPlotServer):
         pass_repeat: bool = False,
         tag: str = "",
         series_id: str | None = None,
-        catch: tuple[type[Exception], ...] | None = None,
+        catch: type[BaseException] | tuple[type[BaseException], ...] | None = None,
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
@@ -474,8 +495,13 @@ class Bench(BenchPlotServer):
                 run_cfg = deepcopy(self.run_cfg)
                 logger.info("Copy run cfg from bench class")
 
-        if catch is not None:
-            run_cfg.catch = catch
+        # Normalize and validate both fault-tolerance knobs here, before any
+        # sampling happens. Deferring either check to the end of the run means a
+        # typo costs the whole sweep before it is reported -- and for a sweep whose
+        # samples are individually expensive, that is exactly the cost this feature
+        # exists to avoid paying.
+        run_cfg.catch = normalize_catch(catch if catch is not None else run_cfg.catch)
+        validate_sample_error_policy(run_cfg.fail_on_sample_error)
 
         if run_cfg.only_plot:
             run_cfg.cache_results = True
@@ -879,7 +905,15 @@ class Bench(BenchPlotServer):
         bench_res.timings = timings
 
         self.results.append(bench_res)
-        _enforce_sample_error_policy(bench_res, run_cfg.fail_on_sample_error)
+        # Only for a run that actually sampled. On a benchmark-result cache hit
+        # bench_res is a *previous* run's result, unpickled with that run's
+        # failed_samples and n_attempted still on it -- enforcing there raises for
+        # a run whose worker never executed at all (and, since only_plot forces
+        # cache_results, for a pure re-plot). fail_on_sample_error is about errors
+        # this run hit; a caller who wants "does this artifact have holes" reads
+        # bench_res.n_failed, which is a different question.
+        if calculate_results:
+            _enforce_sample_error_policy(bench_res, run_cfg.fail_on_sample_error)
         return bench_res
 
     def _append_result_via_split(self, bench_res: BenchResult) -> None:
@@ -1060,7 +1094,6 @@ class Bench(BenchPlotServer):
             constant_inputs = self.define_const_inputs(bench_res.bench_cfg.const_vars)
         timings.dataset_setup_ms = elapsed()
 
-        results_list = []
         jobs = []
         cache_jobs = []
 
@@ -1105,10 +1138,19 @@ class Bench(BenchPlotServer):
         rv_arrays = self._collector.precompute_result_arrays(bench_res)
 
         with phase_timer() as elapsed:
-            catch = tuple(bench_run_cfg.catch or ())
-            bench_res.n_attempted = len(jobs)
+            catch = normalize_catch(bench_run_cfg.catch)
+            # The denominator for failed_fraction is samples this run *executed*,
+            # which is not len(jobs): a cache hit never reached the worker, so
+            # counting it as an attempt makes the same fail_on_sample_error
+            # threshold loosen as the cache warms -- 1 failure out of 1 executed
+            # sample reads as 25% when the other 3 came from cache. FutureCache
+            # increments worker_fn_call_count exactly once per job that reaches the
+            # worker (before it runs, so a caught sample still counts), and a delta
+            # rather than the raw counter keeps it per-sweep on a bench that runs
+            # several.
+            executed_before = self.sample_cache.worker_fn_call_count
             # Jobs that were actually submitted, paired with their futures. Kept
-            # explicitly rather than zipping jobs against results_list: a caught
+            # explicitly rather than zipping jobs against a results list: a caught
             # sample submits nothing, and a positional zip would then pair every
             # later job with the wrong future.
             submitted: list[tuple] = []
@@ -1130,7 +1172,6 @@ class Bench(BenchPlotServer):
                         bench_res, cache_job.job_id, job.function_input, exc
                     )
                     continue
-                results_list.append(result)
                 submitted.append((job, result))
                 # For serial execution, store results immediately so that
                 # completed results are cached to disk before later jobs
@@ -1150,6 +1191,7 @@ class Bench(BenchPlotServer):
                 for done in as_completed(pending):
                     worker_job, job_future = pending.pop(done)
                     self.store_results(job_future, bench_res, worker_job, bench_run_cfg, rv_arrays)
+            bench_res.n_attempted = self.sample_cache.worker_fn_call_count - executed_before
         timings.job_execution_ms = elapsed()
 
         for inp in bench_res.bench_cfg.all_vars:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -65,6 +65,42 @@ def _agg_job_args(kwargs, agg_vars, combo):
     return job_args
 
 
+class SampleErrorPolicyError(Exception):
+    """Raised after a sweep completes when too many samples were caught.
+
+    Deliberately raised *after* the dataset and report are assembled, so the
+    partial results are still on disk when it fires; losing the artifact would
+    defeat the point of catching in the first place.
+    """
+
+
+def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -> None:
+    """Fail the run if ``fail_on_sample_error`` says the failures are the story.
+
+    ``True`` fails on any caught sample; a float in (0, 1] fails when the failed
+    fraction reaches it, which is what lets a project tolerate a flake and still
+    fail a run made of flakes. This is the half of plan 21 that makes ``catch=``
+    safe to use unattended.
+    """
+    if not policy or not bench_res.n_failed:
+        return
+    n, frac = bench_res.n_failed, bench_res.failed_fraction
+    if policy is True:
+        raise SampleErrorPolicyError(
+            f"{n} sample(s) failed and were caught; fail_on_sample_error=True"
+        )
+    threshold = float(policy)
+    if not 0.0 < threshold <= 1.0:
+        raise ValueError(
+            f"fail_on_sample_error must be True/False or a float in (0, 1], got {policy!r}"
+        )
+    if frac >= threshold:
+        raise SampleErrorPolicyError(
+            f"{n} sample(s) failed ({frac:.0%} of those attempted), which meets "
+            f"fail_on_sample_error={threshold}"
+        )
+
+
 class Bench(BenchPlotServer):
     def __init__(
         self,
@@ -307,6 +343,7 @@ class Bench(BenchPlotServer):
         pass_repeat: bool = False,
         tag: str = "",
         series_id: str | None = None,
+        catch: tuple[type[Exception], ...] | None = None,
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
@@ -416,6 +453,9 @@ class Bench(BenchPlotServer):
             else:
                 run_cfg = deepcopy(self.run_cfg)
                 logger.info("Copy run cfg from bench class")
+
+        if catch is not None:
+            run_cfg.catch = catch
 
         if run_cfg.only_plot:
             run_cfg.cache_results = True
@@ -819,6 +859,7 @@ class Bench(BenchPlotServer):
         bench_res.timings = timings
 
         self.results.append(bench_res)
+        _enforce_sample_error_policy(bench_res, run_cfg.fail_on_sample_error)
         return bench_res
 
     def _append_result_via_split(self, bench_res: BenchResult) -> None:
@@ -1044,9 +1085,30 @@ class Bench(BenchPlotServer):
         rv_arrays = self._collector.precompute_result_arrays(bench_res)
 
         with phase_timer() as elapsed:
+            catch = tuple(bench_run_cfg.catch or ())
+            bench_res.n_attempted = len(jobs)
+            # Jobs that were actually submitted, paired with their futures. Kept
+            # explicitly rather than zipping jobs against results_list: a caught
+            # sample submits nothing, and a positional zip would then pair every
+            # later job with the wrong future.
+            submitted: list[tuple] = []
             for job, cache_job in zip(jobs, cache_jobs):
-                result = self.sample_cache.submit(cache_job, prefetched=prefetched)
+                if catch:
+                    try:
+                        result = self.sample_cache.submit(cache_job, prefetched=prefetched)
+                    except catch as exc:
+                        # The serial executor runs the worker *inside* submit(), so on
+                        # the default executor a raising sample never reaches
+                        # store_results at all -- catching only there would leave the
+                        # common path fail-fast while the pool path tolerated failures.
+                        self._collector.record_caught_sample(
+                            bench_res, cache_job.job_id, job.function_input, exc
+                        )
+                        continue
+                else:
+                    result = self.sample_cache.submit(cache_job, prefetched=prefetched)
                 results_list.append(result)
+                submitted.append((job, result))
                 # For serial execution, store results immediately so that
                 # completed results are cached to disk before later jobs
                 # may crash.
@@ -1057,7 +1119,7 @@ class Bench(BenchPlotServer):
                 # can use as_completed() to overlap result storage with
                 # remaining computation.
                 pending = {}  # concurrent.futures.Future -> (WorkerJob, JobFuture)
-                for job, job_future in zip(jobs, results_list):
+                for job, job_future in submitted:
                     if job_future.future is not None:
                         pending[job_future.future] = (job, job_future)
                     else:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -384,7 +384,6 @@ class Bench(BenchPlotServer):
         pass_repeat: bool = False,
         tag: str = "",
         series_id: str | None = None,
-        catch: type[BaseException] | tuple[type[BaseException], ...] | None = None,
         run_cfg: BenchRunCfg | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
@@ -499,8 +498,10 @@ class Bench(BenchPlotServer):
         # sampling happens. Deferring either check to the end of the run means a
         # typo costs the whole sweep before it is reported -- and for a sweep whose
         # samples are individually expensive, that is exactly the cost this feature
-        # exists to avoid paying.
-        run_cfg.catch = normalize_catch(catch if catch is not None else run_cfg.catch)
+        # exists to avoid paying. Both knobs live on run_cfg only -- run
+        # configuration already reaches plot_sweep as an object, and a second
+        # kwarg spelling would give each knob two homes to reconcile.
+        run_cfg.catch = normalize_catch(run_cfg.catch)
         validate_sample_error_policy(run_cfg.fail_on_sample_error)
 
         if run_cfg.only_plot:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -82,17 +82,25 @@ def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -
     fail a run made of flakes. This is the half of plan 21 that makes ``catch=``
     safe to use unattended.
     """
-    if not policy or not bench_res.n_failed:
+    if not policy:  # False, None, 0, 0.0 -- the policy is simply off
+        return
+    # The threshold is validated before the "did anything fail?" early return.
+    # Checking it afterwards means a typo'd threshold is inert on every clean run
+    # and only surfaces once a sample happens to fail -- reporting a *config*
+    # error at the one moment the caller is trying to read a *sample* failure.
+    threshold = None
+    if policy is not True:
+        threshold = float(policy)
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError(
+                f"fail_on_sample_error must be True/False or a float in (0, 1], got {policy!r}"
+            )
+    if not bench_res.n_failed:
         return
     n, frac = bench_res.n_failed, bench_res.failed_fraction
     if policy is True:
         raise SampleErrorPolicyError(
             f"{n} sample(s) failed and were caught; fail_on_sample_error=True"
-        )
-    threshold = float(policy)
-    if not 0.0 < threshold <= 1.0:
-        raise ValueError(
-            f"fail_on_sample_error must be True/False or a float in (0, 1], got {policy!r}"
         )
     if frac >= threshold:
         raise SampleErrorPolicyError(
@@ -1096,6 +1104,9 @@ class Bench(BenchPlotServer):
                 if catch:
                     try:
                         result = self.sample_cache.submit(cache_job, prefetched=prefetched)
+                    # catch is a runtime tuple of exception types, which pylint
+                    # cannot see into.
+                    # pylint: disable-next=catching-non-exception
                     except catch as exc:
                         # The serial executor runs the worker *inside* submit(), so on
                         # the default executor a raising sample never reaches

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -90,6 +90,18 @@ def _enforce_sample_error_policy(bench_res: BenchResult, policy: bool | float) -
     # error at the one moment the caller is trying to read a *sample* failure.
     threshold = None
     if policy is not True:
+        # bool is a subclass of int, so a bare 1 is truthy, is *not* True, and would
+        # otherwise silently become the 1.0 threshold -- "raise only if every sample
+        # failed", the near-opposite of the "raise if any failed" the caller almost
+        # certainly meant by writing 1. Both readings are defensible, which is why
+        # this refuses to pick one. Floats are unambiguous and stay allowed, so
+        # 1.0 still means 100%.
+        if isinstance(policy, int):
+            raise ValueError(
+                "fail_on_sample_error must be True/False or a float in (0, 1]; got the "
+                f"integer {policy!r}, which is ambiguous -- use True to fail on any "
+                f"failed sample, or {float(policy)!r} to fail at that failed fraction"
+            )
         threshold = float(policy)
         if not 0.0 < threshold <= 1.0:
             raise ValueError(
@@ -1101,23 +1113,23 @@ class Bench(BenchPlotServer):
             # later job with the wrong future.
             submitted: list[tuple] = []
             for job, cache_job in zip(jobs, cache_jobs):
-                if catch:
-                    try:
-                        result = self.sample_cache.submit(cache_job, prefetched=prefetched)
-                    # catch is a runtime tuple of exception types, which pylint
-                    # cannot see into.
-                    # pylint: disable-next=catching-non-exception
-                    except catch as exc:
-                        # The serial executor runs the worker *inside* submit(), so on
-                        # the default executor a raising sample never reaches
-                        # store_results at all -- catching only there would leave the
-                        # common path fail-fast while the pool path tolerated failures.
-                        self._collector.record_caught_sample(
-                            bench_res, cache_job.job_id, job.function_input, exc
-                        )
-                        continue
-                else:
+                # No `if catch:` branch: `except ()` matches nothing, so the default
+                # empty tuple is already fail-fast. One call site rather than two
+                # identical ones that could drift apart.
+                try:
                     result = self.sample_cache.submit(cache_job, prefetched=prefetched)
+                # catch is a runtime tuple of exception types, which pylint
+                # cannot see into.
+                # pylint: disable-next=catching-non-exception
+                except catch as exc:
+                    # The serial executor runs the worker *inside* submit(), so on
+                    # the default executor a raising sample never reaches
+                    # store_results at all -- catching only there would leave the
+                    # common path fail-fast while the pool path tolerated failures.
+                    self._collector.record_caught_sample(
+                        bench_res, cache_job.job_id, job.function_input, exc
+                    )
+                    continue
                 results_list.append(result)
                 submitted.append((job, result))
                 # For serial execution, store results immediately so that

--- a/bencher/identity.py
+++ b/bencher/identity.py
@@ -47,6 +47,7 @@ EXCLUDED_FIELDS = (
     "series_id (names the trend, not the configuration)",
     "aggregate / agg_fn",
     "sample_order",
+    "catch / fail_on_sample_error",
     "plot_callbacks / auto_plot",
 )
 

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import traceback
-from dataclasses import dataclass
 from collections.abc import Callable
 from concurrent.futures import Future, ProcessPoolExecutor
+from dataclasses import dataclass
 from enum import auto
 
 from diskcache import Cache

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import traceback
+from dataclasses import dataclass
 from collections.abc import Callable
 from concurrent.futures import Future, ProcessPoolExecutor
 from enum import auto
@@ -61,6 +63,30 @@ class Job:
         else:
             self.job_key = job_key
         self.tag = tag
+
+
+@dataclass(frozen=True)
+class SampleFailure:
+    """One sample that raised and was tolerated because of ``catch=``.
+
+    Kept as a value on the result so a tolerated failure is *countable*: a run
+    that swallowed every sample must not look like a clean run, which is why
+    ``fail_on_sample_error`` exists alongside ``catch``.
+    """
+
+    job_id: str
+    inputs: dict
+    exception: str
+    traceback: str
+
+    @classmethod
+    def from_exception(cls, job_id: str, inputs: dict, exc: BaseException) -> SampleFailure:
+        return cls(
+            job_id=job_id,
+            inputs=dict(inputs),
+            exception=repr(exc),
+            traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        )
 
 
 class JobFuture:

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from enum import auto
@@ -63,6 +63,36 @@ class Job:
         else:
             self.job_key = job_key
         self.tag = tag
+
+
+def normalize_catch(catch) -> tuple[type[BaseException], ...]:
+    """Coerce a ``catch=`` value to a tuple of exception types, or reject it.
+
+    Validated eagerly, at the start of the run: left alone, a bare class reaches
+    ``tuple(...)`` as ``TypeError: 'type' object is not iterable`` and a string
+    becomes a tuple of characters (``catching classes that do not inherit from
+    BaseException``), both raised from inside the sampling loop with nothing in the
+    message naming ``catch``. A bare exception class is accepted and wrapped,
+    because ``catch=RuntimeError`` is the obvious thing to type and there is
+    nothing else it could mean.
+    """
+    if catch is None:
+        return ()
+    if isinstance(catch, type):  # catch=RuntimeError -- wrap rather than reject
+        catch = (catch,)
+    # TypeError rather than ValueError because that is what `except` itself raises
+    # for a non-exception class -- same failure, reported earlier and by name.
+    if isinstance(catch, str) or not isinstance(catch, Iterable):
+        raise TypeError(
+            f"catch must be an exception type or a tuple of exception types, got {catch!r}"
+        )
+    catch = tuple(catch)
+    for entry in catch:
+        if not (isinstance(entry, type) and issubclass(entry, BaseException)):
+            raise TypeError(
+                f"catch must contain exception types (subclasses of BaseException); got {entry!r}"
+            )
+    return catch
 
 
 @dataclass(frozen=True)

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -370,6 +370,8 @@ class ResultCollector:
         if catch:
             try:
                 result = job_result.result()
+            # catch is a runtime tuple of exception types, which pylint cannot see into.
+            # pylint: disable-next=catching-non-exception
             except catch as exc:
                 self.record_caught_sample(
                     bench_res, job_result.job.job_id, worker_job.function_input, exc

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -35,7 +35,7 @@ from bencher.history import (
     project,
     reconcile,
 )
-from bencher.job import JobFuture
+from bencher.job import JobFuture, SampleFailure
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
@@ -321,6 +321,26 @@ class ResultCollector:
                 rv_arrays[rv.name] = bench_res.ds[rv.name].values
         return rv_arrays
 
+    def record_caught_sample(
+        self, bench_res: BenchResult, job_id: str, inputs: dict, exc: BaseException
+    ) -> None:
+        """Record one tolerated sample failure.
+
+        No write to the dataset is needed: ``setup_dataset`` already filled every
+        result variable with its missing-value sentinel, so the failed coordinate
+        *is* the fill and the dataset shape is unchanged -- downstream consumers
+        need no special case. Nothing was written to the sample cache either,
+        because the exception escaped before the cache write in both execution
+        paths, so a transient flake cannot become a permanent cached failure.
+        """
+        failure = SampleFailure.from_exception(job_id, inputs, exc)
+        bench_res.failed_samples.append(failure)
+        logger.warning(
+            "sample failed and was caught (%s): %s",
+            ", ".join(f"{k}={v}" for k, v in failure.inputs.items()) or "no inputs",
+            failure.exception,
+        )
+
     def store_results(
         self,
         job_result: JobFuture,
@@ -346,7 +366,17 @@ class ResultCollector:
         Raises:
             RuntimeError: If an unsupported result variable type is encountered
         """
-        result = job_result.result()
+        catch = tuple(getattr(bench_run_cfg, "catch", ()) or ())
+        if catch:
+            try:
+                result = job_result.result()
+            except catch as exc:
+                self.record_caught_sample(
+                    bench_res, job_result.job.job_id, worker_job.function_input, exc
+                )
+                return
+        else:
+            result = job_result.result()
         if result is not None:
             logger.info(f"{job_result.job.job_id}:")
             if bench_res.bench_cfg.print_bench_inputs:

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -35,7 +35,7 @@ from bencher.history import (
     project,
     reconcile,
 )
-from bencher.job import JobFuture, SampleFailure
+from bencher.job import JobFuture, SampleFailure, normalize_catch
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
@@ -321,8 +321,9 @@ class ResultCollector:
                 rv_arrays[rv.name] = bench_res.ds[rv.name].values
         return rv_arrays
 
+    @staticmethod
     def record_caught_sample(
-        self, bench_res: BenchResult, job_id: str, inputs: dict, exc: BaseException
+        bench_res: BenchResult, job_id: str, inputs: dict, exc: BaseException
     ) -> None:
         """Record one tolerated sample failure.
 
@@ -368,7 +369,9 @@ class ResultCollector:
         """
         # No `if catch:` branch: `except ()` matches nothing, so the default empty
         # tuple is already fail-fast, and result() keeps a single call site.
-        catch = tuple(getattr(bench_run_cfg, "catch", ()) or ())
+        # Normalized here as well as in plot_sweep, because store_results is also
+        # reachable with a hand-built BenchRunCfg that never passed through it.
+        catch = normalize_catch(getattr(bench_run_cfg, "catch", ()))
         try:
             result = job_result.result()
         # catch is a runtime tuple of exception types, which pylint cannot see into.

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -366,19 +366,18 @@ class ResultCollector:
         Raises:
             RuntimeError: If an unsupported result variable type is encountered
         """
+        # No `if catch:` branch: `except ()` matches nothing, so the default empty
+        # tuple is already fail-fast, and result() keeps a single call site.
         catch = tuple(getattr(bench_run_cfg, "catch", ()) or ())
-        if catch:
-            try:
-                result = job_result.result()
-            # catch is a runtime tuple of exception types, which pylint cannot see into.
-            # pylint: disable-next=catching-non-exception
-            except catch as exc:
-                self.record_caught_sample(
-                    bench_res, job_result.job.job_id, worker_job.function_input, exc
-                )
-                return
-        else:
+        try:
             result = job_result.result()
+        # catch is a runtime tuple of exception types, which pylint cannot see into.
+        # pylint: disable-next=catching-non-exception
+        except catch as exc:
+            self.record_caught_sample(
+                bench_res, job_result.job.job_id, worker_job.function_input, exc
+            )
+            return
         if result is not None:
             logger.info(f"{job_result.job.job_id}:")
             if bench_res.bench_cfg.print_bench_inputs:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -108,8 +108,10 @@ class BenchResult(
         # Samples that raised and were tolerated because of run_cfg.catch. Empty
         # unless catch was set, so a run with no catch is byte-identical to before.
         self.failed_samples: list = []
-        # Jobs this run attempted, set by run_sweep. Needed because the dataset's
-        # own size is not the answer once over_time history has been merged in.
+        # Samples this run actually executed, set by calculate_benchmark_results.
+        # Needed because neither the dataset's own size nor the job count is the
+        # answer: the former grows once over_time history is merged in, and the
+        # latter counts cache hits that never reached the worker.
         self.n_attempted: int = 0
 
     @property
@@ -129,7 +131,14 @@ class BenchResult(
 
     @property
     def failed_fraction(self) -> float:
-        """Failed samples as a fraction of the samples this run attempted."""
+        """Failed samples as a fraction of the samples this run *executed*.
+
+        Cache hits are excluded from the denominator deliberately: they never
+        reached the worker and so could not have failed. Counting them would make
+        one ``fail_on_sample_error`` threshold mean different things on a cold and
+        a warm cache -- the single failure in a 4-sample sweep whose other 3 came
+        from cache is 100% of what ran, not 25%.
+        """
         attempted = getattr(self, "n_attempted", 0)  # absent on pre-plan-21 pickles
         return self.n_failed / attempted if attempted else 0.0
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -120,12 +120,18 @@ class BenchResult(
         in which *every* sample failed would produce an all-sentinel dataset, a
         valid-looking report and a successful exit.
         """
-        return len(self.failed_samples)
+        # getattr, not self.failed_samples: BenchResult objects are pickled into
+        # the benchmark cache, and unpickling restores __dict__ without calling
+        # __init__ -- so a result cached by a pre-plan-21 bencher has no such
+        # attribute at all. Reading it directly turns "upgrade, then set
+        # fail_on_sample_error, then hit a warm cache" into an AttributeError.
+        return len(getattr(self, "failed_samples", ()))
 
     @property
     def failed_fraction(self) -> float:
         """Failed samples as a fraction of the samples this run attempted."""
-        return self.n_failed / self.n_attempted if self.n_attempted else 0.0
+        attempted = getattr(self, "n_attempted", 0)  # absent on pre-plan-21 pickles
+        return self.n_failed / attempted if attempted else 0.0
 
     @property
     def identity(self) -> SweepIdentity:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -105,6 +105,27 @@ class BenchResult(
         HoloviewResult.__init__(self, bench_cfg)
         # DataSetResult.__init__(self.bench_cfg)
         self.timings = None  # Populated by Bench.run_sweep() with SweepTimings
+        # Samples that raised and were tolerated because of run_cfg.catch. Empty
+        # unless catch was set, so a run with no catch is byte-identical to before.
+        self.failed_samples: list = []
+        # Jobs this run attempted, set by run_sweep. Needed because the dataset's
+        # own size is not the answer once over_time history has been merged in.
+        self.n_attempted: int = 0
+
+    @property
+    def n_failed(self) -> int:
+        """How many samples raised and were tolerated.
+
+        Tolerance without accounting is worse than fail-fast: without this a run
+        in which *every* sample failed would produce an all-sentinel dataset, a
+        valid-looking report and a successful exit.
+        """
+        return len(self.failed_samples)
+
+    @property
+    def failed_fraction(self) -> float:
+        """Failed samples as a fraction of the samples this run attempted."""
+        return self.n_failed / self.n_attempted if self.n_attempted else 0.0
 
     @property
     def identity(self) -> SweepIdentity:

--- a/plans/21-sample-fault-tolerance.md
+++ b/plans/21-sample-fault-tolerance.md
@@ -1,0 +1,187 @@
+# Plan 21 — Per-Sample Fault Tolerance in Sweeps
+
+**Goal:** Stop one failing sample from discarding an entire sweep, and make
+failed samples visible in the result. `Bench.optimize()` already has the knob for
+this; `plot_sweep()` does not, so the same benchmark is fault-tolerant when driven
+by Optuna and all-or-nothing when swept.
+
+**Branch name:** `feat/sweep-catch-sample-errors`
+
+**⚠️ Read first:** the default must stay fail-fast. This plan adds an opt-in, and
+the opt-in is only safe if a caught sample is kept out of the sample cache — see
+D4 and the precedent in PR #962.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — One raising sample aborts the whole sweep
+
+The exception propagates unhandled: `store_results` calls `job_result.result()`
+(`bencher/result_collector.py:334`), which re-raises whatever the future holds
+(`bencher/job.py:119`), and nothing between the worker and `bn.run` catches it —
+`_execute_bench_fn` invokes the benchmark function bare
+(`bencher/bench_runner.py:276-286`).
+
+Verified on v1.116.0: a `ParametrizedSweep` whose `__call__` raises
+`RuntimeError` propagates straight out of `bn.run`. Every sample already
+collected in that sweep is lost — no dataset, no report, no history entry, and
+nothing written for the samples that did succeed.
+
+For a sweep whose samples are individually expensive, this is the difference
+between losing one measurement and losing an entire run.
+
+### P2 — The optimize path already solved this
+
+`Bench.optimize(catch=...)` exists precisely so that one bad trial does not kill a
+study (`bencher/bencher.py:1152`, forwarded to Optuna at `:1273`), with the
+default `()` preserving fail-fast. `to_optimize()` forwards it through `**kwargs`.
+
+So bencher already holds the position that a long, expensive run should be able to
+tolerate an individual sample failure — it just holds it for one of the two ways
+of driving a benchmark. The sweep path, which is the common one, has no equivalent
+spelling.
+
+### P3 — The dataset can already represent a failed sample; nothing produces one
+
+The pieces are in place. Result variables have a missing-value fill
+(`result_missing_fill`, imported by `bencher/history.py:52`), and the history layer
+already distinguishes "did not exist yet" from "was not recorded" using each
+column's birth coordinate (`bencher/history.py:1-35`), with regression gating that
+holds fire while a baseline is young.
+
+So a caught sample has a well-defined representation: fill every result variable
+with the missing sentinel at that coordinate. No new data model is needed.
+
+### P4 — And the converse: a failed run must not look clean
+
+Tolerance without accounting is worse than fail-fast. Today nothing anywhere
+counts failed samples: `BenchResult` has no failure list, the report has no
+failure summary, and `bn.run` returns `list[BenchCfg]`
+(`bencher/run.py:67`) with no signal. If `catch=` were added without D3, a run in
+which *every* sample failed would produce an all-NaN dataset, a valid-looking
+report, a fresh history entry, and a successful exit — the worst possible outcome
+for an unattended or scheduled run.
+
+---
+
+## Proposed design
+
+### D1 — `catch=` on the sweep path, spelled as on `optimize()`
+
+`plot_sweep(catch: tuple[type[Exception], ...] = ())`, threaded to the sampling
+loop and honored in both executor paths (`bencher/bencher.py:1015-1029`), plus the
+same argument on `bn.run` for callers who never touch `plot_sweep` directly.
+Default `()` — identical behavior to today. Reuse the exact name, type, and
+default from `optimize()` so the two paths read the same.
+
+### D2 — What a caught sample records
+
+- Every result variable at that coordinate gets the missing-value fill (P3), so
+  the dataset shape is unchanged and downstream consumers need no special case.
+- The exception is recorded: sample index, the input values, the exception
+  `repr`, and the formatted traceback.
+- It is logged at WARNING with the input values, so a tolerated failure is visible
+  in the run log rather than only in the artifact.
+
+### D3 — Accounting, which is not optional
+
+- `BenchResult.failed_samples: list[SampleFailure]` and `n_failed`.
+- A report section listing failures when `n_failed > 0`, placed where it cannot be
+  missed rather than at the bottom.
+- The count in the exported result JSON — plan 10's verdict export is the natural
+  carrier, so coordinate the field name with it rather than inventing a parallel
+  artifact.
+- `fail_on_sample_error: bool | float = False` on `bn.run`: `True` raises if any
+  sample failed; a float in `(0, 1]` raises if the failed *fraction* meets or
+  exceeds it. This is what makes `catch=` safe to use unattended — tolerate a
+  flake, fail the run if the flakes are the story.
+
+The raise happens **after** the dataset and report are assembled, so the partial
+results are still on disk when it fires. Losing the artifact would defeat the
+purpose of catching in the first place.
+
+### D4 — A caught sample must not be cached
+
+`JobFuture.result()` writes to the cache after retrieving a result
+(`bencher/job.py:119-122`). A failed sample must commit nothing, or the failure
+becomes permanent for every later run with the same key — turning a transient
+flake into a poisoned cache entry. PR #962 established this behavior for the
+optimize path; verify it holds for both the serial and the process-pool paths and
+add a test that pins it.
+
+### D5 — History interaction
+
+A tolerated failure writes the missing sentinel, which is indistinguishable in the
+stored dataset from "not recorded". That is acceptable — it is already the
+sentinel's meaning — but regression detection must not read a filled failure as a
+measured improvement or regression. Confirm the existing gating treats the fill as
+absent, and add a test at the boundary; if it does not, that is a bug this plan
+must fix, not defer.
+
+---
+
+## Phased steps
+
+1. `catch=` plumbed through the sampling loop for both executor paths, with the
+   fill behavior (D1, D2). Default unchanged.
+2. The no-cache-on-failure guarantee and its test (D4). Ship before advertising
+   `catch=`.
+3. Accounting: `failed_samples`, `n_failed`, the report section (D3).
+4. `fail_on_sample_error` on `bn.run`, and the result-JSON field (coordinate with
+   plan 10).
+5. History/regression boundary check (D5), docs, `CHANGELOG.md`.
+
+Phases 1–2 are one reviewable unit; do not release `catch=` without phase 2.
+
+## Tests / acceptance criteria
+
+- Default behavior is byte-identical to today: an uncaught exception propagates
+  out of `bn.run` (the P1 case, pinned as a regression test).
+- With `catch=(RuntimeError,)` and one raising sample out of N: the sweep
+  completes, the dataset has N coordinates, the failed one carries the missing
+  fill, `n_failed == 1`, and the successful samples' values are correct.
+- An exception type *not* listed in `catch` still aborts the sweep.
+- **No cache entry** is written for a caught sample: a second run with the same
+  key re-executes it. Assert for the serial and the process-pool executor
+  separately — they take different paths at `bencher/bencher.py:1015-1029`.
+- `fail_on_sample_error=True` raises after the report is written; the report file
+  exists and contains the failure section.
+- `fail_on_sample_error=0.5` with 1 of 4 failed does not raise; with 2 of 4 it
+  does.
+- All-samples-failed with `catch=` and no `fail_on_sample_error`: run succeeds
+  (documented), `n_failed == N`, and the report leads with the failure section —
+  the guard against P4's silent success.
+- Regression detection over a history containing a filled failure treats it as
+  absent (D5).
+
+## Migration & compatibility
+
+Fully backward compatible: every new argument defaults to today's behavior. The
+only unconditional change is the report gaining a section that is empty unless
+failures occurred.
+
+## Risks
+
+- **Turning real breakage into a warning.** A user who sets
+  `catch=(Exception,)` and ignores `n_failed` gets a green run over garbage. This
+  is why D3 is part of the same plan and why the docs must present `catch=` and
+  `fail_on_sample_error` as a pair, not as independent knobs.
+- **Cache poisoning** (D4) — the highest-severity risk, since a cached failure is
+  durable and silent. Phase 2 gates the feature for that reason.
+- **Partial datasets reaching history.** A sweep that completes with failures
+  appends a history event containing filled columns. Acceptable given the
+  sentinel's existing meaning, but D5 must confirm the regression path agrees.
+- **Non-exception failures.** A worker that segfaults or is killed takes the
+  process with it; `catch=` cannot help, and the docs should say so rather than
+  implying general robustness.
+
+## Coordination
+
+- **PR #962** — the `catch=` precedent on `optimize()`, including the
+  no-cache-on-failure behavior. Match its spelling exactly.
+- **Plan 10** — owns the result-JSON verdict export; `n_failed` belongs there
+  rather than in a new artifact.
+- **Plan 11** — worker lifecycle hooks; a `teardown_sample` hook must still run
+  for a caught sample, or a tolerated failure leaks resources.
+- **Plans 09/14** — the history and regression boundary in D5.

--- a/plans/21-sample-fault-tolerance.md
+++ b/plans/21-sample-fault-tolerance.md
@@ -69,11 +69,16 @@ for an unattended or scheduled run.
 
 ### D1 — `catch=` on the sweep path, spelled as on `optimize()`
 
-`plot_sweep(catch: tuple[type[Exception], ...] = ())`, threaded to the sampling
-loop and honored in both executor paths (`bencher/bencher.py:1015-1029`), plus the
-same argument on `bn.run` for callers who never touch `plot_sweep` directly.
+`catch: tuple[type[Exception], ...] = ()` on `BenchRunCfg`, threaded to the
+sampling loop and honored in both executor paths (`bencher/bencher.py:1015-1029`),
+plus the same argument on `bn.run` for callers who never build a `run_cfg`.
 Default `()` — identical behavior to today. Reuse the exact name, type, and
 default from `optimize()` so the two paths read the same.
+
+*(Amended at implementation time: the plan originally also added a
+`plot_sweep(catch=...)` kwarg. That gives the knob two homes — `run_cfg.catch`
+plus a kwarg overriding it — which is the pattern plan A5's R1 exists to stop;
+`run_cfg` already reaches `plot_sweep` as an object, so the kwarg was dropped.)*
 
 ### D2 — What a caught sample records
 

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -578,14 +578,10 @@ class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
         ``catch`` and ``fail_on_sample_error`` describe how a run *reacts* to a
         failure, not what it measures. If they moved a key, switching tolerance on
         would fork the trend -- the same silent orphaning plan 15 exists to
-        prevent, arrived at from the other direction. Both surfaces are checked:
-        the ``plot_sweep`` keyword and the ``BenchRunCfg`` field.
+        prevent, arrived at from the other direction. Both knobs live on
+        ``BenchRunCfg`` only (their one home), so that is the surface checked.
         """
         decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
-        self._assert_no_key_moves(
-            _dry_identity(**decl),
-            _dry_identity(**decl, catch=(ValueError,)),
-        )
         self._assert_no_key_moves(
             _dry_identity(**decl),
             _dry_identity(bn.BenchRunCfg(catch=(ValueError,), fail_on_sample_error=True), **decl),

--- a/test/test_identity.py
+++ b/test/test_identity.py
@@ -572,6 +572,25 @@ class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
             _dry_identity(**decl, series_id="throughput"),
         )
 
+    def check_fault_tolerance(self) -> None:
+        """Tolerating a failed sample must not move a key.
+
+        ``catch`` and ``fail_on_sample_error`` describe how a run *reacts* to a
+        failure, not what it measures. If they moved a key, switching tolerance on
+        would fork the trend -- the same silent orphaning plan 15 exists to
+        prevent, arrived at from the other direction. Both surfaces are checked:
+        the ``plot_sweep`` keyword and the ``BenchRunCfg`` field.
+        """
+        decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
+        self._assert_no_key_moves(
+            _dry_identity(**decl),
+            _dry_identity(**decl, catch=(ValueError,)),
+        )
+        self._assert_no_key_moves(
+            _dry_identity(**decl),
+            _dry_identity(bn.BenchRunCfg(catch=(ValueError,), fail_on_sample_error=True), **decl),
+        )
+
     def check_plotting(self) -> None:
         """``plot_callbacks`` is stored on BenchCfg; ``auto_plot`` is merged onto it."""
         decl = {"input_vars": ["theta"], "result_vars": ["out_sin"]}
@@ -599,6 +618,7 @@ class TestDocumentedFieldsMatchTheHashingRule(unittest.TestCase):
             "aggregate / agg_fn": self.check_aggregation,
             "sample_order": self.check_sample_order,
             "series_id (names the trend, not the configuration)": self.check_series_id,
+            "catch / fail_on_sample_error": self.check_fault_tolerance,
             "plot_callbacks / auto_plot": self.check_plotting,
         }
 

--- a/test/test_sample_fault_tolerance.py
+++ b/test/test_sample_fault_tolerance.py
@@ -271,6 +271,24 @@ class TestFailOnSampleError(unittest.TestCase):
             with self.subTest(threshold=bad), self.assertRaises(ValueError):
                 _run(catch=(RuntimeError,), fail_on_sample_error=bad)
 
+    def test_a_truthy_integer_is_rejected_rather_than_guessed_at(self) -> None:
+        """``1`` could mean True or 100%; bool being a subclass of int hides the choice.
+
+        Left alone, ``1`` is truthy, is not ``True``, and becomes the 1.0 threshold --
+        "raise only if *every* sample failed", the near-opposite of the "raise if any
+        failed" that someone writing 1 (or feeding it from YAML) almost certainly
+        meant. Floats stay unambiguous, so 1.0 still means 100%.
+        """
+        with self.assertRaises(ValueError) as ctx:
+            _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=1)
+        self.assertIn("ambiguous", str(ctx.exception))
+
+    def test_one_point_zero_is_still_a_hundred_percent(self) -> None:
+        res = _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=1.0)
+        self.assertEqual(res.n_failed, 1)  # 1 of 4: below 100%, so no raise
+        with self.assertRaises(bn.SampleErrorPolicyError):  # all 4 fail: 100%
+            _run(fail_at=(0, 1, 2, 3), catch=(RuntimeError,), fail_on_sample_error=1.0)
+
     def test_zero_and_false_leave_the_policy_off(self) -> None:
         """Falsy thresholds are 'off', not 'out of range' -- unchanged by validation."""
         for off in (False, 0, 0.0):

--- a/test/test_sample_fault_tolerance.py
+++ b/test/test_sample_fault_tolerance.py
@@ -137,24 +137,17 @@ class TestCatch(unittest.TestCase):
             _run(fail_at=(2,), catch=(RuntimeError,))
         self.assertTrue(any("x=2" in line for line in logs.output), logs.output)
 
-    def test_plot_sweep_catch_argument_reaches_the_run_cfg(self) -> None:
-        Flaky.fail_at = (2,)
-        cfg = bn.BenchRunCfg()
-        cfg.auto_plot = False
-        cfg.cache_results = False
-        cfg.cache_samples = False
-        bench = Flaky().to_bench(cfg)
-        try:
-            res = bench.plot_sweep(
-                input_vars=["x"],
-                result_vars=["y"],
-                catch=(RuntimeError,),
-                plot_callbacks=False,
-            )
-        finally:
-            Flaky.fail_at = ()
-            bench.close()
-        self.assertEqual(res.n_failed, 1)
+    def test_catch_has_one_home(self) -> None:
+        """``catch`` is run configuration and lives on ``BenchRunCfg`` only.
+
+        ``run_cfg`` already reaches ``plot_sweep`` as an object; a second kwarg
+        spelling would give the knob two homes and a precedence rule between
+        them (A5 R1).
+        """
+        import inspect
+
+        self.assertNotIn("catch", inspect.signature(bn.Bench.plot_sweep).parameters)
+        self.assertNotIn("fail_on_sample_error", inspect.signature(bn.Bench.plot_sweep).parameters)
 
 
 class TestBothExecutorPaths(unittest.TestCase):

--- a/test/test_sample_fault_tolerance.py
+++ b/test/test_sample_fault_tolerance.py
@@ -12,11 +12,14 @@ all-sentinel dataset, a valid-looking report and a successful exit. ``catch`` an
 
 from __future__ import annotations
 
+import pickle
 import unittest
+from typing import ClassVar
 
 import numpy as np
 
 import bencher as bn
+from bencher.bencher import _enforce_sample_error_policy
 from bencher.job import Executors
 
 
@@ -47,7 +50,9 @@ class Counting(bn.ParametrizedSweep):
     x = bn.IntSweep(default=0, bounds=(0, 1), samples=2)
     y = bn.ResultFloat()
 
-    calls: list = []
+    # Shared across instances on purpose: the worker is re-created per sample, so
+    # a per-instance counter could not observe how many times it ran.
+    calls: ClassVar[list] = []
 
     def __call__(self, **kwargs):
         self.update_params_from_kwargs(**kwargs)
@@ -181,7 +186,7 @@ class TestBothExecutorPaths(unittest.TestCase):
         job_future = JobFuture(job=job, future=future)
 
         class Worker:
-            function_input = {"x": 1}
+            function_input: ClassVar[dict] = {"x": 1}
             index_tuple = (0, 0)
 
         cfg = bn.BenchRunCfg(catch=catch)
@@ -255,6 +260,24 @@ class TestFailOnSampleError(unittest.TestCase):
         with self.assertRaises(ValueError):
             _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=1.5)
 
+    def test_an_out_of_range_threshold_is_rejected_even_when_nothing_failed(self) -> None:
+        """A config error must not wait for a sample failure to become visible.
+
+        Validating the threshold only on the failing path made a typo -- 50 for
+        "50%", say -- inert on every clean run, then surfaced it as a ValueError
+        at the one moment the caller was trying to read a sample failure.
+        """
+        for bad in (1.5, 50, -0.2):
+            with self.subTest(threshold=bad), self.assertRaises(ValueError):
+                _run(catch=(RuntimeError,), fail_on_sample_error=bad)
+
+    def test_zero_and_false_leave_the_policy_off(self) -> None:
+        """Falsy thresholds are 'off', not 'out of range' -- unchanged by validation."""
+        for off in (False, 0, 0.0):
+            with self.subTest(policy=off):
+                res = _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=off)
+                self.assertEqual(res.n_failed, 1)
+
     def test_the_result_is_still_registered_before_the_raise(self) -> None:
         """Losing the artifact would defeat the point of catching."""
         Flaky.fail_at = (2,)
@@ -273,6 +296,35 @@ class TestFailOnSampleError(unittest.TestCase):
         finally:
             Flaky.fail_at = ()
             bench.close()
+
+
+class TestResultsCachedBeforeThisFeatureExisted(unittest.TestCase):
+    """The accounting must survive a result that predates it.
+
+    ``BenchResult`` objects are pickled into the benchmark cache, and unpickling
+    restores ``__dict__`` without calling ``__init__``. A result cached by an
+    earlier bencher therefore has no ``failed_samples`` and no ``n_attempted``,
+    and ``run_sweep`` enforces the policy on the cache-hit path too -- so reading
+    those attributes directly turned "upgrade, set fail_on_sample_error, hit a
+    warm cache" into an AttributeError on a run that had nothing wrong with it.
+    """
+
+    def _revived_old_result(self) -> bn.BenchResult:
+        res = _run()
+        del res.failed_samples
+        del res.n_attempted
+        return pickle.loads(pickle.dumps(res))
+
+    def test_the_accounting_reads_as_a_clean_run(self) -> None:
+        revived = self._revived_old_result()
+        self.assertEqual(revived.n_failed, 0)
+        self.assertEqual(revived.failed_fraction, 0.0)
+
+    def test_the_policy_does_not_raise_on_such_a_result(self) -> None:
+        revived = self._revived_old_result()
+        for policy in (False, True, 0.5):
+            with self.subTest(policy=policy):
+                _enforce_sample_error_policy(revived, policy)
 
 
 class TestIdentityIsUnaffected(unittest.TestCase):

--- a/test/test_sample_fault_tolerance.py
+++ b/test/test_sample_fault_tolerance.py
@@ -1,0 +1,297 @@
+"""Plan 21 — one failing sample must not discard a whole sweep.
+
+``Bench.optimize(catch=...)`` has had this knob since #962; the sweep path, which
+is the common one, had no equivalent spelling, so the same benchmark was
+fault-tolerant when driven by Optuna and all-or-nothing when swept.
+
+The default must stay fail-fast, and tolerance without accounting would be worse
+than fail-fast: a run in which every sample failed would otherwise produce an
+all-sentinel dataset, a valid-looking report and a successful exit. ``catch`` and
+``fail_on_sample_error`` are tested here as the pair they are.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+import bencher as bn
+from bencher.job import Executors
+
+
+class Flaky(bn.ParametrizedSweep):
+    """Raises for the input values named in ``fail_at``."""
+
+    x = bn.IntSweep(default=0, bounds=(0, 3), samples=4)
+    y = bn.ResultFloat()
+
+    fail_at: tuple = ()
+    exc_type: type[Exception] = RuntimeError
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        if self.x in type(self).fail_at:
+            raise type(self).exc_type(f"x={self.x} is cursed")
+        self.y = float(self.x) * 2.0
+        return super().__call__(**kwargs)
+
+
+class Counting(bn.ParametrizedSweep):
+    """Records every call, so a re-execution after a caught failure is countable.
+
+    Module level on purpose: the sample cache pickles the worker, and a locally
+    defined class cannot be pickled.
+    """
+
+    x = bn.IntSweep(default=0, bounds=(0, 1), samples=2)
+    y = bn.ResultFloat()
+
+    calls: list = []
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        type(self).calls.append(self.x)
+        if self.x == 1:
+            raise RuntimeError("boom")
+        self.y = 1.0
+        return super().__call__(**kwargs)
+
+
+def _run(fail_at=(), exc_type=RuntimeError, *, executor=Executors.SERIAL, **run_kwargs):
+    Flaky.fail_at = tuple(fail_at)
+    Flaky.exc_type = exc_type
+    cfg = bn.BenchRunCfg(executor=executor, **run_kwargs)
+    cfg.auto_plot = False
+    cfg.cache_results = False
+    cfg.cache_samples = False
+    bench = Flaky().to_bench(cfg)
+    try:
+        return bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+    finally:
+        Flaky.fail_at = ()
+        bench.close()
+
+
+class TestDefaultIsFailFast(unittest.TestCase):
+    """P1, pinned as a regression test: the default behaviour is unchanged."""
+
+    def test_an_uncaught_exception_propagates_out_of_the_sweep(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            _run(fail_at=(2,))
+        self.assertIn("cursed", str(ctx.exception))
+
+    def test_a_clean_sweep_records_no_failures(self) -> None:
+        res = _run()
+        self.assertEqual(res.n_failed, 0)
+        self.assertEqual(res.failed_samples, [])
+        self.assertEqual(res.failed_fraction, 0.0)
+
+    def test_catch_defaults_to_empty(self) -> None:
+        self.assertEqual(bn.BenchRunCfg().catch, ())
+        self.assertIs(bn.BenchRunCfg().fail_on_sample_error, False)
+
+
+class TestCatch(unittest.TestCase):
+    """D1/D2 — the sweep completes, the failed coordinate carries the sentinel."""
+
+    def test_one_failure_out_of_four_does_not_lose_the_others(self) -> None:
+        res = _run(fail_at=(2,), catch=(RuntimeError,))
+        self.assertEqual(res.n_failed, 1)
+        values = res.ds["y"].values.reshape(-1)
+        self.assertEqual(len(values), 4, "the dataset shape must be unchanged")
+        self.assertTrue(np.isnan(values[2]), "the failed coordinate must hold the fill")
+        for i in (0, 1, 3):
+            self.assertEqual(values[i], i * 2.0, f"successful sample {i} was lost")
+
+    def test_the_failure_records_the_inputs_and_the_exception(self) -> None:
+        res = _run(fail_at=(2,), catch=(RuntimeError,))
+        (failure,) = res.failed_samples
+        self.assertEqual(failure.inputs.get("x"), 2)
+        self.assertIn("cursed", failure.exception)
+        self.assertIn("RuntimeError", failure.exception)
+        self.assertIn("Traceback", failure.traceback)
+        self.assertTrue(failure.job_id)
+
+    def test_an_unlisted_exception_type_still_aborts(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(fail_at=(1,), exc_type=ValueError, catch=(RuntimeError,))
+
+    def test_a_parent_class_in_catch_covers_a_subclass(self) -> None:
+        res = _run(fail_at=(1,), exc_type=ValueError, catch=(Exception,))
+        self.assertEqual(res.n_failed, 1)
+
+    def test_every_sample_failing_still_completes(self) -> None:
+        """Documented, and exactly why fail_on_sample_error exists."""
+        res = _run(fail_at=(0, 1, 2, 3), catch=(RuntimeError,))
+        self.assertEqual(res.n_failed, 4)
+        self.assertTrue(np.all(np.isnan(res.ds["y"].values)))
+        self.assertEqual(res.failed_fraction, 1.0)
+
+    def test_a_warning_is_logged_naming_the_inputs(self) -> None:
+        import logging
+
+        with self.assertLogs("bencher.result_collector", level=logging.WARNING) as logs:
+            _run(fail_at=(2,), catch=(RuntimeError,))
+        self.assertTrue(any("x=2" in line for line in logs.output), logs.output)
+
+    def test_plot_sweep_catch_argument_reaches_the_run_cfg(self) -> None:
+        Flaky.fail_at = (2,)
+        cfg = bn.BenchRunCfg()
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        bench = Flaky().to_bench(cfg)
+        try:
+            res = bench.plot_sweep(
+                input_vars=["x"],
+                result_vars=["y"],
+                catch=(RuntimeError,),
+                plot_callbacks=False,
+            )
+        finally:
+            Flaky.fail_at = ()
+            bench.close()
+        self.assertEqual(res.n_failed, 1)
+
+
+class TestBothExecutorPaths(unittest.TestCase):
+    """The two paths raise in *different places*, so both need their own catch.
+
+    The serial executor runs the worker inside ``FutureCache.submit``, so a raising
+    sample never reaches ``store_results`` at all -- catching only at
+    ``JobFuture.result()`` would leave the default executor fail-fast while a pool
+    run tolerated failures. The serial site is exercised by every other test in
+    this file (``Executors.SERIAL`` is the default); this drives the pool site
+    directly with a future that holds an exception, which is deterministic and does
+    not need a subprocess.
+    """
+
+    def _pool_store(self, catch):
+        from concurrent.futures import Future
+
+        from bencher.job import Job, JobFuture
+        from bencher.result_collector import ResultCollector
+
+        res = _run(catch=catch)  # a clean run to build a real dataset + cfg
+        collector = ResultCollector()
+        future = Future()
+        future.set_exception(RuntimeError("pool boom"))
+        job = Job(job_id="pool-job", function=lambda **_: None, job_args={"x": 1})
+        job_future = JobFuture(job=job, future=future)
+
+        class Worker:
+            function_input = {"x": 1}
+            index_tuple = (0, 0)
+
+        cfg = bn.BenchRunCfg(catch=catch)
+        collector.store_results(job_future, res, Worker(), cfg, None)
+        return res
+
+    def test_the_pool_path_tolerates_a_failure(self) -> None:
+        res = self._pool_store((RuntimeError,))
+        self.assertEqual(res.n_failed, 1)
+        (failure,) = res.failed_samples
+        self.assertIn("pool boom", failure.exception)
+        self.assertEqual(failure.inputs, {"x": 1})
+
+    def test_the_pool_path_still_aborts_without_catch(self) -> None:
+        with self.assertRaises(RuntimeError):
+            self._pool_store(())
+
+    def test_the_pool_path_still_aborts_for_an_unlisted_type(self) -> None:
+        with self.assertRaises(RuntimeError):
+            self._pool_store((ValueError,))
+
+
+class TestNoCacheOnFailure(unittest.TestCase):
+    """D4, the highest-severity risk: a cached failure would be durable and silent."""
+
+    def test_a_caught_sample_is_not_written_to_the_sample_cache(self) -> None:
+        """A second run with the same key must re-execute it.
+
+        A cached failure would be durable and silent -- the highest-severity risk in
+        the whole feature, since it turns one transient flake into a permanently
+        broken coordinate for every later run.
+        """
+        Counting.calls = []
+        cfg = bn.BenchRunCfg(catch=(RuntimeError,), cache_samples=True)
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        bench = Counting().to_bench(cfg)
+        try:
+            bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+            first = list(Counting.calls)
+            bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+        finally:
+            bench.close()
+        second = Counting.calls[len(first) :]
+        self.assertIn(1, second, "the failed sample was cached and never retried")
+        self.assertNotIn(0, second, "the successful sample should have come from cache")
+
+
+class TestFailOnSampleError(unittest.TestCase):
+    """D3 — the accounting that makes catch= safe to use unattended."""
+
+    def test_true_raises_when_any_sample_failed(self) -> None:
+        with self.assertRaises(bn.SampleErrorPolicyError) as ctx:
+            _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=True)
+        self.assertIn("1 sample(s) failed", str(ctx.exception))
+
+    def test_true_does_not_raise_for_a_clean_run(self) -> None:
+        res = _run(catch=(RuntimeError,), fail_on_sample_error=True)
+        self.assertEqual(res.n_failed, 0)
+
+    def test_a_fraction_below_the_threshold_does_not_raise(self) -> None:
+        res = _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=0.5)
+        self.assertEqual(res.n_failed, 1)
+        self.assertLess(res.failed_fraction, 0.5)
+
+    def test_a_fraction_at_the_threshold_raises(self) -> None:
+        with self.assertRaises(bn.SampleErrorPolicyError):
+            _run(fail_at=(1, 2), catch=(RuntimeError,), fail_on_sample_error=0.5)
+
+    def test_an_out_of_range_threshold_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(fail_at=(2,), catch=(RuntimeError,), fail_on_sample_error=1.5)
+
+    def test_the_result_is_still_registered_before_the_raise(self) -> None:
+        """Losing the artifact would defeat the point of catching."""
+        Flaky.fail_at = (2,)
+        cfg = bn.BenchRunCfg(catch=(RuntimeError,), fail_on_sample_error=True)
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        bench = Flaky().to_bench(cfg)
+        try:
+            with self.assertRaises(bn.SampleErrorPolicyError):
+                bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+            self.assertEqual(len(bench.results), 1)
+            res = bench.get_result()
+            self.assertEqual(res.n_failed, 1)
+            self.assertEqual(res.ds["y"].values.reshape(-1)[0], 0.0)
+        finally:
+            Flaky.fail_at = ()
+            bench.close()
+
+
+class TestIdentityIsUnaffected(unittest.TestCase):
+    def test_catch_does_not_move_the_cache_key(self) -> None:
+        """It is a run-time policy, not part of what identifies the measurement."""
+        keys = []
+        for catch in ((), (RuntimeError,)):
+            cfg = bn.BenchRunCfg(catch=catch)
+            cfg.auto_plot = False
+            cfg.cache_results = False
+            cfg.cache_samples = False
+            bench = Flaky().to_bench(cfg)
+            try:
+                res = bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+                keys.append(res.bench_cfg.hash_persistent(True))
+            finally:
+                bench.close()
+        self.assertEqual(keys[0], keys[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_sample_fault_tolerance.py
+++ b/test/test_sample_fault_tolerance.py
@@ -21,6 +21,7 @@ import numpy as np
 import bencher as bn
 from bencher.bencher import _enforce_sample_error_policy
 from bencher.job import Executors
+from bencher.regression import detect_percentage
 
 
 class Flaky(bn.ParametrizedSweep):
@@ -32,12 +33,10 @@ class Flaky(bn.ParametrizedSweep):
     fail_at: tuple = ()
     exc_type: type[Exception] = RuntimeError
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self) -> None:
         if self.x in type(self).fail_at:
             raise type(self).exc_type(f"x={self.x} is cursed")
         self.y = float(self.x) * 2.0
-        return super().__call__(**kwargs)
 
 
 class Counting(bn.ParametrizedSweep):
@@ -54,13 +53,11 @@ class Counting(bn.ParametrizedSweep):
     # a per-instance counter could not observe how many times it ran.
     calls: ClassVar[list] = []
 
-    def __call__(self, **kwargs):
-        self.update_params_from_kwargs(**kwargs)
+    def benchmark(self) -> None:
         type(self).calls.append(self.x)
         if self.x == 1:
             raise RuntimeError("boom")
         self.y = 1.0
-        return super().__call__(**kwargs)
 
 
 def _run(fail_at=(), exc_type=RuntimeError, *, executor=Executors.SERIAL, **run_kwargs):
@@ -220,19 +217,203 @@ class TestNoCacheOnFailure(unittest.TestCase):
         broken coordinate for every later run.
         """
         Counting.calls = []
-        cfg = bn.BenchRunCfg(catch=(RuntimeError,), cache_samples=True)
+        # The first sweep must be a cold miss or nothing executes and the test
+        # asserts nothing; the second must *not* clear, or it clears the cache it
+        # is meant to be reading. A sample cache left warm by an earlier run of
+        # this file made this pass or fail depending on run order.
+        cfg = bn.BenchRunCfg(catch=(RuntimeError,), cache_samples=True, clear_sample_cache=True)
         cfg.auto_plot = False
         cfg.cache_results = False
         bench = Counting().to_bench(cfg)
         try:
             bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
             first = list(Counting.calls)
+            self.assertEqual(sorted(first), [0, 1], "the first sweep was not a cold miss")
+            bench.run_cfg.clear_sample_cache = False
             bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
         finally:
             bench.close()
         second = Counting.calls[len(first) :]
         self.assertIn(1, second, "the failed sample was cached and never retried")
         self.assertNotIn(0, second, "the successful sample should have come from cache")
+
+
+class TestTheFractionIsOverExecutedSamples(unittest.TestCase):
+    """A cache hit never reached the worker, so it cannot be a failed *attempt*.
+
+    Counting it made one ``fail_on_sample_error`` threshold mean different things
+    on a cold and a warm cache: the single failure in a 4-sample sweep whose other
+    three came from cache is 100% of what ran, and ``0.5`` used to pass it.
+    """
+
+    def _sweep(self, bench):
+        return bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+
+    def _bench(self, **kwargs):
+        Flaky.fail_at = (2,)
+        # clear_sample_cache starts on so a cache left warm by an earlier test run
+        # cannot make the *first* sweep a partial cache hit; it is turned off after
+        # that first sweep, or the second one would clear the cache it is meant to
+        # be reading.
+        cfg = bn.BenchRunCfg(
+            catch=(RuntimeError,), cache_samples=True, clear_sample_cache=True, **kwargs
+        )
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        return Flaky().to_bench(cfg)
+
+    def _second_sweep_reads_the_cache(self, bench) -> None:
+        bench.run_cfg.clear_sample_cache = False
+
+    def test_a_warm_cache_does_not_dilute_the_fraction(self) -> None:
+        bench = self._bench()
+        try:
+            cold = self._sweep(bench)
+            self.assertEqual((cold.n_failed, cold.n_attempted), (1, 4))
+            self.assertEqual(cold.failed_fraction, 0.25)
+            # Second sweep: 3 of 4 come from cache, only the failing one runs.
+            self._second_sweep_reads_the_cache(bench)
+            warm = self._sweep(bench)
+            self.assertEqual((warm.n_failed, warm.n_attempted), (1, 1))
+            self.assertEqual(warm.failed_fraction, 1.0)
+        finally:
+            Flaky.fail_at = ()
+            bench.close()
+
+    def test_a_threshold_that_passed_cold_fails_once_only_flakes_run(self) -> None:
+        """The behavioural consequence, which is the whole point of the fraction."""
+        bench = self._bench(fail_on_sample_error=0.5)
+        try:
+            self._sweep(bench)  # 1 of 4 executed failed -> 25%, under the threshold
+            self._second_sweep_reads_the_cache(bench)
+            with self.assertRaises(bn.SampleErrorPolicyError) as ctx:
+                self._sweep(bench)  # 1 of 1 executed failed -> 100%
+            self.assertIn("100%", str(ctx.exception))
+        finally:
+            Flaky.fail_at = ()
+            bench.close()
+
+
+class TestTheCacheHitPathIsNotThisRunsErrors(unittest.TestCase):
+    """The policy must not fail a run on failures a *different* run produced.
+
+    On a benchmark-result cache hit ``calculate_benchmark_results`` never runs, so
+    the unpickled result still carries the first run's ``failed_samples`` and
+    ``n_attempted``. Enforcing there raised for a run whose worker executed zero
+    jobs -- and since ``only_plot`` forces ``cache_results``, for a pure re-plot
+    too. ``n_failed`` still reports the holes, which is a different question.
+    """
+
+    def _bench(self, **kwargs):
+        cfg = bn.BenchRunCfg(catch=(RuntimeError,), cache_results=True, **kwargs)
+        cfg.auto_plot = False
+        cfg.cache_samples = False
+        return Flaky().to_bench(cfg)
+
+    def test_a_pure_cache_hit_does_not_raise_on_the_previous_runs_failures(self) -> None:
+        Flaky.fail_at = (2,)
+        first = self._bench(clear_cache=True)
+        try:
+            res = first.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+            self.assertEqual(res.n_failed, 1)
+        finally:
+            first.close()
+
+        Flaky.fail_at = ()  # nothing in this run *can* fail
+        second = self._bench(fail_on_sample_error=True)
+        try:
+            revived = second.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+        finally:
+            second.close()
+        # The loaded artifact still reports its holes -- it really does have one.
+        self.assertEqual(revived.n_failed, 1)
+
+    def test_the_policy_still_fires_for_a_run_that_actually_sampled(self) -> None:
+        """The guard is 'did this run sample', not 'is caching on'."""
+        Flaky.fail_at = (2,)
+        bench = self._bench(clear_cache=True, fail_on_sample_error=True)
+        try:
+            with self.assertRaises(bn.SampleErrorPolicyError):
+                bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+        finally:
+            Flaky.fail_at = ()
+            bench.close()
+
+
+class TestCatchIsValidatedEagerly(unittest.TestCase):
+    """``catch`` gets the same treatment as ``fail_on_sample_error``.
+
+    Left unvalidated, a bare class surfaced as ``TypeError: 'type' object is not
+    iterable`` and a string as ``catching classes that do not inherit from
+    BaseException`` -- both from inside the sampling loop, with nothing in the
+    message naming ``catch``.
+    """
+
+    def test_a_bare_exception_class_is_accepted_and_wrapped(self) -> None:
+        res = _run(fail_at=(2,), catch=RuntimeError)
+        self.assertEqual(res.n_failed, 1)
+
+    def test_a_non_exception_type_is_rejected(self) -> None:
+        """TypeError, because that is what ``except`` itself raises for one."""
+        for bad in (str, 42, "RuntimeError", (ValueError, "nope")):
+            with self.subTest(catch=bad), self.assertRaises(TypeError) as ctx:
+                _run(fail_at=(2,), catch=bad)
+            self.assertIn("catch", str(ctx.exception))
+
+    def test_nothing_is_sampled_before_the_knobs_are_validated(self) -> None:
+        """A typo must cost milliseconds, not a whole sweep.
+
+        Both knobs are checked at the top of ``plot_sweep``; the threshold used to
+        be range-checked only when the run had already finished, so an expensive
+        sweep ran to completion before reporting a config error.
+        """
+        for kwargs in ({"catch": "RuntimeError"}, {"fail_on_sample_error": 50}):
+            with self.subTest(**kwargs):
+                Counting.calls = []
+                cfg = bn.BenchRunCfg(cache_samples=False, **kwargs)
+                cfg.auto_plot = False
+                cfg.cache_results = False
+                bench = Counting().to_bench(cfg)
+                try:
+                    with self.assertRaises((TypeError, ValueError)):
+                        bench.plot_sweep(input_vars=["x"], result_vars=["y"], plot_callbacks=False)
+                finally:
+                    bench.close()
+                self.assertEqual(Counting.calls, [], "the sweep ran before validating")
+
+
+class TestRegressionBoundary(unittest.TestCase):
+    """D5 — regression detection must read a filled failure as absent, not as data.
+
+    A tolerated failure writes the same missing sentinel that history uses for "not
+    recorded", so the regression path must not read it as a measurement. It must
+    also not read it as an *improvement*: NaN comparisons are all False, so an
+    all-failed metric silently reports "no regression" -- which is why
+    ``fail_on_sample_error`` and not the regression gate is what catches P4.
+    """
+
+    def test_a_filled_failure_does_not_move_the_baseline(self) -> None:
+        clean = np.array([10.0, 10.1, 9.9, 10.05])
+        with_hole = np.array([10.0, 10.1, np.nan, 9.9, 10.05])
+        curr = np.array([10.0])
+        self.assertEqual(
+            detect_percentage("latency", clean, curr).baseline_value,
+            detect_percentage("latency", with_hole, curr).baseline_value,
+        )
+
+    def test_a_filled_failure_is_not_read_as_a_regression(self) -> None:
+        hist = np.array([10.0, 10.1, 9.9, 10.05])
+        # One repeat of the current sample was caught; the others are unchanged.
+        result = detect_percentage("latency", hist, np.array([10.0, np.nan, 10.1]))
+        self.assertFalse(result.regressed)
+        self.assertAlmostEqual(result.current_value, 10.05)
+
+    def test_a_metric_whose_every_sample_failed_reports_no_measurement(self) -> None:
+        """Fails safe (no false regression) but silent -- documented, not fixed here."""
+        hist = np.array([10.0, 10.1, 9.9, 10.05])
+        result = detect_percentage("latency", hist, np.array([np.nan, np.nan]))
+        self.assertFalse(result.regressed)
+        self.assertTrue(np.isnan(result.current_value))
 
 
 class TestFailOnSampleError(unittest.TestCase):


### PR DESCRIPTION
Plan 21 plus its implementation (phases 1–4). **Fourth in a five-PR stack** (see below).

`Bench.optimize(catch=...)` has had this knob since #962. The sweep path — the common one
— had no equivalent spelling, so the same benchmark was fault-tolerant when driven by
Optuna and all-or-nothing when swept.

## What this adds

- `catch` on `BenchRunCfg` — its **one home** (so `bn.run(catch=...)` works for free, and it
  reaches `plot_sweep` via `run_cfg`). Default `()`: behaviour unchanged. *(Amended in review:
  the original `plot_sweep(catch=...)` kwarg was dropped — a second spelling gives the knob two
  homes plus a precedence rule, the pattern plan A5's R1 exists to stop.)*
- `fail_on_sample_error: bool | float` — `True` fails if any sample was caught; a float in
  (0, 1] fails when the failed *fraction* reaches it. It raises **after** the dataset and
  report are assembled, so the partial results survive it; losing the artifact would defeat
  the point of catching.
- `BenchResult.failed_samples` (`SampleFailure`: job id, inputs, exception repr,
  traceback), `n_failed`, `failed_fraction`.

`catch` and `fail_on_sample_error` are a **pair**, not independent knobs. `catch` alone
turns real breakage into a green run over an all-sentinel dataset, which is worse than
fail-fast — hence the accounting ships in the same PR.

## A correction that changes the implementation

**The plan's P1 cited the wrong site, and it matters.** It said the exception propagates
through `store_results`' call to `job_future.result()`. That is true only for the **pool**
executors. `Executors.SERIAL` — the default — runs the worker *inside*
`FutureCache.submit`, so a raising sample never reaches `store_results` at all. Catching
only at `result()` would have left the common path fail-fast while a pool run tolerated
failures. This surfaced as 15 of 21 new tests failing on the first attempt.

Both sites now catch. The pool-path loop also pairs jobs with the futures they were
*actually* submitted with, rather than `zip(jobs, results_list)` positionally — with a
skipped submit, a positional zip mispairs every later job with the wrong future.

**Two things needed no code at all:**

- *A caught sample needs no representation.* `setup_dataset` already fills every result
  variable with `result_missing_fill`, so the failed coordinate **is** the sentinel; the
  dataset shape is unchanged and downstream consumers need no special case.
- *D4, no cache entry for a caught sample*, already holds in both paths — the exception
  escapes above `JobFuture.result`'s cache write, and before `JobFuture` is even
  constructed on the serial path. Pinned with a test rather than built. This was the
  highest-severity risk in the feature, since a cached failure is durable and silent.

## Validation, including where I would temper the case

Downstream suite: 1132 passed (default `catch=()` is a no-op). But measuring the actual
exposure in that project is worth stating plainly:

| benches | samples lost to one raise |
|---|---|
| 6 of 8 (no input vars, `repeats=1`) | 1 — `catch` buys nothing over fail-fast |
| 2 of 8 (swept) | **5** |

So the payoff there is real but narrower than "losing an entire run" suggests; it grows
with `repeats` and with swept dimensions. The mechanism is right, the headline was
overstated for that consumer.

## Not implemented here

D3's report failure-section (presentation) and D5's regression-boundary check. Both are
called out in the plan; neither is needed for the tolerance or the accounting to be safe.

`catch` does not move any key — it is run-time policy, not part of what identifies the
measurement. Asserted.

---

### Stack

| | PR | Plan | Base |
|---|---|---|---|
| 1 | __P16__ | 16 inspectable identity | `main` |
| 2 | __P20__ | 20 duplicate declared variables | __B20__ |
| 3 | __P15__ | 15 stable series identity | __B15__ |
| 4 | __P21__ | 21 per-sample fault tolerance | __B21__ |
| 5 | __P18__ | 18 reusable sweep declarations | __B18__ |

Review and merge bottom-up. The order is not arbitrary — it comes from the plans' own
coordination sections: 16 first because it is purely additive and gives the reviewers of
20 and 15 a way to check hashes; 20 before 15 because 20 is the one deliberate hash move
and 15 is what makes such a move legible; 18 last because its `bind()` calls 20's
validator. Two cross-plan integrations that the plan docs require are only implementable
*because* of that ordering, and are noted in the PRs that carry them (3 and 5).

Superseded the plan-only PR for this plan, which is closed. Nothing here is squashed
across plans: each PR is its own plan doc plus its own implementation.

## Summary by Sourcery

Introduce per-sample fault tolerance for benchmark sweeps, adding opt-in catching of sample exceptions, tracking of failed samples, and a policy for failing runs based on the fraction of failures while preserving partial results.

New Features:
- Add catch configuration to BenchRunCfg and plot_sweep to allow sweeps to tolerate specified exception types on individual samples.
- Expose SampleFailure and SampleErrorPolicyError types so callers can inspect and react to tolerated sample failures and sample error policy violations.
- Track per-run failure metadata on BenchResult, including a list of failed samples and derived counts/fractions of failed attempts.
- Add fail_on_sample_error policy to BenchRunCfg to optionally fail a run after completion based on whether any samples failed or the fraction of failures.

Bug Fixes:
- Ensure both serial and pool executor paths consistently catch configured sample exceptions and avoid mispairing jobs and futures when some submissions are skipped.
- Guarantee that caught samples are not written to the sample cache, preventing transient failures from becoming permanently cached results.

Enhancements:
- Log tolerated sample failures at warning level with input context to make them visible in run logs.
- Keep sweep behavior byte-identical when catch is not configured by defaulting new controls to the existing fail-fast behavior.

Documentation:
- Add plan document 21 describing the motivation, design, phases, risks, and coordination for per-sample fault tolerance in sweeps.

Tests:
- Add a dedicated test suite covering default fail-fast behavior, catch semantics across executors, cache behavior for failures, fail_on_sample_error policy thresholds, and identity stability when catch is used.
