### PR TITLE
feat: merge a sweep's rerun recordings into one viewer

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -146,6 +146,7 @@ try:
         RerunRecording,
         RerunViewKind,
     )
+    from .results.rerun_summary import RerunSummaryResult
 except ModuleNotFoundError:
     pass
 

--- a/bencher/example/generated/rerun/example_rerun_summary.py
+++ b/bencher/example/generated/rerun/example_rerun_summary.py
@@ -1,0 +1,63 @@
+"""Auto-generated example: Rerun Summary — merge a whole sweep into one viewer."""
+
+import rerun as rr
+
+import bencher as bn
+
+
+class RerunSummarySweep(bn.ParametrizedSweep):
+    """Record a step response per sample, then merge the whole sweep into one viewer.
+
+    Sweeping a ``ResultRerun`` normally embeds one rerun web viewer *per sample*,
+    so this 3x2 sweep would spawn six independent wasm viewers with no way to
+    compare across them.  ``rerun_summary`` merges every recording into a single
+    recording plus blueprint instead.
+    """
+
+    damping = bn.FloatSweep(default=0.5, bounds=[0.2, 0.9], samples=3)
+    omega_n = bn.FloatSweep(default=6.0, bounds=[4.0, 8.0], samples=2)
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        recording = rr.RecordingStream("rerun_summary_sample", make_default=False)
+        n_steps, dt = 80, 0.025
+        y, dy, trace = 0.0, 0.0, []
+        for step in range(n_steps):
+            # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+            ddy = self.omega_n**2 * (1.0 - y) - 2 * self.damping * self.omega_n * dy
+            dy += ddy * dt
+            y += dy * dt
+            trace.append([step * dt, y])
+
+            recording.set_time("time_s", duration=step * dt)
+            recording.log("scene/trace", rr.LineStrips2D([trace]))
+            recording.log("metrics/output", rr.Scalars(y))
+
+        self.out_rerun = bn.capture_rerun_rrd(recording)
+        return super().benchmark()
+
+
+def example_rerun_summary(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Rerun Summary — merge a whole sweep into one viewer."""
+    bench = RerunSummarySweep().to_bench(run_cfg)
+    bench.plot_sweep(
+        input_vars=["damping", "omega_n"],
+        result_vars=["out_rerun"],
+        description="Each of the six samples records its own step response to a separate "
+        "``.rrd``, which is what diskcache keys on.  ``rerun_summary`` walks the result "
+        "dataset afterwards and merges all six into ONE recording, re-homing each sample "
+        "under its own entity-path branch and generating a Blueprint to lay them out.  "
+        "The result is a single embedded viewer instead of six, and because everything "
+        "shares one recording the samples can be scrubbed on a common timeline.",
+        post_description="``rerun_summary`` sequences every dimension onto one timeline; "
+        "``rerun_grid`` lays the dimensions out in space instead.  Both are named-only "
+        "plot types because merging every recording is expensive.",
+        plot_callbacks=[bn.BenchResult.to_rerun_summary],
+    )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_rerun_summary)

--- a/bencher/example/meta/generate_meta_rerun.py
+++ b/bencher/example/meta/generate_meta_rerun.py
@@ -6,6 +6,7 @@ Generates rerun examples for:
 - sweep: 1 input var (damping_ratio), single sweep, no over_time
 - composable_{right,down,sequence,overlay}: combine two complete recordings, each
   animated over a ``time_s`` timeline so the composition modes are distinguishable
+- summary: 2 input vars, every per-sample recording merged into ONE viewer
 """
 
 import bencher as bn
@@ -21,6 +22,7 @@ RERUN_EXAMPLES = [
     "composable_down",
     "composable_sequence",
     "composable_overlay",
+    "summary",
 ]
 
 # What each composition mode does to the two recordings, appended to the
@@ -53,6 +55,8 @@ class MetaRerun(MetaGeneratorBase):
             self._generate_sweep()
         elif self.example.startswith("composable_"):
             self._generate_composable(self.example.removeprefix("composable_"))
+        elif self.example == "summary":
+            self._generate_summary()
 
     def _generate_capture_window(self):
         """Capture a rerun viewer window as a Panel widget inside a sweep."""
@@ -167,6 +171,69 @@ bench.plot_sweep(
             imports=imports,
             body=body,
             run_kwargs={"subsampling_divisions": 3},
+        )
+
+    def _generate_summary(self):
+        """Merge every per-sample recording of a sweep into a single viewer."""
+        imports = "import rerun as rr\n\nimport bencher as bn"
+        class_code = '''
+class RerunSummarySweep(bn.ParametrizedSweep):
+    """Record a step response per sample, then merge the whole sweep into one viewer.
+
+    Sweeping a ``ResultRerun`` normally embeds one rerun web viewer *per sample*,
+    so this 3x2 sweep would spawn six independent wasm viewers with no way to
+    compare across them.  ``rerun_summary`` merges every recording into a single
+    recording plus blueprint instead.
+    """
+
+    damping = bn.FloatSweep(default=0.5, bounds=[0.2, 0.9], samples=3)
+    omega_n = bn.FloatSweep(default=6.0, bounds=[4.0, 8.0], samples=2)
+
+    out_rerun = bn.ResultRerun(width=900, height=520)
+
+    def benchmark(self):
+        recording = rr.RecordingStream("rerun_summary_sample", make_default=False)
+        n_steps, dt = 80, 0.025
+        y, dy, trace = 0.0, 0.0, []
+        for step in range(n_steps):
+            # Euler integration of  y'' + 2*zeta*wn*y' + wn^2*y = wn^2
+            ddy = self.omega_n**2 * (1.0 - y) - 2 * self.damping * self.omega_n * dy
+            dy += ddy * dt
+            y += dy * dt
+            trace.append([step * dt, y])
+
+            recording.set_time("time_s", duration=step * dt)
+            recording.log("scene/trace", rr.LineStrips2D([trace]))
+            recording.log("metrics/output", rr.Scalars(y))
+
+        self.out_rerun = bn.capture_rerun_rrd(recording)
+        return super().benchmark()
+'''
+        body = """\
+bench = RerunSummarySweep().to_bench(run_cfg)
+bench.plot_sweep(
+    input_vars=["damping", "omega_n"],
+    result_vars=["out_rerun"],
+    description="Each of the six samples records its own step response to a separate "
+    "``.rrd``, which is what diskcache keys on.  ``rerun_summary`` walks the result "
+    "dataset afterwards and merges all six into ONE recording, re-homing each sample "
+    "under its own entity-path branch and generating a Blueprint to lay them out.  "
+    "The result is a single embedded viewer instead of six, and because everything "
+    "shares one recording the samples can be scrubbed on a common timeline.",
+    post_description="``rerun_summary`` sequences every dimension onto one timeline; "
+    "``rerun_grid`` lays the dimensions out in space instead.  Both are named-only "
+    "plot types because merging every recording is expensive.",
+    plot_callbacks=[bn.BenchResult.to_rerun_summary],
+)
+"""
+        self.generate_example(
+            title="Rerun Summary — merge a whole sweep into one viewer",
+            output_dir=OUTPUT_DIR,
+            filename="example_rerun_summary",
+            function_name="example_rerun_summary",
+            imports=imports,
+            class_code=class_code,
+            body=body,
         )
 
     def _generate_composable(self, compose: str):

--- a/bencher/plugins/builtins.py
+++ b/bencher/plugins/builtins.py
@@ -111,6 +111,7 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
     from bencher.results.holoview_results.xy_histogram_result import XYHistogramResult
     from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
     from bencher.results.rerun_result import RerunResult
+    from bencher.results.rerun_summary import RerunSummaryResult
     from bencher.results.video_summary import VideoSummaryResult
 
     # Appended rather than grouped next to "dataset" so existing priorities keep their
@@ -127,6 +128,10 @@ def _named_only_specs() -> list[tuple[str, str, Callable]]:
         ("dataset", "panel", DataSetResult.to_plot),
         ("video_summary", "panel", VideoSummaryResult.to_video_summary),
         ("rerun", "rerun", RerunResult.to_rerun),
+        # Merge every per-sample ResultRerun recording into one viewer.  Named-only
+        # (like video_summary) because merging every recording is expensive.
+        ("rerun_summary", "rerun", RerunSummaryResult.to_rerun_summary),
+        ("rerun_grid", "rerun", RerunSummaryResult.to_rerun_grid),
         ("xy_scatter", "holoviews", XYScatterResult.to_plot),
         ("xy_curve", "holoviews", XYCurveResult.to_plot),
         ("xy_histogram", "holoviews", XYHistogramResult.to_plot),

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -49,6 +49,7 @@ from bencher.results.holoview_results.xy_histogram_result import XYHistogramResu
 from bencher.results.holoview_results.xy_scatter_result import XYScatterResult
 from bencher.results.optuna_result import OptunaResult
 from bencher.results.pane_result import PaneResult
+from bencher.results.rerun_summary import RerunSummaryResult
 from bencher.results.video_summary import VideoSummaryResult
 from bencher.results.volume_result import VolumeResult
 from bencher.utils import listify, resolve_aggregate
@@ -90,6 +91,7 @@ class BenchResult(
     XYHexbinResult,
     HoloviewResult,
     VideoSummaryResult,
+    RerunSummaryResult,
     DataSetResult,
     OptunaResult,
 ):  # pylint: disable=too-many-ancestors

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -30,6 +30,43 @@ class ComposeType(StrEnum):
         return ComposeType.right if horizontal else ComposeType.down
 
 
+def compose_method_list_for_dims(
+    num_dims: int,
+    first_compose_method: ComposeType = ComposeType.down,
+    time_sequence_dimension: int = 0,
+) -> list[ComposeType]:
+    """Choose a composition method per dimension for a *num_dims*-dimensional sweep.
+
+    By default the methods alternate between right and down (so nested dimensions
+    stay readable) and a trailing sequence is appended for the level that varies
+    fastest.  Levels up to *time_sequence_dimension* are forced to sequence.
+
+    Args:
+        num_dims (int): Number of dimensions being composed.
+        first_compose_method (ComposeType, optional): Direction of the first
+            composition. Defaults to ComposeType.down.
+        time_sequence_dimension (int, optional): Compose dimensions up to this
+            index in time rather than in space. ``-1`` sequences everything.
+            Defaults to 0.
+
+    Returns:
+        list[ComposeType]: One composition method per level, consumed from the end.
+    """
+    if time_sequence_dimension == -1:  # use time sequence for everything
+        return [ComposeType.sequence] * (num_dims + 1)
+
+    compose_method_list = [first_compose_method]
+    compose_method_list.extend(
+        ComposeType.flip(compose_method_list[-1]) for _ in range(num_dims - 1)
+    )
+    compose_method_list.append(ComposeType.sequence)
+
+    for i in range(min(len(compose_method_list), time_sequence_dimension + 1)):
+        compose_method_list[i] = ComposeType.sequence
+
+    return compose_method_list
+
+
 class PaneLayout(StrEnum):
     """Controls how multi-dimensional data is laid out in panel displays.
 

--- a/bencher/results/rerun_summary.py
+++ b/bencher/results/rerun_summary.py
@@ -1,0 +1,255 @@
+"""Combine the per-sample rerun recordings of a sweep into one viewer.
+
+``ResultRerun`` records one ``.rrd`` per benchmark sample — that is the unit
+diskcache keys on, so it has to stay that way.  Rendering a sweep therefore
+means one embedded web viewer *per sample*: a 3x3 sweep spawns nine independent
+wasm viewers and nothing can be compared across them.
+
+:class:`~bencher.results.composable_container.composable_container_rerun.ComposableContainerRerun`
+already knows how to merge several complete recordings into one recording plus
+blueprint, but it is driven from inside ``benchmark()``, where only a single
+sample's recordings are visible.  This module drives the same container from the
+*result* side instead: it walks the result dataset, collects the cached ``.rrd``
+path of every sample, and composes them by ``ComposeType``.
+
+Because the container both accepts ``.rrd`` paths and renders to one, nesting is
+just recursion — each sweep dimension builds a container whose children are
+either leaf sample paths or the rendered output of the dimension below it.
+
+Mirrors :class:`~bencher.results.video_summary.VideoSummaryResult`, which does
+the same thing for ``ResultImage``/``ResultVideo`` samples.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from copy import deepcopy
+
+import panel as pn
+import xarray as xr
+from param import Parameter
+
+from bencher.plotting.plot_filter import PlotFilter, VarRange
+from bencher.results.bench_result_base import BenchResultBase, ReduceType
+from bencher.results.composable_container.composable_container_base import (
+    ComposeType,
+    compose_method_list_for_dims,
+)
+from bencher.results.composable_container.composable_container_rerun import (
+    ComposableContainerRerun,
+)
+from bencher.utils import callable_name
+from bencher.variables.results import ResultRerun, result_is_missing
+
+logger = logging.getLogger(__name__)
+
+
+class RerunSummaryResult(BenchResultBase):
+    """Renders all ``ResultRerun`` samples of a sweep as one merged recording."""
+
+    def to_rerun_summary(
+        self,
+        result_var: Parameter | None = None,
+        result_types=(ResultRerun,),
+        **kwargs,
+    ) -> pn.panel | None:
+        """Merge every recording into one viewer, played back as a time sequence.
+
+        Every swept dimension is composed in time rather than in space, so the
+        samples play one after another on a single timeline instead of tiling
+        into nested grids.
+
+        Args:
+            result_var (Parameter, optional): The result var to render. Defaults to None (all).
+            result_types (tuple, optional): Result types to render. Defaults to (ResultRerun,).
+            **kwargs: Passed through to :meth:`to_rerun_grid`.
+
+        Returns:
+            pn.panel | None: a panel pane holding a single rerun viewer.
+        """
+        return self.to_rerun_grid(
+            result_var=result_var,
+            result_types=result_types,
+            time_sequence_dimension=-1,
+            **kwargs,
+        )
+
+    def to_rerun_grid(
+        self,
+        result_var: Parameter | None = None,
+        result_types=(ResultRerun,),
+        pane_collection: pn.pane = None,
+        time_sequence_dimension: int = 0,
+        compose_method_list: list | None = None,
+        reverse: bool = False,
+        **kwargs,
+    ) -> pn.panel | None:
+        """Merge every recording of the sweep into one embedded rerun viewer.
+
+        Args:
+            result_var (Parameter, optional): The result var to render. Defaults to None (all).
+            result_types (tuple, optional): Result types to render. Defaults to (ResultRerun,).
+            pane_collection (pn.pane, optional): Collection to stack multiple result
+                vars into. Defaults to ``pn.Row()``.
+            time_sequence_dimension (int, optional): Compose dimensions up to this index
+                onto a timeline instead of in space. ``-1`` sequences every dimension.
+                Defaults to 0.
+            compose_method_list (list, optional): Explicit per-dimension composition
+                methods, overriding the defaults. See ``bn.ComposeType``.
+            reverse (bool, optional): Reverse the dimension order. Defaults to False.
+            **kwargs: Passed to the viewer pane (e.g. ``width``, ``height``).
+
+        Returns:
+            pn.panel | None: a panel pane holding one rerun viewer per result var.
+        """
+        plot_filter = PlotFilter(
+            float_range=VarRange(0, None),
+            cat_range=VarRange(0, None),
+            panel_range=VarRange(1, None),
+            input_range=VarRange(1, None),
+        )
+        matches_res = plot_filter.matches_result(
+            self.plt_cnt_cfg, callable_name(self.to_rerun_grid), override=False
+        )
+        if not matches_res.overall:
+            return matches_res.to_panel()
+
+        if pane_collection is None:
+            pane_collection = pn.Row()
+
+        dataset = self.to_dataset(ReduceType.SQUEEZE, deep=False)
+        for rv in self.get_results_var_list(result_var):
+            if isinstance(rv, result_types):
+                pane = self.to_rerun_grid_ds(
+                    dataset,
+                    rv,
+                    time_sequence_dimension=time_sequence_dimension,
+                    compose_method_list=compose_method_list,
+                    reverse=reverse,
+                    **kwargs,
+                )
+                if pane is not None:
+                    pane_collection.append(pane)
+        return pane_collection
+
+    def to_rerun_grid_ds(
+        self,
+        dataset: xr.Dataset,
+        result_var: Parameter,
+        time_sequence_dimension: int = 0,
+        compose_method_list: list | None = None,
+        reverse: bool = False,
+        target_dimension: int = 0,
+        width: int | None = None,
+        height: int | None = None,
+        **kwargs,
+    ) -> pn.pane.HTML | None:
+        """Merge *result_var*'s recordings in *dataset* into one viewer pane.
+
+        Args:
+            dataset (xr.Dataset): The dataset holding the benchmark results.
+            result_var (Parameter): The result variable to render.
+            time_sequence_dimension (int, optional): See :meth:`to_rerun_grid`. Defaults to 0.
+            compose_method_list (list, optional): Explicit composition methods.
+            reverse (bool, optional): Reverse the dimension order. Defaults to False.
+            target_dimension (int, optional): Recursion floor. Defaults to 0.
+            width (int, optional): Viewer width. Defaults to the result var's width.
+            height (int, optional): Viewer height. Defaults to the result var's height.
+            **kwargs: Unused, accepted for parity with other renderers.
+
+        Returns:
+            pn.pane.HTML | None: the viewer pane, or None if nothing was recorded.
+        """
+        from bencher.utils_rrd import rrd_file_to_pane
+
+        merged = self._compose_ds(
+            dataset,
+            result_var=result_var,
+            target_dimension=target_dimension,
+            time_sequence_dimension=time_sequence_dimension,
+            compose_method_list=compose_method_list,
+            reverse=reverse,
+        )
+        if merged is None:
+            logger.debug("no rerun recordings to compose for %s", result_var.name)
+            return None
+
+        return rrd_file_to_pane(
+            merged,
+            width=width if width is not None else result_var.width,
+            height=height if height is not None else result_var.height,
+        )
+
+    def _compose_ds(
+        self,
+        dataset: xr.Dataset,
+        result_var: Parameter,
+        target_dimension: int = 0,
+        compose_method: ComposeType = ComposeType.right,
+        compose_method_list: list | None = None,
+        time_sequence_dimension: int = 0,
+        reverse: bool = False,
+    ) -> str | None:
+        """Recursively compose *dataset* into a single ``.rrd`` path.
+
+        Peels one dimension per level (outermost last, matching
+        ``VideoSummaryResult._to_video_panes_ds``).  Each level renders its own
+        ``.rrd``, which the level above appends as a child recording, so the
+        merge engine in ``ComposableContainerRerun`` is reused unchanged.
+
+        Returns:
+            str | None: path to the composed recording, or None if this branch
+            of the sweep recorded nothing.
+        """
+        num_dims = len(dataset.sizes)
+        dims = list(dataset.sizes)
+        if reverse:
+            dims = list(reversed(dims))
+
+        if compose_method_list is None:
+            compose_method_list = compose_method_list_for_dims(
+                num_dims,
+                first_compose_method=compose_method,
+                time_sequence_dimension=time_sequence_dimension,
+            )
+
+        remaining = deepcopy(compose_method_list)
+        if len(remaining) > 1:
+            compose_method = remaining.pop()
+
+        if num_dims <= target_dimension or num_dims == 0:
+            return self._leaf_path(dataset, result_var)
+
+        selected_dim = dims[-1]
+        outer = ComposableContainerRerun(compose_method=compose_method, name=selected_dim)
+        for i in range(dataset.sizes[selected_dim]):
+            sliced = dataset.isel({selected_dim: i})
+            child = self._compose_ds(
+                sliced,
+                result_var=result_var,
+                target_dimension=target_dimension,
+                compose_method_list=remaining,
+                time_sequence_dimension=time_sequence_dimension,
+            )
+            if child is None:
+                continue
+            # Label each child with the slice it represents so the generated
+            # blueprint names its view after the swept value.
+            label_val = sliced.coords[selected_dim].values.item()
+            outer.append(child, label=f"{selected_dim}={label_val}")
+
+        if not outer.container:
+            return None
+        return outer.render()
+
+    def _leaf_path(self, dataset: xr.Dataset, result_var: Parameter) -> str | None:
+        """Return the ``.rrd`` path for a fully-sliced *dataset*, or None if unrecorded."""
+        value = self.zero_dim_da_to_val(dataset[result_var.name])
+        if result_is_missing(result_var, value):
+            return None
+        path = str(value)
+        if not path or not os.path.isfile(path):
+            logger.debug("rerun recording %s missing on disk", path)
+            return None
+        return path

--- a/bencher/results/rerun_summary.py
+++ b/bencher/results/rerun_summary.py
@@ -143,7 +143,7 @@ class RerunSummaryResult(BenchResultBase):
         target_dimension: int = 0,
         width: int | None = None,
         height: int | None = None,
-        **kwargs,
+        **_kwargs,
     ) -> pn.pane.HTML | None:
         """Merge *result_var*'s recordings in *dataset* into one viewer pane.
 
@@ -156,13 +156,12 @@ class RerunSummaryResult(BenchResultBase):
             target_dimension (int, optional): Recursion floor. Defaults to 0.
             width (int, optional): Viewer width. Defaults to the result var's width.
             height (int, optional): Viewer height. Defaults to the result var's height.
-            **kwargs: Unused, accepted for parity with other renderers.
+            **_kwargs: Unused, accepted for parity with other renderers (plot
+                callbacks are invoked with ``override=``).
 
         Returns:
             pn.pane.HTML | None: the viewer pane, or None if nothing was recorded.
         """
