### PR TITLE
plan 18 + implementation: reusable sweep declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`bn.SweepSpec` — a sweep declaration as a value (plan 18, phase 1).** A frozen record
+  of `plot_sweep`'s seven declarative arguments (title, descriptions, input/result/const
+  vars, tag) that can be built once, composed (`with_`, `plus_input_vars`,
+  `plus_result_vars`, `merge`), compared (`bn.diff_specs`), pickled, and bound to any
+  worker: `bench.plot_sweep(**spec.bind(Worker))`. `bind(worker)` checks every by-name
+  variable up front and runs the duplicate-variable validation at bind time, where the
+  composition that caused a duplicate is in view. Run configuration (`repeats`, `run_cfg`,
+  `plot_callbacks`, …) is deliberately absent — a spec states what is measured, not how the
+  run is driven — and a callable in any field is rejected at construction. Purely additive:
+  every existing `plot_sweep` call is unchanged.
 - **Per-sample fault tolerance on the sweep path: `catch=` and `fail_on_sample_error`.**
   `Bench.optimize(catch=...)` has had this knob since #962, so the same benchmark was
   fault-tolerant when driven by Optuna and all-or-nothing when swept. `catch` lives on

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -45,6 +45,7 @@ from .identity import (
     sweep_identity,
 )
 from .job import SampleFailure
+from .sweep_spec import SweepSpec, diff_specs
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -45,7 +45,6 @@ from .identity import (
     sweep_identity,
 )
 from .job import SampleFailure
-from .sweep_spec import SweepSpec, diff_specs
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,
@@ -76,6 +75,7 @@ from .scorecard import (
     generate_scorecard,
 )
 from .sparkline import sparkline_svg
