### PR TITLE
release: v1.117.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.117.0] - 2026-07-31
+
 ### Added
+- **Stable benchmark series identity: `plot_sweep(series_id=...)`** (plan 15, #1012).
+  Names the over_time *trend* a benchmark appends to, independently of what identifies its
+  configuration: `tag` partitions storage, `series_id` names the trend. Deliberately not
+  part of `hash_persistent`, so declaring one re-keys nothing — it exists so a trend
+  survives a worker rename or a move between modules.
+- **Inspectable, pinnable benchmark identity: `bn.sweep_identity()`, `bn.identity_of()`,
+  `bn.diff_identities()`** (plan 16, #1010). Returns the exact cache/history keys a
+  declaration resolves to *without running it*, taking `plot_sweep`'s declarative arguments
+  with the same spellings; diff two identities to see precisely which field moved a key.
+  Pairs with `SweepSpec`: `bn.sweep_identity(**spec.bind(W), worker=W)`.
+- **`bn.ComposableContainerRerun` — compose rerun recordings** (#1007). Combines complete
+  `.rrd` recordings right/down/sequence/overlay into one recording plus a generated
+  Blueprint, from inside `benchmark()`; the composition itself renders to a `.rrd`, so
+  nesting is plain recursion.
+- **`rerun_summary` / `rerun_grid` — merge a whole sweep's rerun recordings into one
+  viewer** (#1017). Sweeping a `ResultRerun` previously embedded one wasm web viewer per
+  sample (blank past ~16 due to browser WebGL context limits, nothing comparable across
+  iframes). These walk the result dataset and merge every sample's cached `.rrd` into a
+  single recording — `rerun_summary` on one shared timeline, `rerun_grid` laid out in
+  space with `compose_method_list=` control. Named-only (opt-in) like `video_summary`.
+  The dimension-ordering policy is extracted to `compose_method_list_for_dims()` so the
+  video and rerun summary renderers share it.
+- **Single-point sweep ranges** (plan 17, #1001). `with_bounds` and `bn.sweep` accept
+  `low == high`, yielding exactly one sample (previously: a raise, or N linspace copies /
+  an empty arange if the guard had simply been relaxed). `samples > 1` over a zero-width
+  range raises at declaration, and `bn.sweep` validates an inverted range at construction
+  instead of mid-run. `bounds=(x, x)` and `values=[x]` keep deliberately distinct
+  identities.
+- **Unnamed parameters are rejected at resolution time** (plan 19, #1003). A variable
+  declared on a plain (non-`Parameterized`) mixin registers with `param.name=None` and
+  used to fail far from the declaration (a `KeyError` in result storage, or a bare
+  `ValueError` from param, depending on param version). Resolution now raises a
+  `TypeError` naming the metaclass cause and the remedy; parameter objects built by
+  `bn.box()`/`bn.sweep()` are unaffected.
 - **`bn.SweepSpec` — a sweep declaration as a value (plan 18, phase 1).** A frozen record
   of `plot_sweep`'s seven declarative arguments (title, descriptions, input/result/const
   vars, tag) that can be built once, composed (`with_`, `plus_input_vars`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.116.0"
+version = "1.117.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
## Summary

Cuts **v1.117.0** — an all-additive minor release. **Merging this PR publishes to PyPI** (CI-gated per plan 01), so merge when ready.

### What's in it (since v1.116.0)

The plans 15–21 series, complete:
- **Stable series identity** — `plot_sweep(series_id=...)` (plan 15, #1012)
- **Inspectable identity** — `bn.sweep_identity()` / `identity_of()` / `diff_identities()` (plan 16, #1010)
- **Single-point sweep ranges** — `low == high` yields one sample (plan 17, #1001)
- **`bn.SweepSpec`** — a sweep declaration as a value, phase 1: build/compose/`bind()`/`diff_specs` (plan 18, #1014)
- **Unnamed-parameter rejection** at resolution time with a cause-naming error (plan 19, #1003)
- **Duplicate declared variables** rejected or normalised (plan 20, #1011)
- **Per-sample fault tolerance** — `catch` + `fail_on_sample_error` on `BenchRunCfg`, with failure accounting (plan 21, #1013)

Rerun stack:
- **`ComposableContainerRerun`** — compose recordings into one viewer + blueprint (#1007)
- **Declared containers honoured on `ResultRerun` with over_time history** (#1015)
- **`rerun_summary` / `rerun_grid`** — merge a whole sweep's recordings into one viewer (#1017)

Plus the `ResultDataSet`/xy-chart family, container extensions, A2 S1 signature enrichment, per-module logging, and the fixes already recorded in the changelog.

### Housekeeping in this PR
- Version 1.116.0 → **1.117.0** (`pyproject.toml`)
- `[Unreleased]` → `[1.117.0] - 2026-07-31`, adding the six feature entries that merged without one (#1010, #1012, #1007, #1017, #1001, #1003)

### Explicitly NOT in this release
No breaking changes. The A5 config-surface-reduction train (plan #1018) — the bench_cfg split (#923), analysis extraction, dead-flag cull — targets the **next major release**, per the sequencing note recorded in A5 §5.

### Validation
Full local CI green on the release branch: **2352 passed, 3 skipped**, pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cut release v1.117.0 and record its features and changes in the changelog.

New Features:
- Document new benchmark series identity support via plot_sweep(series_id=...).
- Document new benchmark identity inspection helpers sweep_identity, identity_of, and diff_identities.
- Document new ComposableContainerRerun support for composing rerun recordings.
- Document new rerun_summary and rerun_grid utilities for merging sweep rerun recordings into a single viewer.
- Document support for single-point sweep ranges where low equals high.
- Document rejection of unnamed parameters at resolution time with clearer errors.
- Document the initial bn.SweepSpec value-based sweep declaration feature.

Build:
- Bump project version from 1.116.0 to 1.117.0 in pyproject.toml.

Documentation:
- Finalize the 1.117.0 changelog entry with added feature descriptions since v1.116.0.