-        from bencher.utils_rrd import rrd_file_to_pane
-
         merged = self._compose_ds(
             dataset,
             result_var=result_var,
@@ -174,6 +173,17 @@ class RerunSummaryResult(BenchResultBase):
         if merged is None:
             logger.debug("no rerun recordings to compose for %s", result_var.name)
             return None
+
+        # A container declared on the result var wins over the rerun viewer, the same
+        # precedence ds_to_container and the over_time path use.  The composition is
+        # itself an .rrd path, so a single-argument renderer applies unchanged.
+        render = self.declared_container(result_var)
+        if render is not None:
+            return render(merged)
+
+        # Imported only when it is actually the renderer, so a declared container
+        # does not drag in the rerun viewer stack.
+        from bencher.utils_rrd import rrd_file_to_pane
 
         return rrd_file_to_pane(
             merged,

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -9,6 +9,9 @@ from param import Parameter
 
 from bencher.plotting.plot_filter import PlotFilter, VarRange
 from bencher.results.bench_result_base import BenchResultBase, ReduceType
+from bencher.results.composable_container.composable_container_base import (
+    compose_method_list_for_dims,
+)
 from bencher.results.composable_container.composable_container_video import (
     ComposableContainerVideo,
     ComposeType,
@@ -164,20 +167,11 @@ class VideoSummaryResult(BenchResultBase):
             list[ComposeType]: A list of composition methods for composing the dataset result
         """
 
-        num_dims = len(dataset.sizes)
-        if time_sequence_dimension == -1:  # use time sequence for everything
-            compose_method_list = [ComposeType.sequence] * (num_dims + 1)
-        else:
-            compose_method_list = [first_compose_method]
-            compose_method_list.extend(
-                ComposeType.flip(compose_method_list[-1]) for _ in range(num_dims - 1)
-            )
-            compose_method_list.append(ComposeType.sequence)
-
-            for i in range(min(len(compose_method_list), time_sequence_dimension + 1)):
-                compose_method_list[i] = ComposeType.sequence
-
-        return compose_method_list
+        return compose_method_list_for_dims(
+            len(dataset.sizes),
+            first_compose_method=first_compose_method,
+            time_sequence_dimension=time_sequence_dimension,
+        )
 
     def _to_video_panes_ds(
         self,

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -279,6 +279,27 @@ View types are inferred from recorded archetypes; pass `view_kinds=` to `append(
 to override inference. See the
 [Rerun Integration gallery](reference/meta/rerun/index) for complete examples.
 
+That composition happens *inside* `benchmark()`, so it can only combine recordings
+made by a single sample. To combine the recordings of a whole **sweep**, use the
+`rerun_summary` or `rerun_grid` plot callbacks instead. Each sample still caches its
+own `.rrd`, but the renderer merges them all into one recording, so a sweep shows a
+single viewer rather than one embedded viewer per sample:
+
+```python
+bench.plot_sweep(
+    input_vars=["damping", "omega_n"],
+    result_vars=["out_rerun"],
+    plot_callbacks=[bn.BenchResult.to_rerun_summary],
+)
+```
+
+`to_rerun_summary()` puts every dimension on one timeline so the samples can be
+scrubbed together; `to_rerun_grid()` lays the dimensions out in space instead and
+takes `compose_method_list=` for explicit per-dimension control. Both are named-only
+plot types — like `video_summary`, they are opt-in because merging every recording is
+expensive. This is the `ResultRerun` counterpart to `video_summary` for
+`ResultImage`/`ResultVideo`.
+
 ## Running a Sweep
 
 ```python

--- a/test/test_rerun_summary.py
+++ b/test/test_rerun_summary.py
@@ -1,0 +1,116 @@
+"""Tests for merging a sweep's per-sample rerun recordings into one viewer."""
+
+import rerun as rr
+from rerun.experimental import RrdReader
+
+import bencher as bn
+from bencher.results.bench_result_base import ReduceType
+from bencher.results.composable_container.composable_container_base import (
+    ComposeType,
+    compose_method_list_for_dims,
+)
+
+
+class RerunSweep(bn.ParametrizedSweep):
+    """Records one short scalar timeline per sample."""
+
+    freq = bn.FloatSweep(default=1.0, bounds=[1.0, 3.0], samples=3)
+    amp = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    out_rerun = bn.ResultRerun(width=200, height=150)
+
+    def benchmark(self):
+        recording = rr.RecordingStream("test_rerun_summary", make_default=False)
+        for step in range(4):
+            recording.set_time("time_s", duration=step * 0.1)
+            recording.log("wave", rr.Scalars(self.amp * self.freq * step))
+        self.out_rerun = bn.capture_rerun_rrd(recording)
+        return super().benchmark()
+
+
+def _leaf_entity_paths(path: str) -> set[str]:
+    """Return the data entity paths of a composed recording."""
+    reader = RrdReader(str(path))
+    return {
+        str(chunk.entity_path)
+        for chunk in reader.stream(store=reader.recordings()[0])
+        if str(chunk.entity_path).endswith("/wave")
+    }
+
+
+def _sweep(input_vars):
+    bench = RerunSweep().to_bench()
+    return bench.plot_sweep(input_vars=input_vars, result_vars=["out_rerun"])
+
+
+class TestComposeMethodListForDims:
+    def test_alternates_and_appends_sequence(self):
+        methods = compose_method_list_for_dims(2, first_compose_method=ComposeType.down)
+        assert methods[-1] == ComposeType.sequence
+        # down -> right alternation, plus the trailing sequence.
+        assert methods[1] == ComposeType.right
+
+    def test_negative_sequences_everything(self):
+        methods = compose_method_list_for_dims(3, time_sequence_dimension=-1)
+        assert methods == [ComposeType.sequence] * 4
+
+    def test_forces_sequence_up_to_dimension(self):
+        methods = compose_method_list_for_dims(3, time_sequence_dimension=1)
+        assert methods[0] == ComposeType.sequence
+        assert methods[1] == ComposeType.sequence
+
+    def test_matches_video_summary_helper(self):
+        """The extracted helper must agree with VideoSummaryResult's method."""
+        res = _sweep(["freq"])
+        dataset = res.to_dataset(ReduceType.SQUEEZE, deep=False)
+        assert res.dataset_to_compose_list(dataset) == compose_method_list_for_dims(
+            len(dataset.sizes)
+        )
+
+
+class TestRerunSummary:
+    def test_one_pane_for_a_2d_sweep(self):
+        """A 3x2 sweep collapses to a single viewer pane, not six."""
+        res = _sweep(["freq", "amp"])
+        assert dict(res.to_dataset().sizes) == {"freq": 3, "amp": 2}
+        pane = res.to_rerun_grid()
+        assert pane is not None
+        assert len(pane) == 1
+
+    def test_every_sample_reaches_the_merged_recording(self):
+        """Nesting must not drop samples: 3x2 leaves land in one recording."""
+        res = _sweep(["freq", "amp"])
+        rv = res.bench_cfg.result_vars[0]
+        merged = res._compose_ds(res.to_dataset(ReduceType.SQUEEZE, deep=False), result_var=rv)
+        assert merged is not None
+        paths = _leaf_entity_paths(merged)
+        assert len(paths) == 6, paths
+        # Two levels of nesting, one per swept dimension.
+        assert all(p.count("/item_") == 2 for p in paths), paths
+
+    def test_1d_sweep_composes(self):
+        res = _sweep(["freq"])
+        rv = res.bench_cfg.result_vars[0]
+        merged = res._compose_ds(res.to_dataset(ReduceType.SQUEEZE, deep=False), result_var=rv)
+        assert merged is not None
+        assert len(_leaf_entity_paths(merged)) == 3
+
+    def test_summary_sequences_every_dimension(self):
+        """to_rerun_summary is to_rerun_grid with everything on a timeline."""
+        res = _sweep(["freq", "amp"])
+        pane = res.to_rerun_summary()
+        assert pane is not None
+        assert len(pane) == 1
+
+    def test_explicit_compose_method_list(self):
+        res = _sweep(["freq", "amp"])
+        pane = res.to_rerun_grid(
+            compose_method_list=[ComposeType.right, ComposeType.down, ComposeType.sequence]
+        )
+        assert pane is not None
+        assert len(pane) == 1
+
+    def test_registered_as_named_only_plots(self):
+        from bencher.plugins.builtins import _named_only_specs
+
+        names = {name for name, _, _ in _named_only_specs()}
+        assert {"rerun_summary", "rerun_grid"} <= names

--- a/test/test_rerun_summary.py
+++ b/test/test_rerun_summary.py
@@ -1,5 +1,12 @@
 """Tests for merging a sweep's per-sample rerun recordings into one viewer."""
 
+# _compose_ds is exercised directly: it returns the composed .rrd path, which the
+# public renderers wrap in a pane, so it is the only way to assert on the merge.
+# pylint: disable=protected-access
+
+from pathlib import Path
+
+import panel as pn
 import rerun as rr
 from rerun.experimental import RrdReader
 
@@ -25,6 +32,21 @@ class RerunSweep(bn.ParametrizedSweep):
             recording.log("wave", rr.Scalars(self.amp * self.freq * step))
         self.out_rerun = bn.capture_rerun_rrd(recording)
         return super().benchmark()
+
+
+def name_only(path: str) -> pn.pane.Markdown:
+    """A declared container that names the composition instead of embedding a viewer.
+
+    Module level, not a closure: the declared container is pickled into the cache
+    along with the result var.
+    """
+    return pn.pane.Markdown(f"composed: {Path(path).name}")
+
+
+class DeclaredContainerSweep(RerunSweep):
+    """A ResultRerun declaring how it renders, in place of the rerun viewer."""
+
+    out_rerun = bn.ResultRerun(width=200, height=150, container=name_only)
 
 
 def _leaf_entity_paths(path: str) -> set[str]:
@@ -108,6 +130,21 @@ class TestRerunSummary:
         )
         assert pane is not None
         assert len(pane) == 1
+
+    def test_declared_container_wins_over_the_rerun_viewer(self):
+        """Same precedence as ds_to_container and the over_time path (PR #1015).
+
+        The declared container receives the *composed* recording, so unlike
+        test_rerun_declared_container the leaves must be real .rrd files.
+        """
+        bench = DeclaredContainerSweep().to_bench()
+        res = bench.plot_sweep(input_vars=["freq"], result_vars=["out_rerun"])
+        pane = res.to_rerun_grid()
+        assert pane is not None and len(pane) == 1
+        rendered = pane[0]
+        assert isinstance(rendered, pn.pane.Markdown), type(rendered)
+        assert rendered.object.startswith("composed: ")
+        assert rendered.object.endswith(".rrd")
 
     def test_registered_as_named_only_plots(self):
         from bencher.plugins.builtins import _named_only_specs


### PR DESCRIPTION
## Summary

`ComposableContainerRerun` (#1007) composes recordings from **inside `benchmark()`**, where only one sample's recordings are visible — all four of its examples use `input_vars=[]`. Sweeping a `ResultRerun` therefore still embeds **one wasm web viewer per sample**:

- `ResultRerun.to_container()` returns `partial(rrd_file_to_pane, ...)`, and `rrd_file_to_pane` emits an iframe loading the `@rerun-io/web-viewer` bundle. A 3×3 sweep spawns nine independent viewers.
- Chrome caps live WebGL contexts around 8–16, then starts evicting them — so past ~4×4 a sweep doesn't degrade, earlier viewers go blank.
- Nothing can be compared across iframes: no shared timeline, no shared axes.

This adds `RerunSummaryResult`, which drives the **same** container from the result side: it walks the result dataset, collects each sample's cached `.rrd`, and composes them by `ComposeType`. Per-sample caching is untouched — composition happens at render time.

Because the container both accepts `.rrd` paths and renders to one, nesting is plain recursion, so there is **no second merge engine**.

- **`rerun_summary`** — every dimension on one timeline, so the whole sweep can be scrubbed together.
- **`rerun_grid`** — dimensions laid out in space; `compose_method_list=` for explicit per-dimension control.

Both are named-only (opt-in) like `video_summary`, since merging every recording is expensive. This is the `ResultRerun` counterpart to `VideoSummaryResult`.

Also:
- Extracts `compose_method_list_for_dims()` out of `VideoSummaryResult` so both summary renderers share one dimension-ordering policy (`dataset_to_compose_list` now delegates to it).
- Honours a **declared container** in the summary renderers, the precedence #1015 established for the over_time path and `ds_to_container` — otherwise this would be the only path ignoring it.

## Test plan

- `pixi run ci` green: ruff, pylint 10.00/10, ty, `generate-examples` (no drift), **2238 passed / 3 skipped**.
- `test/test_rerun_summary.py` (11 tests): 3×2 sweep collapses to one pane; **all 6 leaves reach the merged recording, nested two deep** (`/item_0/item_0/wave` … `/item_1/item_2/wave`) so nesting provably doesn't drop samples; 1-D sweep; explicit `compose_method_list`; declared-container precedence; named-only registration; and a parity test pinning the extracted helper to `dataset_to_compose_list`.
- `#1007`'s `test_composable_container_rerun.py` and `#1015`'s `test_rerun_declared_container.py` pass unchanged — the merge engine is untouched.
- Verified by hand: a 10×10 sweep (100 recordings) renders as **1 pane**.
- Verified `import bencher` still works with `rerun` unavailable (no module-scope rerun import added).
- New generated example `example_rerun_summary.py` runs end-to-end (100% covered); `rerun_summary.py` at 88%.

## Review notes

- **`reverse` only reorders the outermost dimension.** It isn't propagated into the recursion — this matches `VideoSummaryResult._to_video_panes_ds`, which doesn't propagate it either. Kept identical rather than making one renderer diverge.
- **One intermediate `.rrd` is written and re-read per nesting level** (O(depth) passes over the data). That is the cost of reusing #1007's engine instead of duplicating it; a single-pass tree merger is possible later if deep sweeps make it matter.

## Summary by Sourcery

Add support for merging all per-sample ResultRerun recordings of a sweep into a single embedded rerun viewer, with shared composition logic and documentation/examples for using the new summary plot types.

New Features:
- Introduce RerunSummaryResult with to_rerun_summary and to_rerun_grid callbacks to render sweep-wide merged rerun recordings as a single viewer.
- Add a new rerun summary example sweep that records per-sample step responses and demonstrates merging them into one viewer via plot_sweep.

Enhancements:
- Extract compose_method_list_for_dims into the composable container base so video and rerun summary renderers share the same per-dimension composition policy.
- Respect declared containers when rendering merged rerun recordings, giving them precedence over the default rerun viewer in line with other result paths.

Documentation:
- Document the rerun_summary and rerun_grid plot callbacks, explaining how they merge sweep recordings into one viewer and how they relate to video_summary.

Tests:
- Add tests covering compose_method_list_for_dims behaviour and RerunSummaryResult merging semantics, including sweep dimensionality, nesting, declared-container precedence, and named-only registration.