### PR TITLE
feat: reachability garbage collection for the content-addressed blob store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cache_results` and `cache_samples` both default to `False`, so with the defaults nothing
   on disk references the blobs of a plain (non-`over_time`) sweep, and a stored history
   holds paths rather than payload copies. GC is therefore an offline maintenance step, as
-  `clean_orphaned_media` already is — `min_age_seconds=` adds a grace period if you must run
-  it near a live sweep — and there is deliberately no size- or age-based eviction of
-  *referenced* blobs, because nothing could restore them. An unreadable cache entry makes
+  `clean_orphaned_media` already is. `min_age_seconds=` adds a grace period, but it is a
+  mitigation, not a guarantee: it protects blobs a concurrent sweep *wrote* during the
+  window, yet a sweep that deduplicates onto an existing old blob gets no protection at any
+  grace period — a content hit skips the write and never refreshes the file's mtime
+  (pinned by `test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob`).
+  Run GC only when no sweep is in flight. There is deliberately no size- or age-based
+  eviction of *referenced* blobs, because nothing could restore them. An unreadable cache
+  entry makes
   absence-of-reference unprovable, so a corrupt cache collects **nothing** in either mode
   and warns with the offending entries named.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New gallery example `example_result_dataset_1d_over_time`** under
   `reference/meta/result_types/result_dataset/`; no existing example combined
   `ResultDataSet` with `over_time`.
+- **Garbage collection for the blob store: `bn.clean_orphaned_blobs()`.** `cachedir/blobs/`
+  previously grew until an explicit `clear_media()`/`clear_all()` wiped it whole; a nightly
+  sweep whose payloads drift accumulated a file per distinct payload forever, since content
+  addressing only deduplicates byte-identical ones. The new call reclaims exactly the files
+  nothing references any more, and `dry_run=True` is the default:
+
+  ```python
+  bn.clean_orphaned_blobs()                                    # report only
+  bn.clean_orphaned_blobs(dry_run=False)                        # reclaim
+  bn.clean_orphaned_blobs(dry_run=False, extra_roots=["runs/"])  # protect saved results
+  ```
+
+  It returns `(orphan_paths, total_bytes)` like `clean_orphaned_media`, and
+  `bn.print_orphaned_blobs()` prints the same report the way `print_cache_stats` does. Two
+  pixi tasks wrap it: `pixi run cache-blob-orphans` (report) and `pixi run cache-blob-gc`
+  (reclaim). `bn.blob_reachability()` exposes the live set on its own for auditing.
+
+  The model is **reachability, not ownership**. A blob is content-addressed, so one file may
+  back cells from many job keys, sweeps and `over_time` events at once — which is precisely
+  why `cleanup_job_media`/`clean_orphaned_media` must never touch it and why their per-job
+  model could not be reused. Instead, every blob name referenced from any dataset in the
+  `benchmark_inputs` and `history` diskcaches is collected first, and only files outside
+  that set are deleted. The `history` scan reads the *stored* record rather than the served
+  projection, so a reference held only by an old `over_time` event, or by a dormant or
+  retired column, still counts as live. Matching is on the blob's filename (which *is* its
+  content hash), so a stored absolute path from a cachedir that has since moved still
+  protects its payload. `sample_cache` is deliberately not a root: it holds what the worker
+  returned, before materialization, so it cannot name a blob — and a payload still in it
+  re-materializes to the same path on the next hit.
+
+  Two limitations are explicit rather than papered over. **Results saved outside the cache
+  are invisible**: nothing records where `bencher.render.save_result` wrote, so GC can strand
+  a saved result's payloads (it still loads; its dataset cells render as placeholders). Pass
+  the archive as `extra_roots=` to protect it. **A blob is primary storage, not a cache**:
+  `cache_results` and `cache_samples` both default to `False`, so with the defaults nothing
+  on disk references the blobs of a plain (non-`over_time`) sweep, and a stored history
+  holds paths rather than payload copies. GC is therefore an offline maintenance step, as
+  `clean_orphaned_media` already is — `min_age_seconds=` adds a grace period if you must run
+  it near a live sweep — and there is deliberately no size- or age-based eviction of
+  *referenced* blobs, because nothing could restore them. An unreadable cache entry makes
+  absence-of-reference unprovable, so a corrupt cache collects **nothing** in either mode
+  and warns with the offending entries named.
+
+  Practical note on where the garbage actually comes from: a per-variable `max_time_events`
+  limit ages an old `over_time` cell out by overwriting it with the missing-value sentinel,
+  and `_null_old_entries` deliberately does *not* delete the file (a deduplicated blob may
+  still back a live cell), so every aged-out payload was an immediate permanent leak before
+  this change.
 
 ### Changed
 - **BREAKING: a `ResultDataSet` dataset cell holds a blob path string, not an index.**
@@ -92,11 +140,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deliberately left out of #1021.
 
 ### Notes
-- **`cachedir/blobs/` has no garbage collection.** Every distinct dataset payload from every
-  run is retained until an explicit `clear_media()` or `clear_all()`; content addressing
-  only deduplicates byte-identical payloads. It is at least visible in `cache_stats()` now.
-  Reclaiming it per job key is not possible by design (one blob, many owners); an artifact
-  manifest that could is A4's job.
+- **`cachedir/blobs/` is garbage-collected by reachability, never per job key.** Reclaiming
+  it per job key is impossible by design (one blob, many owners), so `clean_orphaned_blobs()`
+  above deletes only what no live reference names — see that entry for the roots it scans and
+  the two cases it cannot see. What it does *not* do is bound the store's size: blobs that
+  are still referenced are never evicted, because with `cache_results`/`cache_samples`
+  defaulting to `False` and a stored history holding paths rather than payloads, there is
+  nothing to restore them from. Capping growth still means `max_time_events` plus a GC run,
+  or the artifact manifest A4 owns.
 - Blob filenames use the first 16 hex chars (64 bits) of the sha256, so two *different*
   payloads sharing that prefix would collide and the second would load back as the first.
   The birthday bound puts even odds at ~2^32 blobs in one cache directory, so the risk is

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -155,15 +155,19 @@ except ModuleNotFoundError:
 
 from .cache_management import (
     DEFAULT_CACHE_SIZE_BYTES,
+    BlobReachability,
     CacheDirStats,
     CacheStats,
+    blob_reachability,
     cache_stats,
+    clean_orphaned_blobs,
     clean_orphaned_media,
     cleanup_job_media,
     clear_all,
     clear_media,
     ensure_cache_version,
     print_cache_stats,
+    print_orphaned_blobs,
 )
 from .git_info import git_time_event
 from .history import HistoryEvent, HistoryResetError

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -754,8 +754,16 @@ def clean_orphaned_blobs(
         as placeholders).  Pass such archives as *extra_roots* to protect them.
         The same applies to a result held only in memory by a sweep running
         concurrently with GC: with the default ``cache_results=False`` nothing
-        on disk references its blobs yet.  ``min_age_seconds`` is the guard for
-        that case; running GC between sessions avoids it entirely.
+        on disk references its blobs yet.  ``min_age_seconds`` mitigates only
+        part of that exposure — it protects a blob the concurrent sweep *wrote*
+        during the grace window, but **not** a blob the sweep deduplicated
+        onto: a content hit skips the write entirely and never refreshes the
+        file's mtime, so an old blob that just gained a new reference looks
+        old to any grace period, however large
+        (``test_blob_store_races.py::test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob``
+        pins this).  The only sufficient guard is to run GC with no sweep in
+        flight — between sessions, as :func:`clean_orphaned_media` is already
+        used.
 
     An unreadable root makes the scan untrustworthy, since a record that cannot
     be deserialized may name any blob.  In that case **nothing** is reported or
@@ -768,8 +776,10 @@ def clean_orphaned_blobs(
         extra_roots: Saved-result pickles, or directories of them, whose
             references count as live.  See :func:`blob_reachability`.
         min_age_seconds: Skip blobs modified more recently than this.  A
-            non-zero grace period protects an in-flight sweep whose result is
-            not on disk yet; 0 (the default) collects regardless of age.
+            non-zero grace period protects blobs an in-flight sweep has
+            *written* during the window, but not an old blob it deduplicated
+            onto (see the warning above); 0 (the default) collects regardless
+            of age.
 
     Returns:
         (orphan_blobs, total_bytes) — paths of unreferenced blob files and their

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -15,15 +15,34 @@ makes lifecycle management trivial:
 
 A ``CACHE_VERSION`` file inside ``cachedir/`` guards against stale data
 from older formats.  ``ensure_cache_version()`` auto-clears on mismatch.
+
+Blob store lifecycle
+--------------------
+``cachedir/blobs/`` (see :mod:`bencher.blob_store`) is content-addressed and
+therefore has no owner: one file may back cells belonging to many job keys,
+sweeps and ``over_time`` history events at once, because byte-identical
+payloads deduplicate to a single name.  None of the per-job machinery above
+applies to it, and deliberately so.  Its lifecycle is instead
+**reachability-based**: :func:`clean_orphaned_blobs` builds the set of blob
+names still referenced by anything the cache can see and deletes only the
+files that no reference names.  See that function for the roots it scans, and
+for the one it provably cannot see (results saved outside the cache with
+``bencher.render.save_result``).
 """
 
 from __future__ import annotations
 
 import dataclasses
 import logging
+import pickle
+import re
 import shutil
+import time
+from collections.abc import Iterable
 from pathlib import Path
 
+import numpy as np
+import xarray as xr
 from diskcache import Cache
 
 logger = logging.getLogger(__name__)
@@ -61,8 +80,10 @@ _MEDIA_FOLDERS = ("img", "vid", "rrd", "generic")
 # meaningful here: deleting the blob for one job key can strand a cell belonging
 # to another. These folders are therefore counted by ``cache_stats`` and removed
 # wholesale by ``clear_media``/``clear_all`` (a cleared blob renders as a
-# placeholder, exactly like a cleared image), but never pruned per job.
-_CONTENT_FOLDERS = ("blobs",)
+# placeholder, exactly like a cleared image), but never pruned per job.  What
+# *can* reclaim them selectively is reachability GC — ``clean_orphaned_blobs``.
+_BLOBS_FOLDER = "blobs"
+_CONTENT_FOLDERS = (_BLOBS_FOLDER,)
 
 # File extensions recognized as media when cleaning up legacy (pre-v2) files.
 _MEDIA_EXTENSIONS = frozenset(
@@ -398,3 +419,397 @@ def clean_orphaned_media(cachedir: str = "cachedir", dry_run: bool = True) -> tu
         orphan_bytes,
     )
     return orphans, orphan_bytes
+
+
+# ---------------------------------------------------------------------------
+# Blob store garbage collection (reachability)
+# ---------------------------------------------------------------------------
+
+# Diskcaches whose *values* can name a blob.
+#
+# ``sample_cache`` is deliberately absent.  It stores what the worker returned,
+# which is the payload *before* materialization: blobs are written by
+# ``ResultCollector._materialize_dataset_value`` at the moment the value is
+# placed in the result dataset, so a sample-cache value holds a DataFrame or a
+# ``ResultDataSet`` wrapper, never a blob path.  A payload still in the sample
+# cache also re-materializes to the *same* content-addressed path on the next
+# cache hit, so collecting its blob is recoverable rather than lossy — the one
+# place in this module where that is true (see the warning in
+# ``clean_orphaned_blobs``).
+#
+# ``benchmark_inputs`` stores whole pickled ``BenchResult`` objects and
+# ``history`` stores over_time records; both carry datasets whose cells are blob
+# path strings, so both are roots.
+_BLOB_REFERENCE_CACHES = ("benchmark_inputs", "history")
+
+# Extensions ``blob_store._serialize`` can emit.  ``.da.nc`` ends with ``.nc``,
+# so the fast prefilter below does not need to list it separately.
+_BLOB_SUFFIXES = (".parquet", ".nc", ".bin", ".pkl")
+
+# A blob filename is a truncated sha256 in lowercase hex plus one of the format
+# extensions.  The digest length is not pinned: ``blob_store._HASH_CHARS`` may be
+# raised without invalidating existing blobs, and this must keep matching both.
+_BLOB_NAME_RE = re.compile(r"^[0-9a-f]+(?:\.parquet|\.da\.nc|\.nc|\.bin|\.pkl)$")
+
+# Recursion bound for the reference walk.  Every real root is shallow (a history
+# record is dict → Dataset; a cached result is BenchResult → Dataset), so this is
+# a guard against pathological nesting, not a working limit.
+_MAX_REF_WALK_DEPTH = 8
+
+
+@dataclasses.dataclass(frozen=True)
+class BlobReachability:
+    """Which blob files are still named by something the cache can see.
+
+    Attributes:
+        names: Blob *filenames* (not full paths) reached from some root.
+        unreadable: One human-readable line per root that could not be scanned.
+            A single entry makes the whole scan untrustworthy — an unreadable
+            record may name any blob — so :attr:`complete` gates deletion.
+    """
+
+    names: frozenset[str]
+    unreadable: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        """True when every root was scanned, so absence of a name proves garbage."""
+        return not self.unreadable
+
+
+def _blob_name(value: str) -> str | None:
+    """The blob filename *value* names, or None when it is not a blob path.
+
+    Matching is on the **basename**, not the full path: a blob's name *is* its
+    content hash, so a name is a complete and location-independent identity.
+    That keeps references valid when a stored dataset carries an absolute path
+    from a cachedir that has since been moved, copied or renamed — the case
+    where resolving against the current ``blobs/`` directory would silently
+    declare every reference dead.
+    """
+    if not value.endswith(_BLOB_SUFFIXES):
+        return None
+    name = Path(value).name
+    return name if _BLOB_NAME_RE.match(name) else None
+
+
+def _collect_array_blob_names(values, names: set[str]) -> None:
+    """Add every blob name appearing in a numpy array of dataset cells."""
+    arr = np.asarray(values)
+    # Cells holding paths are object or unicode dtype; numeric dtypes (including
+    # the -1 legacy sentinel and NaN fills) cannot hold a reference.
+    if arr.dtype.kind not in ("O", "U"):
+        return
+    for val in arr.flat:
+        if isinstance(val, str):
+            name = _blob_name(val)
+            if name is not None:
+                names.add(name)
+
+
+def _collect_xarray_blob_names(obj: xr.Dataset | xr.DataArray, names: set[str]) -> None:
+    """Add every blob name in *obj*, including coordinates.
+
+    A ``Dataset`` is scanned through ``.variables``, which is every data
+    variable **and** every coordinate.  For a history record that matters: the
+    stored dataset is a superset holding dormant and retired columns as ordinary
+    data variables alongside the live ones, and a projection onto the current
+    config would hide exactly the references nothing else can see.
+    """
+    if isinstance(obj, xr.Dataset):
+        for var in obj.variables.values():
+            _collect_array_blob_names(var.values, names)
+    else:
+        _collect_array_blob_names(obj.values, names)
+        for coord in obj.coords.values():
+            _collect_array_blob_names(coord.values, names)
+
+
+def _walk_blob_references(value, names: set[str], seen: set[int], depth: int = 0) -> None:
+    """Recursively add every blob name reachable from *value*.
+
+    Descends through the shapes that actually hold cached datasets: containers,
+    xarray objects, numpy arrays, and the instance dicts of bencher-owned
+    objects (``BenchResult``, ``BenchCfg``, ...).  Objects from other packages
+    are leaves — walking param/numpy internals would cost far more than it could
+    find, since a blob path only ever lives in a dataset cell.
+    """
+    if depth > _MAX_REF_WALK_DEPTH or isinstance(
+        value, (bool, int, float, bytes, bytearray, type(None))
+    ):
+        return
+    if isinstance(value, str):
+        name = _blob_name(value)
+        if name is not None:
+            names.add(name)
+    elif isinstance(value, (xr.Dataset, xr.DataArray)):
+        _collect_xarray_blob_names(value, names)
+    elif isinstance(value, np.ndarray):
+        _collect_array_blob_names(value, names)
+    elif id(value) not in seen:
+        # Every object added here stays reachable from the root for the duration
+        # of the walk, so an id() can never be recycled underneath us.
+        seen.add(id(value))
+        for item in _blob_reference_children(value):
+            _walk_blob_references(item, names, seen, depth + 1)
+
+
+def _blob_reference_children(value) -> Iterable:
+    """The sub-values of *value* worth recursing into, empty for a leaf."""
+    if isinstance(value, dict):
+        return value.values()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return value
+    if type(value).__module__.split(".")[0] == "bencher" and hasattr(value, "__dict__"):
+        return vars(value).values()
+    return ()
+
+
+def _scan_cache_for_blob_names(cache_path: Path, names: set[str], unreadable: list[str]) -> None:
+    """Walk every value in one diskcache, recording roots that cannot be read."""
+    try:
+        cache = Cache(str(cache_path))
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        unreadable.append(f"{cache_path}: cannot open ({type(exc).__name__}: {exc})")
+        return
+    try:
+        keys = list(cache.iterkeys())
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        unreadable.append(f"{cache_path}: cannot enumerate ({type(exc).__name__}: {exc})")
+        cache.close()
+        return
+    try:
+        for key in keys:
+            try:
+                value = cache[key]
+            except KeyError:
+                # Evicted between listing and reading: it references nothing now.
+                continue
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                unreadable.append(
+                    f"{cache_path}[{key!r}]: cannot deserialize ({type(exc).__name__}: {exc})"
+                )
+                continue
+            _walk_blob_references(value, names, set())
+    finally:
+        cache.close()
+
+
+def _extra_root_files(
+    extra_roots: Iterable[str | Path] | None, unreadable: list[str]
+) -> list[Path]:
+    """Resolve *extra_roots* to pickle files, recording anything that is missing.
+
+    A file is taken as-is; a directory contributes every ``*.pkl`` under it,
+    recursively.  A path that does not exist is recorded as unreadable rather
+    than skipped: a caller naming an archive to protect and getting a typo'd
+    path must not silently get an unprotected GC run.
+    """
+    files: list[Path] = []
+    for entry in extra_roots or ():
+        path = Path(entry)
+        if path.is_file():
+            files.append(path)
+        elif path.is_dir():
+            files.extend(sorted(f for f in path.rglob("*.pkl") if f.is_file()))
+        else:
+            unreadable.append(f"{path}: extra root does not exist")
+    return files
+
+
+def blob_reachability(
+    cachedir: str = "cachedir",
+    extra_roots: Iterable[str | Path] | None = None,
+) -> BlobReachability:
+    """Collect every blob filename still referenced from the cache.
+
+    Roots scanned: the ``benchmark_inputs`` and ``history`` diskcaches under
+    *cachedir*, plus any saved-result pickles named by *extra_roots*.  A missing
+    cache directory contributes no references (it is empty, not unreadable); a
+    cache that exists but cannot be opened, listed, or deserialized is recorded
+    in :attr:`BlobReachability.unreadable`.
+
+    Args:
+        cachedir: Root cache directory.
+        extra_roots: Extra ``save_result`` pickles, or directories of them, to
+            treat as live references.  **Unpickling runs arbitrary code**, the
+            same trust assumption ``bencher.render.load_result`` already makes,
+            so pass only paths you wrote.
+
+    Returns:
+        A :class:`BlobReachability` describing the live set and any root that
+        could not be scanned.
+    """
+    names: set[str] = set()
+    unreadable: list[str] = []
+    root = Path(cachedir)
+
+    for cache_name in _BLOB_REFERENCE_CACHES:
+        cache_path = root / cache_name
+        if cache_path.is_dir():
+            _scan_cache_for_blob_names(cache_path, names, unreadable)
+
+    for path in _extra_root_files(extra_roots, unreadable):
+        try:
+            with path.open("rb") as fh:
+                value = pickle.load(fh)
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            unreadable.append(f"{path}: cannot load ({type(exc).__name__}: {exc})")
+            continue
+        _walk_blob_references(value, names, set())
+
+    return BlobReachability(names=frozenset(names), unreadable=tuple(unreadable))
+
+
+def _unreferenced_blobs(
+    cachedir: str,
+    reachability: BlobReachability,
+    dry_run: bool,
+    min_age_seconds: float,
+) -> tuple[list[str], int]:
+    """List (and optionally delete) blobs whose name is in no live reference."""
+    blobs_dir = Path(cachedir) / _BLOBS_FOLDER
+    if not blobs_dir.is_dir():
+        return [], 0
+
+    now = time.time()
+    orphans: list[str] = []
+    orphan_bytes = 0
+    for blob in sorted(blobs_dir.iterdir()):
+        if not blob.is_file():
+            continue
+        # Anything not shaped like a blob is not ours to delete: notably the
+        # ``.tmp-<uuid>`` files materialize_blob renames from, which may belong
+        # to a worker writing right now.
+        if not _BLOB_NAME_RE.match(blob.name):
+            continue
+        if blob.name in reachability.names:
+            continue
+        try:
+            stat = blob.stat()
+        except OSError as exc:
+            logger.warning("Could not stat blob %s: %s", blob, exc)
+            continue
+        if min_age_seconds > 0 and (now - stat.st_mtime) < min_age_seconds:
+            continue
+        orphans.append(str(blob))
+        orphan_bytes += stat.st_size
+        if not dry_run:
+            try:
+                blob.unlink()
+            except OSError as exc:
+                logger.warning("Failed to remove unreferenced blob %s: %s", blob, exc)
+
+    action = "Dry run: found" if dry_run else "Deleted"
+    logger.info("%s %d unreferenced blobs (%d bytes)", action, len(orphans), orphan_bytes)
+    return orphans, orphan_bytes
+
+
+def _report_incomplete(reachability: BlobReachability) -> None:
+    """Log why an incomplete reachability scan collected nothing."""
+    logger.warning(
+        "Blob GC collected nothing: %d cache root(s) could not be scanned, so no "
+        "blob can be proven unreferenced. Fix or delete the entries below (bencher "
+        "discards unreadable history records itself on the next run) and retry:\n%s",
+        len(reachability.unreadable),
+        "\n".join(f"  {line}" for line in reachability.unreadable),
+    )
+
+
+def clean_orphaned_blobs(
+    cachedir: str = "cachedir",
+    dry_run: bool = True,
+    extra_roots: Iterable[str | Path] | None = None,
+    min_age_seconds: float = 0.0,
+) -> tuple[list[str], int]:
+    """Find and optionally delete blobs that no live reference names.
+
+    ``cachedir/blobs/`` is content-addressed, so a file has no owner: one blob
+    may back cells from many job keys, sweeps and ``over_time`` events at once,
+    because byte-identical payloads deduplicate to a single name.  That rules
+    out the per-job model used by :func:`cleanup_job_media` and
+    :func:`clean_orphaned_media` — deleting "this job's blob" can strand another
+    job's live cell — so collection is reachability-based instead: the union of
+    every blob name referenced from any root is computed first (see
+    :func:`blob_reachability`), and only files outside that set are deleted.
+
+    .. warning::
+        **A blob is primary storage, not a recomputable cache.**  Both
+        ``cache_results`` and ``cache_samples`` default to False, and a stored
+        ``over_time`` history holds paths rather than payload copies, so for
+        historical events there is nothing anywhere to regenerate a deleted blob
+        from.  Two consequences:
+
+        * ``dry_run=True`` is the default.  Deleting a still-referenced blob
+          silently degrades a cell to a render-time placeholder, so the safe
+          direction has to be the one you get by accident.
+        * This is GC, not eviction.  There is no size or age based reclamation
+          of *referenced* blobs, because nothing could restore them.
+
+    .. warning::
+        **Results saved outside the cache are invisible.**  A result written
+        with ``bencher.render.save_result`` is a pickle at a user-chosen path;
+        nothing records where, so its blob references cannot be discovered and
+        GC can strand it (the result still loads, and its dataset cells render
+        as placeholders).  Pass such archives as *extra_roots* to protect them.
+        The same applies to a result held only in memory by a sweep running
+        concurrently with GC: with the default ``cache_results=False`` nothing
+        on disk references its blobs yet.  ``min_age_seconds`` is the guard for
+        that case; running GC between sessions avoids it entirely.
+
+    An unreadable root makes the scan untrustworthy, since a record that cannot
+    be deserialized may name any blob.  In that case **nothing** is reported or
+    deleted in either mode (so a dry run stays an accurate preview of the real
+    one) and a warning names the offending entries.
+
+    Args:
+        cachedir: Root cache directory.
+        dry_run: If True (the default), only report unreferenced blobs.
+        extra_roots: Saved-result pickles, or directories of them, whose
+            references count as live.  See :func:`blob_reachability`.
+        min_age_seconds: Skip blobs modified more recently than this.  A
+            non-zero grace period protects an in-flight sweep whose result is
+            not on disk yet; 0 (the default) collects regardless of age.
+
+    Returns:
+        (orphan_blobs, total_bytes) — paths of unreferenced blob files and their
+        combined size, matching :func:`clean_orphaned_media`'s convention.
+    """
+    reachability = blob_reachability(cachedir, extra_roots=extra_roots)
+    if not reachability.complete:
+        _report_incomplete(reachability)
+        return [], 0
+    return _unreferenced_blobs(cachedir, reachability, dry_run, min_age_seconds)
+
+
+def print_orphaned_blobs(
+    cachedir: str = "cachedir",
+    dry_run: bool = True,
+    extra_roots: Iterable[str | Path] | None = None,
+    min_age_seconds: float = 0.0,
+) -> None:
+    """Print a human-readable :func:`clean_orphaned_blobs` report.
+
+    The counterpart of :func:`print_cache_stats` for blob GC, and what the
+    ``cache-blob-orphans`` / ``cache-blob-gc`` pixi tasks call.  Arguments are
+    :func:`clean_orphaned_blobs`'s.
+    """
+    reachability = blob_reachability(cachedir, extra_roots=extra_roots)
+    if not reachability.complete:
+        print("Blob GC aborted: these cache roots could not be scanned, so no blob")
+        print("can be proven unreferenced. Nothing was deleted.")
+        for line in reachability.unreadable:
+            print(f"  {line}")
+        return
+
+    orphans, freed = _unreferenced_blobs(cachedir, reachability, dry_run, min_age_seconds)
+    verb = "Would reclaim" if dry_run else "Reclaimed"
+    print(f"Blob store: {Path(cachedir) / _BLOBS_FOLDER}")
+    print(f"  live references: {len(reachability.names)}")
+    print(f"  {verb} {len(orphans)} unreferenced blobs ({_fmt_size(freed)})")
+    for path in orphans[:20]:
+        print(f"    {path}")
+    if len(orphans) > 20:
+        print(f"    ... and {len(orphans) - 20} more")
+    if dry_run and orphans:
+        print("  Dry run: nothing deleted. Re-run with dry_run=False to reclaim.")

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -259,6 +259,13 @@ available and as a labelled placeholder where it is not. See the
 [ResultDataSet over time example](reference/meta/result_types/result_dataset/example_result_dataset_1d_over_time)
 for a working sweep.
 
+Those payloads accumulate in `cachedir/blobs/`, one file per distinct payload, and aging an
+event out with `max_time_events` leaves its file behind. `bn.clean_orphaned_blobs()` reports
+the blobs no stored result or history event references any more (`dry_run=False` reclaims
+them; `pixi run cache-blob-orphans` / `cache-blob-gc` from a checkout). Results written with
+`bn.save_result` live at paths bencher does not record, so pass them as
+`extra_roots=[...]` to keep their payloads protected.
+
 For images: use `bn.gen_image_path("name")` to generate unique paths.
 For videos: use `bn.VideoWriter()` to collect frames and `.write()` to save.
 See the [ResultImage gallery](reference/meta/result_types/result_image/index) and

--- a/plans/22-grammar-phase-1-data-model.md
+++ b/plans/22-grammar-phase-1-data-model.md
@@ -258,6 +258,21 @@ rather than silently worked around:
    until an explicit clear, so they must not be invisible in a size audit) and
    removed by `clear_media`, degrading affected cells to placeholders exactly as a
    cleared image does.
+9. **"Orphan cleanup is A4's artifact-manifest scope, not this plan's" (Cache safety,
+   above) no longer holds and is retired.** It conflated two things: reclaiming a blob
+   *per owner*, which really does need A4's manifest and remains out of scope, and
+   reclaiming a blob *nothing references*, which needs no manifest at all — the
+   `benchmark_inputs` and `history` diskcaches already hold every dataset the cache can
+   see, so the live set is computable today. Leaving the store with no GC at all was the
+   cost of that conflation: a per-variable `max_time_events` limit nulls an aged-out
+   `over_time` cell without deleting its file (correctly — the blob may still back a live
+   cell), so every aged-out payload leaked permanently. `cache_management`
+   gained `blob_reachability` / `clean_orphaned_blobs` / `print_orphaned_blobs`
+   (reachability-based, `dry_run=True` by default) in the follow-up PR to #1021. Two
+   limits are documented rather than designed away: `save_result` pickles live at
+   unrecorded paths and must be declared via `extra_roots=`, and referenced blobs are
+   never evicted by size or age, since with `cache_results`/`cache_samples` defaulting to
+   False nothing could restore them.
 
 ## Coordination
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,8 +205,12 @@ cache-clear-media = "python -c 'from bencher.cache_management import clear_media
 cache-clean-orphans = "python -c 'from bencher.cache_management import clean_orphaned_media; clean_orphaned_media(dry_run=False)'"
 # Reachability GC for the content-addressed blob store. Report first (blobs are
 # primary storage, so a mistaken delete is data loss), then reclaim.
+# The reclaim task passes a one-hour grace period so blobs a concurrent sweep just
+# wrote are not collected. This is a mitigation, not a guarantee: no grace period
+# protects a blob a concurrent sweep deduplicated onto (a content hit never
+# refreshes mtime) — run GC only when no sweep is in flight.
 cache-blob-orphans = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs()'"
-cache-blob-gc = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs(dry_run=False)'"
+cache-blob-gc = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs(dry_run=False, min_age_seconds=3600)'"
 
 #demos
 benchmark-save = "python scripts/benchmark_save.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,10 @@ cache-stats = "python -c 'from bencher.cache_management import print_cache_stats
 cache-clear = "python -c 'from bencher.cache_management import clear_all; clear_all()'"
 cache-clear-media = "python -c 'from bencher.cache_management import clear_media; clear_media()'"
 cache-clean-orphans = "python -c 'from bencher.cache_management import clean_orphaned_media; clean_orphaned_media(dry_run=False)'"
+# Reachability GC for the content-addressed blob store. Report first (blobs are
+# primary storage, so a mistaken delete is data loss), then reclaim.
+cache-blob-orphans = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs()'"
+cache-blob-gc = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs(dry_run=False)'"
 
 #demos
 benchmark-save = "python scripts/benchmark_save.py"

--- a/test/test_blob_store_edge_cases.py
+++ b/test/test_blob_store_edge_cases.py
@@ -1,0 +1,399 @@
+"""Edge cases of blob serialization, loading, and reachability classification.
+
+Complements ``test_blob_store.py`` (the happy-path round trips) and the blob-GC
+tests in ``test_cache_management.py`` (the reachability shapes) by pushing on the
+boundaries where a wrong answer is silent rather than loud:
+
+* **Sentinels that look like data.** A ``ResultDataSet`` cell can hold the string
+  ``"NAN"``, a legacy ``-1`` index, or a float ``NaN``. None of them is a blob
+  reference, and none is a filename. Misclassifying one either strands a live blob
+  or, worse, protects nothing and deletes it. This class of bug is easy to write
+  and invisible in normal use — a scan that treats ``"NAN"`` as a reference simply
+  protects one blob too few, silently.
+* **Payloads the structured formats cannot hold.** The contract is that anything
+  inside "any picklable object" round-trips *exactly*; the dtype whitelist and the
+  fallbacks exist to keep that promise, so the interesting cases are the ones that
+  fall between formats.
+* **Files that are not blobs.** Everything in ``blobs/`` that is not a blob must be
+  left strictly alone, because it may belong to a writer running right now.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from diskcache import Cache
+
+from bencher import cache_management
+from bencher.blob_store import load_blob, materialize_blob
+from bencher.cache_management import blob_reachability, clean_orphaned_blobs
+from bencher.variables.results import ResultDataSet, result_is_missing
+
+
+def blob_basename(path: str) -> str:
+    """Basename of *path*, which is the identity the reachability scan matches on."""
+    return Path(path).name
+
+
+def store_dataset(cachedir, cells, dtype=object, cache_name="history"):
+    """Store a history-shaped record whose ``table`` cells are *cells*."""
+    arr = np.array(cells, dtype=dtype)
+    ds = xr.Dataset({"table": (("over_time",), arr)}, coords={"over_time": np.arange(len(cells))})
+    with Cache(str(cachedir / cache_name)) as cache:
+        cache["record"] = {"format": 1, "dataset": ds, "columns": {}, "retired": {}}
+
+
+class TestSentinelsAreNotReferences:
+    """Missing-value sentinels must never be mistaken for blob paths.
+
+    Both generations of sentinel coexist permanently in a mixed ``over_time``
+    history, so the scan meets them routinely.
+    """
+
+    @pytest.mark.parametrize(
+        "sentinel",
+        ["NAN", "nan", "", "-1", "None", "null"],
+        ids=["NAN", "lower-nan", "empty", "str-minus-1", "None", "null"],
+    )
+    def test_string_sentinels_contribute_no_reference(self, tmp_path, sentinel):
+        store_dataset(tmp_path, [sentinel])
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+    def test_legacy_int_and_float_cells_contribute_no_reference(self, tmp_path):
+        """Pre-plan-22 cells are ``-1``/index ints, and an over_time concat can
+        promote them to float. Numeric dtypes cannot name a blob."""
+        store_dataset(tmp_path, [-1, 0, 3], dtype=np.int64)
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+        store_dataset(tmp_path, [-1.0, np.nan, 2.0], dtype=np.float64)
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+    def test_none_cells_contribute_no_reference(self, tmp_path):
+        store_dataset(tmp_path, [None, None])
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+    def test_a_sentinel_next_to_a_real_path_does_not_hide_it(self, tmp_path):
+        """The mixed-history shape: the real reference must still be found, and the
+        sentinel must not add a bogus name."""
+        real = materialize_blob(pd.DataFrame({"v": [1.0]}), tmp_path)
+        store_dataset(tmp_path, ["NAN", real, -1])
+
+        names = blob_reachability(str(tmp_path)).names
+        assert names == frozenset({blob_basename(real)})
+
+        orphans, _ = clean_orphaned_blobs(str(tmp_path), dry_run=False)
+        assert orphans == []
+
+    def test_sentinel_semantics_match_the_result_variable_oracle(self):
+        """Guard on the assumption above: these values really are the sentinels the
+        result layer calls missing, so this suite tests the right strings."""
+        rv = ResultDataSet()
+        for missing in ("NAN", -1, -1.0, float("nan"), None):
+            assert result_is_missing(rv, missing)
+        assert not result_is_missing(rv, "cachedir/blobs/abcdef0123456789.parquet")
+
+
+class TestPathsThatAreNotBlobs:
+    """Strings that resemble a path but do not name a blob."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "cachedir/img/plot/key/plot.png",  # a media path
+            "cachedir/blobs/not-hex.parquet",  # right place, wrong stem
+            "cachedir/blobs/ABCDEF0123456789.parquet",  # uppercase hex
+            "cachedir/blobs/abcdef0123456789.txt",  # unknown extension
+            "cachedir/blobs/abcdef0123456789",  # no extension
+            "/etc/passwd",
+            "abcdef0123456789.parquet.bak",
+            "some prose mentioning .parquet in passing",
+        ],
+    )
+    def test_non_blob_strings_are_not_references(self, tmp_path, value):
+        store_dataset(tmp_path, [value])
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+    def test_a_blob_name_is_recognised_from_any_directory(self, tmp_path):
+        """Matching is by basename so a stored absolute path from a moved cachedir
+        still protects its payload."""
+        store_dataset(tmp_path, ["/somewhere/else/entirely/abcdef0123456789.parquet"])
+        assert blob_reachability(str(tmp_path)).names == frozenset({"abcdef0123456789.parquet"})
+
+    @pytest.mark.parametrize("ext", [".parquet", ".nc", ".da.nc", ".bin", ".pkl"])
+    def test_every_emitted_extension_is_recognised(self, tmp_path, ext):
+        """A format the store can write but the scan cannot recognise would be
+        deleted while live — the whitelist must cover every emitted suffix."""
+        store_dataset(tmp_path, [f"cachedir/blobs/abcdef0123456789{ext}"])
+        assert blob_reachability(str(tmp_path)).names == frozenset({f"abcdef0123456789{ext}"})
+
+
+class TestSerializationBoundaries:
+    """Payloads that sit between the structured formats and the pickle fallback."""
+
+    def test_empty_dataframe_round_trips(self, tmp_path):
+        payload = pd.DataFrame({"v": pd.Series([], dtype="float64")})
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        pd.testing.assert_frame_equal(loaded, payload)
+
+    def test_dataframe_with_integer_column_names_round_trips(self, tmp_path):
+        payload = pd.DataFrame({0: [1.0, 2.0], 1: [3.0, 4.0]})
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        pd.testing.assert_frame_equal(loaded, payload)
+
+    def test_dataframe_with_duplicate_column_names_round_trips(self, tmp_path):
+        """Parquet cannot represent duplicate names; the fallback must catch it
+        rather than let the sweep die."""
+        payload = pd.DataFrame([[1.0, 2.0]], columns=["v", "v"])
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        pd.testing.assert_frame_equal(loaded, payload)
+
+    def test_dataframe_with_nan_and_inf_round_trips(self, tmp_path):
+        payload = pd.DataFrame({"v": [np.nan, np.inf, -np.inf, 0.0]})
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        pd.testing.assert_frame_equal(loaded, payload)
+
+    def test_dataframe_with_a_datetime_index_round_trips(self, tmp_path):
+        payload = pd.DataFrame(
+            {"v": [1.0, 2.0]}, index=pd.to_datetime(["2024-01-01", "2024-01-02"])
+        )
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        pd.testing.assert_frame_equal(loaded, payload)
+
+    def test_dataset_with_a_zero_length_dimension_round_trips(self, tmp_path):
+        payload = xr.Dataset({"v": ("x", np.array([], dtype="float64"))})
+        xr.testing.assert_identical(load_blob(materialize_blob(payload, tmp_path)), payload)
+
+    def test_dataset_mixing_safe_and_unsafe_dtypes_round_trips_exactly(self, tmp_path):
+        """One unsafe variable must divert the *whole* payload to pickle: writing
+        part as netCDF would silently narrow it."""
+        payload = xr.Dataset(
+            {
+                "safe": ("x", np.arange(3, dtype="float64")),
+                "unsafe": ("x", np.arange(3, dtype="int64")),
+            }
+        )
+        path = materialize_blob(payload, tmp_path)
+        assert path.endswith(".pkl")
+        loaded = load_blob(path)
+        xr.testing.assert_identical(loaded, payload)
+        assert loaded["unsafe"].dtype == np.dtype("int64"), "dtype was narrowed"
+
+    def test_dataset_attrs_survive(self, tmp_path):
+        payload = xr.Dataset({"v": ("x", np.arange(3, dtype="float64"))})
+        payload.attrs["units"] = "metres"
+        payload["v"].attrs["long_name"] = "value"
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        assert loaded.attrs.get("units") == "metres"
+        assert loaded["v"].attrs.get("long_name") == "value"
+
+    def test_bool_dataset_keeps_its_dtype(self, tmp_path):
+        """bool is on the netCDF3 whitelist, so it must survive as bool rather than
+        come back as int8."""
+        payload = xr.Dataset({"v": ("x", np.array([True, False, True]))})
+        loaded = load_blob(materialize_blob(payload, tmp_path))
+        assert loaded["v"].dtype == np.dtype("bool")
+        xr.testing.assert_identical(loaded, payload)
+
+    def test_empty_bytes_round_trip(self, tmp_path):
+        path = materialize_blob(b"", tmp_path)
+        assert path.endswith(".bin")
+        assert load_blob(path) == b""
+
+    def test_nested_result_dataset_wrapper_round_trips(self, tmp_path):
+        """A per-sample ``container=`` travels as a pickled wrapper, so the wrapper
+        itself must survive as a payload."""
+        inner = pd.DataFrame({"v": [1.0, 2.0]})
+        wrapper = ResultDataSet(inner, container=len)
+        path = materialize_blob(wrapper, tmp_path)
+        assert path.endswith(".pkl")
+        loaded = load_blob(path)
+        assert isinstance(loaded, ResultDataSet)
+        pd.testing.assert_frame_equal(loaded.obj, inner)
+        assert loaded.container is len
+
+    def test_distinct_payloads_of_different_types_do_not_share_a_name(self, tmp_path):
+        """Content addressing is over the serialized bytes, and the extension
+        distinguishes formats, so unrelated payloads must not collide."""
+        paths = {
+            materialize_blob(pd.DataFrame({"v": [1.0]}), tmp_path),
+            materialize_blob(xr.Dataset({"v": ("x", [1.0])}), tmp_path),
+            materialize_blob(b"\x01\x02", tmp_path),
+            materialize_blob({"a": 1}, tmp_path),
+        }
+        assert len(paths) == 4
+
+
+class TestLoadBlobFailureModes:
+    """A corrupt or truncated blob must fail catchably; the render path turns any
+    exception into a placeholder, but it must not hang or return junk."""
+
+    @pytest.mark.parametrize("ext", [".parquet", ".nc", ".da.nc", ".pkl"])
+    def test_empty_file_raises_rather_than_returning_junk(self, tmp_path, ext):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        bad = blobs / f"abcdef0123456789{ext}"
+        bad.write_bytes(b"")
+        with pytest.raises(Exception):  # noqa: B017 - any failure is acceptable here
+            load_blob(bad)
+
+    @pytest.mark.parametrize("ext", [".parquet", ".nc", ".pkl"])
+    def test_truncated_file_raises(self, tmp_path, ext):
+        good = materialize_blob(
+            pd.DataFrame({"v": [1.0, 2.0]}) if ext == ".parquet" else {"a": 1}, tmp_path
+        )
+        data = (tmp_path / "blobs" / blob_basename(good)).read_bytes()
+        bad = tmp_path / "blobs" / f"abcdef0123456789{ext}"
+        bad.write_bytes(data[: max(1, len(data) // 2)])
+        with pytest.raises(Exception):  # noqa: B017
+            load_blob(bad)
+
+    def test_empty_bin_is_valid_and_not_an_error(self, tmp_path):
+        """Raw bytes have no header, so an empty ``.bin`` is legitimately empty."""
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        blob = blobs / "abcdef0123456789.bin"
+        blob.write_bytes(b"")
+        assert load_blob(blob) == b""
+
+    def test_missing_file_raises_filenotfound(self, tmp_path):
+        with pytest.raises((FileNotFoundError, OSError)):
+            load_blob(tmp_path / "blobs" / "abcdef0123456789.parquet")
+
+    @pytest.mark.parametrize("name", ["x.txt", "x", "x.parquet.gz", "x.nc.old"])
+    def test_unknown_extension_raises_valueerror_not_something_vaguer(self, tmp_path, name):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / name).write_bytes(b"data")
+        with pytest.raises(ValueError, match="unknown blob extension"):
+            load_blob(blobs / name)
+
+
+class TestGCLeavesNonBlobsAlone:
+    """Everything in ``blobs/`` that is not a blob may belong to a live writer."""
+
+    def test_temp_files_subdirectories_and_strays_are_untouched(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        keep = {
+            blobs / "abcdef0123456789.parquet.tmp-deadbeef": b"in-flight write",
+            blobs / "README": b"notes",
+            blobs / "not-hex.parquet": b"not ours",
+            blobs / "ABCDEF0123456789.parquet": b"uppercase stem",
+        }
+        for path, data in keep.items():
+            path.write_bytes(data)
+        (blobs / "subdir").mkdir()
+        (blobs / "subdir" / "abcdef0123456789.parquet").write_bytes(b"nested")
+        collectable = blobs / "0123456789abcdef.parquet"
+        collectable.write_bytes(b"garbage")
+
+        orphans, _ = clean_orphaned_blobs(str(tmp_path), dry_run=False)
+
+        assert orphans == [str(collectable)]
+        for path in keep:
+            assert path.exists(), f"{path.name} should not have been touched"
+        assert (blobs / "subdir" / "abcdef0123456789.parquet").exists()
+
+    def test_missing_blobs_directory_is_a_noop(self, tmp_path):
+        assert clean_orphaned_blobs(str(tmp_path), dry_run=False) == ([], 0)
+
+    def test_blobs_path_that_is_a_file_is_a_noop(self, tmp_path):
+        """A stray ``blobs`` *file* must not crash the walk."""
+        (tmp_path / "blobs").write_bytes(b"not a directory")
+        assert clean_orphaned_blobs(str(tmp_path), dry_run=False) == ([], 0)
+
+
+class TestReachabilityWalkRobustness:
+    """The walk descends arbitrary pickled objects, so it must not hang or explode."""
+
+    def test_self_referential_structure_terminates_and_still_finds_the_reference(self, tmp_path):
+        """A cycle must not loop forever.
+
+        Note what actually provides termination here: the **depth bound**, not the
+        ``seen`` set — mutation-testing this file showed the cycle case still passes
+        with ``seen`` removed entirely. ``seen`` is what keeps the walk from
+        exploding on shared substructure, which the next test covers; this one pins
+        that a cycle is survivable and does not swallow the real reference.
+        """
+        cyclic: dict = {"name": "cachedir/blobs/abcdef0123456789.parquet"}
+        cyclic["self"] = cyclic
+        with Cache(str(tmp_path / "history")) as cache:
+            cache["record"] = cyclic
+
+        names = blob_reachability(str(tmp_path)).names
+        assert names == frozenset({"abcdef0123456789.parquet"})
+
+    def test_shared_substructure_is_visited_once_not_exponentially(self, tmp_path):
+        """The real job of the ``seen`` set.
+
+        A DAG where every node fans out to the *same* child is linear to walk if
+        visited nodes are remembered and exponential if they are not. With fan-out 4
+        inside the depth bound that is a handful of visits versus thousands, so
+        counting visits detects a missing ``seen`` set — which a cycle test cannot.
+        """
+        leaf = "cachedir/blobs/abcdef0123456789.parquet"
+        node: object = {"cell": leaf}
+        for _ in range(6):
+            node = {f"child{i}": node for i in range(4)}
+        with Cache(str(tmp_path / "history")) as cache:
+            cache["record"] = node
+
+        calls = 0
+        # pylint: disable=protected-access  # the walk's internals are the subject here
+        real_children = cache_management._blob_reference_children
+
+        def counting_children(value):
+            nonlocal calls
+            calls += 1
+            return real_children(value)
+
+        with mock.patch.object(cache_management, "_blob_reference_children", counting_children):
+            names = blob_reachability(str(tmp_path)).names
+
+        assert names == frozenset({"abcdef0123456789.parquet"})
+        # Linear in unique nodes (~8) rather than 4**6 = 4096. The bound is loose so
+        # it cannot fail spuriously, but it is far below any exponential walk.
+        assert calls < 100, f"walk visited {calls} nodes — shared substructure re-walked"
+
+    def test_reference_nested_deeper_than_the_walk_limit_is_not_found(self, tmp_path):
+        """**Pinned limitation.** The walk is depth-bounded, so a pathologically
+        nested reference is missed and its blob looks like garbage. Real roots are
+        shallow (record -> Dataset), so this documents the bound rather than
+        endorsing it: if a future root nests deeper, this test is the alarm."""
+        deep: object = "cachedir/blobs/abcdef0123456789.parquet"
+        for _ in range(20):
+            deep = {"next": deep}
+        with Cache(str(tmp_path / "history")) as cache:
+            cache["record"] = deep
+
+        assert blob_reachability(str(tmp_path)).names == frozenset()
+
+    def test_reference_inside_a_list_tuple_and_set_is_found(self, tmp_path):
+        with Cache(str(tmp_path / "history")) as cache:
+            cache["record"] = {
+                "list": ["cachedir/blobs/1111111111111111.parquet"],
+                "tuple": ("cachedir/blobs/2222222222222222.nc",),
+                "set": {"cachedir/blobs/3333333333333333.pkl"},
+            }
+        assert blob_reachability(str(tmp_path)).names == frozenset(
+            {
+                "1111111111111111.parquet",
+                "2222222222222222.nc",
+                "3333333333333333.pkl",
+            }
+        )
+
+    def test_reference_in_a_dataset_coordinate_is_found(self, tmp_path):
+        """Coordinates are scanned as well as data variables."""
+        ds = xr.Dataset(
+            {"v": ("k", np.array([1.0]))},
+            coords={"k": np.array(["cachedir/blobs/abcdef0123456789.pkl"], dtype=object)},
+        )
+        with Cache(str(tmp_path / "history")) as cache:
+            cache["record"] = {"dataset": ds}
+        assert blob_reachability(str(tmp_path)).names == frozenset({"abcdef0123456789.pkl"})

--- a/test/test_blob_store_races.py
+++ b/test/test_blob_store_races.py
@@ -1,0 +1,479 @@
+"""Concurrency and data-race behaviour of the blob store and its garbage collector.
+
+The blob store is written by workers and read by renderers, and its GC deletes
+files that a *snapshot* of the cache said nothing referenced. That combination has
+three genuinely concurrent surfaces, and this module pins the behaviour of each:
+
+1. **Two writers, one payload.** Content addressing means concurrent workers
+   routinely materialize byte-identical payloads to the same filename.
+   ``materialize_blob`` writes through a uniquely-named temp file and an atomic
+   rename, so a reader must never observe a partial or interleaved blob.
+2. **GC versus a writer.** ``clean_orphaned_blobs`` computes reachability and
+   *then* lists the directory. Anything that becomes referenced inside that window
+   is invisible to the snapshot but present in the listing. These tests establish
+   exactly how far the guarantees reach, including the two cases
+   ``min_age_seconds`` does **not** cover — they are the reason GC is documented as
+   a between-sessions operation.
+3. **GC versus GC, and GC versus a reader.** Both must degrade rather than raise:
+   a losing racer sees ``FileNotFoundError`` from its own ``unlink``, and a
+   renderer whose blob vanished must produce a placeholder.
+
+Interleavings are **injected deterministically** (a wrapper around the scan, or a
+barrier) rather than produced by sleeping and hoping. A race test that only fails
+under load is worse than no test, because it teaches the suite to be ignored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pickle
+import threading
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from diskcache import Cache
+
+from bencher import cache_management
+from bencher.blob_store import _HASH_CHARS, load_blob, materialize_blob
+from bencher.cache_management import blob_reachability, clean_orphaned_blobs
+
+# Enough concurrency to interleave on a normal CI box without making the suite slow.
+_THREADS = 16
+_PROCESSES = 4
+
+
+def frame(scale: float, rows: int = 64) -> pd.DataFrame:
+    """A payload big enough that a torn write would be visible, not a single page."""
+    return pd.DataFrame({"t": np.arange(rows), "v": np.arange(rows, dtype=float) * scale})
+
+
+def write_reference(cachedir: Path, *blob_paths: str, cache_name: str = "history") -> None:
+    """Store a history-shaped record naming *blob_paths*, as a real sweep would."""
+    cells = np.array(list(blob_paths), dtype=object)
+    ds = xr.Dataset(
+        {"table": (("over_time",), cells)},
+        coords={"over_time": np.arange(len(blob_paths))},
+    )
+    with Cache(str(cachedir / cache_name)) as cache:
+        cache["record"] = {"format": 1, "dataset": ds, "columns": {}, "retired": {}}
+
+
+class TestConcurrentMaterialize:
+    """Many writers, one content-addressed directory."""
+
+    def test_threads_writing_identical_payload_produce_one_intact_blob(self, tmp_path):
+        """The dedup case: every worker computes the same name, so they all race on
+        one filename. Exactly one file must exist and it must be complete."""
+        payload = frame(1.0)
+        barrier = threading.Barrier(_THREADS)
+
+        def worker() -> str:
+            barrier.wait()  # maximise overlap on the write window
+            return materialize_blob(payload, tmp_path)
+
+        with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+            paths = list(pool.map(lambda _: worker(), range(_THREADS)))
+
+        assert len(set(paths)) == 1, "identical payloads must map to one path"
+        blobs = sorted((tmp_path / "blobs").iterdir())
+        assert len(blobs) == 1, f"expected exactly one blob, got {[b.name for b in blobs]}"
+        pd.testing.assert_frame_equal(load_blob(paths[0]), payload)
+
+    def test_no_temp_files_survive_a_concurrent_write_storm(self, tmp_path):
+        """Every temp file must have been renamed away, not left as garbage the GC
+        deliberately refuses to touch."""
+        payload = frame(2.0)
+        with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+            list(pool.map(lambda _: materialize_blob(payload, tmp_path), range(_THREADS)))
+
+        leftovers = [p.name for p in (tmp_path / "blobs").iterdir() if ".tmp-" in p.name]
+        assert leftovers == []
+
+    def test_threads_writing_distinct_payloads_all_round_trip(self, tmp_path):
+        """No cross-talk: concurrent distinct payloads keep their own contents."""
+        payloads = {i: frame(float(i + 1)) for i in range(_THREADS)}
+        barrier = threading.Barrier(_THREADS)
+
+        def worker(i: int) -> tuple[int, str]:
+            barrier.wait()
+            return i, materialize_blob(payloads[i], tmp_path)
+
+        with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+            results = dict(pool.map(worker, range(_THREADS)))
+
+        assert len(set(results.values())) == _THREADS, "distinct payloads must not collide"
+        for i, path in results.items():
+            pd.testing.assert_frame_equal(load_blob(path), payloads[i])
+
+    def test_blob_is_published_by_atomic_rename_not_a_partial_write(self, tmp_path):
+        """Deterministic guard on the publish mechanism.
+
+        The stress test below cannot reliably *lose* this race — a small payload is
+        often a single write syscall — and mutation testing confirmed it still passes
+        when the temp-file rename is replaced by a direct write. Atomic publication
+        has no black-box signature, so assert the mechanism itself: at the instant
+        before the rename the final name must not yet exist, and the complete bytes
+        must already be in a temp sibling. If publication stops going through
+        ``Path.replace`` at all, the hook never fires and this fails.
+        """
+        payload = frame(3.5, rows=256)
+        observed: dict[str, object] = {}
+        real_replace = Path.replace
+
+        def watching_replace(self, target):
+            observed["final_existed_before_rename"] = Path(target).exists()
+            observed["tmp_name"] = self.name
+            observed["tmp_bytes"] = self.read_bytes()
+            return real_replace(self, target)
+
+        with mock.patch.object(Path, "replace", watching_replace):
+            path = Path(materialize_blob(payload, tmp_path))
+
+        assert observed, "blob was published without going through an atomic rename"
+        assert observed["final_existed_before_rename"] is False
+        assert ".tmp-" in observed["tmp_name"], "staged file is not a temp sibling"
+        # The staged bytes were already complete before the name became visible.
+        assert observed["tmp_bytes"] == path.read_bytes()
+        pd.testing.assert_frame_equal(load_blob(path), payload)
+
+    def test_reader_racing_a_writer_never_sees_a_partial_blob(self, tmp_path):
+        """Stress companion to the mechanism test above: under sustained read
+        pressure a reader must only ever see complete bytes or a clean miss.
+
+        This cannot *prove* atomicity (it may simply never hit the window), so it
+        guards against gross regressions while the test above pins the mechanism.
+        """
+        payload = frame(3.0, rows=512)
+        expected_path = Path(materialize_blob(payload, tmp_path))
+        expected_bytes = expected_path.read_bytes()
+        expected_path.unlink()  # re-materialize below while readers hammer it
+
+        errors: list[Exception] = []
+        torn: list[int] = []
+        stop = threading.Event()
+
+        def reader() -> None:
+            while not stop.is_set():
+                try:
+                    data = expected_path.read_bytes()
+                except FileNotFoundError:
+                    continue  # legitimate: the rename has not landed yet
+                except OSError as exc:  # pragma: no cover - would be a real defect
+                    errors.append(exc)
+                    return
+                if data and data != expected_bytes:
+                    torn.append(len(data))
+                    return
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(40):
+                materialize_blob(payload, tmp_path)
+                expected_path.unlink(missing_ok=True)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join()
+
+        assert errors == [], f"reader saw unexpected OS errors: {errors}"
+        assert torn == [], f"reader observed {len(torn)} partial blob(s), sizes {torn}"
+
+
+def _materialize_in_subprocess(args: tuple[str, int]) -> str:
+    """Module-level so it is picklable for ProcessPoolExecutor."""
+    cache_dir, rows = args
+    return materialize_blob(frame(1.0, rows=rows), cache_dir)
+
+
+class TestCrossProcessMaterialize:
+    """Real sweeps run workers in separate processes, so the atomic-rename
+    guarantee has to hold across processes, not just threads."""
+
+    def test_processes_writing_identical_payload_produce_one_intact_blob(self, tmp_path):
+        args = [(str(tmp_path), 128)] * _PROCESSES
+        with ProcessPoolExecutor(max_workers=_PROCESSES) as pool:
+            paths = list(pool.map(_materialize_in_subprocess, args))
+
+        assert len(set(paths)) == 1
+        blobs = [p for p in (tmp_path / "blobs").iterdir() if ".tmp-" not in p.name]
+        assert len(blobs) == 1
+        pd.testing.assert_frame_equal(load_blob(paths[0]), frame(1.0, rows=128))
+        assert [p.name for p in (tmp_path / "blobs").iterdir() if ".tmp-" in p.name] == []
+
+
+class TestGCRacingAWriter:
+    """``clean_orphaned_blobs`` snapshots reachability, then lists the directory.
+
+    These tests pin what happens to work that lands inside that window. They are
+    deterministic: the interleaving is injected by wrapping the scan, so the exact
+    window is hit on every run rather than occasionally.
+    """
+
+    def _inject_after_scan(self, monkeypatch, hook) -> None:
+        """Run *hook* immediately after reachability is computed, before deletion."""
+        real = cache_management.blob_reachability
+
+        def wrapper(*args, **kwargs):
+            result = real(*args, **kwargs)
+            hook()
+            return result
+
+        monkeypatch.setattr(cache_management, "blob_reachability", wrapper)
+
+    def test_blob_written_after_the_scan_is_deleted_despite_being_referenced(
+        self, tmp_path, monkeypatch
+    ):
+        """**Known hazard, pinned deliberately.** A sweep that materializes a blob
+        and records its reference *after* the scan is invisible to that snapshot, so
+        the default ``min_age_seconds=0`` collects a live blob. This is why GC is
+        documented as a between-sessions operation; the test exists so the exposure
+        cannot change silently."""
+
+        def concurrent_sweep() -> None:
+            path = materialize_blob(frame(9.0), tmp_path)
+            write_reference(tmp_path, path)
+
+        self._inject_after_scan(monkeypatch, concurrent_sweep)
+        orphans, _ = clean_orphaned_blobs(str(tmp_path), dry_run=False)
+
+        assert len(orphans) == 1, "the post-scan blob is collected (documented hazard)"
+        # And the reference recorded by that sweep is now dangling.
+        assert blob_reachability(str(tmp_path)).names, "sweep did record a reference"
+        assert not Path(orphans[0]).exists()
+
+    def test_min_age_seconds_closes_the_window_for_a_freshly_written_blob(
+        self, tmp_path, monkeypatch
+    ):
+        """The documented mitigation: a grace period longer than the write window
+        protects the blob the previous test loses."""
+
+        def concurrent_sweep() -> None:
+            path = materialize_blob(frame(9.0), tmp_path)
+            write_reference(tmp_path, path)
+
+        self._inject_after_scan(monkeypatch, concurrent_sweep)
+        orphans, nbytes = clean_orphaned_blobs(str(tmp_path), dry_run=False, min_age_seconds=3600)
+
+        assert orphans == [] and nbytes == 0
+        assert len(list((tmp_path / "blobs").iterdir())) == 1
+
+    def test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob(
+        self, tmp_path, monkeypatch
+    ):
+        """**The gap ``min_age_seconds`` cannot close.** Dedup lets a *new* sweep
+        reference an *old* blob without rewriting it: ``materialize_blob`` returns
+        the existing path and leaves mtime untouched. So an age-based grace period —
+        which reasons about write time — offers no protection at all here, however
+        large it is set. Only running GC while nothing sweeps is sufficient."""
+        old_path = materialize_blob(frame(7.0), tmp_path)
+        os.utime(old_path, (1, 1))  # backdate beyond any plausible grace period
+
+        def concurrent_sweep_dedups_onto_it() -> None:
+            again = materialize_blob(frame(7.0), tmp_path)  # same content -> same name
+            assert again == old_path, "precondition: this is the dedup path"
+            write_reference(tmp_path, again)
+
+        self._inject_after_scan(monkeypatch, concurrent_sweep_dedups_onto_it)
+        orphans, _ = clean_orphaned_blobs(str(tmp_path), dry_run=False, min_age_seconds=86_400)
+
+        assert orphans == [str(old_path)], "a huge grace period does not help here"
+        assert not Path(old_path).exists()
+
+    def test_a_blob_referenced_before_the_scan_is_never_at_risk(self, tmp_path):
+        """The ordinary, safe case: reference recorded first, so GC sees it."""
+        path = materialize_blob(frame(4.0), tmp_path)
+        write_reference(tmp_path, path)
+
+        orphans, nbytes = clean_orphaned_blobs(str(tmp_path), dry_run=False)
+
+        assert orphans == [] and nbytes == 0
+        assert Path(path).exists()
+
+
+class TestGCRacingGC:
+    """Two collectors over one directory must both survive."""
+
+    def test_concurrent_collectors_do_not_raise_on_double_delete(self, tmp_path):
+        """Each racer deletes from its own listing, so the loser's ``unlink`` hits a
+        file that is already gone. That is an ``OSError`` the loop must swallow."""
+        for i in range(24):
+            materialize_blob(frame(float(i)), tmp_path)  # all unreferenced
+
+        results: list[tuple[list[str], int]] = []
+        errors: list[Exception] = []
+        barrier = threading.Barrier(2)
+
+        def collector() -> None:
+            try:
+                barrier.wait()
+                results.append(clean_orphaned_blobs(str(tmp_path), dry_run=False))
+            # pylint: disable=broad-exception-caught  # any raise at all is the failure
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=collector) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"concurrent GC raised: {errors}"
+        assert len(results) == 2
+        blobs = [p for p in (tmp_path / "blobs").iterdir() if _blob_like(p)]
+        assert blobs == [], "every unreferenced blob should be gone"
+
+    def test_blob_vanishing_between_listing_and_stat_is_skipped(self, tmp_path, monkeypatch):
+        """The narrower window inside the loop: the file disappears after
+        ``iterdir`` but before ``stat``. It must be skipped, not raise."""
+        doomed = Path(materialize_blob(frame(5.0), tmp_path))
+        real_stat = Path.stat
+        removed = threading.Event()
+
+        def vanishing_stat(self, *args, **kwargs):
+            # One-shot, and never re-enter Path.exists()/is_file() from here: those
+            # call stat() themselves, which would recurse into this very patch.
+            if self == doomed and not removed.is_set():
+                removed.set()
+                os.unlink(doomed)  # simulate the other racer winning right here
+            return real_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", vanishing_stat)
+        orphans, nbytes = clean_orphaned_blobs(str(tmp_path), dry_run=False)
+
+        assert orphans == [] and nbytes == 0
+        assert not doomed.exists()
+
+
+class TestGCRacingAReader:
+    """A renderer holding a path whose blob is collected mid-flight."""
+
+    def test_load_blob_raises_a_catchable_error_when_the_blob_is_collected(self, tmp_path):
+        """The render path catches per-cell load failures and substitutes a
+        placeholder, so ``load_blob`` only has to fail catchably rather than
+        crash the process or return corrupt data."""
+        path = materialize_blob(frame(6.0), tmp_path)
+        clean_orphaned_blobs(str(tmp_path), dry_run=False)  # unreferenced -> collected
+
+        with pytest.raises((FileNotFoundError, OSError)):
+            load_blob(path)
+
+    def test_readers_and_a_collector_interleave_without_corruption(self, tmp_path):
+        """Under sustained read pressure a collector must produce only two outcomes
+        per read: the correct payload, or a clean miss. Never wrong bytes."""
+        payload = frame(8.0, rows=256)
+        path = materialize_blob(payload, tmp_path)
+        write_reference(tmp_path, path)  # keep it live, so reads should mostly succeed
+
+        wrong: list[str] = []
+        stop = threading.Event()
+
+        def reader() -> None:
+            while not stop.is_set():
+                try:
+                    got = load_blob(path)
+                except (FileNotFoundError, OSError):
+                    continue
+                try:
+                    pd.testing.assert_frame_equal(got, payload)
+                except AssertionError as exc:  # pragma: no cover - real defect
+                    wrong.append(str(exc))
+                    return
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(20):
+                clean_orphaned_blobs(str(tmp_path), dry_run=False)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join()
+
+        assert wrong == [], f"reader observed corrupt payloads: {wrong[:1]}"
+        assert Path(path).exists(), "a referenced blob must survive every GC pass"
+
+
+def _blob_like(path: Path) -> bool:
+    """True for a real blob filename, excluding temp and stray files.
+
+    Reuses the production pattern rather than restating it, so a change to what
+    counts as a blob cannot silently desynchronise this helper from the collector.
+    """
+    # pylint: disable=protected-access  # deliberate: one source of truth for the shape
+    return bool(cache_management._BLOB_NAME_RE.match(path.name))
+
+
+class TestContentAddressingUnderConcurrency:
+    """Invariants that must hold no matter how writers interleave."""
+
+    def test_filename_is_always_the_digest_of_the_bytes_on_disk(self, tmp_path):
+        """A blob whose name did not match its contents would make dedup unsound
+        and every reachability decision meaningless."""
+        payloads = [frame(float(i)) for i in range(8)] + [
+            xr.Dataset({"v": ("x", np.arange(4, dtype="float64"))}),
+            b"raw-bytes-payload",
+            {"picklable": "object"},
+        ]
+        with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+            list(pool.map(lambda p: materialize_blob(p, tmp_path), payloads))
+
+        for blob in (tmp_path / "blobs").iterdir():
+            digest = hashlib.sha256(blob.read_bytes()).hexdigest()[:_HASH_CHARS]
+            stem = blob.name.split(".")[0]
+            assert stem == digest, f"{blob.name} does not match its content digest"
+
+    def test_repeated_materialize_never_rewrites_an_existing_blob(self, tmp_path):
+        """Skipping the write on a content hit is what makes concurrent dedup cheap
+        and keeps mtime stable — the property the dedup/min_age test above relies on."""
+        payload = frame(1.5)
+        path = Path(materialize_blob(payload, tmp_path))
+        first_mtime = path.stat().st_mtime_ns
+
+        for _ in range(5):
+            assert materialize_blob(payload, tmp_path) == str(path)
+        assert path.stat().st_mtime_ns == first_mtime, "an existing blob was rewritten"
+
+
+class TestPickleRoundTripUnderConcurrency:
+    """The pickle fallback shares the same write path, so it needs the same guarantee."""
+
+    def test_concurrent_pickle_fallback_payloads_stay_intact(self, tmp_path):
+        """int64 datasets take the pickle branch; concurrent writers must not tear
+        each other's files."""
+        payloads = [
+            xr.Dataset({"v": ("x", np.arange(32, dtype="int64") + i)}) for i in range(_THREADS)
+        ]
+        barrier = threading.Barrier(_THREADS)
+
+        def worker(i: int) -> tuple[int, str]:
+            barrier.wait()
+            return i, materialize_blob(payloads[i], tmp_path)
+
+        with ThreadPoolExecutor(max_workers=_THREADS) as pool:
+            results = dict(pool.map(worker, range(_THREADS)))
+
+        for i, path in results.items():
+            assert path.endswith(".pkl"), "int64 must take the pickle fallback"
+            xr.testing.assert_identical(load_blob(path), payloads[i])
+        # Sanity: pickle bytes are deterministic here, so all names are distinct.
+        assert len(set(results.values())) == _THREADS
+
+    def test_unpicklable_payload_fails_loudly_rather_than_writing_a_bad_blob(self, tmp_path):
+        """A lambda is outside the documented 'any picklable object' contract. It
+        must raise rather than silently persist something unloadable, and must not
+        leave a temp file behind."""
+        with pytest.raises((pickle.PicklingError, AttributeError, TypeError)):
+            materialize_blob(lambda x: x, tmp_path)
+
+        blobs_dir = tmp_path / "blobs"
+        leftovers = list(blobs_dir.iterdir()) if blobs_dir.is_dir() else []
+        assert leftovers == [], f"failed write left files behind: {leftovers}"

--- a/test/test_cache_management.py
+++ b/test/test_cache_management.py
@@ -1,25 +1,38 @@
 """Tests for bencher.cache_management."""
 
+import contextlib
+import io
 import os
+import pickle
 import shutil
 import tempfile
+import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
+import numpy as np
+import xarray as xr
 from diskcache import Cache
 
+import bencher as bn
+from bencher.blob_store import materialize_blob
 from bencher.cache_management import (
     CACHE_VERSION,
     DEFAULT_CACHE_SIZE_BYTES,
     CacheDirStats,
     CacheStats,
+    blob_reachability,
     cache_stats,
+    clean_orphaned_blobs,
     clean_orphaned_media,
     cleanup_job_media,
     clear_all,
     clear_media,
     ensure_cache_version,
+    print_orphaned_blobs,
 )
+from bencher.result_collector import ResultCollector
 
 
 class TestConstant(unittest.TestCase):
@@ -315,6 +328,483 @@ class TestCleanOrphanedMedia(_TempCacheMixin, unittest.TestCase):
 
         orphans, _ = clean_orphaned_media(self.cachedir, dry_run=True)
         self.assertEqual(len(orphans), 0)
+
+
+BLOB_A = "aaaa000000000000.parquet"
+BLOB_B = "bbbb000000000000.nc"
+BLOB_C = "cccc000000000000.pkl"
+
+# The object sentinel setup_dataset fills object-dtype result columns with.
+MISSING = "NAN"
+
+
+def _cells(*rows) -> xr.Dataset:
+    """A history-shaped dataset: one column ``table`` over (repeat, over_time).
+
+    ``_cells(["a", "b"])`` is one repeat with two over_time events.
+    """
+    values = np.array(rows, dtype=object)
+    return xr.Dataset(
+        {"table": (("repeat", "over_time"), values)},
+        coords={"repeat": list(range(values.shape[0])), "over_time": list(range(values.shape[1]))},
+    )
+
+
+def _record(dataset: xr.Dataset, columns=None, retired=None) -> dict:
+    """The stored over_time history record shape (see bencher.history)."""
+    return {
+        "format": 1,
+        "dataset": dataset,
+        "columns": columns if columns is not None else {"table": {"identity": "x"}},
+        "retired": retired or {},
+    }
+
+
+def _dataset_result_var(name: str, **kwargs) -> bn.ResultDataSet:
+    """A named ResultDataSet, as the metaclass would produce on a class body."""
+    rv = bn.ResultDataSet(**kwargs)
+    rv.name = name
+    return rv
+
+
+def _bench_result(dataset: xr.Dataset) -> bn.BenchResult:
+    """A BenchResult carrying *dataset*, as ``cache_results=True`` stores it."""
+    result = bn.BenchResult(bn.BenchCfg())
+    result.ds = dataset
+    return result
+
+
+class TestBlobReachability(_TempCacheMixin, unittest.TestCase):
+    """The live set is the union of every blob name any root still names."""
+
+    def test_missing_caches_are_empty_not_unreadable(self):
+        reach = blob_reachability(self.cachedir)
+        self.assertEqual(reach.names, frozenset())
+        self.assertTrue(reach.complete)
+
+    def test_history_and_benchmark_caches_are_both_roots(self):
+        self._make_managed_cache("history", {"k": _record(_cells([f"/c/blobs/{BLOB_A}"]))})
+        self._make_managed_cache(
+            "benchmark_inputs", {"k": _bench_result(_cells([f"/c/blobs/{BLOB_B}"]))}
+        )
+        reach = blob_reachability(self.cachedir)
+        self.assertEqual(reach.names, frozenset({BLOB_A, BLOB_B}))
+
+    def test_non_blob_strings_are_not_references(self):
+        """Only content-addressed names count, so ordinary media paths are ignored."""
+        self._make_managed_cache(
+            "history",
+            {"k": _record(_cells(["cachedir/img/img/key/img.png", "not a path", MISSING]))},
+        )
+        self.assertEqual(blob_reachability(self.cachedir).names, frozenset())
+
+    def test_bare_strings_arrays_and_dataarrays_are_all_scanned(self):
+        """The walk does not assume a Dataset: any shape a cached value can take
+        (a loose path string, a numpy array, a DataArray and its coords) counts."""
+        self._make_managed_cache(
+            "benchmark_inputs",
+            {
+                "loose_string": f"/c/blobs/{BLOB_A}",
+                "array": np.array([f"/c/blobs/{BLOB_B}"], dtype=object),
+                "data_array": xr.DataArray(
+                    np.array([f"/c/blobs/{BLOB_C}"], dtype=object),
+                    dims="i",
+                    coords={"i": np.array(["label"], dtype=object)},
+                ),
+            },
+        )
+        reach = blob_reachability(self.cachedir)
+        self.assertEqual(reach.names, frozenset({BLOB_A, BLOB_B, BLOB_C}))
+
+
+class TestCleanOrphanedBlobs(_TempCacheMixin, unittest.TestCase):
+    """Reachability GC for the content-addressed blob store."""
+
+    def _history(self, dataset, columns=None, retired=None):
+        self._make_managed_cache("history", {"key": _record(dataset, columns, retired)})
+
+    def test_referenced_blob_survives_and_unreferenced_is_collected(self):
+        live = self._make_blob(BLOB_A)
+        dead = self._make_blob(BLOB_B, b"y" * 40)
+        self._history(_cells([f"{self.cachedir}/blobs/{BLOB_A}"]))
+
+        orphans, freed = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [dead])
+        self.assertEqual(freed, 40)
+        self.assertTrue(os.path.exists(live))
+        self.assertFalse(os.path.exists(dead))
+
+    def test_dry_run_is_the_default_and_deletes_nothing(self):
+        dead = self._make_blob(BLOB_B, b"y" * 40)
+
+        orphans, freed = clean_orphaned_blobs(self.cachedir)
+
+        self.assertEqual(orphans, [dead])
+        self.assertEqual(freed, 40)
+        self.assertTrue(os.path.exists(dead))
+
+    def test_blob_referenced_only_by_a_historical_event_survives(self):
+        """The case a naive implementation gets wrong: an over_time history's
+        oldest event is the sole reference, and looking at only the latest event
+        (or the served projection) would declare the blob garbage."""
+        old = self._make_blob(BLOB_A)
+        self._history(_cells([f"/old/cachedir/blobs/{BLOB_A}", MISSING, MISSING]))
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(old))
+
+    def test_blob_referenced_only_by_a_retired_column_survives(self):
+        """A ``meaning_version`` bump retires a column under a mangled name; the
+        data stays in the stored superset dataset but is projected away from
+        consumers, so only the raw record shows the reference."""
+        retired_blob = self._make_blob(BLOB_A)
+        dataset = xr.Dataset(
+            {
+                "table": (("repeat", "over_time"), np.array([[MISSING]], dtype=object)),
+                "table__retired_deadbeef": (
+                    ("repeat", "over_time"),
+                    np.array([[f"/c/blobs/{BLOB_A}"]], dtype=object),
+                ),
+            },
+            coords={"repeat": [0], "over_time": [0]},
+        )
+        self._history(
+            dataset,
+            columns={"table": {"identity": "new"}},
+            retired={"table__retired_deadbeef": {"identity": "old", "retired_from": "table"}},
+        )
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(retired_blob))
+
+    def test_blob_referenced_only_by_a_dormant_column_survives(self):
+        """A column whose variable left the config is retained but not served,
+        so it carries no entry in the record's ``columns`` metadata."""
+        dormant_blob = self._make_blob(BLOB_A)
+        dataset = xr.Dataset(
+            {"gone": (("repeat", "over_time"), np.array([[f"/c/blobs/{BLOB_A}"]], dtype=object))},
+            coords={"repeat": [0], "over_time": [0]},
+        )
+        self._history(dataset, columns={"table": {"identity": "x"}})
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(dormant_blob))
+
+    def test_deduplicated_blob_survives_while_another_cell_still_names_it(self):
+        """Content addressing means one file backs many cells, which is exactly
+        why per-cell (ownership) cleanup is unsound: the oldest event no longer
+        references BLOB_A, but the newest still does."""
+        shared = self._make_blob(BLOB_A)
+        aged_out = self._make_blob(BLOB_C, b"z" * 10)
+        path_a = f"/c/blobs/{BLOB_A}"
+        self._history(_cells([MISSING, path_a, path_a]))
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [aged_out])
+        self.assertTrue(os.path.exists(shared))
+
+    def test_reference_is_matched_by_name_so_a_moved_cachedir_still_protects(self):
+        """A blob name *is* its content hash, so a stale absolute prefix from a
+        cachedir that has since moved must not strand the payload."""
+        blob = self._make_blob(BLOB_A)
+        self._history(_cells([f"/somewhere/else/entirely/blobs/{BLOB_A}"]))
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_partial_writes_and_stray_files_are_left_alone(self):
+        """``materialize_blob`` renames from ``<name>.tmp-<uuid>``; one may belong
+        to a worker writing right now, and neither it nor a stray file is a blob."""
+        tmp_write = self._make_blob(f"{BLOB_A}.tmp-0123456789abcdef")
+        stray = self._make_blob("README.txt")
+        subdir = Path(self.cachedir, "blobs", "nested")
+        subdir.mkdir()
+
+        orphans, freed = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertEqual(freed, 0)
+        self.assertTrue(os.path.exists(tmp_write))
+        self.assertTrue(os.path.exists(stray))
+        self.assertTrue(subdir.is_dir())
+
+    def test_no_reference_caches_at_all_means_every_blob_is_garbage(self):
+        """The default configuration writes neither cache (``cache_results`` and
+        ``cache_samples`` both default to False), so a plain sweep leaves blobs
+        that nothing on disk references — exactly as ``clean_orphaned_media``
+        treats every media dir as orphaned when the sample cache is empty. GC is
+        an offline maintenance step, not something to run beside a live sweep."""
+        blob = self._make_blob(BLOB_A)
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [blob])
+
+    def test_min_age_seconds_protects_a_recently_written_blob(self):
+        recent = self._make_blob(BLOB_A)
+        old = self._make_blob(BLOB_B, b"y" * 40)
+        os.utime(old, (time.time() - 7200, time.time() - 7200))
+
+        orphans, freed = clean_orphaned_blobs(self.cachedir, dry_run=False, min_age_seconds=3600)
+
+        self.assertEqual(orphans, [old])
+        self.assertEqual(freed, 40)
+        self.assertTrue(os.path.exists(recent))
+
+    def test_empty_blob_store_is_a_noop(self):
+        self.assertEqual(clean_orphaned_blobs(self.cachedir), ([], 0))
+
+
+class TestBlobGCDegradesSafely(_TempCacheMixin, unittest.TestCase):
+    """An unreadable root makes absence-of-reference unprovable, so nothing goes."""
+
+    def _corrupt_history_value(self):
+        """Store a value large enough to live in its own file, then garble it.
+
+        diskcache keeps values above ``disk_min_file_size`` in ``*.val`` files,
+        so this reproduces a genuinely undeserializable cache entry.
+        """
+        self._make_managed_cache("history", {"key": {"payload": b"x" * 200_000}})
+        vals = list(Path(self.cachedir, "history").rglob("*.val"))
+        self.assertEqual(len(vals), 1)
+        vals[0].write_bytes(b"not a pickle")
+
+    def test_corrupt_record_collects_nothing_and_keeps_every_blob(self):
+        blob = self._make_blob(BLOB_A)
+        self._corrupt_history_value()
+
+        orphans, freed = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual((orphans, freed), ([], 0))
+        self.assertTrue(os.path.exists(blob))
+
+    def test_incomplete_scan_reports_the_offending_entry(self):
+        self._corrupt_history_value()
+        reach = blob_reachability(self.cachedir)
+        self.assertFalse(reach.complete)
+        self.assertEqual(len(reach.unreadable), 1)
+        self.assertIn("cannot deserialize", reach.unreadable[0])
+
+    def test_unopenable_cache_collects_nothing(self):
+        blob = self._make_blob(BLOB_A)
+        self._make_managed_cache("history", {"key": "value"})
+
+        with mock.patch("bencher.cache_management.Cache", side_effect=OSError("disk on fire")):
+            orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_unenumerable_cache_collects_nothing(self):
+        blob = self._make_blob(BLOB_A)
+        self._make_managed_cache("history", {"key": "value"})
+
+        with mock.patch.object(Cache, "iterkeys", side_effect=OSError("bad index")):
+            orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_undeletable_blob_is_still_reported(self):
+        """Matching clean_orphaned_media: the report is what was identified as
+        garbage, so a permission failure is logged rather than hidden."""
+        blob = self._make_blob(BLOB_A)
+
+        with mock.patch.object(Path, "unlink", side_effect=OSError("read-only")):
+            orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [blob])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_dry_run_matches_the_real_run_when_the_scan_is_incomplete(self):
+        """A dry run has to stay an accurate preview, so it reports nothing too."""
+        self._make_blob(BLOB_A)
+        self._corrupt_history_value()
+        self.assertEqual(clean_orphaned_blobs(self.cachedir), ([], 0))
+
+
+class TestBlobGCExtraRoots(_TempCacheMixin, unittest.TestCase):
+    """Results saved outside the cache are invisible unless declared."""
+
+    def _saved_result(self, name: str, blob_name: str) -> Path:
+        path = Path(self.tmpdir, name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as fh:
+            pickle.dump(_bench_result(_cells([f"/c/blobs/{blob_name}"])), fh)
+        return path
+
+    def test_saved_result_is_stranded_without_extra_roots(self):
+        """The honest limitation: nothing records where save_result wrote."""
+        blob = self._make_blob(BLOB_A)
+        self._saved_result("archive/run.pkl", BLOB_A)
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False)
+
+        self.assertEqual(orphans, [blob])
+
+    def test_extra_root_file_protects_a_saved_result(self):
+        blob = self._make_blob(BLOB_A)
+        saved = self._saved_result("archive/run.pkl", BLOB_A)
+
+        orphans, _ = clean_orphaned_blobs(self.cachedir, dry_run=False, extra_roots=[saved])
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_extra_root_directory_protects_every_pickle_under_it(self):
+        blob_a = self._make_blob(BLOB_A)
+        blob_b = self._make_blob(BLOB_B)
+        dead = self._make_blob(BLOB_C, b"z" * 5)
+        self._saved_result("archive/one.pkl", BLOB_A)
+        self._saved_result("archive/nested/two.pkl", BLOB_B)
+
+        orphans, _ = clean_orphaned_blobs(
+            self.cachedir, dry_run=False, extra_roots=[Path(self.tmpdir, "archive")]
+        )
+
+        self.assertEqual(orphans, [dead])
+        self.assertTrue(os.path.exists(blob_a))
+        self.assertTrue(os.path.exists(blob_b))
+
+    def test_missing_extra_root_aborts_rather_than_running_unprotected(self):
+        """A typo'd archive path must not silently become an unprotected GC run."""
+        blob = self._make_blob(BLOB_A)
+
+        orphans, _ = clean_orphaned_blobs(
+            self.cachedir, dry_run=False, extra_roots=[Path(self.tmpdir, "nope")]
+        )
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(blob))
+
+    def test_unloadable_extra_root_aborts(self):
+        blob = self._make_blob(BLOB_A)
+        bad = Path(self.tmpdir, "bad.pkl")
+        bad.write_bytes(b"not a pickle")
+
+        self.assertEqual(
+            clean_orphaned_blobs(self.cachedir, dry_run=False, extra_roots=[bad]), ([], 0)
+        )
+        self.assertTrue(os.path.exists(blob))
+
+
+class TestPrintOrphanedBlobs(_TempCacheMixin, unittest.TestCase):
+    def _output(self, **kwargs) -> str:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            print_orphaned_blobs(self.cachedir, **kwargs)
+        return buf.getvalue()
+
+    def test_dry_run_report_names_the_blob_and_says_nothing_was_deleted(self):
+        dead = self._make_blob(BLOB_B, b"y" * 40)
+        out = self._output()
+        self.assertIn(dead, out)
+        self.assertIn("Would reclaim 1", out)
+        self.assertIn("nothing deleted", out)
+        self.assertTrue(os.path.exists(dead))
+
+    def test_real_run_report(self):
+        self._make_blob(BLOB_B, b"y" * 40)
+        out = self._output(dry_run=False)
+        self.assertIn("Reclaimed 1", out)
+
+    def test_long_report_is_truncated(self):
+        for i in range(25):
+            self._make_blob(f"{i:016x}.pkl")
+        out = self._output()
+        self.assertIn("Would reclaim 25", out)
+        self.assertIn("... and 5 more", out)
+
+    def test_incomplete_scan_report(self):
+        self._make_managed_cache("history", {"key": {"payload": b"x" * 200_000}})
+        for val in Path(self.cachedir, "history").rglob("*.val"):
+            val.write_bytes(b"not a pickle")
+        out = self._output(dry_run=False)
+        self.assertIn("aborted", out)
+        self.assertIn("Nothing was deleted", out)
+
+
+class TestBlobGCReclaimsAgedOutHistory(unittest.TestCase):
+    """``max_time_events`` aging is the real-world blob garbage source.
+
+    ``_null_old_entries`` overwrites an aged-out cell with the sentinel and
+    deliberately does not delete the file — ``ResultDataSet`` is absent from
+    ``_MEDIA_RESULT_TYPES`` precisely because a deduplicated blob may still back
+    another live cell.  So aging leaves reachable-by-nobody blobs, and this is
+    what reachability GC is for.  Runs against a throwaway cachedir via chdir,
+    matching test/test_history_reconciliation.py.
+    """
+
+    def setUp(self):
+        self._old_cwd = os.getcwd()
+        self._tmp = tempfile.mkdtemp()
+        os.chdir(self._tmp)
+        self.collector = ResultCollector()
+
+    def tearDown(self):
+        self.collector.close_caches()
+        os.chdir(self._old_cwd)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _event(self, payload, result_var, event: int) -> str:
+        """Materialize *payload* and append it as one over_time event."""
+        blob = materialize_blob(payload, Path("cachedir").absolute())
+        dataset = xr.Dataset(
+            {"table": (("repeat", "over_time"), np.array([[blob]], dtype=object))},
+            coords={"repeat": [0], "over_time": [np.datetime64(f"2020-01-0{event + 1}")]},
+        )
+        self.collector.load_history_cache(
+            dataset,
+            "history-key",
+            False,
+            None,
+            [result_var],
+            bench_name="aging",
+            tag="t",
+            config_summary={"inputs": [], "consts": [], "results": ["table"], "repeats": 1},
+        )
+        return blob
+
+    def test_aged_out_blob_is_reclaimed_and_live_events_survive(self):
+        rv = _dataset_result_var("table", max_time_events=2)
+        blobs = [self._event({"event": i}, rv, i) for i in range(3)]
+        self.assertEqual(len(set(blobs)), 3)
+        # The oldest cell is nulled to the sentinel but its file is left behind.
+        self.assertTrue(all(os.path.exists(b) for b in blobs))
+
+        orphans, freed = clean_orphaned_blobs("cachedir", dry_run=False)
+
+        self.assertEqual([Path(p).name for p in orphans], [Path(blobs[0]).name])
+        self.assertGreater(freed, 0)
+        self.assertFalse(os.path.exists(blobs[0]))
+        self.assertTrue(os.path.exists(blobs[1]))
+        self.assertTrue(os.path.exists(blobs[2]))
+
+    def test_aged_out_cell_sharing_a_blob_with_a_live_cell_keeps_the_file(self):
+        """Identical payloads deduplicate to one file, so the aged-out event and
+        the newest event can be the same blob — a per-cell delete would strand
+        the live reference."""
+        rv = _dataset_result_var("table", max_time_events=2)
+        shared = self._event({"event": "same"}, rv, 0)
+        other = self._event({"event": "middle"}, rv, 1)
+        again = self._event({"event": "same"}, rv, 2)
+        self.assertEqual(shared, again)
+
+        orphans, _ = clean_orphaned_blobs("cachedir", dry_run=False)
+
+        self.assertEqual(orphans, [])
+        self.assertTrue(os.path.exists(shared))
+        self.assertTrue(os.path.exists(other))
 
 
 class TestGenPathWithJobKey(_TempCacheMixin, unittest.TestCase):

--- a/test/test_cache_management.py
+++ b/test/test_cache_management.py
@@ -16,6 +16,7 @@ import xarray as xr
 from diskcache import Cache
 
 import bencher as bn
+from bencher import cache_management
 from bencher.blob_store import materialize_blob
 from bencher.cache_management import (
     CACHE_VERSION,
@@ -415,6 +416,22 @@ class TestBlobReachability(_TempCacheMixin, unittest.TestCase):
         )
         reach = blob_reachability(self.cachedir)
         self.assertEqual(reach.names, frozenset({BLOB_A, BLOB_B, BLOB_C}))
+
+    def test_every_managed_cache_is_a_gc_root_or_the_documented_exclusion(self):
+        """Guard on the hand-maintained coupling between the two cache lists.
+
+        ``_BLOB_REFERENCE_CACHES`` is a manually curated subset of
+        ``_MANAGED_CACHES``: every managed diskcache must either be scanned as a
+        GC root or be ``sample_cache``, whose exclusion is argued in the comment
+        on ``_BLOB_REFERENCE_CACHES`` (it holds pre-materialization worker
+        payloads, which cannot name a blob).  Adding a new managed cache that
+        can hold datasets without also making it a root would let GC delete
+        live blobs — this test forces that decision to be made explicitly.
+        """
+        # pylint: disable=protected-access  # the coupling of the two module constants is the subject
+        managed = set(cache_management._MANAGED_CACHES)
+        roots = set(cache_management._BLOB_REFERENCE_CACHES)
+        self.assertEqual(managed, roots | {"sample_cache"})
 
 
 class TestCleanOrphanedBlobs(_TempCacheMixin, unittest.TestCase):


### PR DESCRIPTION
Follow-up to #1021. That PR added the content-addressed blob store and honestly recorded
that it had **no garbage collection**: every distinct `ResultDataSet` payload from every run
was retained until an explicit `clear_media()`/`clear_all()`, and content addressing only
deduplicates byte-identical payloads, so a nightly sweep whose payloads drift accumulated
files without bound. This PR gives the store a lifecycle.

## The real leak

The worst case is not "the cache grows"; it is a **permanent** leak on a supported feature.
A per-variable `max_time_events` limit ages an old `over_time` cell out by overwriting it
with the missing-value sentinel, and `_null_old_entries` (`bencher/result_collector.py:74`)
deliberately does *not* delete the file — `ResultDataSet` is absent from
`_MEDIA_RESULT_TYPES` for good reason (below). So before this change every aged-out payload
was orphaned on disk forever.

## Why ownership-based cleanup could not be reused

`cleanup_job_media` and `clean_orphaned_media` work because media lives in
`cachedir/{folder}/{filename}/{job_key}/`: one directory, one owner. A blob has **no owner**
— its name is its content hash, so byte-identical payloads from different job keys, sweeps
and time events collapse onto one file. Verified empirically: a 3-event × 2-sample
`over_time` sweep where two events produce the same payload yields 6 cells but 5 blobs, with
one path appearing at two different time coordinates. Deleting "this cell's blob" would
strand the other cell's live reference. That is exactly why adding `ResultDataSet` to
`_MEDIA_RESULT_TYPES` would be the wrong fix, and why per-job pruning must keep its hands
off `blobs/`.

## The reachability model

A blob is garbage iff **no live reference anywhere names it**. `blob_reachability()` unions
every blob name referenced from:

- the **`history`** diskcache — each record's *stored* dataset, not the served projection.
  This is the case a naive implementation gets wrong: the superset dataset holds dormant and
  retired columns as ordinary data variables, and old `over_time` events whose only
  reference is at `over_time=0`. A projection or an `isel(over_time=-1)` would declare all
  of those garbage.
- the **`benchmark_inputs`** diskcache — whole pickled `BenchResult` objects (`cache_results=True`).
- **`extra_roots`** — `save_result` pickles, or directories of them.

`sample_cache` is deliberately **not** a root: it stores what the worker returned, *before*
materialization, so it cannot contain a blob path (blobs are written by
`ResultCollector._materialize_dataset_value` when the value enters the dataset). It is also
the one root whose absence is recoverable — a payload still in the sample cache
re-materializes to the *same* content-addressed path on the next hit.

Matching is on the blob **filename**, not the resolved path. A name *is* a content hash, so
it is a complete, location-independent identity; this keeps references valid when a stored
dataset carries an absolute path from a cachedir that has since been moved or copied, the
case where resolving against the current `blobs/` would silently declare everything dead.

## API

```python
bn.clean_orphaned_blobs()                                      # report only (default)
bn.clean_orphaned_blobs(dry_run=False)                         # reclaim
bn.clean_orphaned_blobs(dry_run=False, extra_roots=["runs/"])  # protect saved results
bn.clean_orphaned_blobs(dry_run=False, min_age_seconds=3600)   # grace period
bn.print_orphaned_blobs()                                      # human-readable report
bn.blob_reachability()                                         # the live set, for auditing
```

`clean_orphaned_blobs` returns `(orphan_paths, total_bytes)` and defaults `dry_run=True`,
matching `clean_orphaned_media`'s shape and convention exactly. `print_orphaned_blobs`
mirrors `print_cache_stats`. Two pixi tasks sit beside the existing cache ones:
`pixi run cache-blob-orphans` (report) and `pixi run cache-blob-gc` (reclaim).

## Deliberate decisions, including one rejected

- **`dry_run=True` is the default.** Deleting a still-referenced blob silently degrades a
  report cell to a placeholder, so the safe direction must be the one you get by accident.
- **Blobs are primary storage, not a recomputable cache** — `cache_results` and
  `cache_samples` both default to `False` (`bencher/bench_cfg.py:262,267`), and a stored
  history holds paths rather than payload copies. So there is deliberately **no size- or
  age-based eviction of referenced blobs**: nothing could restore them. This is GC, not LRU.
- **An unreadable root aborts the run.** A record that cannot be deserialized may name any
  blob, so nothing is provably garbage. `clean_orphaned_blobs` then reports and deletes
  **nothing in either mode** — which also keeps a dry run an accurate preview of the real
  one — and warns with the offending entries named so they can be removed (bencher's own
  `_load_history_record` discards unreadable history records on the next run anyway).
- **`.tmp-<uuid>` partial writes and stray files in `blobs/` are never touched**; a tmp file
  may belong to a worker writing right now.
- **Rejected: adding `ResultDataSet` to `_MEDIA_RESULT_TYPES`** so `_null_old_entries` would
  delete the aged-out file. Unsound for content-addressed storage, per the dedup evidence
  above. Reachability is the only correct model here.
- **Rejected: scanning `sample_cache`.** Its values are arbitrary worker payloads (large
  DataFrames), so a recursive scan would be expensive and unbounded, and it provably cannot
  hold a reference. Documented in `_BLOB_REFERENCE_CACHES` instead.

## The `save_result` gap, stated honestly

A result written with `bencher.render.save_result` is a pickle at a user-chosen path and
**nothing records where**, so its blob references are undiscoverable and GC can strand them
(the result still loads; its dataset cells render as placeholders). This is documented in the
`clean_orphaned_blobs` docstring, in the CHANGELOG, and in `docs/how_to_use_bencher.md`, and
`extra_roots=` is the way out for a known archive. A missing or unloadable `extra_roots`
entry aborts the scan rather than running unprotected, so a typo cannot silently strand an
archive you asked to protect. The same reasoning covers a result held only in memory by a
concurrent sweep — `min_age_seconds=` is the guard, and like `clean_orphaned_media` this is
an offline maintenance step.

## Test coverage

`test/test_cache_management.py`, reusing `_TempCacheMixin`/`_make_blob` (+29 tests, 61 in the
file). `bencher/cache_management.py` is at 94% from this file alone; the two uncovered lines
are a stat/evict race.

Reachability shapes:
- history and `benchmark_inputs` are both roots; a missing cache is empty, not unreadable
- bare strings, numpy arrays, `DataArray`s and their coords are all scanned
- ordinary media paths and non-paths are not treated as references

Survival (the cases a naive implementation gets wrong):
- a blob referenced **only by a historical `over_time` event** survives
- a blob referenced **only by a retired column** (mangled name, projected away) survives
- a blob referenced **only by a dormant column** (absent from `columns` metadata) survives
- a **deduplicated** blob survives while another cell still names it
- a reference with a **stale absolute prefix** from a moved cachedir still protects
- a blob referenced from a **cached `BenchResult`** survives

Collection and reporting:
- an unreferenced blob is collected; `freed` bytes are exact
- `dry_run=True` is the default, reports accurately and deletes nothing
- `min_age_seconds` protects a recently written blob and collects an old one
- `.tmp-*` partial writes, stray files and subdirectories are left alone
- with no reference caches at all every blob is reported garbage (documents the
  default-configuration hazard explicitly)
- `print_orphaned_blobs` dry-run / real-run / truncated (>20) / aborted output

Safe degradation:
- a corrupt (undeserializable) history record collects nothing and keeps every blob
- an unopenable and an unenumerable cache each collect nothing
- a dry run reports nothing when the scan is incomplete, matching the real run
- an undeletable blob is still reported

`save_result` handling:
- a saved result is stranded **without** `extra_roots` (the documented limitation, pinned)
- an `extra_roots` file, and a directory of pickles, both protect
- a missing or unloadable `extra_roots` entry aborts rather than running unprotected

Integration against a real cachedir (`chdir`, matching `test_history_reconciliation.py`):
- `max_time_events` aging → the aged-out blob is reclaimed, live events survive
- an aged-out cell **sharing** its blob with a live cell keeps the file

Also verified manually end-to-end: a real 3-event `over_time` sweep produces 6 blobs, all 6
reachable, 0 orphans reported.

## Docs

- `CHANGELOG.md`: new Added entry; the old "`cachedir/blobs/` has no garbage collection"
  Notes bullet is replaced, since that fact has changed.
- `plans/22-grammar-phase-1-data-model.md`: amendment 9 retires the plan's "orphan cleanup
  is A4's artifact-manifest scope" claim, which conflated per-owner reclamation (still A4)
  with reclaiming what nothing references (needs no manifest).
- `docs/how_to_use_bencher.md`: a short paragraph in the `ResultDataSet` `over_time` section,
  the only place the doc mentions blobs.

## CI

- `pixi run ci` → exit 0. ruff format clean, `ruff check` clean, pylint **10.00/10**, ty
  "All checks passed!", generate-examples clean, **2435 passed, 3 skipped**, coverage
  **90%** total (`fail_under = 85`).
- `pixi run test-split` (`BENCHER_FORCE_SPLIT_RENDER=1`) → **2435 passed, 3 skipped**.
- `pixi.lock` is not in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce reachability-based garbage collection for the content-addressed blob store, including APIs to inspect and reclaim unreferenced blobs and integration with existing cache management.

New Features:
- Add blob_reachability API and BlobReachability dataclass to compute the set of blob filenames still referenced from cache roots and optional external archives.
- Add clean_orphaned_blobs API to report and optionally delete unreferenced blobs in cachedir/blobs with support for dry-run mode, age filtering, and extra roots.
- Add print_orphaned_blobs helper to emit a human-readable GC report and wire it into new pixi tasks for blob orphan reporting and reclamation.

Enhancements:
- Document the blob store lifecycle and reachability GC behavior in cache_management, CHANGELOG, data model plan, and user docs.
- Export new blob GC APIs from the bencher package for direct use.
- Clarify that blob content directories are handled via reachability GC rather than per-job pruning.

Tests:
- Add extensive test coverage for blob reachability computation, orphaned blob collection behavior, safety in the presence of corrupt or unreadable caches, handling of extra roots, and interaction with max_time_events aging in real cachedirs.
- Extend existing cache management tests to cover reporting behavior for orphaned blob GC in both dry-run and real-run modes.