### PR TITLE
build!: drop Python 3.10, raise floor to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [py310, py313]
+        environment: [py311, py313]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **BREAKING: dropped Python 3.10 support.** `requires-python` is now `>=3.11,<3.14`, and
+  the CI matrix runs py311 + py313 (was py310 + py313). The `py310` pixi feature and
+  environment are gone.
+
+  The motivation is type-checking, not any runtime feature: `typing.assert_never` — the
+  mechanism plan 23 uses to make `match` statements exhaustively checked by `ty` — is
+  stdlib only from 3.11. On a 3.10 floor it required a `typing_extensions` dependency the
+  repo had explicitly declined (`result_collector.py`), and the dependency-free
+  workarounds were measured to silently degrade the check to a rule the repo ignores,
+  giving false confidence. Raising the floor removes the dependency and the conflict.
+
+  Two 3.10-era workarounds are now removable and are queued as plan 23 P1 cleanups:
+  `typing.Self` in `ResultCollector.__enter__`, and the third-party `strenum` package.
+  **`strenum` is deliberately retained for now** — stdlib `enum.StrEnum` is not a drop-in
+  replacement, because `auto()` lowercases member names where `strenum` preserves them,
+  which would silently change the values of `Executors` and `SampleOrder` and therefore
+  which strings `BenchRunCfg(executor=...)` accepts. See plan 23 D4.
+
 ### Added
 - **Content-addressed blob store: `bencher/blob_store.py`** (plan 22, phase 1 of the A6
   grammar-of-ND-data migration, #1021). Result payloads that cannot live directly in a

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/holobench)](https://pypi.org/project/holobench/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/holobench)](https://pypistats.org/packages/holobench)
 [![License](https://img.shields.io/pypi/l/bencher)](https://opensource.org/license/mit/)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.13-blue)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 
 ## Install

--- a/bencher/scorecard/render.py
+++ b/bencher/scorecard/render.py
@@ -13,7 +13,7 @@ links so they stay reachable from this page.
 from __future__ import annotations
 
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
@@ -118,7 +118,7 @@ def generate_scorecard(
         nightly_url=_sanitize_url(chrome.nightly_url),
         main_url=_sanitize_url(chrome.main_url),
         stable_url=_sanitize_url(chrome.stable_url),
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        generated_at=datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC"),
     )
 
     output_path = reports_dir / output_name

--- a/docs/conda-environment.yml
+++ b/docs/conda-environment.yml
@@ -2,7 +2,7 @@ name: docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
   - sqlite=3.48.0
   - pip:

--- a/pixi.lock
+++ b/pixi.lock
@@ -361,180 +361,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl
-  py310:
-    channels:
-    - url: https://conda.anaconda.org/conda-forge/
-    - url: https://prefix.dev/blooop/
-    indexes:
-    - https://pypi.org/simple
-    packages:
-      p1:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.96.0-hfc2019e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.48.0-hee588c1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.23.1-h273caaf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/playwright-1.60.0-h0bd9c3d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.16-he725a3c_1_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.48.0-h9eae976_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://prefix.dev/blooop/linux-64/devpod-0.8.12-hb0f4dca_0.conda
-      - pypi: ./
-      - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/11/cd/ec193e471780dfad60e44ded5526c123695c1354910edd537d7aa1d22094/hvplot-0.12.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/13/5a/f8c0868199bbb231a02616286ce8a4ccb85f5387b9215510297dcfedd214/pyviz_comms-3.0.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/19/0c/121f4a7d7be7ddbbc9923f3d5c687cb77e3958b2a2e812be69fd76461e4f/panel-1.9.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/39/f8/a9af1b0e78a4d2a3974eac8289d97f83526346571f5ef3edda13bcff262d/charset_normalizer-3.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/86/123c7b169ad32994a0cd801cd1f11c1a2be84555807e9c8a8a4682c67a9f/psygnal-0.15.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/e8/aa3dbe6f34b76cffb416e571b27e7fff9412ace109d0ecedf373e2b7e0ee/jupyter_bokeh-4.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/28/385bd7bb0391fd37d4487ca15e7c96f0983de4e720fbf7f2cebd25ce248f/rerun_notebook-0.35.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/93/55/be532372738cc4f4e5ce653c381241dade44194bf54d022ad28ec2887d61/jupyter_ui_poll-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/73/7d3b2010baa0b5eb1e4dfa9e4385e89b6716be76f2fa21a6c0fe34b68e5a/moviepy-2.2.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9c/e3/bc943f1139a2397d1561afea7e7fa9385907699ec34bbfd6e46032eb462c/panel_material_ui-0.13.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a8/a9/d23012099dc88ec69a29c6407b41d89681cb674c2043cd5b467c7e299c08/xyzservices-2026.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ab/f3/e5fcd5d9b15771ed6dc10e3a7eeddc672e418f4f4c4653d216cc1d857e2d/optuna-4.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/37/1351bbfabbacbe92cd38774f8779ff680fab48c36b5fed9bcfe0c160009c/param-2.4.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b1/b9/11971acb516a95d2729dc04c4d42b7a12c747d5edc88317e623d045c8d14/rerun_sdk-0.35.0-cp310-abi3-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/d3/b7/b6ffb9e042aa48dc4144a8a65529affaec8dca0685309353614a2a7386ad/coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d6/90/cebd222495832f1a00dcd321ba25f3cab804221a4991b992c2178bec68ee/ty-0.0.56-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ed/b4/3755e3b3f791eefad4131f661ae04eaf70aabd6fc877f41f533e28607a5d/holoviews-1.23.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f3/54/40ff985187f0fd1afcedebc23eda0ba92bdbea1e0605cbb878b45391e5e0/bokeh-3.9.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/4e/afc8c31605cb8be1d3bb4438c4d979daa104dab6306cd2b87abe9c3a7299/narwhals-2.23.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/1a/60a505991247430fd9e4429526292e2b054381615801f3c7efdfa08dc9fb/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f5/c7/28747042e1df8a9cd120a1ebe15529fc4be3b486e13e8d551ff307a82412/greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/f6/d8/502954a4ec0efcf264f99b65b41c3c54e65a647d9f0d6f62cd02227d242c/ipykernel-6.31.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/97/e4a2eb5a8ec5cd3c2a0615a2f15f0afca89ac039229599b9ed0c0ed28e5e/sqlalchemy-2.0.51-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/fc/b7/d8bcec2626c35f96972bff656299fef4578113ea6193c8fdad324710410c/matplotlib-3.10.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1375,38 +1201,6 @@ packages:
   run_exports: {}
   size: 2707149
   timestamp: 1778561318681
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.16-he725a3c_1_cpython.conda
-  build_number: 1
-  sha256: 3f90a2d5062a73cd2dd8a0027718aee1db93f7975b9cfe529e2c9aeec2db262e
-  md5: b887811a901b3aa622a92caf03bc8917
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libffi >=3.4,<4.0a0
-  - libgcc >=13
-  - liblzma >=5.6.3,<6.0a0
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.47.0,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.3.1,<2.0a0
-  - ncurses >=6.5,<7.0a0
-  - openssl >=3.4.0,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  constrains:
-  - python_abi 3.10.* *_cp310
-  license: Python-2.0
-  purls: []
-  run_exports:
-    weak:
-    - python_abi 3.10.* *_cp310
-    noarch:
-    - python
-  size: 25199631
-  timestamp: 1733409331823
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.11-h9e4cc4f_1_cpython.conda
   build_number: 1
   sha256: b29ce0836fce55bdff8d5c5b71c4921a23f87d3b950aea89a9e75784120b06b0
@@ -1655,7 +1449,7 @@ packages:
   - pillow ; extra == 'docs'
   - rerun-sdk>=0.32.0,<=0.35.0 ; extra == 'rerun'
   - rerun-notebook>=0.32.0,<=0.35.0 ; extra == 'rerun'
-  requires_python: '>=3.10,<3.14'
+  requires_python: '>=3.11,<3.14'
 - pypi: https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: prek
   version: 0.4.8
@@ -1675,40 +1469,6 @@ packages:
   name: roman-numerals
   version: 4.1.0
   sha256: 647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/04/59/a639c0e136441ee91a65b56fdf89e5d075927e7a09c559d1b0f5276577db/fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: fonttools
-  version: 4.63.0
-  sha256: d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22
-  requires_dist:
-  - lxml>=4.0 ; extra == 'lxml'
-  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
-  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - zopfli>=0.1.4 ; extra == 'woff'
-  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
-  - lz4>=1.7.4.2 ; extra == 'graphite'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - pycairo ; extra == 'interpolatable'
-  - matplotlib ; extra == 'plot'
-  - sympy ; extra == 'symfont'
-  - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - skia-pathops>=0.5.0 ; extra == 'pathops'
-  - uharfbuzz>=0.45.0 ; extra == 'repacker'
-  - lxml>=4.0 ; extra == 'all'
-  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
-  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
-  - zopfli>=0.1.4 ; extra == 'all'
-  - unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
-  - lz4>=1.7.4.2 ; extra == 'all'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - pycairo ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - sympy ; extra == 'all'
-  - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - skia-pathops>=0.5.0 ; extra == 'all'
-  - uharfbuzz>=0.45.0 ; extra == 'all'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: rpds-py
@@ -2250,49 +2010,6 @@ packages:
   - setuptools ; extra == 'dev'
   - xmlschema ; extra == 'dev'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl
-  name: sphinx
-  version: 8.1.3
-  sha256: 09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2
-  requires_dist:
-  - sphinxcontrib-applehelp>=1.0.7
-  - sphinxcontrib-devhelp>=1.0.6
-  - sphinxcontrib-htmlhelp>=2.0.6
-  - sphinxcontrib-jsmath>=1.0.1
-  - sphinxcontrib-qthelp>=1.0.6
-  - sphinxcontrib-serializinghtml>=1.1.9
-  - jinja2>=3.1
-  - pygments>=2.17
-  - docutils>=0.20,<0.22
-  - snowballstemmer>=2.2
-  - babel>=2.13
-  - alabaster>=0.7.14
-  - imagesize>=1.3
-  - requests>=2.30.0
-  - packaging>=23.0
-  - tomli>=2 ; python_full_version < '3.11'
-  - colorama>=0.4.6 ; sys_platform == 'win32'
-  - sphinxcontrib-websupport ; extra == 'docs'
-  - flake8>=6.0 ; extra == 'lint'
-  - ruff==0.6.9 ; extra == 'lint'
-  - mypy==1.11.1 ; extra == 'lint'
-  - sphinx-lint>=0.9 ; extra == 'lint'
-  - types-colorama==0.4.15.20240311 ; extra == 'lint'
-  - types-defusedxml==0.7.0.20240218 ; extra == 'lint'
-  - types-docutils==0.21.0.20241005 ; extra == 'lint'
-  - types-pillow==10.2.0.20240822 ; extra == 'lint'
-  - types-pygments==2.18.0.20240506 ; extra == 'lint'
-  - types-requests==2.32.0.20240914 ; extra == 'lint'
-  - types-urllib3==1.26.25.14 ; extra == 'lint'
-  - tomli>=2 ; extra == 'lint'
-  - pyright==1.1.384 ; extra == 'lint'
-  - pytest>=6.0 ; extra == 'lint'
-  - pytest>=8.0 ; extra == 'test'
-  - defusedxml>=0.7.1 ; extra == 'test'
-  - cython>=3.0 ; extra == 'test'
-  - setuptools>=70.0 ; extra == 'test'
-  - typing-extensions>=4.9 ; extra == 'test'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/27/0d/98e301ca944bcca5e6bc312406b579c8a6d81546c1b494afb3a9478495d6/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
   version: 3.4.8
@@ -2385,13 +2102,6 @@ packages:
   - pyyaml
   - sphinx>=7.4.0
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/30/76/8f099f9d6482450428b17c4d6b241281af7ce6a9de8149ca8c1c649f6792/pyzmq-27.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
-  name: pyzmq
-  version: 27.1.0
-  sha256: 03ff0b279b40d687691a6217c12242ee71f0fba28bf8626ff50e3ef0f4410e1e
-  requires_dist:
-  - cffi ; implementation_name == 'pypy'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: markupsafe
   version: 3.0.3
@@ -2401,31 +2111,6 @@ packages:
   name: sortedcontainers
   version: 2.4.0
   sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
-- pypi: https://files.pythonhosted.org/packages/32/5c/1ee32d1c7956923202f00cf8d2a14a62ed7517bdc0ee1e55301227fc273c/contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: contourpy
-  version: 1.3.2
-  sha256: ad687a04bc802cbe8b9c399c07162a3c35e227e2daccf1668eb1f278cb698631
-  requires_dist:
-  - numpy>=1.23
-  - furo ; extra == 'docs'
-  - sphinx>=7.2 ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - bokeh ; extra == 'bokeh'
-  - selenium ; extra == 'bokeh'
-  - contourpy[bokeh,docs] ; extra == 'mypy'
-  - bokeh ; extra == 'mypy'
-  - docutils-stubs ; extra == 'mypy'
-  - mypy==1.15.0 ; extra == 'mypy'
-  - types-pillow ; extra == 'mypy'
-  - contourpy[test-no-images] ; extra == 'test'
-  - matplotlib ; extra == 'test'
-  - pillow ; extra == 'test'
-  - pytest ; extra == 'test-no-images'
-  - pytest-cov ; extra == 'test-no-images'
-  - pytest-rerunfailures ; extra == 'test-no-images'
-  - pytest-xdist ; extra == 'test-no-images'
-  - wurlitzer ; extra == 'test-no-images'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
   name: threadpoolctl
   version: 3.6.0
@@ -2586,11 +2271,6 @@ packages:
   version: 6.5.7
   sha256: 8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/39/f8/a9af1b0e78a4d2a3974eac8289d97f83526346571f5ef3edda13bcff262d/charset_normalizer-3.4.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: charset-normalizer
-  version: 3.4.8
-  sha256: 511851c35e4ec8f4be773acd2c0222a7ec6b63971fea8988103632896f174b4b
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/3a/bf/373cb4e14cc5014b33bf2e26720f983cd93da98964397ca92dc7ef07250f/hypothesis-6.156.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: hypothesis
   version: 6.156.1
@@ -2735,97 +2415,6 @@ packages:
   - argcomplete>=3.0 ; extra == 'all'
   - types-decorator ; extra == 'all'
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-  name: pandas
-  version: 2.3.3
-  sha256: dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838
-  requires_dist:
-  - numpy>=1.22.4 ; python_full_version < '3.11'
-  - numpy>=1.23.2 ; python_full_version == '3.11.*'
-  - numpy>=1.26.0 ; python_full_version >= '3.12'
-  - python-dateutil>=2.8.2
-  - pytz>=2020.1
-  - tzdata>=2022.7
-  - hypothesis>=6.46.1 ; extra == 'test'
-  - pytest>=7.3.2 ; extra == 'test'
-  - pytest-xdist>=2.2.0 ; extra == 'test'
-  - pyarrow>=10.0.1 ; extra == 'pyarrow'
-  - bottleneck>=1.3.6 ; extra == 'performance'
-  - numba>=0.56.4 ; extra == 'performance'
-  - numexpr>=2.8.4 ; extra == 'performance'
-  - scipy>=1.10.0 ; extra == 'computation'
-  - xarray>=2022.12.0 ; extra == 'computation'
-  - fsspec>=2022.11.0 ; extra == 'fss'
-  - s3fs>=2022.11.0 ; extra == 'aws'
-  - gcsfs>=2022.11.0 ; extra == 'gcp'
-  - pandas-gbq>=0.19.0 ; extra == 'gcp'
-  - odfpy>=1.4.1 ; extra == 'excel'
-  - openpyxl>=3.1.0 ; extra == 'excel'
-  - python-calamine>=0.1.7 ; extra == 'excel'
-  - pyxlsb>=1.0.10 ; extra == 'excel'
-  - xlrd>=2.0.1 ; extra == 'excel'
-  - xlsxwriter>=3.0.5 ; extra == 'excel'
-  - pyarrow>=10.0.1 ; extra == 'parquet'
-  - pyarrow>=10.0.1 ; extra == 'feather'
-  - tables>=3.8.0 ; extra == 'hdf5'
-  - pyreadstat>=1.2.0 ; extra == 'spss'
-  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
-  - psycopg2>=2.9.6 ; extra == 'postgresql'
-  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
-  - sqlalchemy>=2.0.0 ; extra == 'mysql'
-  - pymysql>=1.0.2 ; extra == 'mysql'
-  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
-  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
-  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
-  - beautifulsoup4>=4.11.2 ; extra == 'html'
-  - html5lib>=1.1 ; extra == 'html'
-  - lxml>=4.9.2 ; extra == 'html'
-  - lxml>=4.9.2 ; extra == 'xml'
-  - matplotlib>=3.6.3 ; extra == 'plot'
-  - jinja2>=3.1.2 ; extra == 'output-formatting'
-  - tabulate>=0.9.0 ; extra == 'output-formatting'
-  - pyqt5>=5.15.9 ; extra == 'clipboard'
-  - qtpy>=2.3.0 ; extra == 'clipboard'
-  - zstandard>=0.19.0 ; extra == 'compression'
-  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
-  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
-  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
-  - beautifulsoup4>=4.11.2 ; extra == 'all'
-  - bottleneck>=1.3.6 ; extra == 'all'
-  - dataframe-api-compat>=0.1.7 ; extra == 'all'
-  - fastparquet>=2022.12.0 ; extra == 'all'
-  - fsspec>=2022.11.0 ; extra == 'all'
-  - gcsfs>=2022.11.0 ; extra == 'all'
-  - html5lib>=1.1 ; extra == 'all'
-  - hypothesis>=6.46.1 ; extra == 'all'
-  - jinja2>=3.1.2 ; extra == 'all'
-  - lxml>=4.9.2 ; extra == 'all'
-  - matplotlib>=3.6.3 ; extra == 'all'
-  - numba>=0.56.4 ; extra == 'all'
-  - numexpr>=2.8.4 ; extra == 'all'
-  - odfpy>=1.4.1 ; extra == 'all'
-  - openpyxl>=3.1.0 ; extra == 'all'
-  - pandas-gbq>=0.19.0 ; extra == 'all'
-  - psycopg2>=2.9.6 ; extra == 'all'
-  - pyarrow>=10.0.1 ; extra == 'all'
-  - pymysql>=1.0.2 ; extra == 'all'
-  - pyqt5>=5.15.9 ; extra == 'all'
-  - pyreadstat>=1.2.0 ; extra == 'all'
-  - pytest>=7.3.2 ; extra == 'all'
-  - pytest-xdist>=2.2.0 ; extra == 'all'
-  - python-calamine>=0.1.7 ; extra == 'all'
-  - pyxlsb>=1.0.10 ; extra == 'all'
-  - qtpy>=2.3.0 ; extra == 'all'
-  - scipy>=1.10.0 ; extra == 'all'
-  - s3fs>=2022.11.0 ; extra == 'all'
-  - sqlalchemy>=2.0.0 ; extra == 'all'
-  - tables>=3.8.0 ; extra == 'all'
-  - tabulate>=0.9.0 ; extra == 'all'
-  - xarray>=2022.12.0 ; extra == 'all'
-  - xlrd>=2.0.1 ; extra == 'all'
-  - xlsxwriter>=3.0.5 ; extra == 'all'
-  - zstandard>=0.19.0 ; extra == 'all'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl
   name: matplotlib-inline
   version: 0.2.2
@@ -2938,14 +2527,6 @@ packages:
   - pytest-xdist ; extra == 'test-no-images'
   - wurlitzer ; extra == 'test-no-images'
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/4b/86/123c7b169ad32994a0cd801cd1f11c1a2be84555807e9c8a8a4682c67a9f/psygnal-0.15.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: psygnal
-  version: 0.15.1
-  sha256: b2e860c11fe075fd80c93a24081c577ef7ec5c9da41f0e75990aa4cccf3f79cf
-  requires_dist:
-  - wrapt ; extra == 'proxy'
-  - pydantic ; extra == 'pydantic'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl
   name: snowballstemmer
   version: 3.1.1
@@ -3055,67 +2636,6 @@ packages:
   version: 2026.6.3
   sha256: acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: scikit-learn
-  version: 1.7.2
-  sha256: 7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8
-  requires_dist:
-  - numpy>=1.22.0
-  - scipy>=1.8.0
-  - joblib>=1.2.0
-  - threadpoolctl>=3.1.0
-  - numpy>=1.22.0 ; extra == 'build'
-  - scipy>=1.8.0 ; extra == 'build'
-  - cython>=3.0.10 ; extra == 'build'
-  - meson-python>=0.17.1 ; extra == 'build'
-  - numpy>=1.22.0 ; extra == 'install'
-  - scipy>=1.8.0 ; extra == 'install'
-  - joblib>=1.2.0 ; extra == 'install'
-  - threadpoolctl>=3.1.0 ; extra == 'install'
-  - matplotlib>=3.5.0 ; extra == 'benchmark'
-  - pandas>=1.4.0 ; extra == 'benchmark'
-  - memory-profiler>=0.57.0 ; extra == 'benchmark'
-  - matplotlib>=3.5.0 ; extra == 'docs'
-  - scikit-image>=0.19.0 ; extra == 'docs'
-  - pandas>=1.4.0 ; extra == 'docs'
-  - seaborn>=0.9.0 ; extra == 'docs'
-  - memory-profiler>=0.57.0 ; extra == 'docs'
-  - sphinx>=7.3.7 ; extra == 'docs'
-  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
-  - sphinx-gallery>=0.17.1 ; extra == 'docs'
-  - numpydoc>=1.2.0 ; extra == 'docs'
-  - pillow>=8.4.0 ; extra == 'docs'
-  - pooch>=1.6.0 ; extra == 'docs'
-  - sphinx-prompt>=1.4.0 ; extra == 'docs'
-  - sphinxext-opengraph>=0.9.1 ; extra == 'docs'
-  - plotly>=5.14.0 ; extra == 'docs'
-  - polars>=0.20.30 ; extra == 'docs'
-  - sphinx-design>=0.5.0 ; extra == 'docs'
-  - sphinx-design>=0.6.0 ; extra == 'docs'
-  - sphinxcontrib-sass>=0.3.4 ; extra == 'docs'
-  - pydata-sphinx-theme>=0.15.3 ; extra == 'docs'
-  - sphinx-remove-toctrees>=1.0.0.post1 ; extra == 'docs'
-  - towncrier>=24.8.0 ; extra == 'docs'
-  - matplotlib>=3.5.0 ; extra == 'examples'
-  - scikit-image>=0.19.0 ; extra == 'examples'
-  - pandas>=1.4.0 ; extra == 'examples'
-  - seaborn>=0.9.0 ; extra == 'examples'
-  - pooch>=1.6.0 ; extra == 'examples'
-  - plotly>=5.14.0 ; extra == 'examples'
-  - matplotlib>=3.5.0 ; extra == 'tests'
-  - scikit-image>=0.19.0 ; extra == 'tests'
-  - pandas>=1.4.0 ; extra == 'tests'
-  - pytest>=7.1.2 ; extra == 'tests'
-  - pytest-cov>=2.9.0 ; extra == 'tests'
-  - ruff>=0.11.7 ; extra == 'tests'
-  - mypy>=1.15 ; extra == 'tests'
-  - pyamg>=4.2.1 ; extra == 'tests'
-  - polars>=0.20.30 ; extra == 'tests'
-  - pyarrow>=12.0.0 ; extra == 'tests'
-  - numpydoc>=1.2.0 ; extra == 'tests'
-  - pooch>=1.6.0 ; extra == 'tests'
-  - conda-lock==3.0.1 ; extra == 'maintenance'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/5a/e8/aa3dbe6f34b76cffb416e571b27e7fff9412ace109d0ecedf373e2b7e0ee/jupyter_bokeh-4.1.0-py3-none-any.whl
   name: jupyter-bokeh
   version: 4.1.0
@@ -3203,11 +2723,6 @@ packages:
   - pytest ; extra == 'test'
   - coverage ; extra == 'test'
   - pytest-cov ; extra == 'test'
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: rpds-py
-  version: 0.30.0
-  sha256: 0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
   name: jinja2
@@ -3312,11 +2827,6 @@ packages:
   - xlsxwriter>=3.2.0 ; extra == 'all'
   - zstandard>=0.23.0 ; extra == 'all'
   requires_python: '>=3.11'
-- pypi: https://files.pythonhosted.org/packages/67/33/f75e91b9a64c3f33c787e263c93b871ad91b8a4a68c1d5cebddd9840e835/pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl
-  name: pyarrow
-  version: 24.0.0
-  sha256: e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
   name: jsonschema
   version: 4.26.0
@@ -3552,16 +3062,6 @@ packages:
   - wrapt ; extra == 'proxy'
   - pydantic ; extra == 'pydantic'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: pyyaml
-  version: 6.0.3
-  sha256: 9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b
-  requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl
-  name: tomli
-  version: 2.4.1
-  sha256: 0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
   name: joblib
   version: 1.5.3
@@ -3607,52 +3107,6 @@ packages:
   version: 4.10.0
   sha256: fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl
-  name: xarray
-  version: 2025.6.1
-  sha256: 8b988b47f67a383bdc3b04c5db475cd165e580134c1f1943d52aee4a9c97651b
-  requires_dist:
-  - numpy>=1.24
-  - packaging>=23.2
-  - pandas>=2.1
-  - scipy ; extra == 'accel'
-  - bottleneck ; extra == 'accel'
-  - numbagg ; extra == 'accel'
-  - numba>=0.54 ; extra == 'accel'
-  - flox ; extra == 'accel'
-  - opt-einsum ; extra == 'accel'
-  - xarray[accel,etc,io,parallel,viz] ; extra == 'complete'
-  - netcdf4 ; extra == 'io'
-  - h5netcdf ; extra == 'io'
-  - scipy ; extra == 'io'
-  - pydap ; python_full_version < '3.10' and extra == 'io'
-  - zarr ; extra == 'io'
-  - fsspec ; extra == 'io'
-  - cftime ; extra == 'io'
-  - pooch ; extra == 'io'
-  - sparse ; extra == 'etc'
-  - dask[complete] ; extra == 'parallel'
-  - cartopy ; extra == 'viz'
-  - matplotlib ; extra == 'viz'
-  - nc-time-axis ; extra == 'viz'
-  - seaborn ; extra == 'viz'
-  - pandas-stubs ; extra == 'types'
-  - scipy-stubs ; extra == 'types'
-  - types-pyyaml ; extra == 'types'
-  - types-pygments ; extra == 'types'
-  - types-colorama ; extra == 'types'
-  - types-decorator ; extra == 'types'
-  - types-defusedxml ; extra == 'types'
-  - types-docutils ; extra == 'types'
-  - types-networkx ; extra == 'types'
-  - types-pexpect ; extra == 'types'
-  - types-psutil ; extra == 'types'
-  - types-pycurl ; extra == 'types'
-  - types-openpyxl ; extra == 'types'
-  - types-python-dateutil ; extra == 'types'
-  - types-pytz ; extra == 'types'
-  - types-setuptools ; extra == 'types'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl
   name: prompt-toolkit
   version: 3.0.52
@@ -3678,14 +3132,6 @@ packages:
   - wheel ; extra == 'dev'
   - twine ; extra == 'dev'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl
-  name: exceptiongroup
-  version: 1.3.1
-  sha256: a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
-  requires_dist:
-  - typing-extensions>=4.6.0 ; python_full_version < '3.13'
-  - pytest>=6 ; extra == 'test'
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: pyyaml
   version: 6.0.3
@@ -3761,49 +3207,6 @@ packages:
   sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
   requires_dist:
   - pytest ; extra == 'tests'
-- pypi: https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: scipy
-  version: 1.15.3
-  sha256: 9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40
-  requires_dist:
-  - numpy>=1.23.5,<2.5
-  - pytest ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - asv ; extra == 'test'
-  - mpmath ; extra == 'test'
-  - gmpy2 ; extra == 'test'
-  - threadpoolctl ; extra == 'test'
-  - scikit-umfpack ; extra == 'test'
-  - pooch ; extra == 'test'
-  - hypothesis>=6.30 ; extra == 'test'
-  - array-api-strict>=2.0,<2.1.1 ; extra == 'test'
-  - cython ; extra == 'test'
-  - meson ; extra == 'test'
-  - ninja ; sys_platform != 'emscripten' and extra == 'test'
-  - sphinx>=5.0.0,<8.0.0 ; extra == 'doc'
-  - intersphinx-registry ; extra == 'doc'
-  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
-  - sphinx-copybutton ; extra == 'doc'
-  - sphinx-design>=0.4.0 ; extra == 'doc'
-  - matplotlib>=3.5 ; extra == 'doc'
-  - numpydoc ; extra == 'doc'
-  - jupytext ; extra == 'doc'
-  - myst-nb ; extra == 'doc'
-  - pooch ; extra == 'doc'
-  - jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
-  - jupyterlite-pyodide-kernel ; extra == 'doc'
-  - mypy==1.10.0 ; extra == 'dev'
-  - typing-extensions ; extra == 'dev'
-  - types-psutil ; extra == 'dev'
-  - pycodestyle ; extra == 'dev'
-  - ruff>=0.0.292 ; extra == 'dev'
-  - cython-lint>=0.12.2 ; extra == 'dev'
-  - rich-click ; extra == 'dev'
-  - doit>=0.36.0 ; extra == 'dev'
-  - pydevtool ; extra == 'dev'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl
   name: anywidget
   version: 0.11.0
@@ -3814,11 +3217,6 @@ packages:
   - typing-extensions>=4.2.0
   - watchfiles>=1.1.0 ; extra == 'dev'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
-  name: docutils
-  version: 0.21.2
-  sha256: dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/90/54/44012d32fd77d991256d2ff793ba3807c51d40cb27a85b4796224f6744df/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
   version: 2.0.51
@@ -4404,11 +3802,6 @@ packages:
   - nest-asyncio ; extra == 'tests-pypy'
   - numpy ; extra == 'tests-pypy'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: markupsafe
-  version: 3.0.3
-  sha256: f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl
   name: astroid
   version: 4.0.4
@@ -4508,11 +3901,6 @@ packages:
   - pytest-timeout ; extra == 'testing'
   - requests ; extra == 'testing'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: numpy
-  version: 2.2.6
-  sha256: fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl
   name: linkify-it-py
   version: 2.1.0
@@ -4607,59 +3995,6 @@ packages:
   - objgraph ; extra == 'test'
   - psutil ; extra == 'test'
   - setuptools ; extra == 'test'
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl
-  name: ipython
-  version: 8.39.0
-  sha256: bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f
-  requires_dist:
-  - colorama ; sys_platform == 'win32'
-  - decorator
-  - exceptiongroup ; python_full_version < '3.11'
-  - jedi>=0.16
-  - matplotlib-inline
-  - pexpect>4.3 ; sys_platform != 'emscripten' and sys_platform != 'win32'
-  - prompt-toolkit>=3.0.41,<3.1.0
-  - pygments>=2.4.0
-  - stack-data
-  - traitlets>=5.13.0
-  - typing-extensions>=4.6 ; python_full_version < '3.12'
-  - black ; extra == 'black'
-  - docrepr ; extra == 'doc'
-  - exceptiongroup ; extra == 'doc'
-  - intersphinx-registry ; extra == 'doc'
-  - ipykernel ; extra == 'doc'
-  - ipython[test] ; extra == 'doc'
-  - matplotlib ; extra == 'doc'
-  - setuptools>=18.5 ; extra == 'doc'
-  - sphinx-rtd-theme ; extra == 'doc'
-  - sphinx>=1.3 ; extra == 'doc'
-  - sphinxcontrib-jquery ; extra == 'doc'
-  - tomli ; python_full_version < '3.11' and extra == 'doc'
-  - typing-extensions ; extra == 'doc'
-  - ipykernel ; extra == 'kernel'
-  - nbconvert ; extra == 'nbconvert'
-  - nbformat ; extra == 'nbformat'
-  - ipywidgets ; extra == 'notebook'
-  - notebook ; extra == 'notebook'
-  - ipyparallel ; extra == 'parallel'
-  - qtconsole ; extra == 'qtconsole'
-  - pytest ; extra == 'test'
-  - pytest-asyncio<0.22 ; extra == 'test'
-  - testpath ; extra == 'test'
-  - pickleshare ; extra == 'test'
-  - packaging ; extra == 'test'
-  - ipython[test] ; extra == 'test-extra'
-  - curio ; extra == 'test-extra'
-  - jupyter-ai ; extra == 'test-extra'
-  - matplotlib!=3.2.0 ; extra == 'test-extra'
-  - nbformat ; extra == 'test-extra'
-  - numpy>=1.23 ; extra == 'test-extra'
-  - pandas ; extra == 'test-extra'
-  - trio ; extra == 'test-extra'
-  - matplotlib ; extra == 'matplotlib'
-  - ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole] ; extra == 'all'
-  - ipython[test,test-extra] ; extra == 'all'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c1/1b/f7ea6cde25621cd9236541c66ff018f4268012a534ec31032bcb187dc5e7/proglog-0.1.12-py3-none-any.whl
   name: proglog
@@ -4849,11 +4184,6 @@ packages:
   - skia-pathops>=0.5.0 ; extra == 'all'
   - uharfbuzz>=0.45.0 ; extra == 'all'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
-  name: tzdata
-  version: '2026.2'
-  sha256: bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7
-  requires_python: '>=2'
 - pypi: https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl
   name: asttokens
   version: 3.0.1
@@ -4865,13 +4195,6 @@ packages:
   - pytest-cov ; extra == 'test'
   - pytest-xdist ; extra == 'test'
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/d3/b7/b6ffb9e042aa48dc4144a8a65529affaec8dca0685309353614a2a7386ad/coverage-7.15.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-  name: coverage
-  version: 7.15.0
-  sha256: be616bf61346883b2cfdc5178669647e03531d81ab761a7e378558b7e8bcb628
-  requires_dist:
-  - tomli ; python_full_version <= '3.11' and extra == 'toml'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: pillow
   version: 11.3.0
@@ -5165,10 +4488,6 @@ packages:
   requires_dist:
   - six>=1.5
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
-- pypi: https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl
-  name: pytz
-  version: '2026.2'
-  sha256: 04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126
 - pypi: https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: numpy
   version: 2.5.1
@@ -5196,41 +4515,6 @@ packages:
   version: 2026.6.17
   sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-  name: pillow
-  version: 11.3.0
-  sha256: 4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae
-  requires_dist:
-  - furo ; extra == 'docs'
-  - olefile ; extra == 'docs'
-  - sphinx>=8.2 ; extra == 'docs'
-  - sphinx-autobuild ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - sphinx-inline-tabs ; extra == 'docs'
-  - sphinxext-opengraph ; extra == 'docs'
-  - olefile ; extra == 'fpx'
-  - olefile ; extra == 'mic'
-  - pyarrow ; extra == 'test-arrow'
-  - check-manifest ; extra == 'tests'
-  - coverage>=7.4.2 ; extra == 'tests'
-  - defusedxml ; extra == 'tests'
-  - markdown2 ; extra == 'tests'
-  - olefile ; extra == 'tests'
-  - packaging ; extra == 'tests'
-  - pyroma ; extra == 'tests'
-  - pytest ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  - pytest-timeout ; extra == 'tests'
-  - pytest-xdist ; extra == 'tests'
-  - trove-classifiers>=2024.10.12 ; extra == 'tests'
-  - typing-extensions ; python_full_version < '3.10' and extra == 'typing'
-  - defusedxml ; extra == 'xmp'
-  requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/f1/0e/ba4ae25d03722f64de8b2c13e80d82ab537a06b30fc7065183c6439357e3/kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-  name: kiwisolver
-  version: 1.5.0
-  sha256: 62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
   name: stack-data
   version: 0.6.3
@@ -5323,60 +4607,6 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/f5/1a/60a505991247430fd9e4429526292e2b054381615801f3c7efdfa08dc9fb/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  name: hypothesis
-  version: 6.156.1
-  sha256: 63131c150146b44f49dd6be4d417e1ee62390951403569043e759e8513763426
-  requires_dist:
-  - exceptiongroup>=1.0.0 ; python_full_version < '3.11'
-  - sortedcontainers>=2.1.0,<3.0.0
-  - black>=20.8b0 ; extra == 'all'
-  - click>=7.0 ; extra == 'all'
-  - crosshair-tool>=0.0.107 ; extra == 'all'
-  - django>=5.2 ; extra == 'all'
-  - dpcontracts>=0.4 ; extra == 'all'
-  - hypothesis-crosshair>=0.0.28 ; extra == 'all'
-  - lark>=0.10.1 ; extra == 'all'
-  - libcst>=0.3.16 ; extra == 'all'
-  - numpy>=1.21.6 ; extra == 'all'
-  - pandas>=1.1 ; extra == 'all'
-  - pytest>=4.6 ; extra == 'all'
-  - python-dateutil>=1.4 ; extra == 'all'
-  - pytz>=2014.1 ; extra == 'all'
-  - redis>=3.0.0 ; extra == 'all'
-  - rich>=9.0.0 ; extra == 'all'
-  - tzdata>=2026.2 ; (sys_platform == 'emscripten' and extra == 'all') or (sys_platform == 'win32' and extra == 'all')
-  - watchdog>=4.0.0 ; extra == 'all'
-  - click>=7.0 ; extra == 'cli'
-  - black>=20.8b0 ; extra == 'cli'
-  - rich>=9.0.0 ; extra == 'cli'
-  - libcst>=0.3.16 ; extra == 'codemods'
-  - hypothesis-crosshair>=0.0.28 ; extra == 'crosshair'
-  - crosshair-tool>=0.0.107 ; extra == 'crosshair'
-  - python-dateutil>=1.4 ; extra == 'dateutil'
-  - django>=5.2 ; extra == 'django'
-  - dpcontracts>=0.4 ; extra == 'dpcontracts'
-  - black>=20.8b0 ; extra == 'ghostwriter'
-  - lark>=0.10.1 ; extra == 'lark'
-  - numpy>=1.21.6 ; extra == 'numpy'
-  - pandas>=1.1 ; extra == 'pandas'
-  - pytest>=4.6 ; extra == 'pytest'
-  - pytz>=2014.1 ; extra == 'pytz'
-  - redis>=3.0.0 ; extra == 'redis'
-  - watchdog>=4.0.0 ; extra == 'watchdog'
-  - tzdata>=2026.2 ; (sys_platform == 'emscripten' and extra == 'zoneinfo') or (sys_platform == 'win32' and extra == 'zoneinfo')
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/f5/c7/28747042e1df8a9cd120a1ebe15529fc4be3b486e13e8d551ff307a82412/greenlet-3.5.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-  name: greenlet
-  version: 3.5.3
-  sha256: 9bcd2d72ccd70a1ec68ba6ef93e7fbb4420ef9997dabc7010d893bd4015e0bec
-  requires_dist:
-  - sphinx ; extra == 'docs'
-  - furo ; extra == 'docs'
-  - objgraph ; extra == 'test'
-  - psutil ; extra == 'test'
-  - setuptools ; extra == 'test'
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: scipy
   version: 1.18.0
@@ -5553,61 +4783,4 @@ packages:
   sha256: 20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4
   requires_dist:
   - tomli ; python_full_version <= '3.11' and extra == 'toml'
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/fc/97/e4a2eb5a8ec5cd3c2a0615a2f15f0afca89ac039229599b9ed0c0ed28e5e/sqlalchemy-2.0.51-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-  name: sqlalchemy
-  version: 2.0.51
-  sha256: 2e54ff2dd657f2e3e0fbf2b097db1182f7bfea263eca4353f00065bae2a67c3d
-  requires_dist:
-  - importlib-metadata ; python_full_version < '3.8'
-  - greenlet>=1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
-  - typing-extensions>=4.6.0
-  - greenlet>=1 ; extra == 'asyncio'
-  - mypy>=0.910 ; extra == 'mypy'
-  - pyodbc ; extra == 'mssql'
-  - pymssql ; extra == 'mssql-pymssql'
-  - pyodbc ; extra == 'mssql-pyodbc'
-  - mysqlclient>=1.4.0 ; extra == 'mysql'
-  - mysql-connector-python ; extra == 'mysql-connector'
-  - mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10 ; extra == 'mariadb-connector'
-  - cx-oracle>=8 ; extra == 'oracle'
-  - oracledb>=1.0.1 ; extra == 'oracle-oracledb'
-  - psycopg2>=2.7 ; extra == 'postgresql'
-  - pg8000>=1.29.1 ; extra == 'postgresql-pg8000'
-  - greenlet>=1 ; extra == 'postgresql-asyncpg'
-  - asyncpg ; extra == 'postgresql-asyncpg'
-  - psycopg2-binary ; extra == 'postgresql-psycopg2binary'
-  - psycopg2cffi ; extra == 'postgresql-psycopg2cffi'
-  - psycopg>=3.0.7 ; extra == 'postgresql-psycopg'
-  - psycopg[binary]>=3.0.7 ; extra == 'postgresql-psycopgbinary'
-  - pymysql ; extra == 'pymysql'
-  - greenlet>=1 ; extra == 'aiomysql'
-  - aiomysql>=0.2.0 ; extra == 'aiomysql'
-  - greenlet>=1 ; extra == 'aioodbc'
-  - aioodbc ; extra == 'aioodbc'
-  - greenlet>=1 ; extra == 'asyncmy'
-  - asyncmy>=0.2.3,!=0.2.4,!=0.2.6 ; extra == 'asyncmy'
-  - greenlet>=1 ; extra == 'aiosqlite'
-  - aiosqlite ; extra == 'aiosqlite'
-  - typing-extensions!=3.10.0.1 ; extra == 'aiosqlite'
-  - sqlcipher3-binary ; extra == 'sqlcipher'
-  requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/fc/b7/d8bcec2626c35f96972bff656299fef4578113ea6193c8fdad324710410c/matplotlib-3.10.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-  name: matplotlib
-  version: 3.10.9
-  sha256: 1aa972116abb4c9d201bf245620b433726cb6856f3bef6a78f776a00f5c92d37
-  requires_dist:
-  - contourpy>=1.0.1
-  - cycler>=0.10
-  - fonttools>=4.22.0
-  - kiwisolver>=1.3.1
-  - numpy>=1.23
-  - packaging>=20.0
-  - pillow>=8
-  - pyparsing>=3
-  - python-dateutil>=2.7
-  - meson-python>=0.13.1,<0.17.0 ; extra == 'dev'
-  - pybind11>=2.13.2,!=2.13.3 ; extra == 'dev'
-  - setuptools-scm>=7,<10 ; extra == 'dev'
-  - setuptools>=64 ; extra == 'dev'
   requires_python: '>=3.10'

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -11,6 +11,14 @@ tightening enforcement mechanism. Fix the live bugs the audit found along the wa
 Per plans-README rule 7, confirm each `file:line` against the current tree before
 relying on it; the symbol is the durable reference.
 
+**⚠️ Amended by [plan 24](24-assert-never-boundary-discipline.md).** D2's `assert_never`
+guarantee holds only where `ty` can establish the match subject's type, which it cannot
+for `param`-descriptor reads (`pyproject.toml:281` documents them as `Unknown`) — and no
+type checker, nor D1's strict-list ratchet, closes that gap. Plan 24 adds the missing
+boundary-normalization precondition (D2 category three), scopes it to **P2** (`executor`)
+and **P11** (`agg_fn`), and re-affirms §1's "`ty` only" non-goal with measurements. Read
+plan 24 §3 before executing P1, P2 or P11.
+
 **⚠️ Read first:** §1 Scope. Config-surface findings (regression method/thresholds,
 `fail_on_sample_error`, `show`, `plot_size`, subsampling knobs) are **out of scope** —
 they belong to A5's breaking-release train and are recorded here only as amendments

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -82,26 +82,37 @@ Out of scope (recorded as amendments in §8, do not implement here):
    supports `[[tool.ty.overrides]]` blocks with `include=` globs that relax or
    re-enable rules per path. Verified in a scratch project. No checker change needed.
 
-3. **Exhaustiveness enforcement — verified in detail, and the result constrains D2.**
-   ty derives its target Python version from `requires-python` (`>=3.10`,
-   `pyproject.toml:10`), i.e. it checks against **3.10**. Consequences, all measured:
+3. **Exhaustiveness enforcement — `assert_never` comes from the stdlib.** ty derives its
+   target Python version from `requires-python`, which is now `>=3.11,<3.14`
+   (`pyproject.toml:10`), so `from typing import assert_never` resolves and
+   `error[type-assertion-failure]: Argument does not have asserted type 'Never'` fires on
+   an incomplete match, with a clean pass on a complete one. Verified with stdlib `Enum`,
+   the third-party `strenum.StrEnum` the repo uses, and frozen-dataclass unions.
 
-   | Import form | Result on the py310 target |
+   **History, because it explains why the floor moved.** This plan was originally written
+   against a `>=3.10` floor, where the same probes measured:
+
+   | Import form (py310 target) | Result |
    |---|---|
-   | `from typing_extensions import assert_never` | ✅ `error[type-assertion-failure]: Argument does not have asserted type 'Never'` on an incomplete match; **clean pass** on a complete one |
-   | `from typing import assert_never` | ❌ `error[unresolved-import]: Module 'typing' has no member 'assert_never'` — it is 3.11+ |
-   | `if TYPE_CHECKING or sys.version_info >= (3, 11): from typing import assert_never` with a runtime `def` fallback | ❌ **does not work** — same unresolved-import, and the exhaustiveness signal degrades to `invalid-return-type` |
+   | `from typing_extensions import assert_never` | ✅ works |
+   | `from typing import assert_never` | ❌ `unresolved-import` — it is 3.11+ |
+   | `TYPE_CHECKING`-guarded import with a runtime `def` fallback | ❌ **silently degrades** to `invalid-return-type` |
 
-   So `typing_extensions` is **required**, not a convenience (see D2 for why this
-   overrides the repo's existing precedent against it). Verified with both stdlib
-   `Enum` and the third-party `strenum.StrEnum` the repo uses.
+   That made a `typing_extensions` dependency unavoidable and put this plan in conflict
+   with the repo's existing decision against one. **Raising the floor to 3.11 dissolved
+   that conflict** — hence the floor change landed first, as a prerequisite. Retained here
+   so nobody reintroduces the dependency thinking it is still required.
 
-4. **`type-assertion-failure` is not in the ignore list**, so once the import exists the
-   discipline is enforced with no rules-config change. Note the fallback signal
+4. **`type-assertion-failure` is not in the ignore list**, so the discipline is enforced
+   with no rules-config change. Note the degraded-fallback signal
    (`invalid-return-type`) *is* currently ignored — a second reason to land Tier B.
 
-5. `typing_extensions` 4.16.0 is already in the environment transitively and imports
-   cleanly; it is **not** a declared dependency.
+5. **Two 3.10-era workarounds are now removable** (both are P1 cleanups, not new work):
+   - `bencher/result_collector.py:242-243` declines a `typing_extensions` dependency so
+     that `__enter__` can avoid `typing.Self`. `Self` is stdlib at 3.11 — delete the
+     comment, annotate `-> Self`, drop the `# noqa: PYI034`.
+   - `strenum` (`>=0.4.0`) exists only because `enum.StrEnum` is 3.11+. Migration is now
+     possible but is **explicitly not part of this plan** — see the hazard in D4.
 
 ## 3. Problem statement (with evidence)
 
@@ -305,19 +316,10 @@ Three layers in `pyproject.toml`, mechanism verified in §2.2:
 
 ### D2 — `assert_never` discipline
 
-- Add **`typing_extensions>=4.4`** to `[project] dependencies` and import
-  `from typing_extensions import assert_never`.
-- **This overrides an existing repo decision, deliberately.**
-  `bencher/result_collector.py:242-243` declines a `typing_extensions` dependency
-  ("`typing.Self` needs python 3.11 and the package floor is 3.10, so keep the
-  concrete return type rather than take a typing_extensions dependency"). That call was
-  right for `typing.Self`, which is cosmetic. It does not transfer here: `assert_never`
-  is the mechanism the whole plan's exhaustiveness thesis rests on, and §2.3 measured
-  that **there is no working alternative on the py310 floor** — plain
-  `typing.assert_never` is an `unresolved-import`, and a `TYPE_CHECKING`-guarded import
-  with a runtime fallback silently degrades the check to `invalid-return-type`. The
-  package is already in the environment (§2.5). P1 should update that comment to point
-  at this decision so the two do not read as contradictory.
+- Import `from typing import assert_never` — **stdlib, no new dependency.** This is the
+  payoff of the 3.11 floor (§2.3); earlier revisions of this plan required
+  `typing_extensions` and had to argue past the repo's decision against it. Both the
+  dependency and that argument are now unnecessary. Do not reintroduce either.
 - **Convention (applies to all future code):** every `match` over a closed enum or
   union ends in `case _ as unreachable: assert_never(unreachable)` — **unless** the
   match subject crosses a trust boundary (deserialized cache/user input), where a
@@ -395,14 +397,36 @@ Other design points:
   a guard — a parameter whose class is defined in `bencher.variables.results` but
   absent from the registry **raises** instead of becoming an input variable.
 
-### D4 — Sum-type conventions (py310 + param constraints)
+### D4 — Sum-type conventions (py311 + param constraints)
 
 - Sum types = small frozen dataclasses joined by `|`, destructured with exhaustive
-  `match` + `assert_never`. No new dependencies beyond `typing_extensions`.
-- Closed string vocabularies = `strenum.StrEnum` (the package already in use; stdlib
-  `enum.StrEnum` is 3.11+).
+  `match` + `assert_never`. **No new dependencies at all** (§2.3).
+- Closed string vocabularies = `strenum.StrEnum`, i.e. **keep using the existing
+  package** for now, matching every enum already in the tree.
+- **Do not opportunistically migrate `strenum` → stdlib `enum.StrEnum` as part of this
+  plan.** The 3.11 floor makes it possible, but the two are *not* drop-in equivalents and
+  the difference is silent:
+
+  ```
+  strenum.StrEnum + auto()  ->  member name verbatim   ('SERIAL')
+  enum.StrEnum    + auto()  ->  lowercased name        ('serial')
+  ```
+
+  Measured across the seven StrEnums in `bencher/`: five have lowercase member names and
+  are unaffected (`ComposeType`, `PaneLayout`, `RerunViewKind`, `OptDir`, `ShowMode`).
+  **Two would silently change value** — `Executors` (`SERIAL`/`MULTIPROCESSING`/`SCOOP`)
+  and `SampleOrder` (`INORDER`/`REVERSED`). Because `executor` is a
+  `param.Selector(objects=list(Executors))` (`bench_cfg.py:241`), that flips which string
+  callers may pass: `executor="SERIAL"` is valid today and would start raising. Verified
+  *not* a cache-invalidation risk — neither enum feeds `hash_persistent`, and
+  `sample_order` is in `EXCLUDED_FIELDS` (`identity.py:49`) — so this is a narrow public
+  API break, not data corruption. If the migration is ever wanted, it belongs in its own
+  PR that gives those two enums **explicit string values** rather than `auto()`, and it
+  is A5's call whether the accepted-string change ships in a breaking release.
 - Normalize enum-typed param fields at the config boundary so `==` vs `is` can never
-  diverge again (B4's class of bug).
+  diverge (C13). Note plan 24 §2.2–2.3: a `match` on a raw `param`-descriptor read is
+  *not* a type ty can establish, so boundary normalization is a precondition for
+  `assert_never` there, not merely tidiness.
 
 ## 5. Phases
 
@@ -416,8 +440,11 @@ and may be reordered or dropped individually.
 
 ### P1 — Enforcement floor
 
-- Add `typing_extensions>=4.4` to dependencies; update the counter-precedent comment
-  at `result_collector.py:242-243` to reference D2.
+- **Prerequisite (landed separately):** the `>=3.11` floor. No dependency to add —
+  `assert_never` is stdlib (§2.3).
+- Clear the two 3.10-era workarounds (§2.5): annotate `ResultCollector.__enter__` as
+  `-> Self` and delete the now-false comment at `result_collector.py:242-243` plus its
+  `# noqa: PYI034`. Leave `strenum` alone (D4).
 - Re-enable Tier-A rules globally; fix the 17 resulting errors (guard the
   `scoop`/`playwright` imports; carve `setup.py` into the relaxed block or delete per
   plan 03). Preserve the `unused-*-ignore-comment` rationale comment. **Note the
@@ -435,8 +462,8 @@ and may be reordered or dropped individually.
   asserting both diagnostics fire (skip if the `ty` binary is absent). **Use a minimal
   standalone config for the seeded file** — running under the repo config suppresses
   Tier-C rules and the probe silently passes (this bit the author; see §2.3).
-- **DoD:** gate demonstrably fails on a seeded violation; `pixi run ci` green on py310
-  and py313.
+- **DoD:** gate demonstrably fails on a seeded violation; `pixi run ci` green on py311
+  and py313 (the CI matrix after the floor raise).
 
 ### P2 — Collection-path live bugs (B2, B3) + executor normalization (C13)
 
@@ -584,10 +611,12 @@ and may be reordered or dropped individually.
    routed through plan 21's `catch=` — a `None` return or wrong-length vector is a
    harness-contract error, not a sample fault. Alternative (warn + skip) preserves the
    current silent behavior for parallel users.
-3. **D2: take the `typing_extensions` dependency**, overriding the precedent at
-   `result_collector.py:242-243`. Recommendation: **yes** — §2.3 shows no alternative
-   works on the py310 floor, and the package is already in the environment. Declining
-   it means giving up compile-time exhaustiveness, which is most of this plan's value.
+3. ~~**D2: take the `typing_extensions` dependency**~~ — **RESOLVED, no longer a
+   decision.** The owner raised the floor to `>=3.11`, so `assert_never` is stdlib and no
+   dependency is needed (§2.3). Kept as a numbered entry so later references to
+   "decision 3" still resolve. The follow-on question — migrate `strenum` → stdlib
+   `enum.StrEnum` — is deliberately **not** opened here; D4 records why and hands the
+   accepted-string break to A5.
 4. **P1 meta-test: subprocess ty-on-seeded-violation in CI.** Recommendation: **yes**
    (~1–2 s, skip when the binary is absent). Fallback: config-parsing assertion only.
 5. **B5 (P3): fix now vs wait for A5's `RegressionCfg`.** Recommendation: **now** —

--- a/plans/24-assert-never-boundary-discipline.md
+++ b/plans/24-assert-never-boundary-discipline.md
@@ -18,9 +18,19 @@ relying on it; the symbol is the durable reference.
 
 **Tool versions all facts below were measured with:** `ty` 0.0.56 (what
 `.pixi/envs/default` resolves from the pin `ty>=0.0.13,<=0.0.64`,
-`pyproject.toml:80`), `typing_extensions` 4.16.0, py310 target (from
-`requires-python = ">=3.10"`, `pyproject.toml:10`). Cross-checked on `ty` 0.0.64 and
-0.0.65, and on `pyrefly` 1.1.1.
+`pyproject.toml:80`), `typing_extensions` 4.16.0, py310 target. Cross-checked on `ty`
+0.0.64 and 0.0.65, and on `pyrefly` 1.1.1.
+
+**Re-verified after the 3.11 floor raise:** the floor is now
+`requires-python = ">=3.11,<3.14"` (`pyproject.toml:10`), so `assert_never` comes from
+the stdlib and `typing_extensions` is no longer involved. **This plan's central finding
+is unaffected** — re-ran the §2.1 ingress probe at a py311 target with
+`from typing import assert_never`: a *complete* `match` fed from an unannotated source is
+still `All checks passed!` while raising
+`AssertionError: Expected code to be unreachable, but got: 'SERIAL'` at runtime. The hole
+is a property of gradual typing at an untyped boundary (§2.5), not of the import source or
+the target version, so every amendment below stands as written. Read
+`typing_extensions.assert_never` as `typing.assert_never` throughout.
 
 ---
 
@@ -227,7 +237,7 @@ Reading:
 - Add A5's third probe to `test/test_ty_gate.py`.
 - **Ordering:** depends on 23-P1 having created `test/test_ty_gate.py`. If Q1 lands
   first, it carries the pin bump only and A5 folds into P1.
-- **DoD:** `pixi run ci` green on py310 and py313; the new probe documents, in a
+- **DoD:** `pixi run ci` green on py311 and py313 (the post-floor-raise matrix); the new probe documents, in a
   comment, that it pins current `ty` behaviour rather than desired behaviour.
 
 ### Folded into existing plan 23 phases (no new PRs)

--- a/plans/24-assert-never-boundary-discipline.md
+++ b/plans/24-assert-never-boundary-discipline.md
@@ -1,0 +1,286 @@
+# Plan 24 — `assert_never` boundary discipline (amends plan 23)
+
+**Goal:** plan 23's D2 exhaustiveness thesis is sound, but it holds *only* where the
+`match` subject's type is established at the boundary. Measured: for `param`-descriptor
+reads it is **not** established, **no** type checker in the field closes the gap, and the
+resulting `assert_never` arm is therefore a live `AssertionError` path rather than a
+proof. This plan adds the missing precondition, scopes it to the two phases that
+actually need it, and re-affirms plan 23's "`ty` only" decision with the evidence that
+decision was originally made without.
+
+**Status:** amendment, not a replacement. Plan 23's P1, P3–P10 and P12 are unchanged.
+Two DoD additions land inside 23-P2 and 23-P11; one small independent phase (Q1) is
+new.
+
+**Citations pinned to:** `main` @ `fa28ba73` (the plan 23 merge, PR #1023, 2026-07-31).
+Per plans-README rule 7, confirm each `file:line` against the current tree before
+relying on it; the symbol is the durable reference.
+
+**Tool versions all facts below were measured with:** `ty` 0.0.56 (what
+`.pixi/envs/default` resolves from the pin `ty>=0.0.13,<=0.0.64`,
+`pyproject.toml:80`), `typing_extensions` 4.16.0, py310 target (from
+`requires-python = ">=3.10"`, `pyproject.toml:10`). Cross-checked on `ty` 0.0.64 and
+0.0.65, and on `pyrefly` 1.1.1.
+
+---
+
+## 1. What plan 23 got right (re-verified — do not re-litigate)
+
+Plan 23 §2.3's controls reproduce exactly at `fa28ba73`:
+
+| Probe | Result |
+|---|---|
+| Complete `match` over a 2-arm frozen-dataclass union + `from typing_extensions import assert_never` | ✅ `All checks passed!` |
+| Same union widened to 3 arms, third arm unhandled | ✅ `error[type-assertion-failure]` |
+
+The diagnostic is also better than plan 23 recorded — it names the residual type, not
+just the failure:
+
+```
+error[type-assertion-failure]: Argument does not have asserted type `Never`
+  --> p2_incomplete.py:32:13
+   |             assert_never(unreachable)
+   |                          Inferred type of argument is `Cancelled & ~Ready & ~Pending`
+```
+
+So D2's mechanism works, §2.4 stands (`type-assertion-failure` is not in the ignore
+list), and the diagnostic names the forgotten variant well enough to drive
+`pixi run agent-iterate` without a human reading the union definition.
+
+One new supporting fact plan 23 did not have: **`ty` narrows tuple `match` subjects
+correctly.** A `match` over `tuple[Side, Side]` covering 3 of 4 combinations raises
+`type-assertion-failure`; the complete 4-of-4 version passes clean. Product-of-sums
+subjects are therefore safe to use under this repo's gate — which is not true of the
+alternative checkers (§4).
+
+## 2. Measured facts (verified 2026-07-31 against `fa28ba73`; do not re-litigate)
+
+1. **The ingress hole.** A **complete** `match` — one plan 23's D2 treats as having a
+   provably-dead `assert_never` arm — is type-clean while raising at runtime, whenever
+   its subject arrives from an untyped source.
+
+   Probe: complete 2-arm union + `typing_extensions.assert_never`; the caller obtains
+   its subject from an unannotated helper returning `"SERIAL"`.
+
+   | Config | `ty` verdict |
+   |---|---|
+   | Replica of the repo's 21-rule `[tool.ty.rules]` ignore list | `All checks passed!` |
+   | Same, but `invalid-argument-type = "error"` | `All checks passed!` |
+
+   Runtime: `AssertionError: Expected code to be unreachable, but got: 'SERIAL'`.
+   Identical on `ty` 0.0.56, 0.0.64 and 0.0.65.
+
+2. **The repo's own config documents the ingress vector.** `pyproject.toml:281`:
+   "param library StrEnum/enum descriptors resolve as **Unknown**". Every `match` whose
+   subject is a read of a `param` field is therefore this shape, by the repo's own
+   analysis.
+
+3. **Reproduced through that exact mechanism.** A `param.Parameterized` with
+   `executor = param.Selector(objects=list(Executors))` (the shape at
+   `bench_cfg.py:241`) and `dispatch(cfg.executor)` where `dispatch` matches both
+   members exhaustively → `All checks passed!`. At runtime, appending a value to
+   `.objects` and assigning it reaches the arm:
+   `AssertionError: Expected code to be unreachable, but got: 'LEGACY'`.
+
+4. **Enabling the Tier-C rule does not close it** (row 2 of the table in fact 1). This is
+   the one gap D1's strict-list ratchet cannot reach — worth stating explicitly, because
+   the natural assumption when reading D1 is that putting a file on the strict list makes
+   its `assert_never` arms sound. It does not.
+
+5. **No other checker closes it either.** `pyrefly` 1.1.1, py310 target, pointed at this
+   repo's site-packages: clean on **both** probes. So this is not "`ty` is behind" — it
+   is a property of gradual typing at an untyped boundary, and it is not fixable by
+   checker choice.
+
+6. **Pin is one release stale.** `ty>=0.0.13,<=0.0.64` (`pyproject.toml:80`); 0.0.65 is
+   the latest published version; the env resolves 0.0.56. Behavior on every probe in
+   this plan is identical across all three.
+
+## 3. Amendments to plan 23
+
+### A1 — D2 gains a third category (it currently has two)
+
+D2 today: `assert_never` everywhere, **except** where the subject crosses a trust
+boundary (deserialized cache / user input), where a runtime `raise` is correct. Add a
+third:
+
+> **Descriptor-sourced subjects.** A `match` may end in `assert_never` only if the
+> subject is a parameter, local, or field whose type `ty` can establish. **A read of a
+> `param` field does not qualify** (§2.2). Normalize at the boundary first — construct
+> the enum (`Executors(value)`, `AggFn(value)`), raising on an unknown value — and cover
+> that normalization with a **runtime** test, because §2.1 and §2.5 show no type checker
+> enforces it.
+
+Rationale to record alongside it: an `assert_never` on an un-established subject is
+strictly worse than the `case _: raise` it replaced, because it reads as a proof while
+behaving as an assertion — and `assert_never`'s message ("Expected code to be
+unreachable") actively misdirects the reader of the traceback, who will look for a
+missing enum member rather than a bad value at the boundary.
+
+### A2 — D4's boundary normalization is promoted from hardening to precondition
+
+D4 already says: "Normalize enum-typed param fields at the config boundary so `==` vs
+`is` can never diverge again (C13's class of bug)." That justification undersells it.
+Normalization is the **precondition that licenses D2 on those fields** — C13's `==`/`is`
+hazard is the lesser of the two things it buys. Reorder the reasoning so a phase author
+who reads D4 and judges C13 "a latent smell, not worth much" does not skip the step D2
+depends on.
+
+### A3 — Scope: exactly two phases are affected
+
+Verified by grepping every `param.Selector` / `param.ObjectSelector` that plan 23
+proposes to match on:
+
+- **23-P2 — `executor`** (`param.Selector(objects=list(Executors))`,
+  `bench_cfg.py:241`). P2 already normalizes it, for C13's reason. **DoD addition:**
+  state in the PR that the normalization is what licenses any later `assert_never` on
+  `executor`, and keep a test asserting an out-of-vocabulary value raises **at
+  normalization**, not at a match site.
+- **23-P11 — `agg_fn`** (`param.ObjectSelector(default="mean", objects=["mean", "sum",
+  "max", "min", "median"])`, `bench_cfg.py:820-824`). Strictly worse than `executor`:
+  the objects are **raw strings, not enum members**, so P11's proposed `AggFn` enum must
+  be *constructed* at the boundary rather than assumed to be what the descriptor holds.
+  **DoD addition:** the "unknown agg raises" test must drive the raw string through the
+  `param` field, not call the enum-typed function directly — the latter passes while the
+  shipped path still reaches `assert_never`.
+
+Explicitly **not** affected, so no phase pays for this twice:
+
+- **23-P1's `reduce`** — a plain annotated parameter (`reduce: ReduceType`,
+  `bench_result_base.py:199`, `:245`), and `ReduceType` is a stdlib `Enum`
+  (`bench_result_base.py:54`), not a `param` field. P1's conversion of the
+  `case _:` at `bench_result_base.py:353` is sound as written. (Its current arm absorbs
+  `ReduceType.NONE` — see the comment at `:354` — so the conversion must enumerate
+  `NONE` explicitly and rely on `_resolve_auto` (`:237-239`) having eliminated `AUTO`,
+  exactly as P1 already says.)
+- **23-P8's `compose_method`** — not a `param` field anywhere in the tree.
+- **23-P7's `HistoryEvent.kind`** — internally produced (`history.py:77`); the
+  policy string read at `load_history_cache` is a genuine trust boundary, which P7
+  already handles with a raise.
+
+### A4 — §9 (plan-level DoD) gains one line
+
+> Every `assert_never` in the tree either has a subject `ty` can type, or is preceded by
+> a normalizing parse that is covered by a test.
+
+And one grep-level check alongside the existing ones: no `assert_never` whose subject
+expression is an attribute read on a `param.Parameterized` instance.
+
+### A5 — 23-P1's meta-test gains a third probe
+
+`test/test_ty_gate.py` (new in P1) should add, beside its non-exhaustive-match and
+Tier-A probes, a case asserting that a **complete** match fed from an unannotated helper
+is type-clean. Two reasons: it pins the boundary of what the gate proves so a future
+reader does not over-trust it, and it converts a future `ty` release that closes the
+hole into a **test failure that tells us**, rather than a silent improvement nobody
+notices. Comment it as pinning current reality, not desired behavior.
+
+### A6 — "`ty` only" re-affirmed, now evidence-backed
+
+Plan 23 §1 lists "switching or adding type checkers" as a non-goal, resolved on
+convenience grounds ("already wired in"). That decision is **correct and should stand**,
+and now has evidence behind it:
+
+- Adding `pyrefly` would not fix the gap this plan is about (§2.5).
+- It would actively break correct code: `pyrefly`, `mypy` and `zuban` all reject a
+  **complete** tuple `match` that `ty` accepts (§4) — pushing authors to add a fallback
+  arm, which is precisely what defeats exhaustiveness.
+
+Two housekeeping items, neither urgent:
+
+- **Raise the pin ceiling to `<=0.0.65`** (§2.6); behavior verified identical.
+- **Governance watch item, no action:** Astral was acquired by OpenAI on 2026-03-19, and
+  `ty` remains `0.0.x` with no stability guarantee (breaking diagnostic changes are
+  permitted between any two releases). The existing upper pin is already the right
+  mitigation; this is recorded so a future reader does not have to rediscover why the
+  ceiling exists.
+
+## 4. Why not add a second checker (measured)
+
+Fourteen constructive-modeling probes were run across `pyright` 1.1.411,
+`basedpyright` 1.39.9, `pyrefly` 1.1.1, `ty` 0.0.65, `mypy` 2.3.0 and `zuban` 0.9.0.
+Only the three rows that discriminate are reproduced here:
+
+| Probe | pyright | basedpyright | pyrefly | ty | mypy | zuban |
+|---|---|---|---|---|---|---|
+| Core exhaustiveness — union / enum / `Literal` / `if`-`elif` / PEP 695 generic / nested union, arm missing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Complete** `tuple[A, A]` match (error here is a false positive) | ✅ clean | ✅ clean | ❌ error | ✅ clean | ❌ error | ❌ error |
+| `Unknown`/`Any` ingress into a complete match | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+Reading:
+
+- The **core is universal** — every checker enforces single-level sum-type
+  exhaustiveness. No checker choice buys bencher anything there.
+- **Tuple subjects discriminate, in `ty`'s favour.** `pyrefly`/`mypy`/`zuban` never
+  narrow tuple subjects, so `assert_never` fails no matter how many combinations are
+  covered.
+- **Nothing catches the ingress hole.** The remedy is a modeling rule (A1), not a tool.
+- Separately, `basedpyright` flags the `case _ as unreachable:` arm itself under
+  `reportUnnecessaryComparison` ("Pattern will never be matched for subject type"), so it
+  cannot express D2's idiom without a config carve-out. Another reason not to add it.
+
+## 5. Phases
+
+### Q1 — pin ceiling + gate-boundary probe (independent, small)
+
+- Raise the `ty` ceiling to `<=0.0.65` (`pyproject.toml:80`).
+- Add A5's third probe to `test/test_ty_gate.py`.
+- **Ordering:** depends on 23-P1 having created `test/test_ty_gate.py`. If Q1 lands
+  first, it carries the pin bump only and A5 folds into P1.
+- **DoD:** `pixi run ci` green on py310 and py313; the new probe documents, in a
+  comment, that it pins current `ty` behaviour rather than desired behaviour.
+
+### Folded into existing plan 23 phases (no new PRs)
+
+- **23-P2** — A3's `executor` DoD addition.
+- **23-P11** — A3's `agg_fn` DoD addition (drive the raw string through the `param`
+  field).
+- **23-P1** — A5, if Q1 has not already landed it.
+- **Plan 23 §9** — A4's DoD line and grep check.
+
+If plan 23's phases are dropped or deferred, A4's grep check is the residue worth
+keeping on its own.
+
+## 6. OWNER DECISIONS
+
+1. **Normalize-at-boundary vs raise-at-match for `param`-sourced enums.**
+   Recommendation: **normalize** — raise on an unknown value where the config is
+   accepted. A raise at each match site is the trust-boundary pattern (D2 category two)
+   and would spread boundary-checking across every consumer of the field, which is the
+   shape plan 23 exists to remove.
+2. **Pin ceiling `<=0.0.65`.** Recommendation: **yes** — §2.6 verified identical
+   behaviour on every probe.
+3. **A5's probe: assert-clean vs `xfail`.** Recommendation: **assert-clean with an
+   explanatory comment** — an `xfail` that starts passing is easy to miss, whereas a
+   failing assertion names the reason in the output.
+4. **Whether A4's grep check ships as a test or a review checklist item.**
+   Recommendation: **test** — it is a one-line `grep` over `bencher/`, and the whole
+   point of this plan is that the type checker cannot carry the invariant.
+
+## 7. Cache safety
+
+Docs-only; no phase here changes stored values. The amendments inherit plan 23 §7's
+constraints, and A3's `executor` normalization is already covered by §7's requirement
+that it "must not perturb any persisted hash" — confirm in 23-P2 and state the finding
+in that PR, as §7 already directs.
+
+## 8. Provenance
+
+Every fact in §1, §2 and §4 was measured in scratch directories outside the repo;
+nothing from the probes is committed. The probes were: complete/incomplete unions,
+enums, `Literal`s, `if`/`elif` chains, PEP 695 generic sum types, nested unions,
+frozen-dataclass mutation, complete and incomplete `tuple[A, A]` matches, and two
+ingress probes (unannotated-helper and `param.Selector`). Reproducing them needs only
+the `.pixi/envs/default` interpreter and a `[rules]` file replicating
+`pyproject.toml:246-285`; the method is worth re-running whenever the `ty` pin moves,
+which is what A5 automates for the one case that matters most.
+
+Two corrections to earlier drafts of this analysis, recorded per plans-README rule 7:
+
+1. An earlier draft claimed `pyrefly` **catches** the ingress hole, based on a probe
+   where the untyped helper was first-party code in the same directory and `pyrefly`
+   inferred through it. Re-run against this repo's environment, `pyrefly` reports the
+   probe clean (§2.5). The stronger claim — "adding `pyrefly` would close the gap" — is
+   **false** and is the reason A6 recommends against adding it rather than for it.
+2. An earlier draft claimed `ty`'s exhaustiveness diagnostic does not name the missing
+   variant. It does (§1) — the intersection type in the `info` line identifies it.

--- a/plans/README.md
+++ b/plans/README.md
@@ -50,6 +50,7 @@ without additional context. **Read the whole plan before starting it.**
 | 21 | [Per-sample fault tolerance in sweeps](21-sample-fault-tolerance.md) | Medium | Medium | **Implemented** in #1013; `catch` lives on `BenchRunCfg` only (amended per A5 R1) |
 | 22 | [Grammar phase 1: self-describing canonical dataset](22-grammar-phase-1-data-model.md) | Medium | Medium | First PR of the A6 stack; 15–21 have landed, ready to implement |
 | 23 | [Constructive data modeling & type enforcement](23-constructive-data-modeling.md) | Low–Med | Medium (12 phased PRs) | P1–P3 (ty gate + live bug fixes) anytime; P4 (result-type registry) before A6 phase 2; P5–P11 independent |
+| 24 | [`assert_never` boundary discipline](24-assert-never-boundary-discipline.md) | Low | Small (amends 23) | **Read before 23-P1/P2/P11** — mostly DoD additions to plan 23; one small independent phase (Q1) |
 
 Plans 01–03 are quick wins (01 is done). Plan 02's headline owner decision — the
 Plotly-vs-plugin-system direction for PRs #830/#932 — was resolved plugin-first on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "A package for benchmarking the performance of arbitrary functions
 readme = "README.md"
 license = "MIT"
 
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
     "holoviews>=1.15,<=1.23.1",
@@ -43,15 +43,13 @@ platforms = ["linux-64"]
 libc = "2.31"
 
 [tool.pixi.dependencies]
-python = ">=3.10"
+python = ">=3.11"
 sqlite = "==3.48.0"
 shellcheck = ">=0.10.0,<0.11"
 devpod = ">=0.8.0,<0.9"
 gh = ">=2.83.0,<3.0"
 playwright = ">=1.50,<2"
 
-[tool.pixi.feature.py310.dependencies]
-python = "3.10.*"
 [tool.pixi.feature.py311.dependencies]
 python = "3.11.*"
 [tool.pixi.feature.py312.dependencies]
@@ -108,7 +106,6 @@ include = ["bencher", "CHANGELOG.md"]
 [tool.pixi.environments]
 default = { features = ["test", "rerun"], solve-group = "default" }
 docs = { features = ["test", "rerun", "docs"], solve-group = "default" }
-py310 = ["py310", "test", "rerun"]
 py311 = ["py311", "test", "rerun"]
 py312 = ["py312", "test", "rerun"]
 py313 = ["py313", "test", "rerun"]


### PR DESCRIPTION
## Summary

**BREAKING:** drops Python 3.10 support and raises the floor to **3.11** (`requires-python = ">=3.11,<3.14"`).

The motivation is **type-checking, not runtime features**. `typing.assert_never` is stdlib only from 3.11 onward. At a 3.10 target it does not resolve, so [plan 23](../blob/main/plans/23-constructive-data-modeling.md)'s exhaustiveness work would have required adding a `typing_extensions` dependency — a dependency this repo had **already explicitly declined** in `result_collector.py`. Raising the floor removes that trade-off entirely: plan 23 can adopt `assert_never` for exhaustive matching with **no new dependency**.

⚠️ **This is a prerequisite and should land BEFORE any of plan 23's typing phases.** Those phases assume `assert_never` is importable from `typing`; merging them first would either reintroduce the `typing_extensions` dependency or land exhaustiveness checks that silently do nothing (see below).

### Measured `ty` behaviour

The 3.10 target was not merely limiting — it was **actively misleading**, giving false confidence that exhaustiveness was checked when it was not:

| Target | `from typing import assert_never` | Signal on a non-exhaustive match | Effective result |
|---|---|---|---|
| **py310** | `unresolved-import` | degrades to `invalid-return-type` | ❌ **silently no diagnostic** — `invalid-return-type` is currently in the repo's ignore list |
| **py311** | resolves cleanly | `error[type-assertion-failure]` | ✅ correctly caught |

Plan 24's untyped-boundary "ingress hole" finding was re-verified and reproduces **identically** at 3.11, so that analysis carries over unchanged.

### Changes

- `requires-python` and `[tool.pixi.dependencies] python` → `>=3.11`
- dropped the `py310` pixi feature and the `py310` environment
- CI matrix `environment: [py310, py313]` → `[py311, py313]`
- README Python badge and `docs/conda-environment.yml` → 3.11
- regenerated `pixi.lock` (drops the whole py310 env, 829 deletions)
- amended plans 23 and 24 to remove the now-unnecessary `typing_extensions` dependency
- `bencher/scorecard/render.py`: `datetime.timezone.utc` → `datetime.UTC`

The `render.py` change is a **ruff UP017 autofix that only activates at a 3.11+ target** — verified clean at `--target-version py310` and flagged at `py311`. It is behaviour-preserving (`datetime.UTC is timezone.utc`) and is included because otherwise the `ruff-lint` CI gate would fail on this branch.

No version bump: per `plans/README` rule 4, and because a version bump auto-publishes to PyPI.

## What is deliberately NOT in this PR

Both are queued as **plan 23 P1 cleanups**:

**1. `strenum` → stdlib `enum.StrEnum`.** Tempting now that 3.11 is the floor, but it is *not* a drop-in swap. `StrEnum` + `auto()` **lowercases** member names, whereas `strenum` **preserves** them. Migrating would silently change every `Executors` and `SampleOrder` value, and therefore **which strings `BenchRunCfg(executor=...)` accepts** — a behaviour-visible, user-facing change that deserves its own PR.

  Verified **not** a cache-invalidation risk: neither enum feeds `hash_persistent`, and `sample_order` is listed in `EXCLUDED_FIELDS`. So the hazard is confined to the accepted-string surface, not to stranding on-disk benchmark caches.

**2. `typing.Self` cleanup in `ResultCollector.__enter__`.** Now expressible without `typing_extensions`, but it is unrelated to the version floor and belongs with plan 23's typing work.

## Test plan

All run in the new `py311` environment:

- `pixi run -e py311 ci` → **passed end to end**; coverage TOTAL **90%** (gate is `fail_under = 85`)
- `pixi run -e py311 ty` → **"All checks passed!"**
- `pixi run -e py311 pytest -q` → **2403 passed, 3 skipped, 147 subtests passed**
- Empirically confirmed `typing.assert_never` fires `error[type-assertion-failure]` at a py311 ty target (it is an `unresolved-import` at py310), and that plan 24's untyped-boundary "ingress hole" finding still reproduces identically at py311
- `prek run --files <all changed files>` → all hooks passed, no rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Raise the project’s Python support floor to 3.11 and update tooling, CI, and documentation accordingly to enable stdlib-based `assert_never` exhaustiveness checking for upcoming typing work.

Enhancements:
- Switch scorecard timestamp generation to use `datetime.UTC`, enabled by the Python 3.11 floor.

Build:
- Update `requires-python` and Pixi base Python dependency to `>=3.11,<3.14`.
- Remove the `py310` Pixi feature and environment, and regenerate `pixi.lock` without the 3.10 environment.

CI:
- Adjust the CI matrix to run against `py311` and `py313` instead of `py310` and `py313`.

Documentation:
- Add plan 24 documenting `assert_never` boundary discipline and link it from the plans index and plan 23.
- Update README and docs conda environment to reference Python 3.11 and record the Python 3.10 deprecation in the changelog.

Chores:
- Clarify plan 23 to reflect the new Python floor, removal of the `typing_extensions` requirement, and the decision to retain `strenum` for now.