+from .sweep_spec import SweepSpec, diff_specs
 from .utils import (
     gen_image_path,
     gen_path,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -34,8 +34,6 @@ from bencher.results.bench_result import BenchResult
 from bencher.results.optimize_result import OptimizeResult
 from bencher.sample_order import SampleOrder
 from bencher.sweep_executor import SweepExecutor, validate_declared_vars, worker_kwargs_wrapper
-from bencher.sweep_executor import SweepExecutor, worker_kwargs_wrapper
-from bencher.sweep_spec import SweepSpec
 from bencher.sweep_timings import SweepTimings, phase_timer
 from bencher.utils import AGG_FN_MAP, params_to_str, resolve_aggregate
 from bencher.variables.inputs import IntSweep
@@ -376,7 +374,7 @@ class Bench(BenchPlotServer):
 
     def plot_sweep(
         self,
-        title: str | SweepSpec | None = None,
+        title: str | None = None,
         input_vars: list[ParametrizedSweep] | None = None,
         result_vars: list[ParametrizedSweep] | None = None,
         const_vars: list[ParametrizedSweep] | None = None,
@@ -450,29 +448,6 @@ class Bench(BenchPlotServer):
             TypeError: If variable parameters are not of the correct type
             FileNotFoundError: If only_plot=True and no cached results exist
         """
-
-        if isinstance(title, SweepSpec):
-            # A spec occupies the first positional slot, which is otherwise title.
-            # Explicit keyword arguments win over it, for one-off tweaks.
-            bound = title.bind()
-            title = bound.pop("title", None)
-            explicit = {
-                "input_vars": input_vars,
-                "result_vars": result_vars,
-                "const_vars": const_vars,
-                "description": description,
-                "post_description": post_description,
-                "tag": tag or None,
-            }
-            for key, value in explicit.items():
-                if value is not None:
-                    bound[key] = value
-            input_vars = bound.get("input_vars")
-            result_vars = bound.get("result_vars")
-            const_vars = bound.get("const_vars")
-            description = bound.get("description")
-            post_description = bound.get("post_description")
-            tag = bound.get("tag") or ""
 
         if self.worker_class_instance is not None:
             if input_vars is not None:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -34,6 +34,8 @@ from bencher.results.bench_result import BenchResult
 from bencher.results.optimize_result import OptimizeResult
 from bencher.sample_order import SampleOrder
 from bencher.sweep_executor import SweepExecutor, validate_declared_vars, worker_kwargs_wrapper
+from bencher.sweep_executor import SweepExecutor, worker_kwargs_wrapper
+from bencher.sweep_spec import SweepSpec
 from bencher.sweep_timings import SweepTimings, phase_timer
 from bencher.utils import AGG_FN_MAP, params_to_str, resolve_aggregate
 from bencher.variables.inputs import IntSweep
@@ -374,7 +376,7 @@ class Bench(BenchPlotServer):
 
     def plot_sweep(
         self,
-        title: str | None = None,
+        title: str | SweepSpec | None = None,
         input_vars: list[ParametrizedSweep] | None = None,
         result_vars: list[ParametrizedSweep] | None = None,
         const_vars: list[ParametrizedSweep] | None = None,
@@ -448,6 +450,29 @@ class Bench(BenchPlotServer):
             TypeError: If variable parameters are not of the correct type
             FileNotFoundError: If only_plot=True and no cached results exist
         """
+
+        if isinstance(title, SweepSpec):
+            # A spec occupies the first positional slot, which is otherwise title.
+            # Explicit keyword arguments win over it, for one-off tweaks.
+            bound = title.bind()
+            title = bound.pop("title", None)
+            explicit = {
+                "input_vars": input_vars,
+                "result_vars": result_vars,
+                "const_vars": const_vars,
+                "description": description,
+                "post_description": post_description,
+                "tag": tag or None,
+            }
+            for key, value in explicit.items():
+                if value is not None:
+                    bound[key] = value
+            input_vars = bound.get("input_vars")
+            result_vars = bound.get("result_vars")
+            const_vars = bound.get("const_vars")
+            description = bound.get("description")
+            post_description = bound.get("post_description")
+            tag = bound.get("tag") or ""
 
         if self.worker_class_instance is not None:
             if input_vars is not None:

--- a/bencher/sweep_spec.py
+++ b/bencher/sweep_spec.py
@@ -1,0 +1,348 @@
+"""Reusable sweep declarations.
+
+``plot_sweep`` takes fifteen keyword arguments and consumes them into a
+``BenchCfg`` inside its own body, so there is no object representing "this sweep".
+A benchmark that must run against more than one worker -- two backends, a mocked
+and a live dependency, two hardware tiers -- therefore has one declaration and N
+call sites, with nothing linking them. They drift: one side gains a result
+variable, one keeps an old constant, and because each side still produces a valid
+benchmark, nothing fails.
+
+:class:`SweepSpec` is that missing object: a frozen record of ``plot_sweep``'s
+*declarative* arguments only. Run configuration (repeats, sampling resolution,
+publishing) is deliberately not here -- a spec states what is measured, not how
+the run is driven.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, fields, replace
+from typing import Any
+
+import param
+
+# The shaping keys bn.sweep() may put in a spec dict. Shaping applies to inputs
+# and consts only: the dict branch of variable conversion calls with_samples /
+# with_bounds / with_sample_values, and result variables are not SweepBase.
+_SHAPING_KEYS = ("values", "bounds", "samples", "max_subsampling_divisions")
+
+# Fields whose value is a mapping merged key-by-key rather than replaced.
+_MERGED_FIELDS = frozenset({"const_vars"})
+
+# Fields that are ordered sequences of variables.
+_VAR_LIST_FIELDS = frozenset({"input_vars", "result_vars"})
+
+
+def _reject_callable(field_name: str, value: Any) -> None:
+    """A spec must stay a serialisable value.
+
+    A callable in any field breaks equality and pickling, which are the two
+    properties that make a spec useful for detecting drift between call sites.
+    ``plot_callbacks`` and the other render-time arguments are excluded from a
+    spec for the same reason, so a callable arriving here is always a mistake.
+    """
+    if callable(value) and not isinstance(value, (type, param.Parameter)):
+        raise TypeError(
+            f"SweepSpec.{field_name} may not contain a callable ({value!r}). A spec is "
+            f"a value: a callable breaks equality and pickling, which is what makes "
+            f"two bindings of one declaration comparable. Compute the value before "
+            f"building the spec, or pass render-time arguments to plot_sweep directly."
+        )
+
+
+def _normalise_var_list(field_name: str, value: Any) -> tuple:
+    if isinstance(value, Mapping):
+        raise TypeError(
+            f"SweepSpec.{field_name} must be a list, not a mapping. Passing the whole "
+            f"variable list as a {{name: values}} dict is deprecated in plot_sweep; use "
+            f"a list of bn.sweep() specs."
+        )
+    out = []
+    for entry in value:
+        _reject_callable(field_name, entry)
+        if field_name == "result_vars" and isinstance(entry, Mapping):
+            shaped = sorted(k for k in _SHAPING_KEYS if entry.get(k))
+            if shaped:
+                raise TypeError(
+                    f"SweepSpec.result_vars entry {entry.get('name')!r} carries sweep "
+                    f"shaping {shaped}. Shaping applies to inputs and consts only -- "
+                    f"result variables are not SweepBase, so this raises AttributeError "
+                    f"mid-run rather than at declaration. Use a bare name."
+                )
+        out.append(entry)
+    return tuple(out)
+
+
+def _normalise_consts(value: Any) -> tuple:
+    """Both accepted spellings become a tuple of (variable, value) pairs."""
+    items = value.items() if isinstance(value, Mapping) else value
+    out = []
+    for entry in items:
+        if isinstance(entry, (str, bytes)) or not isinstance(entry, Sequence):
+            raise TypeError(
+                f"SweepSpec.const_vars list entries must be (variable, value) pairs, "
+                f"got {entry!r}. Use a mapping, or a list of 2-sequences."
+            )
+        if len(entry) != 2:
+            raise TypeError(f"SweepSpec.const_vars entries must be 2-sequences, got {entry!r}")
+        _reject_callable("const_vars", entry[0])
+        _reject_callable("const_vars", entry[1])
+        out.append((entry[0], entry[1]))
+    return tuple(out)
+
+
+@dataclass(frozen=True)
+class SweepSpec:
+    """One sweep declaration, as a value.
+
+    Every field defaults to ``None`` meaning *unset*, so a spec never has to state
+    what it does not care about, and an unset field leaves ``plot_sweep``'s own
+    default in force. ``input_vars=None`` auto-discovers every input on the worker;
+    ``input_vars=()`` declares none.
+
+    Written entirely from *names* -- a plain string, a :func:`bencher.sweep` spec
+    dict, a ``{name: value}`` const mapping -- a spec references no class and can
+    therefore be bound to more than one worker. That by-name form is what makes
+    reuse possible, and it is why :meth:`bind` takes the worker rather than the
+    spec holding one.
+
+    Equality and pickling are the point: two bindings of one declaration can be
+    compared, which is how drift between call sites becomes visible. A spec
+    containing a :func:`bencher.sweep` dict is not *hashable* (a dict is not),
+    exactly as a tuple containing a list is not.
+    """
+
+    title: str | None = None
+    description: str | None = None
+    post_description: str | None = None
+    input_vars: tuple | None = None
+    result_vars: tuple | None = None
+    const_vars: tuple | None = None
+    tag: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("title", "description", "post_description", "tag"):
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, str):
+                raise TypeError(f"SweepSpec.{name} must be a string, got {value!r}")
+        for name in _VAR_LIST_FIELDS:
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(self, name, _normalise_var_list(name, value))
+        if self.const_vars is not None:
+            object.__setattr__(self, "const_vars", _normalise_consts(self.const_vars))
+
+    @property
+    def set_fields(self) -> dict:
+        """The fields this spec actually declares, for merging."""
+        return {
+            f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None
+        }
+
+    def with_(self, **overrides) -> SweepSpec:
+        """A new spec with *overrides* applied, override winning.
+
+        Precedence is per field *kind*, and the asymmetry is deliberate:
+
+        * scalars (``title``, ``tag``, the descriptions) are **replaced**.
+        * ``const_vars`` is **shallow-merged**, override winning per key -- the
+          common case is one environment needing a longer timeout than another.
+        * ``input_vars`` and ``result_vars`` are **replaced, not appended**.
+          Order matters for ``input_vars`` (it sets the dimension layout and is
+          hashed in list order), and silent appending is how duplicate result
+          variables arise. Use :meth:`plus_result_vars` when appending is what you
+          mean, so the intent is written down.
+        """
+        unknown = set(overrides) - {f.name for f in fields(self)}
+        if unknown:
+            raise TypeError(f"SweepSpec has no field(s) {sorted(unknown)}")
+        resolved = {}
+        for name, value in overrides.items():
+            if value is None:
+                resolved[name] = None
+                continue
+            if name in _MERGED_FIELDS and getattr(self, name) is not None:
+                merged = dict(getattr(self, name))
+                merged.update(dict(_normalise_consts(value)))
+                resolved[name] = tuple(merged.items())
+            else:
+                resolved[name] = value
+        return replace(self, **resolved)
+
+    def plus_result_vars(self, *result_vars) -> SweepSpec:
+        """Append result variables to this spec's, keeping order.
+
+        The explicit spelling for the additive case that :meth:`with_` refuses to
+        do implicitly. Appending is exactly how a metric ends up declared twice
+        when lists are assembled from several sources, so the duplicate validation
+        in ``plot_sweep`` is the backstop -- this method just makes the intent
+        legible at the call site.
+        """
+        flat = []
+        for entry in result_vars:
+            if isinstance(entry, (list, tuple)) and not isinstance(entry, str):
+                flat.extend(entry)
+            else:
+                flat.append(entry)
+        return replace(self, result_vars=(*(self.result_vars or ()), *flat))
+
+    def plus_input_vars(self, *input_vars) -> SweepSpec:
+        """Append input variables. Order is the dimension layout, so appending
+        puts the new dimension last."""
+        flat = []
+        for entry in input_vars:
+            if isinstance(entry, (list, tuple)) and not isinstance(entry, str):
+                flat.extend(entry)
+            else:
+                flat.append(entry)
+        return replace(self, input_vars=(*(self.input_vars or ()), *flat))
+
+    def merge(self, other: SweepSpec) -> SweepSpec:
+        """``other``'s declared fields applied on top of this spec's."""
+        return self.with_(**other.set_fields)
+
+    def bind(self, worker: Any = None) -> dict:
+        """The exact keyword arguments ``plot_sweep`` would receive.
+
+        This is the testability payoff: a project can assert what each of its
+        environments resolves to without constructing a bench or running anything,
+        and it pairs directly with ``bn.sweep_identity(**spec.bind(W), worker=W)``.
+
+        *worker* is accepted for symmetry and validation only -- resolution of
+        by-name variables happens inside ``plot_sweep`` against the bench's own
+        worker. Passing it here checks every name up front, so a typo surfaces at
+        bind time with the available parameters listed rather than mid-run.
+
+        Lists, not tuples: ``plot_sweep`` converts its variable lists in place.
+        """
+        inputs = list(self.input_vars) if self.input_vars is not None else None
+        results = list(self.result_vars) if self.result_vars is not None else None
+        consts = [list(pair) for pair in self.const_vars] if self.const_vars is not None else None
+
+        if worker is not None:
+            self._check_names(worker)
+            inputs, results, consts = self._validate(worker, inputs, results, consts)
+
+        out: dict = {}
+        for name in ("title", "description", "post_description", "tag"):
+            if getattr(self, name) is not None:
+                out[name] = getattr(self, name)
+        if inputs is not None:
+            out["input_vars"] = inputs
+        if results is not None:
+            out["result_vars"] = results
+        if consts is not None:
+            out["const_vars"] = consts
+        return out
+
+    def _resolved(self, worker: Any, entry: Any, var_type: str) -> Any:
+        """The param.Parameter *entry* names, or *entry* itself if it is already one."""
+        from bencher.sweep_executor import _resolve_param
+
+        if isinstance(entry, str):
+            return _resolve_param(entry, worker, var_type)
+        if isinstance(entry, Mapping):
+            return _resolve_param(entry["name"], worker, var_type)
+        return entry
+
+    def _check_names(self, worker: Any) -> None:
+        """Resolve every by-name variable now, so a typo fails at bind time."""
+        for var_type, entries in (
+            ("input", self.input_vars or ()),
+            ("result", self.result_vars or ()),
+            ("const", [pair[0] for pair in self.const_vars or ()]),
+        ):
+            for entry in entries:
+                self._resolved(worker, entry, var_type)
+
+    def _validate(self, worker: Any, inputs, results, consts):
+        """Run ``plot_sweep``'s duplicate-variable validation at bind time.
+
+        A spec is the main *source* of duplicates -- composing overlapping groups
+        from several places is exactly what specs make easy -- so a spec should not
+        be able to hand ``plot_sweep`` a declaration that ``plot_sweep`` will then
+        reject or silently dedupe. Calling the one validation site here means a
+        duplicate input variable fails at ``bind()``, where the composition that
+        caused it is in view, and a duplicate result variable is warned about and
+        dropped once rather than twice.
+
+        Comparison is on the *resolved* name, and the entries returned are the
+        caller's own declaration forms -- strings, spec dicts, param objects -- so
+        the bound arguments stay bindable to a different worker.
+        """
+        from bencher.sweep_executor import validate_declared_vars
+
+        def by_name(entries, var_type):
+            return [self._resolved(worker, e, var_type) for e in entries or ()]
+
+        kept_inputs, kept_results, kept_consts = validate_declared_vars(
+            by_name(inputs, "input"),
+            by_name(results, "result"),
+            [[self._resolved(worker, pair[0], "const"), pair[1]] for pair in consts or ()],
+        )
+
+        def survivors(entries, kept_names, var_type, name_of):
+            """The caller's own entries, filtered to the names validation kept.
+
+            Consumed from a list rather than a set so that when validation keeps one
+            of two same-named entries, exactly one original survives.
+            """
+            if entries is None:
+                return None
+            wanted = list(kept_names)
+            out = []
+            for entry in entries:
+                name = name_of(entry)
+                if name in wanted:
+                    wanted.remove(name)
+                    out.append(entry)
+            return out
+
+        def input_name(entry):
+            return self._resolved(worker, entry, "input").name
+
+        def result_name(entry):
+            return self._resolved(worker, entry, "result").name
+
+        def const_name(pair):
+            return self._resolved(worker, pair[0], "const").name
+
+        return (
+            survivors(inputs, [v.name for v in kept_inputs], "input", input_name),
+            survivors(results, [v.name for v in kept_results], "result", result_name),
+            survivors(consts, [v[0].name for v in kept_consts], "const", const_name),
+        )
+
+    def describe(self) -> str:
+        """One line per declared field, for eyeballing two specs side by side."""
+
+        def name_of(entry: Any) -> str:
+            if isinstance(entry, Mapping):
+                return str(entry.get("name"))
+            return str(getattr(entry, "name", entry))
+
+        lines = []
+        for key, value in self.set_fields.items():
+            if key in _VAR_LIST_FIELDS:
+                rendered = ", ".join(name_of(v) for v in value) or "(none)"
+            elif key == "const_vars":
+                rendered = ", ".join(f"{name_of(v)}={val!r}" for v, val in value) or "(none)"
+            else:
+                rendered = str(value)
+            lines.append(f"{key}: {rendered}")
+        return "\n".join(lines)
+
+
+def diff_specs(left: SweepSpec, right: SweepSpec) -> list[str]:
+    """Lines naming every field in which two specs differ.
+
+    The drift detector: two bindings of one declaration that should agree can be
+    compared directly instead of by reading both call sites side by side.
+    """
+    out = []
+    for f in fields(left):
+        a, b = getattr(left, f.name), getattr(right, f.name)
+        if a != b:
+            out.append(f"{f.name}: {a!r} != {b!r}")
+    return out

--- a/bencher/sweep_spec.py
+++ b/bencher/sweep_spec.py
@@ -282,7 +282,7 @@ class SweepSpec:
             [[self._resolved(worker, pair[0], "const"), pair[1]] for pair in consts or ()],
         )
 
-        def survivors(entries, kept_names, var_type, name_of):
+        def survivors(entries, kept_names, name_of):
             """The caller's own entries, filtered to the names validation kept.
 
             Consumed from a list rather than a set so that when validation keeps one
@@ -309,9 +309,9 @@ class SweepSpec:
             return self._resolved(worker, pair[0], "const").name
 
         return (
-            survivors(inputs, [v.name for v in kept_inputs], "input", input_name),
-            survivors(results, [v.name for v in kept_results], "result", result_name),
-            survivors(consts, [v[0].name for v in kept_consts], "const", const_name),
+            survivors(inputs, [v.name for v in kept_inputs], input_name),
+            survivors(results, [v.name for v in kept_results], result_name),
+            survivors(consts, [v[0].name for v in kept_consts], const_name),
         )
 
     def describe(self) -> str:

--- a/plans/18-reusable-sweep-declarations.md
+++ b/plans/18-reusable-sweep-declarations.md
@@ -1,0 +1,191 @@
+# Plan 18 — Reusable Sweep Declarations
+
+**Goal:** Give a sweep declaration — its input, result, and constant variables,
+its tag, its title — a value object that can be built once, inspected, varied,
+and run against more than one worker class. Today that declaration exists only as
+fifteen keyword arguments to a method on a live `Bench`, so running the same
+measurement in two environments means restating all of it at both sites, with
+nothing to detect drift between them.
+
+**Branch name:** `feat/sweep-spec`
+
+**⚠️ Read first:** plan 13 owns *run* configuration (repeats, sampling
+resolution, `show`, publishing) via `@bn.benchmark(...)`. This plan owns the
+*sweep* declaration — what is measured, not how the run is driven. Keep the two
+surfaces separate; a spec that also carries `repeats` duplicates plan 13.
+
+---
+
+## Problem statement (with evidence)
+
+### P1 — A declaration is not a value
+
+`plot_sweep()` takes fifteen keyword arguments
+(`bencher/bencher.py:271-288`) and immediately consumes them into a `BenchCfg`
+inside its own body. There is no object representing "this sweep", so a
+declaration cannot be stored in a module, passed to a function, compared against
+another, or asserted on in a test without running the benchmark.
+
+### P2 — One measurement in several environments means restating everything
+
+A benchmark that must run against more than one worker — a fast and a slow
+backend, a mocked and a live dependency, two hardware tiers, two library versions
+— has one declaration and N call sites. Every argument is retyped at each site.
+Nothing links them, so the sites drift: one gains a result variable, one keeps an
+old constant, and because each side still produces a valid benchmark, nothing
+fails. The divergence is only visible by reading both call sites side by side.
+
+### P3 — Variation on a shared base is hand-merged dicts
+
+When the environments *should* differ in a couple of places — a longer timeout
+here, an extra metric there — the shared part and the local part have to be
+merged by hand at each site, with the precedence expressed as whatever dict
+literal ordering the author chose. There is no declared rule for which layer
+wins, and no way to enumerate the asymmetries between two bindings of one
+declaration.
+
+### P4 — The class-independent form exists but is undiscoverable
+
+`bn.sweep("name", bounds=...)` returns a spec dict resolved by name at
+`plot_sweep` time (`bencher/variables/inputs.py:753-759`, resolved at
+`bencher/sweep_executor.py:130-145`), and `const_vars` accepts a plain
+`{name: value}` dict (`bencher/bencher.py:437-438`, converted through the same
+by-name resolution). Together these already let a declaration be written without
+referencing any class — which is exactly what makes reuse across workers
+possible.
+
+This is close to unadvertised. The name-based form appears in `bn.sweep`'s
+docstring and, indirectly, in a deprecation warning telling users to stop passing
+`input_vars` as a dict (`bencher/bencher.py:406-411`). Nothing in the docs or
+gallery presents "declare a sweep without naming a class" as a pattern, so users
+reach for `Cls.param.x` and bind their declaration to one class for no reason.
+
+---
+
+## Proposed design
+
+### D1 — `bn.SweepSpec`
+
+A frozen dataclass mirroring `plot_sweep`'s declarative arguments only:
+
+```python
+LATENCY = bn.SweepSpec(
+    title="Request latency",
+    description="...",
+    input_vars=[bn.sweep("concurrency", bounds=(1, 64))],
+    result_vars=["latency_ms", "error_rate"],
+    const_vars={"payload_bytes": 1024},
+    tag="latency",
+)
+```
+
+- Variables may be given in every form `plot_sweep` already accepts; the
+  name-based forms are what make a spec class-independent, and the docstring
+  should say so.
+- Excluded on purpose: `run_cfg`, `pass_repeat`, `auto_plot`, `plot_callbacks`,
+  `sample_order` — run-time and rendering concerns. `plot_callbacks` in
+  particular must stay out, since A2 is moving toward serializable plot specs and
+  a callable in a frozen spec would defeat the point.
+
+### D2 — Composition with one documented rule
+
+```python
+SLOW = LATENCY.with_(const_vars={"timeout_s": 30}, result_vars=[..., "retries"])
+```
+
+- `with_(**overrides)` returns a new spec. Precedence is **override wins**, per
+  field, with one explicit rule per field kind:
+  - scalars (`title`, `tag`, `description`): replaced.
+  - `const_vars`: shallow-merged, override wins per key.
+  - `input_vars` / `result_vars`: **replaced, not appended**, because order
+    matters for `input_vars` (it sets dimension layout and is hashed in list
+    order, `bencher/bench_cfg.py:838`) and silent appending is how duplicate
+    result variables arise (see plan 20). Provide `plus_result_vars(...)` for
+    the additive case so the intent is written down.
+- `merge(other)` for the symmetric case, defined as `self.with_(**other.set_fields)`.
+- Because a spec is a value, `spec_a == spec_b` and a rendered diff of two specs
+  both become available — which is what makes P2's drift visible.
+
+### D3 — `bench.plot_sweep(spec)` and `spec.bind(worker)`
+
+- `plot_sweep` accepts a `SweepSpec` as its first positional argument (it is
+  currently `title`, so accept a spec there by type and keep `title=` working).
+  Explicit keyword arguments passed alongside a spec win over it, for one-off
+  tweaks.
+- `spec.bind(worker_cls) -> dict` resolves the spec against a worker and returns
+  the exact keyword arguments `plot_sweep` would receive. This is the testability
+  payoff: a project can assert what each of its environments resolves to without
+  constructing a bench or running anything, and it pairs directly with plan 16's
+  identity API — `bn.sweep_identity(**spec.bind(Worker))`.
+
+### D4 — Documentation
+
+- A gallery example: one spec, two workers, one report. This is the pattern P2
+  describes and there is currently nothing to point at.
+- A docs section on class-independent declarations (P4): prefer
+  `bn.sweep("name", ...)` and `const_vars={"name": value}` over
+  `Cls.param.name` when a declaration is meant to be reused, and note that
+  by-name resolution raises a clear error listing available parameters when a
+  name is wrong (`bencher/sweep_executor.py:28-36`).
+
+---
+
+## Phased steps
+
+1. `bencher/sweep_spec.py`: the frozen dataclass, `with_`, `plus_result_vars`,
+   `merge`, `bind`. No changes to `plot_sweep` yet — `bench.plot_sweep(**spec.bind(W))`
+   already works and is a complete, shippable increment on its own.
+2. `plot_sweep` accepts a spec positionally, with keyword arguments taking
+   precedence.
+3. Docs and gallery example (D4).
+4. *(Optional)* `SweepSpec` accepted wherever plan 13's declaration bundle is
+   read, so a benchmark can declare both halves in one place.
+
+## Tests / acceptance criteria
+
+- `bench.plot_sweep(spec)` and `bench.plot_sweep(**spec.bind(W))` produce
+  identical `BenchCfg` hashes.
+- A keyword argument passed alongside a spec overrides the spec's value.
+- `with_` precedence per field kind, including that `const_vars` merges and
+  `result_vars` replaces; `plus_result_vars` appends.
+- One spec bound to two different worker classes yields two configs differing
+  *only* in `bench_name`, with identical input/const/result identity — the
+  property that makes P2's drift detectable.
+- A spec is picklable and equality-comparable; a spec containing a lambda in any
+  field is rejected at construction with a message pointing at D1's exclusions.
+- A spec referencing an unknown variable name surfaces the existing `KeyError`
+  from `_resolve_param` at `bind` time, listing available parameters.
+
+## Migration & compatibility
+
+Additive. Every existing `plot_sweep` call keeps working unchanged; a spec is an
+alternative way to supply the same arguments. Phase 1 alone requires no change to
+`bencher.py` at all.
+
+## Risks
+
+- **Overlap with plan 13.** The two must not both own `repeats`/`tag`. Suggested
+  split: plan 13's bundle owns run defaults and *may* carry a default `tag`; a
+  spec's `tag` is part of the measurement declaration and wins when both are
+  present. Settle this before phase 2. **OWNER DECISION.**
+- **A spec drifting into a second config type.** If `SweepSpec` accumulates
+  run-time fields it becomes a rival `BenchCfg`. Keep it strictly a frozen record
+  of `plot_sweep`'s declarative arguments; anything computed belongs in
+  `BenchCfg`.
+- **Encouraging appended `result_vars`.** Convenient appending is exactly how
+  duplicate result variables get declared, which today silently splits a cache
+  key (plan 20). D2's replace-by-default and the explicit `plus_result_vars` are
+  deliberate; plan 20's validation is the backstop.
+
+## Coordination
+
+- **Plan 13** — complementary halves of one declaration; resolve the `tag`
+  ownership question above.
+- **Plan 16** — `spec.bind()` feeding `sweep_identity()` is how a project pins
+  what each environment resolves to.
+- **Plan 17** — programmatically built specs are exactly where computed ranges
+  collapse to a single point.
+- **Plan 20** — spec composition is the main source of duplicate variables;
+  these two plans should land in either order but be aware of each other.
+- **A2/A3** — keep specs free of callables and live objects so they stay
+  serializable under A3's contract.

--- a/plans/18-reusable-sweep-declarations.md
+++ b/plans/18-reusable-sweep-declarations.md
@@ -49,7 +49,7 @@ declaration.
 `bn.sweep("name", bounds=...)` returns a spec dict resolved by name at
 `plot_sweep` time (`bencher/variables/inputs.py:753-759`, resolved at
 `bencher/sweep_executor.py:130-145`), and `const_vars` accepts a plain
-`{name: value}` dict (`bencher/bencher.py:437-438`, converted through the same
+`{name: value}` dict (`bencher/bencher.py:436-437`, converted through the same
 by-name resolution). Together these already let a declaration be written without
 referencing any class — which is exactly what makes reuse across workers
 possible.
@@ -79,13 +79,60 @@ LATENCY = bn.SweepSpec(
 )
 ```
 
-- Variables may be given in every form `plot_sweep` already accepts; the
-  name-based forms are what make a spec class-independent, and the docstring
-  should say so.
-- Excluded on purpose: `run_cfg`, `pass_repeat`, `auto_plot`, `plot_callbacks`,
-  `sample_order` — run-time and rendering concerns. `plot_callbacks` in
-  particular must stay out, since A2 is moving toward serializable plot specs and
-  a callable in a frozen spec would defeat the point.
+Seven fields, one per declarative argument of `plot_sweep`
+(`bencher/bencher.py:271-288`). Every field defaults to `None`, meaning *unset*,
+so a spec never has to state what it does not care about:
+
+| Field | Type | Accepted forms | Notes |
+|---|---|---|---|
+| `title` | `str \| None` | string | Unset keeps `plot_sweep`'s generated title (`bencher/bencher.py:445-456`). Outside cache identity (`bencher/bench_cfg.py:820-823`). |
+| `description` | `str \| None` | string | Rendered before the plots. Not hashed. |
+| `post_description` | `str \| None` | string | Rendered after the plots. Not hashed. |
+| `input_vars` | `list[param.Parameter \| str \| dict] \| None` | `Cls.param.x`, `"x"`, `bn.sweep("x", bounds=(1, 8))` | Order is the dimension layout and is folded into the hash in list order (`bencher/bench_cfg.py:837-838`). Unset auto-discovers every input on the worker (`bencher/bencher.py:347-357`); `[]` declares none. |
+| `result_vars` | `list[param.Parameter \| str \| dict] \| None` | `Cls.param.y`, `"y"`, `bn.sweep("y")` | Contributes as an unordered set (`bencher/bench_cfg.py:840-841`). Sweep shaping is input-only — see below. |
+| `const_vars` | `list[tuple[param.Parameter \| str \| dict, Any]] \| dict[str, Any] \| None` | `[(Cls.param.x, 4)]`, `[("x", 4)]`, `{"x": 4}` | The mapping form expands to pairs (`bencher/bencher.py:436-437`); list entries must be 2-sequences. Unordered set in the hash (`bencher/bench_cfg.py:845-849`). |
+| `tag` | `str \| None` | string | Cache and history identity: hashed (`bencher/bench_cfg.py:834`) and composed as `run_cfg.run_tag + tag` (`bencher/bencher.py:524`, and on the `optimize()` path at `:1224`). Precedence against plan 13 is D5. |
+
+Three facts about the variable fields, each checked against
+`SweepExecutor.convert_vars_to_params` (`bencher/sweep_executor.py:89-149`):
+
+- The by-name forms — a plain string, a `bn.sweep(...)` spec dict, a
+  `{name: value}` const mapping — are what make a spec class-independent, and the
+  docstring should say so. They resolve against the worker at `plot_sweep` time,
+  so a spec written entirely from names raises `TypeError` on a bench with no
+  worker class instance (`bencher/sweep_executor.py:122-126`); pair it with
+  `bind()` (D3), or use param objects.
+- Sweep shaping (`values`, `bounds`, `samples`, `max_subsampling_divisions`)
+  applies to inputs and consts only. A `result_vars` entry may be a bare
+  `bn.sweep("y")`, but `bn.sweep("y", samples=3)` raises `AttributeError`: the
+  dict branch calls `with_samples` (`bencher/sweep_executor.py:132-138`) and
+  result variables are not `SweepBase` (`ResultFloat(Number)`,
+  `bencher/variables/results.py:103`). A spec rejects a shaped result var at
+  construction rather than mid-run.
+- Passing the *whole* `input_vars` field as a `{name: values}` mapping is
+  deprecated and normalized to a list of spec dicts
+  (`bencher/bencher.py:406-416`); a spec holds the list.
+
+Excluded on purpose — the remaining eight arguments, every one a run-time or
+render-time concern:
+
+- `run_cfg` — run configuration; plan 13 owns it, and a spec carrying it
+  duplicates that plan.
+- `pass_repeat` — execution: whether the repeat index reaches the worker
+  (`bencher/sweep_executor.py:61-65`).
+- `sample_order` — sampling traversal only, documented as leaving dataset and
+  plot dimension order unchanged (`bencher/bencher.py:323-324`).
+- `time_src` — the timestamp of one run, not a property of the measurement.
+- `auto_plot` — rendering; resolved through `run_cfg.auto_plot`
+  (`bencher/bencher.py:401-402`).
+- `plot_callbacks` — rendering, and it must stay out for a second reason: a
+  callable in a frozen spec breaks equality and pickling, and A2 is moving toward
+  serializable plot specs.
+- `aggregate` / `agg_fn` — post-collection reduction. They land as
+  `agg_over_dims`/`agg_fn` on `BenchCfg` (`bencher/bencher.py:512`, `:526-527`)
+  and never reach `hash_persistent` (`bencher/bench_cfg.py:828-851`), so they can
+  change between runs without invalidating collected samples: analysis-time, not
+  declaration.
 
 ### D2 — Composition with one documented rule
 
@@ -128,6 +175,40 @@ SLOW = LATENCY.with_(const_vars={"timeout_s": 30}, result_vars=[..., "retries"])
   by-name resolution raises a clear error listing available parameters when a
   name is wrong (`bencher/sweep_executor.py:28-36`).
 
+### D5 — `tag` precedence against plan 13
+
+Plan 13's spine is **env > call-site > declared > library default**, applied to
+the tag in its D3 (*Tag defaulting from the callable*). A spec's `tag` belongs to
+the *measurement* declaration, so it sits at the **declared** tier beside plan
+13's `@bn.benchmark(tag=...)` — and when both are set the spec wins, because the
+spec states what is being measured while the decorator states how the run is
+driven, and the tag is measurement identity (it is hashed,
+`bencher/bench_cfg.py:834`). An explicit `plot_sweep(tag=...)` or
+`bn.run(tag=...)` at the call site still beats both; an env override still beats
+everything.
+
+Effective tag for one sweep, highest precedence first:
+
+1. `BENCHER_TAG` — env (plan 13 D2, *Env overrides in `bn.run`*).
+2. `plot_sweep(tag=...)` or `bn.run(tag=...)` — call site.
+3. `SweepSpec.tag` — declared, measurement side.
+4. `@bn.benchmark(tag=...)` — declared, run side (plan 13 D3).
+5. The decorated callable's `__name__` — plan 13 D3, decorated targets only.
+6. `""` — library default (`bencher/bencher.py:281`).
+
+A spec's `tag=None` is unset and leaves tiers 4–6 alone, so adopting specs
+changes no existing tag. Tier 3 beating tier 4 must be resolved *before* the tag
+reaches `BenchCfg`, not left to the existing plumbing: plan 13's tag lands in
+`run_cfg.run_tag`, a `plot_sweep` tag is the per-sweep component, and the
+effective tag is their concatenation `run_cfg.run_tag + tag`
+(`bencher/bencher.py:524`). Appending instead of suppressing would give a
+spec-tagged sweep both tags and a cache key matching neither. Because the tag is
+hashed, which tier wins decides cache and over_time identity — settled once here,
+not per project.
+
+**OWNER DECISION** — confirm this ordering, tier 3 over tier 4 in particular,
+before phase 2.
+
 ---
 
 ## Phased steps
@@ -152,7 +233,9 @@ SLOW = LATENCY.with_(const_vars={"timeout_s": 30}, result_vars=[..., "retries"])
   *only* in `bench_name`, with identical input/const/result identity — the
   property that makes P2's drift detectable.
 - A spec is picklable and equality-comparable; a spec containing a lambda in any
-  field is rejected at construction with a message pointing at D1's exclusions.
+  field is rejected at construction with a message pointing at D1's exclusions, as
+  is a shaped result var (`bn.sweep("y", samples=3)`) rather than letting it
+  surface as an `AttributeError` mid-run.
 - A spec referencing an unknown variable name surfaces the existing `KeyError`
   from `_resolve_param` at `bind` time, listing available parameters.
 
@@ -164,10 +247,9 @@ alternative way to supply the same arguments. Phase 1 alone requires no change t
 
 ## Risks
 
-- **Overlap with plan 13.** The two must not both own `repeats`/`tag`. Suggested
-  split: plan 13's bundle owns run defaults and *may* carry a default `tag`; a
-  spec's `tag` is part of the measurement declaration and wins when both are
-  present. Settle this before phase 2. **OWNER DECISION.**
+- **Overlap with plan 13.** The two must not both own `repeats`/`tag`. `repeats`
+  stays plan 13's alone; the `tag` split is written out as a full precedence
+  ordering in D5, for the owner to confirm before phase 2. **OWNER DECISION.**
 - **A spec drifting into a second config type.** If `SweepSpec` accumulates
   run-time fields it becomes a rival `BenchCfg`. Keep it strictly a frozen record
   of `plot_sweep`'s declarative arguments; anything computed belongs in
@@ -179,8 +261,9 @@ alternative way to supply the same arguments. Phase 1 alone requires no change t
 
 ## Coordination
 
-- **Plan 13** — complementary halves of one declaration; resolve the `tag`
-  ownership question above.
+- **Plan 13** — complementary halves of one declaration; D5 states the `tag`
+  precedence, and plan 13's D3 (*Tag defaulting from the callable*) is the other
+  half of it.
 - **Plan 16** — `spec.bind()` feeding `sweep_identity()` is how a project pins
   what each environment resolves to.
 - **Plan 17** — programmatically built specs are exactly where computed ranges

--- a/plans/18-reusable-sweep-declarations.md
+++ b/plans/18-reusable-sweep-declarations.md
@@ -56,7 +56,7 @@ possible.
 
 This is close to unadvertised. The name-based form appears in `bn.sweep`'s
 docstring and, indirectly, in a deprecation warning telling users to stop passing
-`input_vars` as a dict (`bencher/bencher.py:406-411`). Nothing in the docs or
+`input_vars` as a dict (`Bench.plot_sweep`, `bencher/bencher.py:406-417`). Nothing in the docs or
 gallery presents "declare a sweep without naming a class" as a pattern, so users
 reach for `Cls.param.x` and bind their declaration to one class for no reason.
 

--- a/plans/18-reusable-sweep-declarations.md
+++ b/plans/18-reusable-sweep-declarations.md
@@ -9,6 +9,12 @@ nothing to detect drift between them.
 
 **Branch name:** `feat/sweep-spec`
 
+**Status:** Phase 1 shipped (`bn.SweepSpec`, composition, `bind()`, `diff_specs`;
+use as `bench.plot_sweep(**spec.bind())`). Phase 2 — accepting a spec in
+`plot_sweep`'s first positional slot — is **deferred** until D5's tag-precedence
+OWNER DECISION is confirmed (now owned by plan A5 §6, which also commits phase 3's
+inversion: `plot_sweep` constructing a `SweepSpec` internally from its kwargs).
+
 **⚠️ Read first:** plan 13 owns *run* configuration (repeats, sampling
 resolution, `show`, publishing) via `@bn.benchmark(...)`. This plan owns the
 *sweep* declaration — what is measured, not how the run is driven. Keep the two

--- a/test/test_sweep_spec.py
+++ b/test/test_sweep_spec.py
@@ -49,7 +49,9 @@ def _bench(worker=ExampleBenchCfg):
 
 class TestValueSemantics(unittest.TestCase):
     def test_frozen(self) -> None:
-        with self.assertRaises(Exception):
+        import dataclasses
+
+        with self.assertRaises(dataclasses.FrozenInstanceError):
             LATENCY.title = "no"
 
     def test_equality_and_pickling(self) -> None:
@@ -156,33 +158,35 @@ class TestComposition(unittest.TestCase):
 
 
 class TestBind(unittest.TestCase):
-    def test_plot_sweep_with_a_spec_matches_plot_sweep_with_its_bind(self) -> None:
+    """Phase 1: a spec reaches ``plot_sweep`` as ``**spec.bind()``.
+
+    Accepting a spec in ``plot_sweep``'s first positional slot is phase 2 of
+    plan 18, deferred until the D5 tag-precedence decision (A5 §6) is confirmed.
+    """
+
+    def test_plot_sweep_with_bind_is_deterministic(self) -> None:
         keys = []
-        for use_spec in (True, False):
+        for _ in range(2):
             bench = _bench()
             try:
-                res = (
-                    bench.plot_sweep(LATENCY, plot_callbacks=False)
-                    if use_spec
-                    else bench.plot_sweep(**LATENCY.bind(), plot_callbacks=False)
-                )
+                res = bench.plot_sweep(**LATENCY.bind(), plot_callbacks=False)
                 keys.append(res.bench_cfg.hash_persistent(True))
             finally:
                 bench.close()
         self.assertEqual(keys[0], keys[1])
 
-    def test_a_keyword_argument_overrides_the_spec(self) -> None:
+    def test_a_dict_override_on_the_bound_arguments_wins(self) -> None:
         bench = _bench()
         try:
-            res = bench.plot_sweep(LATENCY, tag="override", plot_callbacks=False)
+            res = bench.plot_sweep(**{**LATENCY.bind(), "tag": "override"}, plot_callbacks=False)
         finally:
             bench.close()
         self.assertEqual(res.bench_cfg.tag, "override")
 
-    def test_the_spec_title_is_used_when_no_keyword_title_is_given(self) -> None:
+    def test_the_spec_title_reaches_the_config(self) -> None:
         bench = _bench()
         try:
-            res = bench.plot_sweep(LATENCY, plot_callbacks=False)
+            res = bench.plot_sweep(**LATENCY.bind(), plot_callbacks=False)
         finally:
             bench.close()
         self.assertEqual(res.bench_cfg.title, "Request latency")
@@ -280,7 +284,7 @@ class TestOneSpecTwoWorkers(unittest.TestCase):
     def _cfg(self, worker):
         bench = _bench(worker)
         try:
-            return bench.plot_sweep(LATENCY, plot_callbacks=False).bench_cfg
+            return bench.plot_sweep(**LATENCY.bind(), plot_callbacks=False).bench_cfg
         finally:
             bench.close()
 

--- a/test/test_sweep_spec.py
+++ b/test/test_sweep_spec.py
@@ -1,0 +1,331 @@
+"""Plan 18 — one measurement declared once, bound to several workers.
+
+The property that matters is the last test class here: one spec bound to two
+different worker classes yields two configs differing *only* in ``bench_name``,
+with identical input/const/result identity. That is what makes the drift described
+in P2 detectable, and it is unavailable while a declaration exists only as fifteen
+keyword arguments at N call sites.
+"""
+
+from __future__ import annotations
+
+import pickle
+import unittest
+
+import bencher as bn
+from bencher.example.benchmark_data import ExampleBenchCfg
+
+
+class OtherWorker(bn.ParametrizedSweep):
+    """A second worker declaring the same variable names as ExampleBenchCfg."""
+
+    theta = bn.FloatSweep(default=0, bounds=[0, 3.2], units="rad", samples=30)
+    offset = bn.FloatSweep(default=0, bounds=[0, 0.3], units="v", samples=30)
+    out_sin = bn.ResultFloat(units="v")
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.out_sin = self.theta + self.offset
+        return super().__call__(**kwargs)
+
+
+LATENCY = bn.SweepSpec(
+    title="Request latency",
+    description="declared once",
+    input_vars=[bn.sweep("theta", bounds=(0, 1), samples=3)],
+    result_vars=["out_sin"],
+    const_vars={"offset": 0.1},
+    tag="latency",
+)
+
+
+def _bench(worker=ExampleBenchCfg):
+    cfg = bn.BenchRunCfg()
+    cfg.auto_plot = False
+    cfg.cache_results = False
+    cfg.cache_samples = False
+    return worker().to_bench(cfg)
+
+
+class TestValueSemantics(unittest.TestCase):
+    def test_frozen(self) -> None:
+        with self.assertRaises(Exception):
+            LATENCY.title = "no"
+
+    def test_equality_and_pickling(self) -> None:
+        twin = bn.SweepSpec(
+            title="Request latency",
+            description="declared once",
+            input_vars=[bn.sweep("theta", bounds=(0, 1), samples=3)],
+            result_vars=["out_sin"],
+            const_vars={"offset": 0.1},
+            tag="latency",
+        )
+        self.assertEqual(LATENCY, twin)
+        self.assertEqual(pickle.loads(pickle.dumps(LATENCY)), LATENCY)
+
+    def test_unset_fields_are_absent_from_bind(self) -> None:
+        spec = bn.SweepSpec(result_vars=["out_sin"])
+        self.assertEqual(spec.bind(), {"result_vars": ["out_sin"]})
+
+    def test_empty_and_unset_input_vars_are_different(self) -> None:
+        """None auto-discovers; () declares none."""
+        self.assertNotIn("input_vars", bn.SweepSpec(result_vars=["y"]).bind())
+        self.assertEqual(bn.SweepSpec(input_vars=[], result_vars=["y"]).bind()["input_vars"], [])
+
+    def test_a_lambda_is_rejected_at_construction(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            bn.SweepSpec(result_vars=[lambda: None])
+        self.assertIn("may not contain a callable", str(ctx.exception))
+
+    def test_a_shaped_result_var_is_rejected_at_construction(self) -> None:
+        """It would otherwise raise AttributeError mid-run: result vars are not SweepBase."""
+        with self.assertRaises(TypeError) as ctx:
+            bn.SweepSpec(result_vars=[bn.sweep("out_sin", samples=3)])
+        self.assertIn("Shaping applies to inputs and consts only", str(ctx.exception))
+
+    def test_a_bare_sweep_spec_result_var_is_allowed(self) -> None:
+        spec = bn.SweepSpec(result_vars=[bn.sweep("out_sin")])
+        self.assertEqual(len(spec.bind()["result_vars"]), 1)
+
+    def test_the_deprecated_whole_list_mapping_form_is_rejected(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            bn.SweepSpec(input_vars={"theta": [0, 1]})
+        self.assertIn("must be a list, not a mapping", str(ctx.exception))
+
+    def test_a_malformed_const_entry_is_rejected(self) -> None:
+        for bad in ([("offset", 1, 2)], ["offset"], [42]):
+            with self.subTest(value=bad), self.assertRaises(TypeError):
+                bn.SweepSpec(const_vars=bad)
+
+
+class TestComposition(unittest.TestCase):
+    def test_scalars_are_replaced(self) -> None:
+        self.assertEqual(LATENCY.with_(tag="slow").tag, "slow")
+        self.assertEqual(LATENCY.tag, "latency", "with_ must not mutate")
+
+    def test_const_vars_merge_per_key(self) -> None:
+        slow = LATENCY.with_(const_vars={"timeout_s": 30})
+        self.assertEqual(dict(slow.const_vars), {"offset": 0.1, "timeout_s": 30})
+
+    def test_const_vars_override_wins_per_key(self) -> None:
+        self.assertEqual(dict(LATENCY.with_(const_vars={"offset": 0.9}).const_vars)["offset"], 0.9)
+
+    def test_result_vars_are_replaced_not_appended(self) -> None:
+        replaced = LATENCY.with_(result_vars=["out_cos"])
+        self.assertEqual(list(replaced.result_vars), ["out_cos"])
+
+    def test_input_vars_are_replaced_not_appended(self) -> None:
+        replaced = LATENCY.with_(input_vars=["offset"])
+        self.assertEqual(list(replaced.input_vars), ["offset"])
+
+    def test_plus_result_vars_appends(self) -> None:
+        more = LATENCY.plus_result_vars("out_cos", "out_bool")
+        self.assertEqual(list(more.result_vars), ["out_sin", "out_cos", "out_bool"])
+
+    def test_plus_result_vars_accepts_a_list(self) -> None:
+        more = LATENCY.plus_result_vars(["out_cos", "out_bool"])
+        self.assertEqual(list(more.result_vars), ["out_sin", "out_cos", "out_bool"])
+
+    def test_plus_input_vars_appends_last(self) -> None:
+        more = LATENCY.plus_input_vars("offset")
+        self.assertEqual(more.bind()["input_vars"][-1], "offset")
+
+    def test_merge_applies_only_declared_fields(self) -> None:
+        overlay = bn.SweepSpec(tag="slow", const_vars={"timeout_s": 30})
+        merged = LATENCY.merge(overlay)
+        self.assertEqual(merged.tag, "slow")
+        self.assertEqual(merged.title, "Request latency", "an unset field must not clear")
+        self.assertEqual(dict(merged.const_vars), {"offset": 0.1, "timeout_s": 30})
+
+    def test_an_explicit_none_clears_a_field(self) -> None:
+        self.assertIsNone(LATENCY.with_(tag=None).tag)
+
+    def test_an_unknown_field_is_rejected(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            LATENCY.with_(repeats=3)
+        self.assertIn("no field(s) ['repeats']", str(ctx.exception))
+
+    def test_run_configuration_has_no_field(self) -> None:
+        """A spec that carried repeats or run_cfg would be a rival BenchCfg."""
+        from dataclasses import fields
+
+        names = {f.name for f in fields(bn.SweepSpec)}
+        for excluded in ("repeats", "run_cfg", "plot_callbacks", "auto_plot", "aggregate"):
+            self.assertNotIn(excluded, names)
+
+
+class TestBind(unittest.TestCase):
+    def test_plot_sweep_with_a_spec_matches_plot_sweep_with_its_bind(self) -> None:
+        keys = []
+        for use_spec in (True, False):
+            bench = _bench()
+            try:
+                res = (
+                    bench.plot_sweep(LATENCY, plot_callbacks=False)
+                    if use_spec
+                    else bench.plot_sweep(**LATENCY.bind(), plot_callbacks=False)
+                )
+                keys.append(res.bench_cfg.hash_persistent(True))
+            finally:
+                bench.close()
+        self.assertEqual(keys[0], keys[1])
+
+    def test_a_keyword_argument_overrides_the_spec(self) -> None:
+        bench = _bench()
+        try:
+            res = bench.plot_sweep(LATENCY, tag="override", plot_callbacks=False)
+        finally:
+            bench.close()
+        self.assertEqual(res.bench_cfg.tag, "override")
+
+    def test_the_spec_title_is_used_when_no_keyword_title_is_given(self) -> None:
+        bench = _bench()
+        try:
+            res = bench.plot_sweep(LATENCY, plot_callbacks=False)
+        finally:
+            bench.close()
+        self.assertEqual(res.bench_cfg.title, "Request latency")
+
+    def test_bind_returns_mutable_lists(self) -> None:
+        """plot_sweep converts its variable lists in place."""
+        bound = LATENCY.bind()
+        self.assertIsInstance(bound["input_vars"], list)
+        self.assertIsInstance(bound["result_vars"], list)
+        self.assertIsInstance(bound["const_vars"], list)
+        self.assertIsInstance(bound["const_vars"][0], list)
+
+    def test_bind_does_not_share_state_between_calls(self) -> None:
+        first = LATENCY.bind()
+        first["result_vars"].append("out_cos")
+        self.assertEqual(LATENCY.bind()["result_vars"], ["out_sin"])
+
+    def test_bind_with_a_worker_checks_names_up_front(self) -> None:
+        spec = bn.SweepSpec(input_vars=["nope"], result_vars=["out_sin"])
+        with self.assertRaises(KeyError) as ctx:
+            spec.bind(ExampleBenchCfg)
+        self.assertIn("Available parameters", str(ctx.exception))
+
+    def test_bind_with_a_worker_accepts_valid_names(self) -> None:
+        self.assertIn("input_vars", LATENCY.bind(ExampleBenchCfg))
+
+    def test_bind_checks_const_and_result_names_too(self) -> None:
+        for field, spec in {
+            "const": bn.SweepSpec(const_vars={"nope": 1}),
+            "result": bn.SweepSpec(result_vars=["nope"]),
+        }.items():
+            with self.subTest(field=field), self.assertRaises(KeyError):
+                spec.bind(ExampleBenchCfg)
+
+
+class TestBindValidatesDuplicates(unittest.TestCase):
+    """The cross-plan wire: bind() runs plot_sweep's duplicate validation.
+
+    A spec is the main *source* of duplicates -- composing overlapping groups from
+    several places is exactly what specs make easy -- so it must not be able to
+    hand plot_sweep a declaration plot_sweep will then reject. Failing at bind()
+    puts the error where the composition that caused it is in view.
+    """
+
+    def test_a_duplicate_input_var_raises_at_bind(self) -> None:
+        spec = bn.SweepSpec(input_vars=["theta", "theta"], result_vars=["out_sin"])
+        with self.assertRaises(ValueError) as ctx:
+            spec.bind(ExampleBenchCfg)
+        self.assertIn("one dataset dimension", str(ctx.exception))
+
+    def test_a_duplicate_arising_from_composition_raises(self) -> None:
+        """plus_input_vars is how it happens in practice."""
+        with self.assertRaises(ValueError):
+            LATENCY.plus_input_vars("theta").bind(ExampleBenchCfg)
+
+    def test_a_duplicate_result_var_is_warned_and_dropped_once(self) -> None:
+        import warnings
+
+        spec = LATENCY.plus_result_vars("out_sin")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            bound = spec.bind(ExampleBenchCfg)
+        self.assertEqual(bound["result_vars"], ["out_sin"])
+        self.assertEqual(len([w for w in caught if "declared twice" in str(w.message)]), 1)
+
+    def test_the_survivor_is_the_caller_s_own_declaration_form(self) -> None:
+        """Bound arguments must stay bindable to a different worker, so the
+        entries returned are the spec's strings and dicts, not resolved params."""
+        bound = LATENCY.plus_result_vars("out_sin").bind(ExampleBenchCfg)
+        self.assertEqual(bound["result_vars"], ["out_sin"])
+        self.assertIsInstance(bound["input_vars"][0], dict)
+
+    def test_conflicting_duplicate_consts_raise_at_bind(self) -> None:
+        spec = bn.SweepSpec(result_vars=["out_sin"], const_vars=[("offset", 0.1), ("offset", 0.2)])
+        with self.assertRaises(ValueError) as ctx:
+            spec.bind(ExampleBenchCfg)
+        self.assertIn("different values", str(ctx.exception))
+
+    def test_equal_duplicate_consts_collapse_silently(self) -> None:
+        spec = bn.SweepSpec(result_vars=["out_sin"], const_vars=[("offset", 0.1), ("offset", 0.1)])
+        self.assertEqual(spec.bind(ExampleBenchCfg)["const_vars"], [["offset", 0.1]])
+
+    def test_bind_without_a_worker_does_not_validate(self) -> None:
+        """There is nothing to resolve names against, so plot_sweep validates instead."""
+        spec = bn.SweepSpec(input_vars=["theta", "theta"], result_vars=["out_sin"])
+        self.assertEqual(spec.bind()["input_vars"], ["theta", "theta"])
+
+    def test_a_clean_spec_is_unchanged_by_validation(self) -> None:
+        self.assertEqual(LATENCY.bind(ExampleBenchCfg), LATENCY.bind())
+
+
+class TestOneSpecTwoWorkers(unittest.TestCase):
+    """P2 — the property that makes cross-environment drift detectable."""
+
+    def _cfg(self, worker):
+        bench = _bench(worker)
+        try:
+            return bench.plot_sweep(LATENCY, plot_callbacks=False).bench_cfg
+        finally:
+            bench.close()
+
+    def test_two_workers_differ_only_in_bench_name(self) -> None:
+        a, b = self._cfg(ExampleBenchCfg), self._cfg(OtherWorker)
+        self.assertNotEqual(a.bench_name, b.bench_name)
+        self.assertEqual(a.tag, b.tag)
+        self.assertEqual([v.name for v in a.input_vars], [v.name for v in b.input_vars])
+        self.assertEqual([v.name for v in a.result_vars], [v.name for v in b.result_vars])
+        self.assertEqual(
+            sorted((c[0].name, c[1]) for c in a.const_vars),
+            sorted((c[0].name, c[1]) for c in b.const_vars),
+        )
+
+    def test_renaming_only_the_bench_name_leaves_the_rest_identical(self) -> None:
+        """The declaration is the same object, so nothing else *can* drift."""
+        a, b = self._cfg(ExampleBenchCfg), self._cfg(OtherWorker)
+        replaced = a.hash_persistent(True) != b.hash_persistent(True)
+        self.assertTrue(replaced, "bench_name is hashed, so the keys must differ")
+        for cfg in (a, b):
+            self.assertEqual(cfg.title, "Request latency")
+
+    def test_diff_specs_names_every_differing_field(self) -> None:
+        drifted = LATENCY.plus_result_vars("out_cos").with_(tag="other")
+        diff = bn.diff_specs(LATENCY, drifted)
+        self.assertEqual(len(diff), 2, diff)
+        self.assertTrue(any(line.startswith("result_vars:") for line in diff))
+        self.assertTrue(any(line.startswith("tag:") for line in diff))
+
+    def test_identical_specs_diff_to_nothing(self) -> None:
+        self.assertEqual(bn.diff_specs(LATENCY, LATENCY), [])
+
+
+class TestDescribe(unittest.TestCase):
+    def test_describe_lists_only_declared_fields_by_name(self) -> None:
+        text = bn.SweepSpec(input_vars=["theta"], result_vars=["out_sin"]).describe()
+        self.assertIn("input_vars: theta", text)
+        self.assertIn("result_vars: out_sin", text)
+        self.assertNotIn("tag", text)
+
+    def test_describe_renders_sweep_dicts_and_consts_by_name(self) -> None:
+        text = LATENCY.describe()
+        self.assertIn("input_vars: theta", text)
+        self.assertIn("const_vars: offset=0.1", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Plan 18, **phase 1 only**: `bn.SweepSpec` + `bind()` + `diff_specs`, fully additive.

*(Amended in review: the original PR also implemented phase 2 — accepting a spec in
`plot_sweep`'s first positional slot. That is entangled with D5's tag-precedence OWNER
DECISION, now owned by plan A5 §6, so it was stripped; `bench.plot_sweep(**spec.bind(W))`
delivers the full phase-1 value with zero changes to `plot_sweep`. Phase 2 returns as
A5 Phase 3, which also inverts the relationship so `plot_sweep`'s kwargs construct a
spec internally.)*

`plot_sweep` takes fifteen keyword arguments and consumes them into a `BenchCfg` inside its
own body, so there is no object representing "this sweep". A benchmark that must run
against more than one worker has one declaration and N call sites with nothing linking
them — and they drift, silently, because each side still produces a valid benchmark.

## What this adds

`bn.SweepSpec`, a frozen record of `plot_sweep`'s **seven declarative arguments only**,
with `with_` / `plus_result_vars` / `plus_input_vars` / `merge` / `bind`, plus
`bn.diff_specs`. Use it as `bench.plot_sweep(**spec.bind())`; the positional `plot_sweep(spec)` form is phase 2, deferred (see above).

Run configuration is deliberately absent — `repeats`, `run_cfg`, `plot_callbacks`,
`aggregate`, `sample_order`, `time_src`, `auto_plot` — so a spec cannot become a rival
`BenchCfg`. A callable in any field is rejected at construction, because it breaks the
equality and pickling that make two bindings comparable in the first place.

`with_`'s per-field-kind precedence is the load-bearing part:

| Field kind | Rule |
|---|---|
| scalars (`title`, `tag`, descriptions) | replaced |
| `const_vars` | shallow-merged, override wins per key |
| `input_vars`, `result_vars` | **replaced, not appended** |

Order is the dimension layout for inputs and is hashed in list order, and silent appending
is how a metric ends up declared twice — so appending has to be asked for by name.

A shaped result var (`bn.sweep("y", samples=3)`) is rejected at construction rather than
surfacing as an `AttributeError` mid-run: shaping applies to inputs and consts only, since
result variables are not `SweepBase`.

## Cross-plan wire, only possible at this stack position

Sitting on plan 20, `bind(worker)` now runs that plan's duplicate validation. A spec is the
main *source* of duplicates — composing overlapping groups from several places is exactly
what specs make easy — so a duplicate input variable fails at `bind()`, where the
composition that caused it is in view, and a duplicate result variable is warned about and
dropped once instead of twice. Comparison is on the resolved name while the entries
returned are the caller's own declaration forms, so bound arguments stay bindable to a
different worker.

## Validation

Checked against a real downstream reimplementation of this exact layer — a frozen
declaration dataclass, a per-environment overlay, and a function resolving the pair into
`plot_sweep` arguments. Re-expressed with `SweepSpec` doing the composition, **all 16 of
its (benchmark, environment) cells resolve identically**: `input_vars` by name and shape
hash, `const_vars`, `result_vars`, `tag`, `title`.

The only thing left outside the spec was that project's rule that the *environment* owns
certain constant keys, so a declaration setting one is an error rather than a last-wins
silent drop. That is a domain rule, not a composition one — the right split.

Downstream suite: 1132 passed.

## Corrected while writing the plan

A `bn.sweep(...)` shaping dict does **not** work for `result_vars` — `ResultFloat` is not a
`SweepBase`, so `with_samples` raises `AttributeError`. Shaping is input/const-only, which
is now enforced at construction.

## Not implemented here

D4's gallery example, and phase 4 (accepting a spec wherever plan 13's declaration bundle
is read), which needs plan 13 first. **D5's `tag` precedence is still an open OWNER
DECISION**, so `tag` stays a plain replaced field and nothing in this PR depends on the
answer.

---

### Stack

| | PR | Plan | Base |
|---|---|---|---|
| 1 | #1010 | 16 inspectable identity | `main` |
| 2 | #1011 | 20 duplicate declared variables | #1010 |
| 3 | #1012 | 15 stable series identity | #1011 |
| 4 | #1013 | 21 per-sample fault tolerance | #1012 |
| 5 | #1014 | 18 reusable sweep declarations | #1013 |

Review and merge bottom-up. The order is not arbitrary — it comes from the plans' own
coordination sections: 16 first because it is purely additive and gives the reviewers of
20 and 15 a way to check hashes; 20 before 15 because 20 is the one deliberate hash move
and 15 is what makes such a move legible; 18 last because its `bind()` calls 20's
validator. Two cross-plan integrations that the plan docs require are only implementable
*because* of that ordering, and are noted in the PRs that carry them (3 and 5).

Supersedes #1002 (plan-only), which is closed. Nothing here is squashed
across plans: each PR is its own plan doc plus its own implementation.

