### PR TITLE
plan 22 + implementation: self-describing canonical dataset (A6 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Content-addressed blob store: `bencher/blob_store.py`** (plan 22, phase 1 of the A6
+  grammar-of-ND-data migration, #1021). Result payloads that cannot live directly in a
+  dataset cell are serialized under `cachedir/blobs/` and named by the sha256 of their
+  bytes, so identical payloads across repeats and time points deduplicate to one file.
+  Dispatch is by payload type: `DataFrame` → `.parquet`, `Dataset` → `.nc`, `DataArray` →
+  `.da.nc` (name preserved), `bytes` → `.bin`, anything else picklable → `.pkl`. The
+  environment is netCDF3-only (scipy is the sole engine), which silently narrows int64 →
+  int32 and raises on other dtypes, so an empirically-derived whitelist
+  (`_NETCDF3_SAFE_DTYPES`) diverts unsafe payloads to pickle rather than let them
+  round-trip with changed values. Every structured-format failure falls back to pickle with
+  a logged warning: a payload inside the documented contract can never abort a sweep. The
+  `.pkl` branch is the pickle surface plan A3 wants gone and is flagged as such in the
+  module docstring.
+- **`ResultDataSet` renders its full `over_time` history.** Because a cell is now
+  meaningful in any process (see below), the pre-existing `isel(over_time=-1)` restriction
+  is gone: the report shows a labelled per-time grid, one pane per snapshot under its
+  timestamp, instead of only the latest run. Practical effect: a report over a long history
+  gets *N* times wider — bound it with `max_time_events` on the result variable if that
+  matters. Cells cached before this release render real content at the final time event and
+  an explicit labelled placeholder at earlier ones, because the legacy payload list only
+  ever held the final run's samples.
+- **New gallery example `example_result_dataset_1d_over_time`** under
+  `reference/meta/result_types/result_dataset/`; no existing example combined
+  `ResultDataSet` with `over_time`.
+
+### Changed
+- **BREAKING: a `ResultDataSet` dataset cell holds a blob path string, not an index.**
+  Cells were `int` indices into `BenchResult.dataset_list`, valid only inside the process
+  that produced them; they are now absolute `str` paths into the blob store, so any process
+  sharing the cache filesystem can render any sample. Code that introspects a result
+  directly is affected — `res.to_dataset()["var"].values` and `res.to_pandas()` now yield
+  `/…/cachedir/blobs/a1b2c3.parquet` where they yielded `0, 1, 2`. To recover the payload:
+
+  ```python
+  from bencher.blob_store import load_blob
+  cell = res.to_dataset()["my_dataset_var"].sel(x=1.0).values.item()
+  payload = load_blob(cell)   # was: res.dataset_list[int(cell)].obj
+  ```
+
+  Rendering is unaffected — every built-in render path goes through
+  `BenchResultBase.ds_to_container`, which accepts both generations. `result_is_missing`
+  accepts both sentinels (`"NAN"` and the legacy `-1`) permanently, since one mixed
+  `over_time` history contains cells of each kind.
+- **BREAKING: `BenchResult.dataset_list` is now always empty.** It survives as the read
+  path for results collected before this release and is scheduled for removal with phase 3.
+  Nothing in bencher's own examples, docs, or exports used it, but code that did
+  (`res.dataset_list[i].obj`) now sees an empty list rather than an error at the point of
+  change — use `load_blob` on the cell as shown above.
+- **`clear_media()` now also clears `cachedir/blobs/`, and `cache_stats()` counts it.**
+  The blob store is tracked as a third cache category (`_CONTENT_FOLDERS`) rather than as
+  media, because `_MEDIA_FOLDERS` means "contains per-job-key subdirectories" and that
+  layout is what makes per-job and orphan cleanup safe — a deduplicated blob may back cells
+  belonging to many job keys, so `cleanup_job_media` and `clean_orphaned_media` must never
+  touch it, and they don't. A cell whose blob was cleared renders as a placeholder, exactly
+  as a cell whose image was cleared does. `CacheStats` gained a `content` field (defaulted,
+  so existing construction is unaffected) and `cache_stats().total_bytes` now includes
+  blobs, so totals are not comparable across this release.
+- **A `plot_callback` may now be offered a `legacy_trusted=` keyword.** The `over_time`
+  dataset path needs to tell the render layer "a legacy index at this time point cannot be
+  trusted". Since `plot_callback` is a public extension point that a caller may satisfy with
+  a plain `(dataset, result_var)` function, the keyword is passed *only* to callbacks that
+  declare it or carry `**kwargs`; a stricter callback is called exactly as before instead of
+  raising `TypeError`. Every callback in bencher declares `**kwargs`, so nothing internal
+  changes. `ds_to_container` gained the parameter with a default, so overrides written
+  against the old signature keep working.
+- **No `CACHE_VERSION` bump** (stays `5`), so an existing `cachedir` is *not* wiped by this
+  release. Pre-existing sample-cache entries re-materialize into blobs on a cache hit;
+  stored `over_time` histories merge (the int64 column and the new object column concat to
+  object, and legacy cells survive intact); results saved with `save_result` still load.
+  Old data degrades honestly where it cannot support the new capability rather than failing.
+
+### Deprecated
+- **`ResultHmap` is deprecated** and now emits a `DeprecationWarning` on instantiation;
+  removal is scheduled for a later phase of the A6 migration. Its data lives out-of-band in
+  `bench_res.hmaps` rather than in the canonical result dataset, so it cannot participate in
+  the grammar-of-ND-data model. Use `ResultContainer`, or `ResultReference` with a declared
+  `container=`, instead. Behavior and `hash_persistent()` are unchanged until removal. Note
+  for downstream code: this breaks builds that run with `-W error::DeprecationWarning` or
+  pytest `filterwarnings = error`. **Known follow-up:** bencher's own
+  `bencher/example/meta/example_meta.py` still declares a `ResultHmap`, so the flagship
+  meta example warns about itself; migrating it changes generated gallery output and was
+  deliberately left out of #1021.
+
+### Notes
+- **`cachedir/blobs/` has no garbage collection.** Every distinct dataset payload from every
+  run is retained until an explicit `clear_media()` or `clear_all()`; content addressing
+  only deduplicates byte-identical payloads. It is at least visible in `cache_stats()` now.
+  Reclaiming it per job key is not possible by design (one blob, many owners); an artifact
+  manifest that could is A4's job.
+- Blob filenames use the first 16 hex chars (64 bits) of the sha256, so two *different*
+  payloads sharing that prefix would collide and the second would load back as the first.
+  The birthday bound puts even odds at ~2^32 blobs in one cache directory, so the risk is
+  accepted rather than mitigated; `_HASH_CHARS` can be raised without invalidating existing
+  blobs, since `load_blob` dispatches on extension rather than name length.
+
 ## [1.117.0] - 2026-07-31
 
 ### Added

--- a/bencher/blob_store.py
+++ b/bencher/blob_store.py
@@ -45,9 +45,22 @@ import xarray as xr
 logger = logging.getLogger(__name__)
 
 # Number of hex characters of the sha256 digest used in blob filenames.
+#
+# 16 hex chars is 64 bits of the digest, so content addressing is exact only up
+# to a truncated-digest collision: two *different* payloads sharing a prefix
+# would map to one filename, and because a name that already exists is not
+# rewritten, the second payload would silently load back as the first.  The
+# birthday bound puts even odds at ~2**32 distinct blobs in a single cache dir,
+# which no benchmark cache approaches, so the risk is accepted rather than
+# mitigated -- raise this constant (new blobs simply get longer names; existing
+# ones stay loadable, since load_blob dispatches on extension, not name length)
+# if a cache ever grows near that scale.
 _HASH_CHARS = 16
 
-# Subdirectory of the cache dir that holds all blobs.
+# Subdirectory of the cache dir that holds all blobs.  Cache tooling knows this
+# folder as a content-addressed store (``cache_management._CONTENT_FOLDERS``):
+# it is counted in cache stats and cleared wholesale, but never pruned per job
+# key, since one deduplicated blob may back cells from many different jobs.
 _BLOBS_SUBDIR = "blobs"
 
 # Dtypes the scipy netCDF3 engine round-trips *exactly* — same dtype, same

--- a/bencher/blob_store.py
+++ b/bencher/blob_store.py
@@ -10,12 +10,18 @@ deduplicate to a single file for free.
 
 Supported formats, dispatched on the payload type:
 
-- ``pandas.DataFrame`` → ``.parquet``
-- ``xarray.Dataset`` / ``xarray.DataArray`` → ``.nc`` (netCDF; a DataArray
-  loads back as a single-variable Dataset)
+- ``pandas.DataFrame`` → ``.parquet`` (falls back to ``.pkl`` when the
+  contents cannot be written as parquet, e.g. nested-object columns)
+- ``xarray.Dataset`` → ``.nc`` (netCDF3 via the scipy engine; falls back to
+  ``.pkl`` when any data var or coord dtype is not netCDF3-safe, so payloads
+  never round-trip with silently changed dtypes)
+- ``xarray.DataArray`` → ``.da.nc`` (same dtype rules; loads back as a
+  ``DataArray`` with its ``name`` preserved)
 - ``bytes`` → ``.bin`` (raw)
-- an existing file path (str/Path) → returned unchanged, never copied
-- anything else picklable → ``.pkl``
+- anything else picklable, including str/Path payloads → ``.pkl`` (a path
+  string is an ordinary payload: it is pickled, never dereferenced, so the
+  render-time container receives exactly the string the worker stored and
+  every blob stays under the cache dir)
 
 .. warning::
     The ``.pkl`` fallback is the pickle surface that architecture plan A3
@@ -25,13 +31,18 @@ Supported formats, dispatched on the payload type:
 """
 
 import hashlib
+import io
+import logging
 import pickle
 import uuid
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pandas as pd
 import xarray as xr
+
+logger = logging.getLogger(__name__)
 
 # Number of hex characters of the sha256 digest used in blob filenames.
 _HASH_CHARS = 16
@@ -39,20 +50,81 @@ _HASH_CHARS = 16
 # Subdirectory of the cache dir that holds all blobs.
 _BLOBS_SUBDIR = "blobs"
 
+# Dtypes the scipy netCDF3 engine round-trips *exactly* — same dtype, same
+# values, for every value of the type — determined empirically against this
+# environment's only netCDF backend:
+#
+# - float32/float64, int8/int16/int32, bool: preserved exactly (whitelisted);
+# - float16, complex64/128: raise ("NetCDF 3 does not support type ...");
+# - int64 and every unsigned int: silently *narrowed* (int64→int32, uint8→int8,
+#   ...) when the values happen to fit and raise ("could not safely cast")
+#   when they do not — value-dependent, so excluded;
+# - str (<U*): loads back as object dtype (values equal, dtype changed);
+# - object: serializable only for all-str contents, raises otherwise;
+# - datetime64[ns]/timedelta64[ns]: raise for values whose encoding does not
+#   fit int32 (e.g. pre-1677 dates), so also value-dependent.
+_NETCDF3_SAFE_DTYPES = frozenset(
+    np.dtype(name) for name in ("float32", "float64", "int8", "int16", "int32", "bool")
+)
+
+
+def _netcdf3_unsafe_vars(obj: xr.Dataset | xr.DataArray) -> dict[str, str]:
+    """Names → dtypes of every data var and coord netCDF3 cannot round-trip exactly."""
+    if isinstance(obj, xr.Dataset):
+        dtypes = {str(name): var.dtype for name, var in obj.variables.items()}
+    else:
+        dtypes = {str(obj.name) if obj.name is not None else "<unnamed>": obj.dtype}
+        dtypes.update({str(name): coord.dtype for name, coord in obj.coords.items()})
+    return {name: str(dtype) for name, dtype in dtypes.items() if dtype not in _NETCDF3_SAFE_DTYPES}
+
 
 def _serialize(obj: Any) -> tuple[bytes, str]:
-    """Serialize *obj* to bytes, returning ``(data, extension)``."""
-    if isinstance(obj, pd.DataFrame):
-        # Requires a parquet engine (pyarrow is a bencher dependency).
-        import io  # pylint: disable=import-outside-toplevel
+    """Serialize *obj* to bytes, returning ``(data, extension)``.
 
-        buffer = io.BytesIO()
-        obj.to_parquet(buffer)
-        return buffer.getvalue(), ".parquet"
-    if isinstance(obj, (xr.Dataset, xr.DataArray)):
-        # to_netcdf() with no target returns the serialized bytes
-        # (memoryview on newer xarray versions).
-        return bytes(obj.to_netcdf()), ".nc"
+    The structured formats (parquet, netCDF) are attempted first; any payload
+    they cannot represent *exactly* falls back to the pickle branch with a
+    single warning, so collection never fails on an awkward payload and a
+    loaded blob is always identical to what the worker stored.
+    """
+    if isinstance(obj, pd.DataFrame):
+        try:
+            # Requires a parquet engine (pyarrow is a bencher dependency).
+            buffer = io.BytesIO()
+            obj.to_parquet(buffer)
+            return buffer.getvalue(), ".parquet"
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            logger.warning(
+                "blob_store: DataFrame payload could not be serialized to parquet "
+                "(%s: %s); falling back to pickle",
+                type(exc).__name__,
+                exc,
+            )
+    elif isinstance(obj, (xr.Dataset, xr.DataArray)):
+        # A DataArray gets its own suffix so load_blob can hand back a DataArray
+        # (to_netcdf/load_dataarray is xarray's own convention, which also
+        # covers unnamed arrays).
+        extension = ".da.nc" if isinstance(obj, xr.DataArray) else ".nc"
+        unsafe = _netcdf3_unsafe_vars(obj)
+        if unsafe:
+            logger.warning(
+                "blob_store: %s payload has dtypes the scipy netCDF3 engine cannot "
+                "round-trip exactly (%s); falling back to pickle",
+                type(obj).__name__,
+                ", ".join(f"{name}: {dtype}" for name, dtype in unsafe.items()),
+            )
+        else:
+            try:
+                # to_netcdf() with no target returns the serialized bytes
+                # (memoryview on newer xarray versions).
+                return bytes(obj.to_netcdf()), extension
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "blob_store: %s payload could not be serialized to netCDF "
+                    "(%s: %s); falling back to pickle",
+                    type(obj).__name__,
+                    type(exc).__name__,
+                    exc,
+                )
     if isinstance(obj, bytes):
         return obj, ".bin"
     # Pickle fallback — the surface plan A3 wants gone (see module docstring).
@@ -66,8 +138,9 @@ def materialize_blob(obj: Any, cache_dir: str | Path) -> str:
     serialized bytes plus a format extension, so identical payloads map to
     identical paths (content addressing) and are written only once.
 
-    If *obj* is a str/Path pointing at an existing file, it is treated as an
-    already-materialized blob and returned unchanged as ``str``.
+    A str/Path payload is pickled like any other object — even when it names
+    an existing file — so loading the blob returns exactly what the worker
+    stored and every blob lives under *cache_dir*.
 
     Parameters
     ----------
@@ -81,11 +154,8 @@ def materialize_blob(obj: Any, cache_dir: str | Path) -> str:
     Returns
     -------
     str
-        Path to the blob file (or the input path itself for path-like input).
+        Path to the blob file.
     """
-    if isinstance(obj, (str, Path)) and Path(obj).is_file():
-        return str(obj)
-
     data, extension = _serialize(obj)
     digest = hashlib.sha256(data).hexdigest()[:_HASH_CHARS]
 
@@ -107,6 +177,8 @@ def load_blob(path: str | Path) -> Any:
     """Load a blob written by :func:`materialize_blob`, dispatching on extension.
 
     - ``.parquet`` → ``pandas.DataFrame``
+    - ``.da.nc`` → ``xarray.DataArray`` (``name`` preserved, unnamed arrays
+      included, via xarray's own DataArray netCDF convention)
     - ``.nc`` → ``xarray.Dataset`` (fully loaded into memory; the file handle
       is closed so the blob stays re-readable)
     - ``.bin`` → ``bytes``
@@ -118,6 +190,10 @@ def load_blob(path: str | Path) -> Any:
         If the extension is not one of the known blob formats.
     """
     blob_path = Path(path)
+    # .da.nc must be checked before the plain .nc suffix dispatch below.
+    if blob_path.name.endswith(".da.nc"):
+        # load_dataarray reads eagerly, like load_dataset below.
+        return xr.load_dataarray(blob_path)
     extension = blob_path.suffix
     if extension == ".parquet":
         return pd.read_parquet(blob_path)
@@ -131,5 +207,5 @@ def load_blob(path: str | Path) -> Any:
         return pickle.loads(blob_path.read_bytes())
     raise ValueError(
         f"load_blob: unknown blob extension {extension!r} for {blob_path}; "
-        "expected one of .parquet, .nc, .bin, .pkl"
+        "expected one of .parquet, .da.nc, .nc, .bin, .pkl"
     )

--- a/bencher/blob_store.py
+++ b/bencher/blob_store.py
@@ -1,0 +1,135 @@
+"""Content-addressed blob store for materializing result payloads at collect time.
+
+This module implements design D1 of the grammar phase-1 data model
+(plans/22-grammar-phase-1-data-model.md, A6 Law 1): result payloads that
+cannot live directly in a dataset cell are serialized under
+``<cache_dir>/blobs/`` and the cell stores the returned **path string**
+instead of a run-local index.  Filenames are derived from the sha256 of the
+serialized bytes, so identical payloads across repeats and time points
+deduplicate to a single file for free.
+
+Supported formats, dispatched on the payload type:
+
+- ``pandas.DataFrame`` → ``.parquet``
+- ``xarray.Dataset`` / ``xarray.DataArray`` → ``.nc`` (netCDF; a DataArray
+  loads back as a single-variable Dataset)
+- ``bytes`` → ``.bin`` (raw)
+- an existing file path (str/Path) → returned unchanged, never copied
+- anything else picklable → ``.pkl``
+
+.. warning::
+    The ``.pkl`` fallback is the pickle surface that architecture plan A3
+    wants gone.  It exists only because ``ResultDataSet`` documents its
+    payload as "any picklable object"; the A3 migration should tighten this
+    to the structured formats above with its own deprecation story.
+"""
+
+import hashlib
+import pickle
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import xarray as xr
+
+# Number of hex characters of the sha256 digest used in blob filenames.
+_HASH_CHARS = 16
+
+# Subdirectory of the cache dir that holds all blobs.
+_BLOBS_SUBDIR = "blobs"
+
+
+def _serialize(obj: Any) -> tuple[bytes, str]:
+    """Serialize *obj* to bytes, returning ``(data, extension)``."""
+    if isinstance(obj, pd.DataFrame):
+        # Requires a parquet engine (pyarrow is a bencher dependency).
+        import io  # pylint: disable=import-outside-toplevel
+
+        buffer = io.BytesIO()
+        obj.to_parquet(buffer)
+        return buffer.getvalue(), ".parquet"
+    if isinstance(obj, (xr.Dataset, xr.DataArray)):
+        # to_netcdf() with no target returns the serialized bytes
+        # (memoryview on newer xarray versions).
+        return bytes(obj.to_netcdf()), ".nc"
+    if isinstance(obj, bytes):
+        return obj, ".bin"
+    # Pickle fallback — the surface plan A3 wants gone (see module docstring).
+    return pickle.dumps(obj), ".pkl"
+
+
+def materialize_blob(obj: Any, cache_dir: str | Path) -> str:
+    """Serialize *obj* under ``<cache_dir>/blobs/`` and return the file path.
+
+    The filename is the first 16 hex characters of the sha256 of the
+    serialized bytes plus a format extension, so identical payloads map to
+    identical paths (content addressing) and are written only once.
+
+    If *obj* is a str/Path pointing at an existing file, it is treated as an
+    already-materialized blob and returned unchanged as ``str``.
+
+    Parameters
+    ----------
+    obj:
+        The payload to materialize.  See the module docstring for the
+        type → format dispatch table.
+    cache_dir:
+        Root cache directory; blobs live in its ``blobs/`` subdirectory,
+        which is created if needed.
+
+    Returns
+    -------
+    str
+        Path to the blob file (or the input path itself for path-like input).
+    """
+    if isinstance(obj, (str, Path)) and Path(obj).is_file():
+        return str(obj)
+
+    data, extension = _serialize(obj)
+    digest = hashlib.sha256(data).hexdigest()[:_HASH_CHARS]
+
+    blobs_dir = Path(cache_dir) / _BLOBS_SUBDIR
+    blobs_dir.mkdir(parents=True, exist_ok=True)
+    blob_path = blobs_dir / f"{digest}{extension}"
+
+    if not blob_path.exists():
+        # Write via a unique temp file + atomic rename so concurrent workers
+        # materializing the same payload never observe a partial blob.
+        tmp_path = blob_path.with_suffix(blob_path.suffix + f".tmp-{uuid.uuid4().hex}")
+        tmp_path.write_bytes(data)
+        tmp_path.replace(blob_path)
+
+    return str(blob_path)
+
+
+def load_blob(path: str | Path) -> Any:
+    """Load a blob written by :func:`materialize_blob`, dispatching on extension.
+
+    - ``.parquet`` → ``pandas.DataFrame``
+    - ``.nc`` → ``xarray.Dataset`` (fully loaded into memory; the file handle
+      is closed so the blob stays re-readable)
+    - ``.bin`` → ``bytes``
+    - ``.pkl`` → the unpickled object
+
+    Raises
+    ------
+    ValueError
+        If the extension is not one of the known blob formats.
+    """
+    blob_path = Path(path)
+    extension = blob_path.suffix
+    if extension == ".parquet":
+        return pd.read_parquet(blob_path)
+    if extension == ".nc":
+        # load_dataset reads eagerly and closes the underlying file handle,
+        # unlike open_dataset which keeps it lazily open.
+        return xr.load_dataset(blob_path)
+    if extension == ".bin":
+        return blob_path.read_bytes()
+    if extension == ".pkl":
+        return pickle.loads(blob_path.read_bytes())
+    raise ValueError(
+        f"load_blob: unknown blob extension {extension!r} for {blob_path}; "
+        "expected one of .parquet, .nc, .bin, .pkl"
+    )

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -53,6 +53,17 @@ _MANAGED_CACHES = ("sample_cache", "benchmark_inputs", "history")
 # Top-level media folders that contain per-job-key subdirectories.
 _MEDIA_FOLDERS = ("img", "vid", "rrd", "generic")
 
+# Content-addressed stores: flat, sha256-named files that any number of job keys
+# may share, because identical payloads deduplicate to one file (see
+# ``bencher.blob_store``).  Deliberately *not* part of ``_MEDIA_FOLDERS``, whose
+# contract is "contains per-job-key subdirectories" — that layout is what makes
+# ``cleanup_job_media`` and ``clean_orphaned_media`` safe, and neither is
+# meaningful here: deleting the blob for one job key can strand a cell belonging
+# to another. These folders are therefore counted by ``cache_stats`` and removed
+# wholesale by ``clear_media``/``clear_all`` (a cleared blob renders as a
+# placeholder, exactly like a cleared image), but never pruned per job.
+_CONTENT_FOLDERS = ("blobs",)
+
 # File extensions recognized as media when cleaning up legacy (pre-v2) files.
 _MEDIA_EXTENSIONS = frozenset(
     {
@@ -152,6 +163,8 @@ class CacheStats:
     managed: list[CacheDirStats]
     media: list[CacheDirStats]
     total_bytes: int
+    # Defaulted so existing three-argument construction keeps working.
+    content: list[CacheDirStats] = dataclasses.field(default_factory=list)
 
     def summary(self) -> str:
         lines = ["Cache Statistics", "=" * 60]
@@ -162,6 +175,10 @@ class CacheStats:
         if self.media:
             lines.append("Media directories:")
             for s in self.media:
+                lines.append(s.summary_line())
+        if self.content:
+            lines.append("Content-addressed stores:")
+            for s in self.content:
                 lines.append(s.summary_line())
         lines.append("-" * 60)
         lines.append(f"  Total: {_fmt_size(self.total_bytes)}")
@@ -209,7 +226,13 @@ def cache_stats(cachedir: str = "cachedir") -> CacheStats:
         media.append(CacheDirStats(folder, count, size))
         total += size
 
-    return CacheStats(managed=managed, media=media, total_bytes=total)
+    content: list[CacheDirStats] = []
+    for folder in _CONTENT_FOLDERS:
+        count, size = _dir_stats(root / folder)
+        content.append(CacheDirStats(folder, count, size))
+        total += size
+
+    return CacheStats(managed=managed, media=media, total_bytes=total, content=content)
 
 
 def print_cache_stats(cachedir: str = "cachedir") -> None:
@@ -268,14 +291,18 @@ def clear_all(cachedir: str = "cachedir") -> None:
 
 
 def clear_media(cachedir: str = "cachedir") -> tuple[int, int]:
-    """Delete all files in media directories.
+    """Delete all files in media and content-addressed store directories.
+
+    Cells that referenced a deleted file (an image path, a blob path) render as
+    a placeholder afterwards rather than raising — this reclaims space at the
+    cost of the payloads, it does not corrupt a stored result.
 
     Returns (files_deleted, bytes_freed).
     """
     root = Path(cachedir)
     deleted = 0
     freed = 0
-    for folder in _MEDIA_FOLDERS:
+    for folder in _MEDIA_FOLDERS + _CONTENT_FOLDERS:
         media_path = root / folder
         if not media_path.is_dir():
             continue

--- a/bencher/example/generated/result_types/result_dataset/example_result_dataset_1d_over_time.py
+++ b/bencher/example/generated/result_types/result_dataset/example_result_dataset_1d_over_time.py
@@ -1,0 +1,71 @@
+"""Auto-generated example: Result Dataset: 1D input, over time."""
+
+import math
+from datetime import datetime, timedelta
+
+import bencher as bn
+
+
+class TimeseriesCollector(bn.ParametrizedSweep):
+    """Collects a timeseries whose amplitude drifts between runs.
+
+    Each plot_sweep call below is one time snapshot; over_time=True stacks the
+    snapshots into a history. A ResultDataSet cell stores a path into the blob
+    store, so every history point stays renderable and the report shows a
+    labelled per-time grid with one curve per snapshot instead of only the
+    latest run.
+    """
+
+    duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
+
+    result_ds = bn.ResultDataSet(
+        container=bn.xy_curve(x="time", y="result_ds", markers=True),
+        doc="Collected timeseries dataset",
+    )
+
+    _drift = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        import xarray as xr
+
+        n_samples = max(1, int(self.duration))
+        gain = 1.0 + 0.5 * self._drift
+        values = [
+            math.sin(2 * math.pi * i / max(n_samples, 1)) * self.duration * gain
+            for i in range(n_samples)
+        ]
+        data_array = xr.DataArray(values, dims=["time"], coords={"time": list(range(n_samples))})
+        ds = xr.Dataset({"result_ds": data_array})
+        self.result_ds = bn.ResultDataSet(ds.to_pandas())
+
+
+def example_result_dataset_1d_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    """Result Dataset: 1D input, over time."""
+    if run_cfg is None:
+        run_cfg = bn.BenchRunCfg()
+
+    benchable = TimeseriesCollector()
+    bench = benchable.to_bench(run_cfg)
+
+    base_time = datetime(2024, 1, 1)
+    n_snapshots = 3
+    for i in range(n_snapshots):
+        benchable._drift = float(i)
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        run_cfg.auto_plot = i == n_snapshots - 1
+        bench.plot_sweep(
+            "dataset_over_time",
+            input_vars=["duration"],
+            result_vars=["result_ds"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+            description="Demonstrates an xarray/pandas dataset tracked with over_time=True. Dataset cells are stored as blob-store paths, so the report renders every history point as a labelled per-time grid of curves rather than only the latest run.",
+            post_description="Each column of the grid is one time snapshot, labelled with its timestamp. The curve amplitude grows between snapshots, showing that each history point renders its own stored dataset.",
+        )
+
+    return bench
+
+
+if __name__ == "__main__":
+    bn.run(example_result_dataset_1d_over_time, subsampling_divisions=3, over_time=True)

--- a/bencher/example/meta/generate_examples.py
+++ b/bencher/example/meta/generate_examples.py
@@ -370,7 +370,10 @@ def generate_python_files():
     from bencher.example.meta.generate_meta_publish import example_meta_publish
     from bencher.example.meta.generate_meta_regression import example_meta_regression
     from bencher.example.meta.generate_meta_rerun import example_meta_rerun
-    from bencher.example.meta.generate_meta_result_types import example_meta_result_types
+    from bencher.example.meta.generate_meta_result_types import (
+        example_meta_result_dataset_over_time,
+        example_meta_result_types,
+    )
     from bencher.example.meta.generate_meta_sampling import example_meta_sampling
     from bencher.example.meta.generate_meta_statistics import example_meta_statistics
     from bencher.example.meta.generate_meta_workflows import example_meta_workflows
@@ -378,6 +381,7 @@ def generate_python_files():
 
     example_meta()
     example_meta_result_types()
+    example_meta_result_dataset_over_time()
     example_meta_image_video()
     example_meta_composable()
     example_meta_plot_types()

--- a/bencher/example/meta/generate_meta_result_types.py
+++ b/bencher/example/meta/generate_meta_result_types.py
@@ -174,6 +174,101 @@ class MetaResultTypes(MetaGeneratorBase):
         )
 
 
+class MetaResultDatasetOverTime(MetaGeneratorBase):
+    """Generate the ResultDataSet + over_time example.
+
+    Dataset cells are stored as blob-store paths, so every ``over_time`` history
+    point stays renderable: the report shows a labelled per-time grid of curves
+    instead of clipping to the latest run.
+    """
+
+    def benchmark(self):
+        self._generate_dataset_over_time()
+
+    def _generate_dataset_over_time(self):
+        imports = "import math\nfrom datetime import datetime, timedelta\n\nimport bencher as bn"
+        class_code = '''\
+class TimeseriesCollector(bn.ParametrizedSweep):
+    """Collects a timeseries whose amplitude drifts between runs.
+
+    Each plot_sweep call below is one time snapshot; over_time=True stacks the
+    snapshots into a history. A ResultDataSet cell stores a path into the blob
+    store, so every history point stays renderable and the report shows a
+    labelled per-time grid with one curve per snapshot instead of only the
+    latest run.
+    """
+
+    duration = bn.FloatSweep(default=5.0, bounds=[1.0, 10.0], doc="Collection duration")
+
+    result_ds = bn.ResultDataSet(
+        container=bn.xy_curve(x="time", y="result_ds", markers=True),
+        doc="Collected timeseries dataset",
+    )
+
+    _drift = 0.0  # set externally per snapshot
+
+    def benchmark(self):
+        import xarray as xr
+
+        n_samples = max(1, int(self.duration))
+        gain = 1.0 + 0.5 * self._drift
+        values = [
+            math.sin(2 * math.pi * i / max(n_samples, 1)) * self.duration * gain
+            for i in range(n_samples)
+        ]
+        data_array = xr.DataArray(values, dims=["time"], coords={"time": list(range(n_samples))})
+        ds = xr.Dataset({"result_ds": data_array})
+        self.result_ds = bn.ResultDataSet(ds.to_pandas())'''
+
+        description = (
+            "Demonstrates an xarray/pandas dataset tracked with over_time=True. "
+            "Dataset cells are stored as blob-store paths, so the report renders "
+            "every history point as a labelled per-time grid of curves rather "
+            "than only the latest run."
+        )
+        post_description = (
+            "Each column of the grid is one time snapshot, labelled with its "
+            "timestamp. The curve amplitude grows between snapshots, showing "
+            "that each history point renders its own stored dataset."
+        )
+
+        body = f"""\
+if run_cfg is None:
+    run_cfg = bn.BenchRunCfg()
+
+benchable = TimeseriesCollector()
+bench = benchable.to_bench(run_cfg)
+
+base_time = datetime(2024, 1, 1)
+n_snapshots = 3
+for i in range(n_snapshots):
+    benchable._drift = float(i)
+    run_cfg.clear_cache = True
+    run_cfg.clear_history = i == 0
+    run_cfg.auto_plot = i == n_snapshots - 1
+    bench.plot_sweep(
+        "dataset_over_time",
+        input_vars=["duration"],
+        result_vars=["result_ds"],
+        run_cfg=run_cfg,
+        time_src=base_time + timedelta(seconds=i),
+        description={description!r},
+        post_description={post_description!r},
+    )
+"""
+
+        self.generate_example(
+            title="Result Dataset: 1D input, over time",
+            output_dir=f"{OUTPUT_DIR}/result_dataset",
+            filename="example_result_dataset_1d_over_time",
+            function_name="example_result_dataset_1d_over_time",
+            imports=imports,
+            body=body,
+            class_code=class_code,
+            run_kwargs={"subsampling_divisions": 3, "over_time": True},
+        )
+
+
 def example_meta_result_types(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
     bench = MetaResultTypes().to_bench(run_cfg)
 
@@ -183,6 +278,17 @@ def example_meta_result_types(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench
             bn.sweep("result_type", RESULT_TYPES),
             bn.sweep("input_dims", [0, 1, 2]),
         ],
+    )
+
+    return bench
+
+
+def example_meta_result_dataset_over_time(run_cfg: bn.BenchRunCfg | None = None) -> bn.Bench:
+    bench = MetaResultDatasetOverTime().to_bench(run_cfg)
+
+    bench.plot_sweep(
+        title="Result Dataset Over Time",
+        input_vars=[],
     )
 
     return bench

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -12,6 +12,7 @@ import os
 from contextlib import suppress
 from datetime import datetime
 from itertools import product
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -19,6 +20,7 @@ import xarray as xr
 from diskcache import Cache
 
 from bencher.bench_cfg import BenchCfg, BenchRunCfg, DimsCfg
+from bencher.blob_store import materialize_blob
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES
 from bencher.history import (
     HISTORY_FORMAT,
@@ -154,6 +156,26 @@ def _materialize_result_value(rv, value):
         if isinstance(value, ComposableContainerRerun):
             return value.render()
     return value
+
+
+def _materialize_dataset_value(result_value) -> str:
+    """Reduce a worker-returned ``ResultDataSet`` sample to a blob path (plan 22, D2).
+
+    The payload is serialized under ``cachedir/blobs/`` and the returned path
+    string is what the dataset cell stores — self-describing in any process that
+    shares the cache filesystem, exactly like the image/video/rerun path cells.
+    The literal ``cachedir`` root is the same canonical location the rest of
+    collection uses (``gen_path``, ``cachedir/rrd``, the diskcaches above).
+
+    A per-sample ``container=`` attached inside ``benchmark()`` has to travel
+    with the payload to keep the declared-container precedence chain intact, so
+    a wrapper carrying one is materialized whole (pickled); otherwise the bare
+    payload gets its structured blob format (parquet/netCDF/...).
+    """
+    payload = result_value
+    if isinstance(payload, ResultDataSet) and getattr(payload, "container", None) is None:
+        payload = payload.obj
+    return materialize_blob(payload, Path("cachedir").absolute())
 
 
 class ResultCollector:
@@ -408,9 +430,11 @@ class ResultCollector:
                 if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):
                     _set_result_value(bench_res, rv_arrays, rv.name, idx, result_value)
                 elif isinstance(rv, ResultDataSet):
-                    bench_res.dataset_list.append(result_value)
+                    # Plan 22 (D2): the cell stores a blob path, not an index into
+                    # dataset_list.  The list attribute stays, empty, as the read
+                    # path for results collected before path-backed cells.
                     _set_result_value(
-                        bench_res, rv_arrays, rv.name, idx, len(bench_res.dataset_list) - 1
+                        bench_res, rv_arrays, rv.name, idx, _materialize_dataset_value(result_value)
                     )
                 elif isinstance(rv, ResultReference):
                     bench_res.object_index.append(result_value)

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -170,12 +170,30 @@ def _materialize_dataset_value(result_value) -> str:
     A per-sample ``container=`` attached inside ``benchmark()`` has to travel
     with the payload to keep the declared-container precedence chain intact, so
     a wrapper carrying one is materialized whole (pickled); otherwise the bare
-    payload gets its structured blob format (parquet/netCDF/...).
+    payload gets its structured blob format (parquet/netCDF/...).  A wrapper
+    whose container cannot be pickled (a lambda, a closure) never fails the
+    sweep: the bare payload is stored instead and the per-sample container is
+    dropped, with the class-level container still applying at render.
     """
+    cache_dir = Path("cachedir").absolute()
     payload = result_value
-    if isinstance(payload, ResultDataSet) and getattr(payload, "container", None) is None:
-        payload = payload.obj
-    return materialize_blob(payload, Path("cachedir").absolute())
+    if isinstance(payload, ResultDataSet):
+        if getattr(payload, "container", None) is None:
+            payload = payload.obj
+        else:
+            try:
+                return materialize_blob(payload, cache_dir)
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "ResultDataSet sample: per-sample container %r could not be "
+                    "pickled (%s: %s); storing the bare payload without it — a "
+                    "class-level container still applies at render",
+                    payload.container,
+                    type(exc).__name__,
+                    exc,
+                )
+                payload = payload.obj
+    return materialize_blob(payload, cache_dir)
 
 
 class ResultCollector:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -186,7 +186,9 @@ class BenchResult(
         result_instance = result_type(self.bench_cfg)
         result_instance.ds = self.ds
         result_instance.plt_cnt_cfg = self.plt_cnt_cfg
-        result_instance.dataset_list = self.dataset_list
+        # getattr: a result pickled before dataset_list existed (or with it stripped)
+        # must still render — the legacy read path degrades to a placeholder instead.
+        result_instance.dataset_list = getattr(self, "dataset_list", [])
         result_instance.regression_report = self.regression_report
         # Build kwargs for the plot call, only include reduce if explicitly set
         plot_kwargs = {

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -912,9 +912,10 @@ class BenchResultBase:
                 if isinstance(result_var, ResultDataSet):
                     # Path-backed cells (plan 22) make historical payloads loadable
                     # from any run, so every time point renders like the other blob
-                    # types.  Legacy index cells inside a mixed history render where
-                    # dataset_list still covers them and as a labelled placeholder
-                    # where it does not.
+                    # types.  Legacy index cells are only trusted at the final time
+                    # index — dataset_list belongs to the final run, so an in-range
+                    # historical index would silently render the *current* payload
+                    # under a historical label; those render a labelled placeholder.
                     return self._pane_over_time_dataset(
                         dataset, result_var, plot_callback, **kwargs
                     )
@@ -1065,18 +1066,24 @@ class BenchResultBase:
         Path-backed cells are meaningful in any process, so history points render
         instead of being cut down to the latest event (the pre-plan-22
         ``isel(over_time=-1)`` workaround).  A time point whose cell is missing
-        (either generation's sentinel) is skipped; a legacy index cell renders
-        through ``ds_to_container``'s legacy path — the payload where
-        ``dataset_list`` covers it, a placeholder where it does not.
+        (either generation's sentinel) is skipped.  A legacy index cell is only
+        trusted at the *final* time index: ``dataset_list`` holds the final run's
+        payloads alone, so a pre-plan history with in-range indices at every time
+        point would otherwise render the current payload under historical labels.
+        Untrusted legacy cells render as a labelled placeholder instead.
         """
         time_vals = list(dataset.coords["over_time"].values)
         is_datetime = np.issubdtype(dataset.coords["over_time"].dtype, np.datetime64)
         labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
 
         items = []
+        final_idx = len(labels) - 1
         for idx, label in enumerate(labels):
             pane = plot_callback(
-                dataset=dataset.isel(over_time=idx), result_var=result_var, **kwargs
+                dataset=dataset.isel(over_time=idx),
+                result_var=result_var,
+                legacy_trusted=idx == final_idx,
+                **kwargs,
             )
             if pane is None:
                 continue
@@ -1135,7 +1142,9 @@ class BenchResultBase:
                 return candidate
         return None
 
-    def _dataset_sample_to_container(self, val: Any, result_var: Parameter, container) -> Any:
+    def _dataset_sample_to_container(  # pylint: disable=too-many-return-statements
+        self, val: Any, result_var: Parameter, container, legacy_trusted: bool = True
+    ) -> Any:
         """Render one stored ``ResultDataSet`` cell, whichever generation stored it.
 
         Three cell shapes exist (plan 22, D3):
@@ -1144,19 +1153,41 @@ class BenchResultBase:
            ``load_blob``; a payload materialized with a per-sample container is a
            pickled ``ResultDataSet`` wrapper, so the full precedence chain
            (renderer-supplied → sample's → class's → raw object) still applies;
+           a blob that cannot be loaded (deleted, corrupt) renders as a labelled
+           placeholder — never a crash;
         2. an ``int`` index (a result pickled or cached before plan 22) — looked
            up in ``dataset_list`` when this result still carries the list that
-           produced it, and rendered as a labelled placeholder otherwise (an old
-           cell without its list is honestly unrecoverable — never a crash);
+           produced it *and* the cell is trusted (see below), and rendered as a
+           labelled placeholder otherwise (an old cell without its list is
+           honestly unrecoverable — never a crash);
         3. the missing sentinel of either generation (``"NAN"`` / ``-1``) →
            ``None``, which pane composition skips.
+
+        ``legacy_trusted`` guards the over_time case: ``dataset_list`` holds only
+        the *final* run's payloads, so a legacy int at a historical time index is
+        in range yet points at the wrong run's payload.  The over_time render
+        path passes ``legacy_trusted=False`` for every non-final time index;
+        every other call site keeps the default ``True``.
         """
         if result_is_missing(result_var, val):
             return None
         if isinstance(val, str):
             from bencher.blob_store import load_blob
 
-            payload = load_blob(val)
+            try:
+                payload = load_blob(val)
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                logger.warning(
+                    "ResultDataSet '%s': failed to load blob %r (%s: %s)",
+                    result_var.name,
+                    val,
+                    type(exc).__name__,
+                    exc,
+                )
+                return pn.pane.Markdown(
+                    f"*'{result_var.name}': stored blob could not be loaded "
+                    "and is no longer recoverable from this result*"
+                )
             sample = payload if isinstance(payload, ResultDataSet) else None
             if sample is not None:
                 payload = sample.obj
@@ -1175,6 +1206,18 @@ class BenchResultBase:
             )
             return pn.pane.Markdown(
                 f"*'{result_var.name}': stored cell is not renderable ({type(val).__name__})*"
+            )
+        if not legacy_trusted:
+            logger.warning(
+                "ResultDataSet '%s': legacy cell %r at a historical time point; "
+                "dataset_list only holds the final run's payloads, so the "
+                "historical payload is unrecoverable",
+                result_var.name,
+                val,
+            )
+            return pn.pane.Markdown(
+                f"*'{result_var.name}': stored payload predates the path-backed format; "
+                "only the final time event's payload is recoverable from this result*"
             )
         dataset_list = getattr(self, "dataset_list", None)
         if not dataset_list or not 0 <= idx < len(dataset_list):
@@ -1197,9 +1240,20 @@ class BenchResultBase:
         return resolved(ref.obj) if resolved is not None else ref.obj
 
     def ds_to_container(  # pylint: disable=too-many-return-statements
-        self, dataset: xr.Dataset, result_var: Parameter, container, **kwargs
+        self,
+        dataset: xr.Dataset,
+        result_var: Parameter,
+        container,
+        legacy_trusted: bool = True,
+        **kwargs,
     ) -> Any:
         """Render one sample of *result_var* out of *dataset*.
+
+        ``legacy_trusted`` is threaded through to
+        :meth:`_dataset_sample_to_container` for ``ResultDataSet`` cells; the
+        over_time render path passes ``False`` for historical time indices whose
+        legacy int cells cannot be resolved against the final run's
+        ``dataset_list`` (see that method).
 
         Two kinds of container can apply, and they are different contracts:
 
@@ -1228,7 +1282,7 @@ class BenchResultBase:
                 )
         val = self.zero_dim_da_to_val(dataset[result_var.name])
         if isinstance(result_var, ResultDataSet):
-            return self._dataset_sample_to_container(val, result_var, container)
+            return self._dataset_sample_to_container(val, result_var, container, legacy_trusted)
         if isinstance(result_var, ResultReference):
             ref = self.object_index[val]
             if ref is not None:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -910,13 +910,14 @@ class BenchResultBase:
                 if isinstance(result_var, (ResultVideo, ResultImage)):
                     return self._pane_over_time_slider(dataset, result_var)
                 if isinstance(result_var, ResultDataSet):
-                    # A ResultDataSet cell holds an index into dataset_list, which is
-                    # rebuilt from the samples of the run that is rendering.  Rows
-                    # merged in from history therefore address *this* run's list, so a
-                    # slider over them would show the current payload under every past
-                    # run's label.  Render the event being reported instead; scalar
-                    # results keep their real history either way.
-                    dataset = dataset.isel(over_time=-1)
+                    # Path-backed cells (plan 22) make historical payloads loadable
+                    # from any run, so every time point renders like the other blob
+                    # types.  Legacy index cells inside a mixed history render where
+                    # dataset_list still covers them and as a labelled placeholder
+                    # where it does not.
+                    return self._pane_over_time_dataset(
+                        dataset, result_var, plot_callback, **kwargs
+                    )
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
         return outer_container.render()
@@ -1052,6 +1053,39 @@ class BenchResultBase:
             return pn.pane.Markdown("*No rerun data available*")
         return pn.Row(*items)
 
+    def _pane_over_time_dataset(
+        self,
+        dataset: xr.Dataset,
+        result_var,
+        plot_callback: Callable,
+        **kwargs,
+    ) -> pn.Row | None:
+        """Render ``ResultDataSet`` over_time as a grid of labelled per-time panes.
+
+        Path-backed cells are meaningful in any process, so history points render
+        instead of being cut down to the latest event (the pre-plan-22
+        ``isel(over_time=-1)`` workaround).  A time point whose cell is missing
+        (either generation's sentinel) is skipped; a legacy index cell renders
+        through ``ds_to_container``'s legacy path — the payload where
+        ``dataset_list`` covers it, a placeholder where it does not.
+        """
+        time_vals = list(dataset.coords["over_time"].values)
+        is_datetime = np.issubdtype(dataset.coords["over_time"].dtype, np.datetime64)
+        labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
+
+        items = []
+        for idx, label in enumerate(labels):
+            pane = plot_callback(
+                dataset=dataset.isel(over_time=idx), result_var=result_var, **kwargs
+            )
+            if pane is None:
+                continue
+            items.append(pn.Column(pn.pane.Markdown(f"**{label}**"), pane))
+
+        if not items:
+            return None
+        return pn.Row(*items)
+
     def zero_dim_da_to_val(self, da_ds: xr.DataArray | xr.Dataset) -> Any:
         # todo this is really horrible, need to improve
         dim = None
@@ -1101,6 +1135,67 @@ class BenchResultBase:
                 return candidate
         return None
 
+    def _dataset_sample_to_container(self, val: Any, result_var: Parameter, container) -> Any:
+        """Render one stored ``ResultDataSet`` cell, whichever generation stored it.
+
+        Three cell shapes exist (plan 22, D3):
+
+        1. a ``str`` blob path (collected after plan 22) — loaded with
+           ``load_blob``; a payload materialized with a per-sample container is a
+           pickled ``ResultDataSet`` wrapper, so the full precedence chain
+           (renderer-supplied → sample's → class's → raw object) still applies;
+        2. an ``int`` index (a result pickled or cached before plan 22) — looked
+           up in ``dataset_list`` when this result still carries the list that
+           produced it, and rendered as a labelled placeholder otherwise (an old
+           cell without its list is honestly unrecoverable — never a crash);
+        3. the missing sentinel of either generation (``"NAN"`` / ``-1``) →
+           ``None``, which pane composition skips.
+        """
+        if result_is_missing(result_var, val):
+            return None
+        if isinstance(val, str):
+            from bencher.blob_store import load_blob
+
+            payload = load_blob(val)
+            sample = payload if isinstance(payload, ResultDataSet) else None
+            if sample is not None:
+                payload = sample.obj
+            # Renderer-supplied container wins, then the sample's, then the class's.
+            resolved = container or self.declared_container(sample, result_var)
+            return resolved(payload) if resolved is not None else payload
+        # Legacy int cell.  Over_time concat can promote the old int column to
+        # float, so integral floats are legacy indices too.
+        try:
+            idx = int(val)
+        except (TypeError, ValueError):
+            logger.warning(
+                "ResultDataSet '%s': unrecognised cell %r (neither a blob path nor a legacy index)",
+                result_var.name,
+                val,
+            )
+            return pn.pane.Markdown(
+                f"*'{result_var.name}': stored cell is not renderable ({type(val).__name__})*"
+            )
+        dataset_list = getattr(self, "dataset_list", None)
+        if not dataset_list or not 0 <= idx < len(dataset_list):
+            logger.warning(
+                "ResultDataSet '%s': cell %r indexes a dataset_list of length %d; the "
+                "payload predates path-backed storage and its run's list is gone",
+                result_var.name,
+                val,
+                len(dataset_list) if dataset_list else 0,
+            )
+            return pn.pane.Markdown(
+                f"*'{result_var.name}': stored payload predates the path-backed format "
+                "and is no longer recoverable from this result*"
+            )
+        ref = dataset_list[idx]
+        if ref is None:
+            return None
+        # Renderer-supplied container wins, then the sample's, then the class's.
+        resolved = container or self.declared_container(ref, result_var)
+        return resolved(ref.obj) if resolved is not None else ref.obj
+
     def ds_to_container(  # pylint: disable=too-many-return-statements
         self, dataset: xr.Dataset, result_var: Parameter, container, **kwargs
     ) -> Any:
@@ -1120,9 +1215,10 @@ class BenchResultBase:
         download widget.
         """
         if isinstance(result_var, (ResultDataSet, ResultReference)):
-            # These two store an index into a side list, so a value that is still an
-            # array indexes that list with an array several frames from the cause.
-            # Name the dimension the caller did not reduce instead.
+            # These two store a per-sample lookup key (a blob path, or a legacy /
+            # object index into a side list), so a value that is still an array
+            # fails several frames from the cause. Name the dimension the caller
+            # did not reduce instead.
             unreduced = self._unreduced_dims(dataset[result_var.name])
             if unreduced:
                 raise ValueError(
@@ -1132,12 +1228,7 @@ class BenchResultBase:
                 )
         val = self.zero_dim_da_to_val(dataset[result_var.name])
         if isinstance(result_var, ResultDataSet):
-            ref = self.dataset_list[val]
-            if ref is None:
-                return None
-            # Renderer-supplied container wins, then the sample's, then the class's.
-            resolved = container or self.declared_container(ref, result_var)
-            return resolved(ref.obj) if resolved is not None else ref.obj
+            return self._dataset_sample_to_container(val, result_var, container)
         if isinstance(result_var, ResultReference):
             ref = self.object_index[val]
             if ref is not None:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from collections import defaultdict
@@ -89,6 +90,24 @@ def convert_dataset_bool_dims_to_str(dataset: xr.Dataset) -> xr.Dataset:
     if len(bool_coords) > 0:
         return dataset.assign_coords(bool_coords)
     return dataset
+
+
+def _accepts_keyword(callback: Callable, name: str) -> bool:
+    """True when *callback* can be called with the *name* keyword.
+
+    ``plot_callback`` is a public extension point: a caller may pass any callable
+    to ``map_plot_panes``, including one whose signature is exactly
+    ``(dataset, result_var)``.  Render-internal keywords must therefore be
+    offered rather than imposed — a callback that does not declare the keyword
+    (and has no ``**kwargs`` to absorb it) is called the way it always was
+    instead of raising ``TypeError``.  Uninspectable callables (C builtins) are
+    treated as not accepting it, which is the safe direction.
+    """
+    try:
+        params = inspect.signature(callback).parameters
+    except (TypeError, ValueError):
+        return False
+    return name in params or any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 class BenchResultBase:
@@ -1071,18 +1090,27 @@ class BenchResultBase:
         payloads alone, so a pre-plan history with in-range indices at every time
         point would otherwise render the current payload under historical labels.
         Untrusted legacy cells render as a labelled placeholder instead.
+
+        ``legacy_trusted`` is only *offered* to *plot_callback*: it is a
+        render-internal keyword, and ``plot_callback`` is a public extension
+        point that a caller may satisfy with a plain ``(dataset, result_var)``
+        function.  Passing it unconditionally would turn such a callback into a
+        ``TypeError`` the moment its result went over_time, so a callback that
+        cannot name it is called exactly as it was before this path existed.
         """
         time_vals = list(dataset.coords["over_time"].values)
         is_datetime = np.issubdtype(dataset.coords["over_time"].dtype, np.datetime64)
         labels = [str(pd.to_datetime(t)) if is_datetime else str(t) for t in time_vals]
 
+        pass_trust = _accepts_keyword(plot_callback, "legacy_trusted")
         items = []
         final_idx = len(labels) - 1
         for idx, label in enumerate(labels):
+            trust_kwargs = {"legacy_trusted": idx == final_idx} if pass_trust else {}
             pane = plot_callback(
                 dataset=dataset.isel(over_time=idx),
                 result_var=result_var,
-                legacy_trusted=idx == final_idx,
+                **trust_kwargs,
                 **kwargs,
             )
             if pane is None:

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -252,13 +252,28 @@ class ResultVec(param.List):
 
 
 class ResultHmap(param.Parameter):
-    """A class to represent a holomap return type.
+    """Deprecated: use ResultContainer or ResultReference with a declared container instead.
+
+    A class to represent a holomap return type. Its data lives out-of-band in
+    ``bench_res.hmaps`` rather than in the canonical result dataset, so it cannot
+    participate in the A6 grammar-of-ND-data migration; removal is scheduled for
+    a later phase of that migration.
 
     Note: this class has no __slots__, so _hash_slots hashes only the class name.
     Every ResultHmap instance produces the same hash. This is intentional — there are
     no configuration attributes that would differentiate instances. If a slot is added
     in the future, _hash_slots will automatically include it.
     """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "ResultHmap is deprecated and will be removed in a later phase of the A6 "
+            "grammar-of-nd-data migration; use ResultContainer or ResultReference with "
+            "a declared container= instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def hash_persistent(self) -> str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
@@ -458,6 +473,11 @@ class ResultReference(param.Parameter):
 
     The callback receives only the object — no plot kwargs — so single-argument
     callables are safe, and one renderer works for both this and a ``ResultDataSet``.
+
+    This is the documented same-process escape hatch: the stored object stays live,
+    is stripped by both the result cache write and the collect/render split, and is
+    never load-bearing for the core rendering algebra. Use :class:`ResultDataSet`
+    when the payload should survive process boundaries.
     """
 
     __slots__ = ["units", "obj", "container", "max_time_events"]

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -510,6 +510,12 @@ class ResultDataSet(param.Parameter):
     dataclass, or any other object that can travel through the configured result
     cache. Bencher stores and retrieves it without interpreting its type.
 
+    Payloads are materialized into the cache's content-addressed blob store at
+    collect time (parquet for DataFrames, netCDF for xarray objects, pickle
+    otherwise — see :mod:`bencher.blob_store`); the dataset cell stores the blob
+    path, so any process sharing the cache filesystem can render any sample,
+    including over_time history points.
+
     ``container`` is an optional renderer taking the stored object and returning
     something Panel can display. Declare it once on the class and every sample
     renders through it, in ``result_vars`` order, alongside the other results::
@@ -631,14 +637,19 @@ def result_kind(result_var) -> str:
 # there is no single value that is both storage-valid and reduction-aware
 # across every dtype:
 #   - numeric types (float/bool/vec, and any future numeric) -> NaN   (float)
-#   - index-backed reference types (reference/dataset)       -> -1    (int)
+#   - index-backed reference types (reference)               -> -1    (int)
 #   - object/file/string types (path/video/image/string/...) -> "NAN" (object)
+#
+# ResultDataSet cells are blob paths since plan 22 (grammar phase 1), so its
+# fill is the blob-family "NAN"; results collected before that change store -1
+# int indices, and ``result_is_missing`` accepts BOTH generations permanently —
+# a mixed-generation over_time history contains cells of each kind.
 #
 # Both dataset initialisation (``ResultCollector.setup_dataset``) and over_time
 # aging (``_null_old_entries``) build their arrays from ``result_missing_fill``,
 # and consumers test for missingness with ``result_is_missing`` instead of
 # hardcoding ``np.isnan`` / ``== "NAN"`` / ``== -1`` per call site.
-_REFERENCE_MISSING_TYPES = (ResultReference, ResultDataSet)
+_REFERENCE_MISSING_TYPES = (ResultReference,)
 _OBJECT_MISSING_TYPES = (
     ResultPath,
     ResultVideo,
@@ -646,6 +657,7 @@ _OBJECT_MISSING_TYPES = (
     ResultString,
     ResultContainer,
     ResultRerun,
+    ResultDataSet,
 )
 # Single-column result types that get a data variable in the dataset. ResultVec
 # is handled separately (it expands to one column per element); ResultHmap is
@@ -663,6 +675,26 @@ def result_missing_fill(rv) -> tuple[Any, type]:
     return float("nan"), float
 
 
+def _dataset_cell_is_missing(value) -> bool:
+    """Missingness for a ``ResultDataSet`` cell, across both sentinel generations.
+
+    ``"NAN"`` (blob-path cells, plan 22 onwards) and ``-1`` (index-backed cells
+    collected before it, including the float ``-1.0`` an over_time concat can
+    promote an int column to) are both missing, permanently — a mixed-generation
+    history holds cells of each kind.  NaN/``None`` also count as missing so an
+    unrepaired concat fill is never handed to ``load_blob`` or a
+    ``dataset_list`` lookup as data.
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value == "NAN"
+    if isinstance(value, numbers.Real) and not isinstance(value, bool):
+        as_float = float(value)
+        return math.isnan(as_float) or as_float == -1.0
+    return False
+
+
 def result_is_missing(rv, value) -> bool:
     """True when *value* is the missing/unrecorded sentinel for *rv*'s storage.
 
@@ -674,7 +706,12 @@ def result_is_missing(rv, value) -> bool:
     attempted (the *string* ``"nan"`` is real data, not a missing marker). For
     the ``-1`` / ``"NAN"`` sentinel types, missingness is exact equality with
     the sentinel.
+
+    ``ResultDataSet`` accepts BOTH its sentinel generations, permanently — see
+    :func:`_dataset_cell_is_missing`.
     """
+    if isinstance(rv, ResultDataSet):
+        return _dataset_cell_is_missing(value)
     fill, _ = result_missing_fill(rv)
     if isinstance(fill, float) and math.isnan(fill):
         if value is None:

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -137,6 +137,10 @@ reachable/unreachable, pass/fail), always use `ResultBool` — it locks bounds t
 and produces correct boolean-style plots. Only use `ResultFloat` for continuous metrics.
 See the [Result Types gallery](reference/meta/result_types/index) for examples of each type.
 
+**Deprecated:** `bn.ResultHmap` is deprecated (it stores its data outside the result
+dataset) — use `bn.ResultContainer` or `bn.ResultReference` with a declared
+`container=` instead.
+
 **Rendering stored data:** `ResultDataSet` stores the payload without interpreting
 its type. Without a renderer, Panel displays the raw object. Pass `container=` a
 callable taking the stored object and returning anything Panel can display, and every

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -251,10 +251,13 @@ not wanted) — `bench.add(bn.XYScatterResult, x="dx_mm", y="dy_mm")`,
 `to_auto(plot_list=["xy_scatter"], x=..., y=...)`. None of them are ever selected
 automatically, so no existing report gains a plot it did not ask for.
 
-Under `over_time`, a `ResultDataSet` renders the run being reported rather than a slider
-over the history: a cell holds an index into a payload list rebuilt on every run, so
-the indices carried in from earlier runs address the current list and a slider would show
-today's payload under yesterday's label. Scalar results keep their full history.
+Under `over_time`, a `ResultDataSet` renders its full history: each cell stores a
+blob-store path, so every time point's payload stays loadable and the report shows a
+labelled per-time grid — one pane per snapshot under its timestamp. Cells cached before
+the blob store existed (legacy index cells) render where their payload list is still
+available and as a labelled placeholder where it is not. See the
+[ResultDataSet over time example](reference/meta/result_types/result_dataset/example_result_dataset_1d_over_time)
+for a working sweep.
 
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.

--- a/plans/22-grammar-phase-1-data-model.md
+++ b/plans/22-grammar-phase-1-data-model.md
@@ -213,6 +213,35 @@ exact sentence.
   removing `dataset_list`/`ResultHmap` code (phase 3).
 - A2/A3-style serialization of plot *choices* — plans/views arrive in phases 2 and 5.
 
+## Amendments discovered during implementation
+
+Recorded per the plans-README rule that claims which stopped holding are stated
+rather than silently worked around:
+
+1. **The environment is netCDF3-only** (scipy is the sole xarray engine), which
+   silently narrows int64→int32 and raises on other values. D1 therefore carries an
+   empirically-derived dtype whitelist (`_NETCDF3_SAFE_DTYPES` in
+   `bencher/blob_store.py`, evidence in its comment); Datasets/DataArrays with unsafe
+   dtypes take the pickle fallback rather than risk corruption. Structured-format
+   failures of any kind fall back to pickle with a logged warning — a worker payload
+   inside the documented contract must never abort a sweep.
+2. **D4's legacy wording was wrong and is amended.** "Render via D3(2) where the list
+   is available" would resolve in-range historical indices against the *final* run's
+   `dataset_list`, rendering the current payload under historical labels (reproduced
+   in review). Legacy int cells are trusted only at the final time event; earlier
+   events render the placeholder.
+3. **No path passthrough in the blob store**: a str/Path payload is pickled like any
+   object so the render-time container receives exactly what the worker stored.
+4. **Per-sample containers** are preserved by materializing the pickled
+   `ResultDataSet` wrapper (such payloads store as `.pkl`); an unpicklable per-sample
+   container (e.g. a lambda) is dropped with a warning and the bare payload stored —
+   class-level containers still apply.
+5. Both owner decisions resolved to their recorded defaults: the pickle fallback is
+   allowed (flagged for A3), and no `CACHE_VERSION` bump.
+6. D4's gallery evidence required a new example —
+   `example_result_dataset_1d_over_time` — since no existing example combined
+   `ResultDataSet` with `over_time`.
+
 ## Coordination
 
 - **A3/A4:** D1's store is a deliberate step toward A4's artifact manifests — keep the

--- a/plans/22-grammar-phase-1-data-model.md
+++ b/plans/22-grammar-phase-1-data-model.md
@@ -241,6 +241,23 @@ rather than silently worked around:
 6. D4's gallery evidence required a new example —
    `example_result_dataset_1d_over_time` — since no existing example combined
    `ResultDataSet` with `over_time`.
+7. **D4's legacy-trust flag is offered to `plot_callback`, not imposed on it**
+   (found in post-implementation review). `plot_callback` is a public extension
+   point that a caller may satisfy with a plain `(dataset, result_var)` function,
+   so passing `legacy_trusted=` unconditionally turned any such callback into a
+   `TypeError` the moment its result went `over_time` — a regression against
+   pre-plan-22 behaviour, since the old `isel(over_time=-1)` path passed no extra
+   keyword. `_pane_over_time_dataset` now passes it only to callbacks that declare
+   it (or carry `**kwargs`); every callback in bencher does, so behaviour is
+   unchanged internally.
+8. **The blob store is a third cache category, not media.** `cache_management`
+   gained `_CONTENT_FOLDERS` rather than extending `_MEDIA_FOLDERS`, whose contract
+   ("contains per-job-key subdirectories") is what makes per-job and orphan cleanup
+   safe — a content-addressed blob may back cells from many job keys, so it must
+   never be pruned per job. Blobs are counted by `cache_stats` (they grow unbounded
+   until an explicit clear, so they must not be invisible in a size audit) and
+   removed by `clear_media`, degrading affected cells to placeholders exactly as a
+   cleared image does.
 
 ## Coordination
 

--- a/test/test_blob_store.py
+++ b/test/test_blob_store.py
@@ -1,0 +1,146 @@
+"""Tests for the content-addressed blob store (plan 22, design D1, test item 1)."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import xarray as xr
+
+from bencher.blob_store import load_blob, materialize_blob
+
+
+@dataclass
+class ArbitraryPayload:
+    """A picklable payload with no dedicated blob format."""
+
+    name: str
+    value: float
+
+
+def _blob_files(cache_dir: Path) -> list[Path]:
+    return sorted((cache_dir / "blobs").glob("*"))
+
+
+class TestMaterializeRoundTrip:
+    def test_dataframe_parquet(self, tmp_path):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        path = materialize_blob(df, tmp_path)
+        assert isinstance(path, str)
+        assert path.endswith(".parquet")
+        assert Path(path).parent == tmp_path / "blobs"
+        pd.testing.assert_frame_equal(load_blob(path), df)
+
+    def test_xarray_dataset_netcdf(self, tmp_path):
+        ds = xr.Dataset({"speed": ("x", [1.0, 2.0, 3.0])}, coords={"x": [10, 20, 30]})
+        path = materialize_blob(ds, tmp_path)
+        assert path.endswith(".nc")
+        loaded = load_blob(path)
+        xr.testing.assert_identical(loaded, ds)
+
+    def test_xarray_dataarray_netcdf(self, tmp_path):
+        da = xr.DataArray([1.0, 2.0], dims=["x"], name="metric")
+        path = materialize_blob(da, tmp_path)
+        assert path.endswith(".nc")
+        loaded = load_blob(path)
+        # DataArrays load back as single-variable Datasets (documented).
+        assert isinstance(loaded, xr.Dataset)
+        xr.testing.assert_identical(loaded["metric"], da)
+
+    def test_bytes_bin(self, tmp_path):
+        payload = b"\x00\x01raw bytes\xff"
+        path = materialize_blob(payload, tmp_path)
+        assert path.endswith(".bin")
+        assert load_blob(path) == payload
+
+    def test_picklable_dataclass_pkl(self, tmp_path):
+        obj = ArbitraryPayload(name="test", value=1.5)
+        path = materialize_blob(obj, tmp_path)
+        assert path.endswith(".pkl")
+        assert load_blob(path) == obj
+
+    def test_netcdf_blob_is_rereadable(self, tmp_path):
+        """load_blob must close the netCDF handle so the file can be read again."""
+        ds = xr.Dataset({"a": ("x", [1.0])})
+        path = materialize_blob(ds, tmp_path)
+        first = load_blob(path)
+        second = load_blob(path)
+        xr.testing.assert_identical(first, second)
+
+
+class TestContentAddressing:
+    def test_identical_payloads_identical_paths(self, tmp_path):
+        df = pd.DataFrame({"a": [1, 2]})
+        path1 = materialize_blob(df, tmp_path)
+        path2 = materialize_blob(df.copy(), tmp_path)
+        assert path1 == path2
+        assert _blob_files(tmp_path) == [Path(path1)]
+
+    def test_file_written_once(self, tmp_path):
+        payload = b"same content"
+        path1 = materialize_blob(payload, tmp_path)
+        mtime = Path(path1).stat().st_mtime_ns
+        path2 = materialize_blob(payload, tmp_path)
+        assert path1 == path2
+        assert Path(path2).stat().st_mtime_ns == mtime  # not rewritten
+
+    def test_differing_payloads_differing_paths(self, tmp_path):
+        path1 = materialize_blob(b"payload one", tmp_path)
+        path2 = materialize_blob(b"payload two", tmp_path)
+        assert path1 != path2
+        assert len(_blob_files(tmp_path)) == 2
+
+    def test_filename_is_16_hex_chars(self, tmp_path):
+        path = materialize_blob(b"abc", tmp_path)
+        stem = Path(path).stem
+        assert len(stem) == 16
+        int(stem, 16)  # raises ValueError if not hex
+
+    def test_no_leftover_temp_files(self, tmp_path):
+        materialize_blob(b"abc", tmp_path)
+        assert not list((tmp_path / "blobs").glob("*.tmp*"))
+
+
+class TestPathPassthrough:
+    def test_existing_str_path_returned_unchanged(self, tmp_path):
+        existing = tmp_path / "already_materialized.rrd"
+        existing.write_bytes(b"data")
+        assert materialize_blob(str(existing), tmp_path) == str(existing)
+
+    def test_existing_pathlib_path_returned_as_str(self, tmp_path):
+        existing = tmp_path / "file.nc"
+        existing.write_bytes(b"data")
+        result = materialize_blob(existing, tmp_path)
+        assert result == str(existing)
+        assert isinstance(result, str)
+
+    def test_passthrough_writes_no_blob(self, tmp_path):
+        existing = tmp_path / "file.bin"
+        existing.write_bytes(b"data")
+        materialize_blob(str(existing), tmp_path)
+        assert not (tmp_path / "blobs").exists()
+
+    def test_nonexistent_path_string_is_pickled(self, tmp_path):
+        """A str that is not an existing file is an ordinary picklable payload."""
+        path = materialize_blob("/no/such/file.parquet", tmp_path)
+        assert path.endswith(".pkl")
+        assert load_blob(path) == "/no/such/file.parquet"
+
+
+class TestLoadBlobDispatch:
+    def test_unknown_extension_raises(self, tmp_path):
+        weird = tmp_path / "blob.xyz"
+        weird.write_bytes(b"data")
+        with pytest.raises(ValueError, match=r"unknown blob extension '\.xyz'"):
+            load_blob(weird)
+
+    def test_no_extension_raises(self, tmp_path):
+        bare = tmp_path / "blob"
+        bare.write_bytes(b"data")
+        with pytest.raises(ValueError, match="unknown blob extension"):
+            load_blob(bare)
+
+    def test_accepts_str_and_path(self, tmp_path):
+        path = materialize_blob(b"data", tmp_path)
+        assert load_blob(path) == b"data"
+        assert load_blob(Path(path)) == b"data"

--- a/test/test_blob_store.py
+++ b/test/test_blob_store.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -32,7 +33,11 @@ class TestMaterializeRoundTrip:
         pd.testing.assert_frame_equal(load_blob(path), df)
 
     def test_xarray_dataset_netcdf(self, tmp_path):
-        ds = xr.Dataset({"speed": ("x", [1.0, 2.0, 3.0])}, coords={"x": [10, 20, 30]})
+        # int32 coords: int64 is not netCDF3-safe and would take the pickle path.
+        ds = xr.Dataset(
+            {"speed": ("x", [1.0, 2.0, 3.0])},
+            coords={"x": np.array([10, 20, 30], dtype="int32")},
+        )
         path = materialize_blob(ds, tmp_path)
         assert path.endswith(".nc")
         loaded = load_blob(path)
@@ -41,11 +46,22 @@ class TestMaterializeRoundTrip:
     def test_xarray_dataarray_netcdf(self, tmp_path):
         da = xr.DataArray([1.0, 2.0], dims=["x"], name="metric")
         path = materialize_blob(da, tmp_path)
-        assert path.endswith(".nc")
+        assert path.endswith(".da.nc")
         loaded = load_blob(path)
-        # DataArrays load back as single-variable Datasets (documented).
-        assert isinstance(loaded, xr.Dataset)
-        xr.testing.assert_identical(loaded["metric"], da)
+        # F4: DataArrays keep their identity — loaded back as a DataArray
+        # with .name preserved, not as a single-variable Dataset.
+        assert isinstance(loaded, xr.DataArray)
+        assert loaded.name == "metric"
+        xr.testing.assert_identical(loaded, da)
+
+    def test_xarray_dataarray_unnamed_round_trips(self, tmp_path):
+        da = xr.DataArray([3.5, 4.5], dims=["x"])
+        path = materialize_blob(da, tmp_path)
+        assert path.endswith(".da.nc")
+        loaded = load_blob(path)
+        assert isinstance(loaded, xr.DataArray)
+        assert loaded.name is None
+        xr.testing.assert_identical(loaded, da)
 
     def test_bytes_bin(self, tmp_path):
         payload = b"\x00\x01raw bytes\xff"
@@ -101,30 +117,88 @@ class TestContentAddressing:
         assert not list((tmp_path / "blobs").glob("*.tmp*"))
 
 
-class TestPathPassthrough:
-    def test_existing_str_path_returned_unchanged(self, tmp_path):
+class TestStringPayloadPickled:
+    """F3: no path passthrough — a str/Path payload is an ordinary pickled object."""
+
+    def test_existing_file_str_is_pickled(self, tmp_path):
         existing = tmp_path / "already_materialized.rrd"
         existing.write_bytes(b"data")
-        assert materialize_blob(str(existing), tmp_path) == str(existing)
+        path = materialize_blob(str(existing), tmp_path)
+        assert path != str(existing)
+        assert path.endswith(".pkl")
+        assert Path(path).parent == tmp_path / "blobs"
+        loaded = load_blob(path)
+        assert isinstance(loaded, str)
+        assert loaded == str(existing)
 
-    def test_existing_pathlib_path_returned_as_str(self, tmp_path):
+    def test_existing_pathlib_path_is_pickled(self, tmp_path):
         existing = tmp_path / "file.nc"
         existing.write_bytes(b"data")
-        result = materialize_blob(existing, tmp_path)
-        assert result == str(existing)
-        assert isinstance(result, str)
-
-    def test_passthrough_writes_no_blob(self, tmp_path):
-        existing = tmp_path / "file.bin"
-        existing.write_bytes(b"data")
-        materialize_blob(str(existing), tmp_path)
-        assert not (tmp_path / "blobs").exists()
+        path = materialize_blob(existing, tmp_path)
+        assert path.endswith(".pkl")
+        assert load_blob(path) == existing
 
     def test_nonexistent_path_string_is_pickled(self, tmp_path):
         """A str that is not an existing file is an ordinary picklable payload."""
         path = materialize_blob("/no/such/file.parquet", tmp_path)
         assert path.endswith(".pkl")
         assert load_blob(path) == "/no/such/file.parquet"
+
+
+class TestSerializationFallbacks:
+    """F1/F2: structured-format failures fall back to pickle, never raise."""
+
+    def test_nested_object_dataframe_pickled(self, tmp_path):
+        """pyarrow raises ArrowInvalid on nested-object columns; pickle round-trips."""
+        df = pd.DataFrame({"a": [{"nested": 1}, [1, 2]]})
+        path = materialize_blob(df, tmp_path)
+        assert path.endswith(".pkl")
+        pd.testing.assert_frame_equal(load_blob(path), df)
+
+    def test_plain_float_dataframe_still_parquet(self, tmp_path):
+        df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        path = materialize_blob(df, tmp_path)
+        assert path.endswith(".parquet")
+        pd.testing.assert_frame_equal(load_blob(path), df)
+
+    def test_int64_dataset_round_trips_exactly_via_pickle(self, tmp_path):
+        """scipy netCDF3 silently narrows int64→int32 (or raises); pickle preserves it."""
+        ds = xr.Dataset(
+            {"count": ("x", np.array([2**40, 1], dtype="int64"))},
+            coords={"x": np.array([0, 1], dtype="int64")},
+        )
+        path = materialize_blob(ds, tmp_path)
+        assert path.endswith(".pkl")
+        loaded = load_blob(path)
+        assert loaded["count"].dtype == np.dtype("int64")
+        assert loaded["x"].dtype == np.dtype("int64")
+        xr.testing.assert_identical(loaded, ds)
+
+    def test_int64_coord_alone_forces_pickle(self, tmp_path):
+        """Coords are checked as well as data vars (a python-int coord is int64)."""
+        ds = xr.Dataset({"speed": ("x", [1.0, 2.0])}, coords={"x": [10, 20]})
+        assert ds["x"].dtype == np.dtype("int64")
+        path = materialize_blob(ds, tmp_path)
+        assert path.endswith(".pkl")
+        xr.testing.assert_identical(load_blob(path), ds)
+
+    def test_str_coord_dataset_pickled(self, tmp_path):
+        """netCDF3 loads <U coords back as object dtype, so they take the pickle path."""
+        ds = xr.Dataset({"v": ("x", [1.0, 2.0])}, coords={"x": np.array(["a", "b"])})
+        path = materialize_blob(ds, tmp_path)
+        assert path.endswith(".pkl")
+        loaded = load_blob(path)
+        assert loaded["x"].dtype == ds["x"].dtype
+        xr.testing.assert_identical(loaded, ds)
+
+    def test_int64_dataarray_round_trips_via_pickle(self, tmp_path):
+        da = xr.DataArray(np.array([-(2**35), 5], dtype="int64"), dims=["x"], name="metric")
+        path = materialize_blob(da, tmp_path)
+        assert path.endswith(".pkl")
+        loaded = load_blob(path)
+        assert isinstance(loaded, xr.DataArray)
+        assert loaded.dtype == np.dtype("int64")
+        xr.testing.assert_identical(loaded, da)
 
 
 class TestLoadBlobDispatch:

--- a/test/test_cache_management.py
+++ b/test/test_cache_management.py
@@ -94,6 +94,15 @@ class _TempCacheMixin:
             f.write(content)
         return p
 
+    def _make_blob(self, name, content=b"x" * 100):
+        """Create a flat, sha256-named file matching the blob store layout."""
+        blobs_dir = os.path.join(self.cachedir, "blobs")
+        os.makedirs(blobs_dir, exist_ok=True)
+        p = os.path.join(blobs_dir, name)
+        with open(p, "wb") as f:
+            f.write(content)
+        return p
+
     def _make_legacy_media(self, folder, filename, content=b"x" * 100):
         """Create a legacy UUID-named file (pre-v2 layout)."""
         full_dir = os.path.join(self.cachedir, folder, filename)
@@ -168,6 +177,19 @@ class TestCacheStatsIntegration(_TempCacheMixin, unittest.TestCase):
         stats = cache_stats(self.cachedir)
         self.assertEqual(stats.total_bytes, 0)
 
+    def test_blob_store_is_counted(self):
+        """The blob store grows without per-job pruning, so it must not be
+        invisible to anyone auditing cache size."""
+        self._make_blob("abc123def456abcd.parquet")
+        self._make_blob("0123456789abcdef.nc", b"y" * 300)
+
+        stats = cache_stats(self.cachedir)
+        blobs = next(s for s in stats.content if s.path == "blobs")
+        self.assertEqual(blobs.entries, 2)
+        self.assertEqual(blobs.size_bytes, 400)
+        self.assertEqual(stats.total_bytes, 400)
+        self.assertIn("blobs", stats.summary())
+
 
 class TestCleanupJobMedia(_TempCacheMixin, unittest.TestCase):
     def test_removes_job_key_dirs(self):
@@ -213,6 +235,38 @@ class TestClearMedia(_TempCacheMixin, unittest.TestCase):
         c = Cache(os.path.join(self.cachedir, "sample_cache"))
         self.assertEqual(c["k"], "v")
         c.close()
+
+    def test_clears_blobs_too(self):
+        """Blobs are payload files like images: clearing media reclaims them, and
+        the cells that referenced them degrade to placeholders at render."""
+        self._make_managed_cache("sample_cache", {"k": "v"})
+        self._make_blob("abc123def456abcd.parquet", b"q" * 80)
+
+        deleted, freed = clear_media(self.cachedir)
+        self.assertEqual(deleted, 1)
+        self.assertEqual(freed, 80)
+        self.assertFalse(Path(self.cachedir, "blobs").exists())
+
+
+class TestBlobsAreNotPerJobPruned(_TempCacheMixin, unittest.TestCase):
+    """A blob is shared by every job whose payload hashes the same, so the
+    per-job and orphan cleanup paths must never touch it — deleting one job's
+    blob would strand another job's cell."""
+
+    def test_cleanup_job_media_leaves_blobs(self):
+        blob = self._make_blob("abc123def456abcd.parquet")
+        self._make_job_media("img", "img", "abc123")
+
+        cleanup_job_media("abc123", self.cachedir)
+        self.assertTrue(os.path.exists(blob))
+
+    def test_clean_orphaned_media_leaves_blobs(self):
+        # No sample cache at all, so every job key is dead: maximally aggressive.
+        blob = self._make_blob("abc123def456abcd.parquet")
+
+        orphans, _ = clean_orphaned_media(self.cachedir, dry_run=False)
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
 
 
 class TestCleanOrphanedMedia(_TempCacheMixin, unittest.TestCase):

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -11,6 +11,7 @@ import panel as pn
 import xarray as xr
 
 import bencher as bn
+from bencher.blob_store import load_blob
 from bencher.results.bench_result_base import BenchResultBase
 from bencher.results.dataset_result import DataSetResult, render_data_samples
 from bencher.variables.results import PANEL_TYPES
@@ -187,19 +188,18 @@ class TestDataSetResult(unittest.TestCase):
         self.assertIsInstance(viewer, pn.viewable.Viewable)
         self.assertGreater(len(viewer), 0)
 
-    def test_dataset_list_round_trips_worker_frames(self):
-        """Every worker-produced DataFrame is stored and recoverable unchanged."""
-        self.assertEqual(len(self.res.dataset_list), len(SCALES))
-        for ref, scale in zip(self.res.dataset_list, SCALES):
-            pd.testing.assert_frame_equal(ref.obj, expected_frame(scale))
+    def test_path_cells_round_trip_worker_frames(self):
+        """Every worker-produced DataFrame is stored as a blob and recoverable unchanged.
 
-    def test_ds_indices_map_to_correct_frames(self):
-        """The xarray dataset stores indices into dataset_list, keyed by input value."""
+        Since plan 22 the cell stores a path into the blob store rather than an
+        index into dataset_list, which stays empty (it is the legacy read path).
+        """
+        self.assertEqual(len(self.res.dataset_list), 0)
         ds = self.res.to_dataset()
         for scale in SCALES:
-            idx = int(ds["table"].sel(scale=scale).values)
-            frame = self.res.dataset_list[idx].obj
-            pd.testing.assert_frame_equal(frame, expected_frame(scale))
+            cell = ds["table"].sel(scale=scale).values.item()
+            self.assertIsInstance(cell, str)
+            pd.testing.assert_frame_equal(load_blob(cell), expected_frame(scale))
 
     def test_ds_to_container_returns_underlying_frame(self):
         """ds_to_container (used by the viewer) unwraps the stored DataFrame."""
@@ -292,8 +292,9 @@ class TestArbitraryPayload(unittest.TestCase):
         cls.res = run_sweep(ArbitraryPayloadSweep(), "test_dataset_arbitrary_payload")
 
     def test_payload_round_trips_without_tabular_coercion(self):
+        ds = self.res.to_dataset()
         self.assertEqual(
-            [stored.obj for stored in self.res.dataset_list],
+            [load_blob(ds["table"].sel(scale=scale).values.item()) for scale in SCALES],
             [arbitrary_payload(scale) for scale in SCALES],
         )
 
@@ -338,8 +339,10 @@ class TestDeclaredContainer(unittest.TestCase):
 
     def test_stored_frame_is_untouched(self):
         """Rendering is a view: the container never rewrites what was measured."""
-        for ref, scale in zip(self.res.dataset_list, SCALES):
-            pd.testing.assert_frame_equal(ref.obj, expected_frame(scale))
+        ds = self.res.to_dataset()
+        for scale in SCALES:
+            frame = load_blob(ds["table"].sel(scale=scale).values.item())
+            pd.testing.assert_frame_equal(frame, expected_frame(scale))
 
 
 class TestPerSampleContainer(unittest.TestCase):
@@ -369,49 +372,54 @@ class TestContainerIsNotData(unittest.TestCase):
         """A result pickled before the slot existed unpickles with it unset, and still renders.
 
         Unsetting the slot is the only way to reproduce that state in-process, hence
-        the dedicated sweep class: the deletions mutate params this test alone owns.
+        the dedicated sweep class: the deletion mutates a param this test alone owns.
         """
         res = run_sweep(LegacyPickleSweep(), "test_dataset_legacy_pickle")
         rv = res.bench_cfg.result_vars[0]
         del rv.container
-        del res.dataset_list[0].container
         frame = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
         pd.testing.assert_frame_equal(frame, expected_frame(SCALES[0]))
 
 
 class TestOverTimeHistory(unittest.TestCase):
-    """A ResultDataSet has to render on every run, not only the first one.
+    """A ResultDataSet history has to render every event, not only the latest one.
 
-    dataset_list is rebuilt from the samples of whichever run is rendering, so the
-    indices merged in from history address *this* run's list.  Rendering therefore
-    stays on the current event: a slider across the events would show the current
-    table under every past run's label, and before the over_time branch knew about
-    ResultDataSet the render raised out of expand_dims instead.
+    Cells are blob paths since plan 22, meaningful in any run, so the events merged
+    in from history render alongside the current one (D4).  Before that, cells were
+    indices into dataset_list — rebuilt from whichever run was rendering — so the
+    render was forcibly restricted to ``isel(over_time=-1)`` and history existed in
+    the data but could not be shown.
     """
 
     @classmethod
     def setUpClass(cls):
         cls.res = run_sweep_over_time(OverTimeSweep(), "test_dataset_over_time")
-        cls.current_run = OVER_TIME_RUNS - 1
 
     def expected_panes(self) -> list[str]:
-        return [f"declared run={self.current_run} scale={scale:g}" for scale in SCALES]
+        """One pane per (sample, event): samples are peeled outermost, time innermost."""
+        return [
+            f"declared run={run} scale={scale:g}"
+            for scale in SCALES
+            for run in range(OVER_TIME_RUNS)
+        ]
 
     def test_history_accumulated(self):
         """Guard on the fixture: with a single event there is no regression to catch."""
         self.assertEqual(self.res.to_dataset().sizes["over_time"], OVER_TIME_RUNS)
 
-    def test_panes_pass_renders_the_current_run(self):
+    def test_panes_pass_renders_every_run(self):
         self.assertEqual(
             container_output(self.res.to_auto(plot_list=["panes"])), self.expected_panes()
         )
 
-    def test_dataset_view_renders_the_current_run(self):
+    def test_dataset_view_renders_every_run(self):
         self.assertEqual(container_output(self.res.to(DataSetResult)), self.expected_panes())
 
-    def test_one_pane_per_sample_not_per_event(self):
-        """History must not multiply the panes, since the tables are not comparable."""
-        self.assertEqual(len(container_output(self.res.to(DataSetResult))), len(SCALES))
+    def test_one_pane_per_sample_per_event(self):
+        """The D4 payoff: history multiplies the panes, one per stored payload."""
+        self.assertEqual(
+            len(container_output(self.res.to(DataSetResult))), len(SCALES) * OVER_TIME_RUNS
+        )
 
     def test_scalar_results_keep_their_history(self):
         """Slicing the tables must not cost the metrics their over_time series."""

--- a/test/test_grammar_data_model.py
+++ b/test/test_grammar_data_model.py
@@ -9,7 +9,9 @@ Covers items 2-5 and 7 of the plan's test list:
   renders; the same result without its dataset_list renders a labelled
   placeholder instead of raising;
 - item 5: over_time with ResultDataSet across >=2 time points renders ALL points
-  (the D4 payoff), including a mixed history of legacy int and path cells;
+  (the D4 payoff); legacy int cells in a history are only trusted at the final
+  time index (dataset_list holds the final run's payloads alone), so historical
+  legacy cells render a labelled placeholder rather than the wrong run's payload;
 - item 7: the result_is_missing truth table per relevant type.
 
 Item 1 lives in test/test_blob_store.py, item 6 in test/test_hash_persistent.py,
@@ -26,7 +28,7 @@ import pandas as pd
 import panel as pn
 
 import bencher as bn
-from bencher.blob_store import load_blob
+from bencher.blob_store import load_blob, materialize_blob
 from bencher.results.dataset_result import DataSetResult
 from bencher.variables.results import (
     ResultDataSet,
@@ -80,6 +82,42 @@ class PerSampleSweep(PathCellSweep):
 
     def benchmark(self):
         self.table = bn.ResultDataSet(expected_frame(self.scale), container=sample_container)
+
+
+class LambdaContainerSweep(PathCellSweep):
+    """Worker attaches an unpicklable per-sample container (a lambda)."""
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale), container=lambda df: df)
+
+
+def str_container(payload: str) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"declared str={payload}")
+
+
+class StrPayloadSweep(bn.ParametrizedSweep):
+    """Worker stores a plain path string as its ResultDataSet payload."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=str_container, doc="path-string payload")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet("/tmp/whatever.csv")
+
+
+def nested_frame() -> pd.DataFrame:
+    """A frame pyarrow cannot write as parquet (nested object cells)."""
+    return pd.DataFrame({"a": [{"nested": 1}, [1, 2]]})
+
+
+class NestedFrameSweep(bn.ParametrizedSweep):
+    """Worker returns a DataFrame that has no parquet representation."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(doc="nested-object dataframe")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(nested_frame())
 
 
 class OverTimeSweep(bn.ParametrizedSweep):
@@ -291,11 +329,19 @@ class TestOverTimeRendersAllPoints(unittest.TestCase):
         res._to_dataset_cache.clear()  # pylint: disable=protected-access
         return res
 
-    def test_mixed_history_renders_legacy_cell_from_dataset_list(self):
+    def test_mixed_history_legacy_event_is_placeholder_even_with_list(self):
+        """F5: dataset_list is the *final* run's, so a historical legacy int cell
+        must never resolve against it — that would render the current payload
+        under a historical label."""
         res = self._make_mixed([bn.ResultDataSet(tagged_frame(SCALES[0], 99))])
-        rendered = container_output(res.to(DataSetResult))
-        self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS)
-        self.assertIn("declared run=99 scale=1", rendered)
+        view = res.to(DataSetResult)
+        rendered = container_output(view)
+        # The three path cells render; the historical legacy cell degrades.
+        self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS - 1)
+        self.assertNotIn("declared run=99 scale=1", rendered)
+        placeholders = placeholder_output(view)
+        self.assertEqual(len(placeholders), 1)
+        self.assertIn("only the final time event", placeholders[0])
 
     def test_mixed_history_without_dataset_list_degrades_to_placeholder(self):
         res = self._make_mixed([])
@@ -304,6 +350,100 @@ class TestOverTimeRendersAllPoints(unittest.TestCase):
         # The three path cells still render; the orphaned legacy cell degrades.
         self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS - 1)
         self.assertEqual(len(placeholder_output(view)), 1)
+
+
+class TestLegacyOverTimeHistory(unittest.TestCase):
+    """F5: a pre-plan-22 over_time result — int cells at EVERY time point but only
+    the final run's dataset_list — must render the final event's real content and
+    a labelled placeholder for every historical event, never the current payload
+    under a historical label."""
+
+    def _make_full_legacy(self) -> bn.BenchResult:
+        res = run_sweep_over_time(OverTimeSweep(), "test_grammar_over_time_full_legacy")
+        da = res.ds["table"]
+        for i, scale in enumerate(SCALES):
+            da.loc[{"scale": scale}] = i  # in-range int cell at every time point
+        res.dataset_list = [
+            bn.ResultDataSet(tagged_frame(scale, OVER_TIME_RUNS - 1)) for scale in SCALES
+        ]
+        res._to_dataset_cache.clear()  # pylint: disable=protected-access
+        return res
+
+    def test_final_event_real_content_earlier_event_placeholder(self):
+        res = self._make_full_legacy()
+        view = res.to(DataSetResult)
+        # Only the final event resolves against the (final run's) dataset_list.
+        self.assertEqual(
+            container_output(view),
+            [f"declared run={OVER_TIME_RUNS - 1} scale={scale:g}" for scale in SCALES],
+        )
+        # Every historical event degrades to a labelled placeholder.
+        placeholders = placeholder_output(view)
+        self.assertEqual(len(placeholders), len(SCALES) * (OVER_TIME_RUNS - 1))
+        for text in placeholders:
+            self.assertIn("only the final time event", text)
+
+
+class TestSerializationRobustness(unittest.TestCase):
+    """F1/F3/F6 at pipeline level: awkward payloads never fail collection."""
+
+    def test_nested_object_frame_sweep_completes_and_round_trips(self):
+        """F1 escalation: a payload parquet cannot represent completes collection
+        (no raise from store_results) and round-trips via the pickle fallback."""
+        res = run_sweep(NestedFrameSweep(), "test_grammar_nested_frame")
+        ds = res.to_dataset()
+        for scale in SCALES:
+            cell = ds["table"].sel(scale=scale).values.item()
+            with self.subTest(scale=scale):
+                self.assertIsInstance(cell, str)
+                self.assertTrue(cell.endswith(".pkl"))
+                pd.testing.assert_frame_equal(load_blob(cell), nested_frame())
+
+    def test_str_payload_renders_the_stored_string(self):
+        """F3: a path-string payload reaches the container chain as exactly the
+        string the worker stored (the file need not exist)."""
+        res = run_sweep(StrPayloadSweep(), "test_grammar_str_payload")
+        cell = res.to_dataset()["table"].sel(scale=SCALES[0]).values.item()
+        self.assertTrue(cell.endswith(".pkl"))
+        self.assertEqual(load_blob(cell), "/tmp/whatever.csv")
+        rv = res.bench_cfg.result_vars[0]
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        self.assertEqual(pane.object, "declared str=/tmp/whatever.csv")
+        self.assertEqual(
+            container_output(res.to(DataSetResult)),
+            ["declared str=/tmp/whatever.csv"] * len(SCALES),
+        )
+
+    def test_unpicklable_per_sample_container_is_dropped_not_fatal(self):
+        """F6: a lambda per-sample container cannot travel with the payload; the
+        bare payload is stored and the class-level container applies at render."""
+        res = run_sweep(LambdaContainerSweep(), "test_grammar_lambda_container")
+        self.assertEqual(res.dataset_list, [])
+        cell = res.to_dataset()["table"].sel(scale=SCALES[0]).values.item()
+        self.assertIsInstance(cell, str)
+        self.assertTrue(Path(cell).is_file())
+        pd.testing.assert_frame_equal(load_blob(cell), expected_frame(SCALES[0]))
+        rv = res.bench_cfg.result_vars[0]
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        self.assertEqual(pane.object, "declared sum=3")
+
+
+class TestUnloadableBlobPlaceholder(unittest.TestCase):
+    """F7: a path cell whose blob file is gone renders a placeholder, never raises."""
+
+    def test_deleted_blob_renders_placeholder_not_raise(self):
+        res = run_sweep(PathCellSweep(), "test_grammar_deleted_blob")
+        rv = res.bench_cfg.result_vars[0]
+        with tempfile.TemporaryDirectory() as tmp:
+            blob = materialize_blob(expected_frame(3.0), tmp)
+        # TemporaryDirectory cleanup deleted the blob file behind the path cell.
+        self.assertFalse(Path(blob).exists())
+        ds = res.to_dataset().copy(deep=True)
+        ds["table"].loc[{"scale": SCALES[0]}] = blob
+        pane = res.ds_to_container(ds.sel(scale=SCALES[0]), rv, container=None)
+        self.assertIsInstance(pane, pn.pane.Markdown)
+        self.assertIn("could not be loaded", pane.object)
+        self.assertIn("table", pane.object)
 
 
 class TestResultIsMissingTruthTable(unittest.TestCase):

--- a/test/test_grammar_data_model.py
+++ b/test/test_grammar_data_model.py
@@ -1,0 +1,351 @@
+"""Integration tests for plan 22 (grammar phase 1): path-backed ResultDataSet cells.
+
+Covers items 2-5 and 7 of the plan's test list:
+
+- item 2: a sweep with a ResultDataSet var stores str (blob path) cells, appends
+  nothing to dataset_list, and renders through the declared-container chain;
+- item 3: collect -> save_result -> load_result -> render succeeds in-process;
+- item 4: a hand-built legacy result (int cells + populated dataset_list) still
+  renders; the same result without its dataset_list renders a labelled
+  placeholder instead of raising;
+- item 5: over_time with ResultDataSet across >=2 time points renders ALL points
+  (the D4 payoff), including a mixed history of legacy int and path cells;
+- item 7: the result_is_missing truth table per relevant type.
+
+Item 1 lives in test/test_blob_store.py, item 6 in test/test_hash_persistent.py,
+item 8 in test/test_resulthmap_deprecation.py.
+"""
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import panel as pn
+
+import bencher as bn
+from bencher.blob_store import load_blob
+from bencher.results.dataset_result import DataSetResult
+from bencher.variables.results import (
+    ResultDataSet,
+    ResultFloat,
+    ResultPath,
+    ResultReference,
+    result_is_missing,
+)
+
+SCALES = [1.0, 2.0]
+PLACEHOLDER_MARKER = "predates the path-backed format"
+
+
+def expected_frame(scale: float) -> pd.DataFrame:
+    return pd.DataFrame({"y": [scale, scale * 2.0]})
+
+
+def tagged_frame(scale: float, run_id: int) -> pd.DataFrame:
+    """A frame that says which run produced it, so a render traces to its run."""
+    return pd.DataFrame({"y": [scale], "run": [run_id]})
+
+
+def class_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"declared sum={df['y'].sum():g}")
+
+
+def sample_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"per-sample sum={df['y'].sum():g}")
+
+
+def renderer_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"explicit sum={df['y'].sum():g}")
+
+
+def run_tagging_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    return pn.pane.Markdown(f"declared run={df['run'].iloc[0]} scale={df['y'].iloc[0]:g}")
+
+
+class PathCellSweep(bn.ParametrizedSweep):
+    """1-input sweep with a class-declared container on its ResultDataSet."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=class_container, doc="small dataframe result")
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale))
+
+
+class PerSampleSweep(PathCellSweep):
+    """Worker overrides the declared container on the sample it stores."""
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(expected_frame(self.scale), container=sample_container)
+
+
+class OverTimeSweep(bn.ParametrizedSweep):
+    """A run-tagged tabular result, to be run repeatedly against one history."""
+
+    scale = bn.FloatSweep(default=1.0, bounds=[1.0, 2.0], samples=2)
+    table = bn.ResultDataSet(container=run_tagging_container, doc="run-tagged dataframe")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.table = bn.ResultDataSet(tagged_frame(self.scale, self.run_id))
+
+
+def run_sweep(worker: bn.ParametrizedSweep, name: str) -> bn.BenchResult:
+    bench = bn.Bench(name, worker)
+    return bench.plot_sweep(
+        "grammar_sweep",
+        input_vars=["scale"],
+        result_vars=["table"],
+        run_cfg=bn.BenchRunCfg(repeats=1, cache_results=False, cache_samples=False),
+        auto_plot=False,
+    )
+
+
+OVER_TIME_RUNS = 2
+
+
+def run_sweep_over_time(worker: bn.ParametrizedSweep, name: str) -> bn.BenchResult:
+    """Run one sweep repeatedly against a single history, as a nightly rig does."""
+    run_cfg = bn.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 1
+    run_cfg.auto_plot = False
+    bench = bn.Bench(name, worker)
+    base_time = datetime(2000, 1, 1)
+    res = None
+    for i in range(OVER_TIME_RUNS):
+        worker.run_id = i
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = i == 0
+        res = bench.plot_sweep(
+            "grammar_over_time_sweep",
+            input_vars=["scale"],
+            result_vars=["table"],
+            run_cfg=run_cfg,
+            time_src=base_time + timedelta(seconds=i),
+        )
+    return res
+
+
+def container_output(viewable: pn.viewable.Viewable) -> list[str]:
+    """Container-produced Markdown in a rendered pane tree, in render order."""
+    return [
+        pane.object
+        for pane in viewable.select(pn.pane.Markdown)
+        if str(pane.object).startswith(("declared", "per-sample", "explicit"))
+    ]
+
+
+def placeholder_output(viewable: pn.viewable.Viewable) -> list[str]:
+    return [
+        pane.object
+        for pane in viewable.select(pn.pane.Markdown)
+        if PLACEHOLDER_MARKER in str(pane.object)
+    ]
+
+
+def make_legacy(res: bn.BenchResult, payloads: list[bn.ResultDataSet]) -> bn.BenchResult:
+    """Rewrite a fresh result into the pre-plan-22 representation: int cells
+    indexing a populated dataset_list."""
+    res.dataset_list = payloads
+    da = res.ds["table"]
+    for i, scale in enumerate(SCALES):
+        da.loc[{"scale": scale}] = i
+    res._to_dataset_cache.clear()  # pylint: disable=protected-access
+    return res
+
+
+class TestPathBackedCells(unittest.TestCase):
+    """Item 2: str cells, empty dataset_list, unchanged container chain."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep(PathCellSweep(), "test_grammar_path_cells")
+
+    def test_cells_are_blob_paths_that_round_trip(self):
+        ds = self.res.to_dataset()
+        for scale in SCALES:
+            cell = ds["table"].sel(scale=scale).values.item()
+            with self.subTest(scale=scale):
+                self.assertIsInstance(cell, str)
+                self.assertTrue(Path(cell).is_file())
+                pd.testing.assert_frame_equal(load_blob(cell), expected_frame(scale))
+
+    def test_nothing_appended_to_dataset_list(self):
+        self.assertEqual(self.res.dataset_list, [])
+
+    def test_class_declared_container_renders(self):
+        rv = self.res.bench_cfg.result_vars[0]
+        point = self.res.to_dataset().sel(scale=SCALES[0])
+        pane = self.res.ds_to_container(point, rv, container=None)
+        self.assertEqual(pane.object, "declared sum=3")
+
+    def test_renderer_supplied_container_beats_declared(self):
+        rv = self.res.bench_cfg.result_vars[0]
+        point = self.res.to_dataset().sel(scale=SCALES[0])
+        pane = self.res.ds_to_container(point, rv, container=renderer_container)
+        self.assertEqual(pane.object, "explicit sum=3")
+
+    def test_per_sample_container_beats_declared(self):
+        res = run_sweep(PerSampleSweep(), "test_grammar_per_sample_container")
+        self.assertEqual(res.dataset_list, [])
+        rv = res.bench_cfg.result_vars[0]
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        self.assertEqual(pane.object, "per-sample sum=3")
+
+    def test_dataset_view_renders_every_sample_through_the_chain(self):
+        self.assertEqual(
+            container_output(self.res.to(DataSetResult)),
+            ["declared sum=3", "declared sum=6"],
+        )
+
+
+class TestSplitRenderRoundTrip(unittest.TestCase):
+    """Item 3: collect -> save_result -> load_result -> render, in-process."""
+
+    def test_save_load_render(self):
+        res = run_sweep(PathCellSweep(), "test_grammar_split_render")
+        with tempfile.TemporaryDirectory() as tmp:
+            pkl = Path(tmp) / "result.pkl"
+            bn.save_result(res, pkl)
+            loaded = bn.load_result(pkl)
+
+            # The loaded result renders from its path cells alone.
+            self.assertEqual(loaded.dataset_list, [])
+            self.assertEqual(
+                container_output(loaded.to(DataSetResult)),
+                ["declared sum=3", "declared sum=6"],
+            )
+
+            out = bn.render_report(loaded, Path(tmp) / "report")
+            self.assertTrue(out.exists())
+            self.assertGreater(out.stat().st_size, 0)
+
+
+class TestLegacyIntCells(unittest.TestCase):
+    """Item 4: pre-plan-22 results (int cells + dataset_list) keep rendering."""
+
+    def test_legacy_result_renders_from_dataset_list(self):
+        res = make_legacy(
+            run_sweep(PathCellSweep(), "test_grammar_legacy_render"),
+            [bn.ResultDataSet(expected_frame(scale)) for scale in SCALES],
+        )
+        rv = res.bench_cfg.result_vars[0]
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[1]), rv, container=None)
+        self.assertEqual(pane.object, "declared sum=6")
+        self.assertEqual(
+            container_output(res.to(DataSetResult)), ["declared sum=3", "declared sum=6"]
+        )
+
+    def test_missing_dataset_list_renders_placeholder_not_raise(self):
+        res = make_legacy(run_sweep(PathCellSweep(), "test_grammar_legacy_no_list"), [])
+        rv = res.bench_cfg.result_vars[0]
+
+        # Attribute deleted entirely (a result pickled without it).
+        del res.dataset_list
+        pane = res.ds_to_container(res.to_dataset().sel(scale=SCALES[0]), rv, container=None)
+        self.assertIsInstance(pane, pn.pane.Markdown)
+        self.assertIn(PLACEHOLDER_MARKER, pane.object)
+        self.assertIn("table", pane.object)
+
+        # List present but too short (another run's list): same placeholder.
+        res.dataset_list = []
+        view = res.to(DataSetResult)
+        self.assertIsInstance(view, pn.viewable.Viewable)
+        self.assertEqual(container_output(view), [])
+        self.assertEqual(len(placeholder_output(view)), len(SCALES))
+
+
+class TestOverTimeRendersAllPoints(unittest.TestCase):
+    """Item 5: the D4 payoff — every time point renders, mixed histories included."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res = run_sweep_over_time(OverTimeSweep(), "test_grammar_over_time")
+
+    def test_history_accumulated(self):
+        """Guard on the fixture: with a single event there is no payoff to check."""
+        self.assertEqual(self.res.to_dataset().sizes["over_time"], OVER_TIME_RUNS)
+
+    def test_all_time_points_render(self):
+        self.assertEqual(
+            container_output(self.res.to(DataSetResult)),
+            [
+                f"declared run={run} scale={scale:g}"
+                for scale in SCALES
+                for run in range(OVER_TIME_RUNS)
+            ],
+        )
+
+    def _make_mixed(self, payloads: list[bn.ResultDataSet]) -> bn.BenchResult:
+        """Rewrite the oldest cell of the first sample into a legacy int index."""
+        res = run_sweep_over_time(OverTimeSweep(), "test_grammar_over_time_mixed")
+        da = res.ds["table"]
+        first_cell = {dim: 0 for dim in da.dims}
+        da.values[tuple(first_cell[dim] for dim in da.dims)] = 0
+        res.dataset_list = payloads
+        res._to_dataset_cache.clear()  # pylint: disable=protected-access
+        return res
+
+    def test_mixed_history_renders_legacy_cell_from_dataset_list(self):
+        res = self._make_mixed([bn.ResultDataSet(tagged_frame(SCALES[0], 99))])
+        rendered = container_output(res.to(DataSetResult))
+        self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS)
+        self.assertIn("declared run=99 scale=1", rendered)
+
+    def test_mixed_history_without_dataset_list_degrades_to_placeholder(self):
+        res = self._make_mixed([])
+        view = res.to(DataSetResult)
+        rendered = container_output(view)
+        # The three path cells still render; the orphaned legacy cell degrades.
+        self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS - 1)
+        self.assertEqual(len(placeholder_output(view)), 1)
+
+
+class TestResultIsMissingTruthTable(unittest.TestCase):
+    """Item 7: the single missing-value oracle, per relevant type."""
+
+    def test_truth_table(self):
+        nan = float("nan")
+        cases = [
+            (ResultFloat(), [(nan, True), (None, True), (1.5, False), ("NAN", False)]),
+            (
+                ResultReference(),
+                [(-1, True), (np.int64(-1), True), (0, False), (7, False), (None, False)],
+            ),
+            (
+                ResultPath(),
+                [("NAN", True), ("img/frame_001.png", False), ("", False), (None, False)],
+            ),
+            (
+                ResultDataSet(),
+                [
+                    # New generation: the blob-family sentinel.
+                    ("NAN", True),
+                    # Legacy generation: -1 index, including numpy and the float
+                    # promotion an over_time concat applies to int columns.
+                    (-1, True),
+                    (np.int64(-1), True),
+                    (np.float64(-1.0), True),
+                    # Defensive: an unrepaired concat fill is missing, not data.
+                    (nan, True),
+                    (None, True),
+                    # Valid cells of both generations.
+                    ("cachedir/blobs/0123abcd.parquet", False),
+                    (0, False),
+                    (7, False),
+                ],
+            ),
+        ]
+        for rv, pairs in cases:
+            for value, expected in pairs:
+                with self.subTest(rv=type(rv).__name__, value=value):
+                    self.assertEqual(result_is_missing(rv, value), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_grammar_data_model.py
+++ b/test/test_grammar_data_model.py
@@ -351,6 +351,25 @@ class TestOverTimeRendersAllPoints(unittest.TestCase):
         self.assertEqual(len(rendered), len(SCALES) * OVER_TIME_RUNS - 1)
         self.assertEqual(len(placeholder_output(view)), 1)
 
+    def test_strict_signature_plot_callback_still_works(self):
+        """``plot_callback`` is a public extension point, so the render-internal
+        ``legacy_trusted`` keyword must be offered, not imposed: a callback taking
+        exactly ``(dataset, result_var)`` used to work and must keep working."""
+        calls = []
+
+        def strict_callback(dataset, result_var):  # no **kwargs to absorb extras
+            # Each slice is a single event, so over_time has been indexed away.
+            calls.append((result_var.name, "over_time" in dataset.sizes))
+            return pn.pane.Markdown("strict")
+
+        view = self.res.map_plot_panes(strict_callback)
+        self.assertIsInstance(view, pn.viewable.Viewable)
+        # map_plot_panes defaults to target_dimension=2, so the callback is handed
+        # one slice per time event (the samples still inside it) rather than one per
+        # sample: the assertion that matters is that the over_time dataset path ran
+        # for every event instead of raising TypeError on the first.
+        self.assertEqual(calls.count(("table", False)), OVER_TIME_RUNS)
+
 
 class TestLegacyOverTimeHistory(unittest.TestCase):
     """F5: a pre-plan-22 over_time result — int cells at EVERY time point but only

--- a/test/test_hash_persistent.py
+++ b/test/test_hash_persistent.py
@@ -18,6 +18,7 @@ import json
 import subprocess
 import sys
 import textwrap
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from enum import Enum
@@ -56,9 +57,13 @@ def _discover_all_result_classes():
 
 def _make_instance(cls):
     """Create an instance of a result class with sensible defaults."""
-    if cls is ResultVec:
-        return cls(size=3, units="ul", doc="test")
-    return cls(doc="test")
+    with warnings.catch_warnings():
+        # Deprecated classes (e.g. ResultHmap) warn on instantiation but their
+        # hashes must stay pinned until they are actually removed.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        if cls is ResultVec:
+            return cls(size=3, units="ul", doc="test")
+        return cls(doc="test")
 
 
 def _collect_mro_slots(cls):

--- a/test/test_result_missing.py
+++ b/test/test_result_missing.py
@@ -9,6 +9,7 @@ fails loudly here instead of corrupting datasets.
 
 import math
 import unittest
+import warnings
 
 import numpy as np
 
@@ -37,7 +38,11 @@ from bencher.variables.results import (
 
 def _instantiate(cls):
     """A default instance of *cls*; ResultVec needs an explicit size."""
-    return cls(size=2) if cls is ResultVec else cls()
+    with warnings.catch_warnings():
+        # ResultHmap warns on instantiation (deprecated); its storage semantics
+        # are still pinned here until phase 3 removes it.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return cls(size=2) if cls is ResultVec else cls()
 
 
 def _nan_backed_vars():
@@ -102,7 +107,7 @@ class TestDataVarResultTypes(unittest.TestCase):
         # ResultVec expands to one column per element; ResultHmap is stored
         # out-of-band — neither gets a single data var.
         self.assertNotIsInstance(ResultVec(size=2), DATA_VAR_RESULT_TYPES)
-        self.assertNotIsInstance(ResultHmap(), DATA_VAR_RESULT_TYPES)
+        self.assertNotIsInstance(_instantiate(ResultHmap), DATA_VAR_RESULT_TYPES)
 
 
 class TestEveryResultTypeIsStorable(unittest.TestCase):

--- a/test/test_result_missing.py
+++ b/test/test_result_missing.py
@@ -50,10 +50,12 @@ def _nan_backed_vars():
 
 
 def _reference_backed_vars():
-    return [ResultReference(), ResultDataSet()]
+    return [ResultReference()]
 
 
 def _object_backed_vars():
+    # ResultDataSet joined the blob family with plan 22: its cells are paths
+    # into the blob store and its fill is the object-family "NAN" sentinel.
     return [
         ResultPath(),
         ResultVideo(),
@@ -61,6 +63,7 @@ def _object_backed_vars():
         ResultString(),
         ResultContainer(),
         ResultRerun(),
+        ResultDataSet(),
     ]
 
 
@@ -190,6 +193,20 @@ class TestResultIsMissing(unittest.TestCase):
         self.assertFalse(result_is_missing(rv, "img/frame_001.png"))
         self.assertFalse(result_is_missing(rv, ""))
         self.assertFalse(result_is_missing(rv, None))
+
+    def test_dataset_accepts_both_sentinel_generations(self):
+        """A mixed-generation over_time history holds "NAN" path sentinels next to
+        legacy -1 index sentinels (possibly float-promoted by concat), permanently."""
+        rv = ResultDataSet()
+        self.assertTrue(result_is_missing(rv, "NAN"))
+        self.assertTrue(result_is_missing(rv, -1))
+        self.assertTrue(result_is_missing(rv, np.int64(-1)))
+        self.assertTrue(result_is_missing(rv, np.float64(-1.0)))
+        self.assertTrue(result_is_missing(rv, float("nan")))
+        self.assertTrue(result_is_missing(rv, None))
+        self.assertFalse(result_is_missing(rv, "cachedir/blobs/abc123.parquet"))
+        self.assertFalse(result_is_missing(rv, 0))
+        self.assertFalse(result_is_missing(rv, 3))
 
     def test_fill_round_trips_through_typed_array(self):
         # An array initialised with (fill, dtype) — exactly what

--- a/test/test_resulthmap_deprecation.py
+++ b/test/test_resulthmap_deprecation.py
@@ -1,0 +1,13 @@
+"""Plan 22 D6: declaring a ResultHmap emits a DeprecationWarning (test item 8)."""
+
+import pytest
+
+from bencher.variables.results import ResultHmap
+
+
+def test_resulthmap_instantiation_warns_deprecation():
+    """ResultHmap still works but warns, pointing at the container-based replacement."""
+    with pytest.warns(DeprecationWarning, match="ResultContainer") as record:
+        rv = ResultHmap()
+    assert any("ResultReference" in str(w.message) for w in record)
+    assert isinstance(rv, ResultHmap)

--- a/test/test_xy_scatter_result.py
+++ b/test/test_xy_scatter_result.py
@@ -364,28 +364,28 @@ class TestDeclaredOnResultVar(unittest.TestCase):
 
 
 class TestOverTimeHistory(unittest.TestCase):
-    """A cloud has to render on every run, not only the first one.
+    """A cloud history has to render every run, not only the latest one.
 
-    A ResultDataSet cell holds an index into dataset_list, which is rebuilt from the
-    samples of whichever run is rendering, so the indices merged in from history point
-    at *this* run's list. The render therefore stays on the current event; before
-    _to_panes_da handled ResultDataSet it raised out of expand_dims instead, and via
-    to_auto the traceback was swallowed and the plot silently vanished.
+    Cells are blob paths since plan 22, meaningful in any run, so the events merged
+    in from history render alongside the current one (D4).  Before that, a
+    ResultDataSet cell held an index into dataset_list — rebuilt from whichever run
+    was rendering — so the render was forcibly restricted to the current event.
     """
 
     @classmethod
     def setUpClass(cls):
         cls.res = run_sweep_over_time(OverTimeCloudSweep(), "test_xy_scatter_over_time")
-        cls.current_run = OVER_TIME_RUNS - 1
 
-    def assert_current_run(self, points: list[hv.Points]) -> None:
-        self.assertEqual(len(points), len(SPREADS))
-        for element, spread in zip(points, SPREADS):
+    def assert_every_run(self, points: list[hv.Points]) -> None:
+        """One scatter per (sample, event): samples peeled outermost, time innermost."""
+        self.assertEqual(len(points), len(SPREADS) * OVER_TIME_RUNS)
+        expected = [(spread, run) for spread in SPREADS for run in range(OVER_TIME_RUNS)]
+        for element, (spread, run) in zip(points, expected):
             self.assertEqual(len(element), POINTS_PER_SAMPLE)
-            self.assertAlmostEqual(element["dx_mm"].min(), RUN_OFFSET * self.current_run, places=6)
+            self.assertAlmostEqual(element["dx_mm"].min(), RUN_OFFSET * run, places=6)
             self.assertAlmostEqual(
                 element["dx_mm"].max(),
-                spread * (POINTS_PER_SAMPLE - 1) + RUN_OFFSET * self.current_run,
+                spread * (POINTS_PER_SAMPLE - 1) + RUN_OFFSET * run,
                 places=6,
             )
 
@@ -393,16 +393,16 @@ class TestOverTimeHistory(unittest.TestCase):
         """Guard on the fixture: with a single event there is no regression to catch."""
         self.assertEqual(self.res.to_dataset().sizes["over_time"], OVER_TIME_RUNS)
 
-    def test_declared_spec_renders_the_current_run(self):
-        self.assert_current_run(all_points(self.res.to_auto(plot_list=["panes"])))
+    def test_declared_spec_renders_every_run(self):
+        self.assert_every_run(all_points(self.res.to_auto(plot_list=["panes"])))
 
-    def test_chart_type_renders_the_current_run(self):
+    def test_chart_type_renders_every_run(self):
         rendered = self.res.to(XYScatterResult, x="dx_mm", y="dy_mm")
-        self.assert_current_run(all_points(rendered))
+        self.assert_every_run(all_points(rendered))
 
-    def test_named_chart_type_renders_the_current_run(self):
+    def test_named_chart_type_renders_every_run(self):
         rendered = self.res.to_auto(plot_list=["xy_scatter"], x="dx_mm", y="dy_mm")
-        self.assert_current_run(all_points(pn.Column(*rendered)))
+        self.assert_every_run(all_points(pn.Column(*rendered)))
 
     def test_scalar_results_keep_their_history(self):
         """Rendering the current cloud must not cost the metrics their over_time series."""


### PR DESCRIPTION
Implements [plan 22](plans/22-grammar-phase-1-data-model.md) — phase 1 of the [A6 grammar-of-ND-data](plans/architecture/A6-grammar-of-nd-data.md) migration. **Stacked on #1019** (the plan + design record); review and merge that first — this PR's own diff is the five implementation commits.

## What changes

- **`bencher/blob_store.py`** (new): content-addressed store under `cachedir/blobs/` — sha256-named, atomic writes, dedup on content hit. DataFrame→parquet, Dataset→netCDF, DataArray→`.da.nc` (identity-preserving), bytes→raw, everything else→pickle (flagged as the surface A3 wants gone). The environment is netCDF3-only, so an empirically-derived dtype whitelist diverts int64/unsigned/str/datetime payloads to pickle instead of letting scipy silently narrow them — **a payload inside the documented contract can never abort a sweep**: every structured-format failure falls back to pickle with a logged warning.
- **`ResultDataSet` cells are now paths, materialized at collect** (`result_collector.py`), exactly parallel to the existing rerun materialization. `dataset_list` is kept as the legacy read path only.
- **Dual-generation render path** (`bench_result_base.py`): str cell → `load_blob` + the unchanged PR #989 container precedence; legacy int cell → guarded `dataset_list` lookup degrading to a labelled placeholder; every failure mode (deleted blob, unpicklable wrapper, missing list) degrades to a placeholder, never a crash.
- **The `isel(over_time=-1)` restriction is deleted**: dataset history renders every time point via a labelled per-event grid — the one intended visual change. Legacy int cells are trusted **only at the final time event**; resolving historical in-range indices against the current run's list would render today's payload under yesterday's label (reproduced in review), so earlier events get placeholders.
- **One missing-value oracle**: `ResultDataSet` joins the blob sentinel family; `result_is_missing` accepts both generations permanently (mixed histories contain both).
- **`ResultHmap` deprecated** (warning + docs; removal scheduled with phase 3); `ResultReference`'s same-process escape-hatch contract documented.
- **New gallery example** `example_result_dataset_1d_over_time`: its rendered report shows all three history events in the labelled grid — the reviewable D4 before/after A6 Law 10 requires (no prior example combined `ResultDataSet` with `over_time`).

## How it was built

Multi-agent pipeline per the owner's instruction: two parallel implementation agents (blob store; deprecations) → core data-path agent (D2–D5 + tests) → three parallel verification agents (full CI + split suite; adversarial review; gallery regeneration) → fix agent. The adversarial reviewer found **1 blocker + 5 majors + 1 minor, all reproduced** (serialization crashes escaping `catch=`, silent netCDF3 dtype corruption, unloadable path-passthrough cells, DataArray identity loss, the D4 legacy misrendering, lambda per-sample containers crashing collection, unguarded render-time loads) — every one fixed with its own regression test. Plan 22 carries an **"Amendments discovered during implementation"** section recording where its claims stopped holding, per the plans-README rule; both recorded owner decisions resolved to their defaults (pickle fallback allowed, no `CACHE_VERSION` bump).

## Validation

- `pixi run ci`: **2398 passed, 3 skipped**, coverage 90%, pylint 10.00/10.
- `pixi run test-split` (`BENCHER_FORCE_SPLIT_RENDER=1`, full suite): **2398 passed, 3 skipped**.
- `pixi run generate-docs`: 170+ examples clean; tracked generated files byte-identical except the new example; a sweep of every rendered report found **zero** legacy-placeholder fallbacks — nothing outside the dataset path renders differently; the dataset reports demonstrably render from `cachedir/blobs/` parquet.
- Cache safety: `hash_persistent` untouched (pinned-hash tests green); pre-plan cached results and mixed-generation `over_time` histories keep rendering (tested), degrading honestly where an old cache cannot support the new capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a content-addressed blob store and path-backed ResultDataSet cells, enabling robust cross-process rendering and full over_time histories while maintaining backward compatibility and deprecating legacy result types.

New Features:
- Add a content-addressed blob store for result payloads with typed serialization (parquet, netCDF, raw bytes, pickle fallback).
- Store ResultDataSet payloads as blob paths at collect time so any process sharing the cache can render datasets, including over_time history points.
- Render ResultDataSet over_time histories as labelled per-time grids, with support for mixed generations of path-backed and legacy index cells.
- Add a new gallery/meta example demonstrating ResultDataSet combined with over_time and the resulting per-time grid of curves.

Bug Fixes:
- Prevent dataset serialization crashes and silent netCDF3 dtype corruption by whitelisting safe dtypes and falling back to pickle with warnings.
- Ensure deleted or unloadable blobs and missing dataset_list entries render as explicit placeholders instead of raising at render time.
- Fix over_time rendering so historical ResultDataSet events no longer misrender current-run payloads under historical labels.
- Guard legacy results that lack dataset_list so they degrade to placeholders rather than crashing during rendering.

Enhancements:
- Refine ResultDataSet rendering to unify blob-path and legacy index cells under a single container precedence chain and missing-value oracle.
- Update over_time rendering for dataset and scatter results to display one pane per sample per event instead of only the latest run.
- Document and enforce ResultDataSet missing-value semantics across both sentinel generations, integrating with existing result_missing_fill logic.
- Deprecate ResultHmap in favor of container-based ResultContainer/ResultReference, while preserving its behavior and hash semantics until removal.
- Clarify ResultReference as the same-process escape hatch and ResultDataSet as the cross-process, cache-backed payload carrier.

Documentation:
- Update user-facing documentation to describe path-backed ResultDataSet cells, their over_time behavior, and ResultHmap deprecation, including links to the new example.
- Amend plan 22 with implementation-era corrections and decisions around netCDF constraints, legacy index trust, blob behavior, and example coverage.

Tests:
- Add integration tests covering the grammar phase-1 data model, including path-backed cells, split render round trips, legacy and mixed histories, over_time behavior, and missing-value truth tables.
- Add unit tests for the blob store covering type-specific formats, netCDF3 dtype safety, content addressing, fallbacks, and load dispatch.
- Extend existing dataset and scatter tests to assert path-backed storage, unchanged payloads, and full over_time rendering across all runs.
- Add tests verifying ResultHmap deprecation warnings and ensuring hash-persistence and result_missing behavior remain pinned despite deprecation.

Chores:
- Wire new meta/example generators into the example build pipeline so the ResultDataSet over time example is generated alongside existing result type examples.
- Adjust helper test utilities to ignore deprecation warnings when instantiating result types used for hash and missing-value checks.