### PR TITLE
fix: honour a declared container on ResultRerun with over_time history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ruff format`, so regenerated examples stay lint-clean. No runtime behavior change.
 
 ### Fixed
+- **A container declared on a `ResultRerun` now applies with `over_time` history too.**
+  With history off, a rerun result renders through `ds_to_container`, where a declared
+  container wins over the type's built-in viewer. With history on and more than one time
+  point, rendering is routed to `_pane_over_time_grid` instead — a separate path that
+  hardcoded `rrd_file_to_pane`, so the same benchmark honoured its declared renderer on
+  the first run and silently fell back to the rerun viewer on every run after. The grid
+  now resolves the declared container the same way, and only imports the rerun viewer
+  stack when it is the renderer actually being used. `ResultVideo`/`ResultImage` take the
+  matching `_pane_over_time_slider` path but have no container slot to honour, so they are
+  unaffected.
 - **`hover=False` on an intra-sample chart now actually disables hover.** `set_default_opts`
   registers `tools=["hover"]` as a global holoviews default for most element types, so a
   spec that merely omitted the key got hover back and the option was a silent no-op.

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1022,21 +1022,31 @@ class BenchResultBase:
 
         Used for ResultRerun because rerun iframes do not work inside a
         Bokeh JS slider swap (the viewer fails to re-initialise).
-        """
-        from bencher.utils_rrd import rrd_file_to_pane
 
+        A container declared on the result var wins over the rerun viewer, the
+        same way it does on the single-run path in ``ds_to_container``: a renderer
+        that only applied while history was off would draw one thing on the first
+        run and something else on the second.
+        """
         time_vals = list(dataset.coords["over_time"].values)
         over_time_dtype = dataset.coords["over_time"].dtype
         is_datetime = np.issubdtype(over_time_dtype, np.datetime64)
         labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
+
+        render = self.declared_container(result_var)
+        if render is None:
+            # Imported only when it is actually the renderer, so a declared
+            # container does not drag in the rerun viewer stack.
+            from bencher.utils_rrd import rrd_file_to_pane
+
+            render = partial(rrd_file_to_pane, width=result_var.width, height=result_var.height)
 
         items = []
         for idx, label in enumerate(labels):
             filepath = self._over_time_filepath(dataset, result_var, idx)
             if filepath is None:
                 continue
-            pane = rrd_file_to_pane(filepath, width=result_var.width, height=result_var.height)
-            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
+            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), render(filepath)))
 
         if not items:
             return pn.pane.Markdown("*No rerun data available*")

--- a/test/test_rerun_declared_container.py
+++ b/test/test_rerun_declared_container.py
@@ -1,0 +1,98 @@
+"""A declared container on a ResultRerun has to survive over_time.
+
+With history off, a rerun result renders through ``ds_to_container`` and a declared
+container applies. With history on and more than one time point, rendering is routed
+to ``_pane_over_time_grid`` instead — a separate path that used to hardcode the rerun
+viewer, so the same benchmark rendered its declared container on the first run and the
+rerun viewer on every run after. These tests pin both paths to the same renderer.
+
+The declared container reads the stored path itself, so the sweep can write plain text
+files rather than real recordings: what is under test is which renderer is called, not
+what the rerun viewer does with an .rrd.
+"""
+
+import unittest
+from datetime import datetime, timedelta
+
+import panel as pn
+
+import bencher as bn
+
+SIDES = [3, 4]
+SNAPSHOTS = 2
+
+
+def file_contents(path: str) -> pn.pane.Markdown:
+    """A declared container that renders the file rather than the rerun viewer."""
+    with open(path, encoding="utf-8") as handle:
+        return pn.pane.Markdown(f"contents: {handle.read()}")
+
+
+class RerunSweep(bn.ParametrizedSweep):
+    """A ResultRerun declaring how it renders, in place of the rerun viewer."""
+
+    sides = bn.IntSweep(default=3, bounds=[3, 4], samples=2)
+    recording = bn.ResultRerun(width=400, height=400, container=file_contents)
+
+    offset = 0
+
+    def benchmark(self):
+        filename = bn.gen_path("recording", suffix=".txt")
+        with open(filename, "w", encoding="utf-8") as handle:
+            handle.write(f"sides {self.sides} run {self.offset}")
+        self.recording = filename
+
+
+def run_over_time(worker: bn.ParametrizedSweep, name: str, snapshots: int):
+    """Run the sweep once per time point, so over_time carries real history."""
+    run_cfg = bn.BenchRunCfg(over_time=True, repeats=1, auto_plot=False)
+    bench = worker.to_bench(run_cfg)
+    base_time = datetime(2000, 1, 1)
+    res = None
+    for i in range(snapshots):
+        worker.offset = i
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            name,
+            input_vars=["sides"],
+            result_vars=["recording"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+    return res
+
+
+def markdown_text(view) -> list[str]:
+    return [p.object for p in view.select(pn.pane.Markdown)]
+
+
+class TestRerunDeclaredContainerOverTime(unittest.TestCase):
+    """The grid path must use the declared container, at every time point."""
+
+    def test_declared_container_renders_every_time_point(self):
+        res = run_over_time(RerunSweep(), "test_rerun_container_history", SNAPSHOTS)
+        view = res.to_auto(plot_list=["panes"])
+        rendered = [t for t in markdown_text(view) if t.startswith("contents: ")]
+
+        # One pane per (side, time point): the grid renders the whole history,
+        # not just the run being reported.
+        self.assertEqual(len(rendered), len(SIDES) * SNAPSHOTS)
+        for run in range(SNAPSHOTS):
+            self.assertIn(f"contents: sides 3 run {run}", rendered)
+            self.assertIn(f"contents: sides 4 run {run}", rendered)
+
+    def test_single_run_and_history_agree(self):
+        """The whole point: one time point and several render through one renderer."""
+        single = run_over_time(RerunSweep(), "test_rerun_container_single", 1)
+        history = run_over_time(RerunSweep(), "test_rerun_container_multi", SNAPSHOTS)
+
+        single_text = [t for t in markdown_text(single.to_auto(plot_list=["panes"]))]
+        history_text = [t for t in markdown_text(history.to_auto(plot_list=["panes"]))]
+
+        self.assertTrue(any(t.startswith("contents: ") for t in single_text))
+        self.assertTrue(any(t.startswith("contents: ") for t in history_text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_rerun_declared_container.py
+++ b/test/test_rerun_declared_container.py
@@ -87,8 +87,8 @@ class TestRerunDeclaredContainerOverTime(unittest.TestCase):
         single = run_over_time(RerunSweep(), "test_rerun_container_single", 1)
         history = run_over_time(RerunSweep(), "test_rerun_container_multi", SNAPSHOTS)
 
-        single_text = [t for t in markdown_text(single.to_auto(plot_list=["panes"]))]
-        history_text = [t for t in markdown_text(history.to_auto(plot_list=["panes"]))]
+        single_text = list(markdown_text(single.to_auto(plot_list=["panes"])))
+        history_text = list(markdown_text(history.to_auto(plot_list=["panes"])))
 
         self.assertTrue(any(t.startswith("contents: ") for t in single_text))
         self.assertTrue(any(t.startswith("contents: ") for t in history_text))


### PR DESCRIPTION
Follow-up to #994, which gave `ResultRerun` a declared-container slot. The slot only worked while history was off.

## The bug

With `over_time` active and more than one time point, rendering does not go through `ds_to_container` — it is routed to `_pane_over_time_grid` (`bench_result_base.py:908`), a separate path that hardcoded `rrd_file_to_pane` and never consulted the declared renderer.

So the same benchmark rendered its own container on the first run and silently fell back to the rerun viewer on every run after. Nothing reported it; the container just stopped applying.

## The fix

`_pane_over_time_grid` now resolves `declared_container(result_var)` and uses it as the renderer, with `rrd_file_to_pane` as the fallback via `partial`. The rerun viewer import moved inside that fallback branch, so declaring a container no longer drags in the rerun viewer stack.

`_pane_over_time_slider` — the matching `ResultVideo`/`ResultImage` path — is untouched. Those types have no container slot, so handling it there would be dead code today.

## Tests

New `test/test_rerun_declared_container.py` runs a real two-snapshot `over_time` sweep and asserts:

- the declared container renders at **every** time point (4 panes: 2 sides × 2 snapshots, each with the right per-run contents) — the grid renders the whole history, not just the run being reported
- single-run and history render through the same renderer

Verified these catch the bug: with the fix reverted, **2 of 3 fail**.

A third draft test (asserting no rerun iframe was built) passed *without* the fix too, so it was dropped rather than shipped as an assertion that proves nothing.

The sweep writes plain text files rather than real `.rrd` recordings — `_over_time_filepath` only checks `os.path.isfile`, and what is under test is which renderer gets called, not what the viewer does with a recording. Keeps the test free of the rerun SDK.

`pixi run ci` green.

## Not addressed here

Two other things surfaced reviewing #994, left for separate PRs:

- `ResultReference` inverts the precedence #994 documents. The changelog claims a uniform renderer-supplied → sample → class → default order; `ResultDataSet` implements it, `ResultReference` returns its declared container *before* the renderer-supplied one (`bench_result_base.py:1131-1146`). Reachable via `to_video()`.
- `ResultImage`/`ResultVideo` never got the slot, though both are in `PANEL_TYPES` with a `to_container()`. #994's changelog explains the `ResultVolume` exclusion but not these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure declared containers on ResultRerun are honoured when rendering over_time history, aligning grid rendering with the single-run path.

Bug Fixes:
- Fix ResultRerun over_time grid rendering to use a declared container instead of always falling back to the rerun viewer, so containers apply consistently across time points.

Documentation:
- Document the ResultRerun over_time container fix in the changelog, including behavior and unaffected result types.

Tests:
- Add integration-style tests that run a multi-snapshot over_time sweep to verify declared containers render at every time point and that single-run and history paths use the same renderer.