### PR TITLE
feat: make the ty type-check gate real (plan 23 P1)

### DIFF
--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -46,7 +46,7 @@ class _CorsStaticHandler(StaticFileHandler):
         self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
         self.set_header("Access-Control-Allow-Headers", "*")
 
-    def options(self, *_args):
+    def options(self, *_args, **_kwargs):
         self.set_status(204)
         self.finish()
 

--- a/bencher/bench_runner.py
+++ b/bencher/bench_runner.py
@@ -7,7 +7,7 @@ import webbrowser
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from bencher.bench_cfg import BenchCfg, BenchRunCfg, ShowMode, normalize_show
 from bencher.bench_report import BenchReport, GithubPagesCfg, Publisher
@@ -277,13 +277,15 @@ class BenchRunner:
         if len(sig.parameters) == 2:
             # BenchableV1: takes (run_cfg, report)
             report = report or BenchReport()
-            result = bench_fn(run_cfg, report)
+            # The signature check above is the discriminator for the Benchable union; no
+            # type checker can narrow on it, so state the established arm explicitly.
+            result = cast("BenchableV1", bench_fn)(run_cfg, report)
             if getattr(result, "report", None) is None:
                 result.report = report
             return result, report
 
         # BenchableV2: takes (run_cfg)
-        result = bench_fn(run_cfg)
+        result = cast("BenchableV2", bench_fn)(run_cfg)
         result_report = getattr(result, "report", None)
 
         if report is not None:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1673,7 +1673,7 @@ class Bench(BenchPlotServer):
         target_names,
         tag,
         agg_vars=None,
-        agg_callable=None,
+        agg_callable: Callable | None = None,
         repeats=1,
     ):
         """Return an objective function compatible with ``study.optimize()``."""
@@ -1681,7 +1681,9 @@ class Bench(BenchPlotServer):
         def objective(trial: optuna.trial.Trial):
             kwargs = {iv.name: sweep_var_to_suggest(iv, trial) for iv in input_vars}
 
-            if agg_vars or repeats > 1:
+            # Non-None exactly when `needs_agg` held at the caller (agg_vars or repeats>1),
+            # so testing it here narrows the type instead of duplicating that condition.
+            if agg_callable is not None:
                 agg_combos = list(product(*(v.values() for v in agg_vars))) if agg_vars else [()]
                 all_results = [
                     self._run_optuna_job(

--- a/bencher/class_enum.py
+++ b/bencher/class_enum.py
@@ -105,7 +105,7 @@ class ExampleEnum(ClassEnum):
     Class2 = auto()
 
     @classmethod
-    def to_class(cls, enum_val: ExampleEnum) -> BaseClass:
+    def to_class(cls, enum_val: ClassEnum) -> BaseClass:
         """Convert an ExampleEnum value to its corresponding class instance.
 
         Args:

--- a/bencher/class_enum.py
+++ b/bencher/class_enum.py
@@ -109,7 +109,7 @@ class ExampleEnum(ClassEnum):
         """Convert an ExampleEnum value to its corresponding class instance.
 
         Args:
-            enum_val (ExampleEnum): The enum value to convert
+            enum_val (ClassEnum): The enum value to convert
 
         Returns:
             BaseClass: An instance of either Class1 or Class2, depending on the enum value

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -15,7 +15,9 @@ from .utils import hash_sha1
 logger = logging.getLogger(__name__)
 
 try:
-    from scoop import futures as scoop_future_executor
+    # scoop is an optional extra and is not in the default environment; the
+    # except-ImportError below is the intended handling.
+    from scoop import futures as scoop_future_executor  # ty: ignore[unresolved-import]
 except ImportError as e:
     scoop_future_executor = None
 

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from datetime import datetime
 from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import xarray as xr
@@ -239,9 +239,7 @@ class ResultCollector:
             self._history_cache.close()
             self._history_cache = None
 
-    # typing.Self needs python 3.11 and the package floor is 3.10, so keep the
-    # concrete return type rather than take a typing_extensions dependency.
-    def __enter__(self) -> ResultCollector:  # noqa: PYI034
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc_info) -> None:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -450,10 +450,10 @@ class BenchResult(
         if extra_panels:
             for ep in extra_panels:
                 try:
-                    if callable(ep):
-                        plot_cols.append(ep(self))
-                    else:
+                    if isinstance(ep, pn.viewable.Viewable):
                         plot_cols.append(ep)
+                    else:
+                        plot_cols.append(ep(self))
                 except Exception:  # pylint: disable=broad-except
                     name = getattr(ep, "__name__", repr(ep))
                     logger.exception("Extra panel %s failed", name)

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -450,10 +450,14 @@ class BenchResult(
         if extra_panels:
             for ep in extra_panels:
                 try:
-                    if isinstance(ep, pn.viewable.Viewable):
-                        plot_cols.append(ep)
-                    else:
+                    # Call only genuine factories. Excluding Viewable keeps a Viewable
+                    # that defined __call__ from being invoked, while objects that are
+                    # neither callable nor Viewable (a str, an hv element, a DataFrame)
+                    # still fall through to append, where Column.append coerces them.
+                    if callable(ep) and not isinstance(ep, pn.viewable.Viewable):
                         plot_cols.append(ep(self))
+                    else:
+                        plot_cols.append(ep)
                 except Exception:  # pylint: disable=broad-except
                     name = getattr(ep, "__name__", repr(ep))
                     logger.exception("Extra panel %s failed", name)

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from enum import Enum, auto
 from functools import partial
 from textwrap import wrap
-from typing import Any, Literal
+from typing import Any, Literal, assert_never
 
 import holoviews as hv
 import numpy as np
@@ -57,6 +57,13 @@ class ReduceType(Enum):
     REDUCE = auto()  # get the mean and std dev of the data along the "repeat" dimension
     MINMAX = auto()  # get the minimum and maximum of data along the "repeat" dimension
     NONE = auto()  # don't reduce
+
+
+# ReduceType with AUTO excluded: the return type of _resolve_auto, so that the match in
+# to_dataset is provably exhaustive over four members rather than relying on a catch-all.
+ResolvedReduceType = Literal[
+    ReduceType.SQUEEZE, ReduceType.REDUCE, ReduceType.MINMAX, ReduceType.NONE
+]
 
 
 class EmptyContainer:
@@ -234,9 +241,9 @@ class BenchResultBase:
             )
         )
 
-    def _resolve_auto(self, reduce: ReduceType) -> ReduceType:
+    def _resolve_auto(self, reduce: ReduceType) -> ResolvedReduceType:
         """Resolve AUTO to a concrete ReduceType based on repeat count."""
-        if reduce == ReduceType.AUTO:
+        if reduce is ReduceType.AUTO:
             return ReduceType.REDUCE if self.bench_cfg.repeats > 1 else ReduceType.SQUEEZE
         return reduce
 
@@ -350,9 +357,11 @@ class BenchResultBase:
                     ds_out = ds_out.squeeze("repeat", drop=True).copy(deep=True)
                 else:
                     ds_out = ds_out.squeeze(drop=True).copy(deep=True)
-            case _:
-                # ReduceType.NONE — deep copy for mutation safety
+            case ReduceType.NONE:
+                # deep copy for mutation safety
                 ds_out = ds_out.copy(deep=True)
+            case _ as unreachable:
+                assert_never(unreachable)
 
         # Optional aggregation across non-repeat dimensions (e.g., categorical)
         if agg_over_dims:
@@ -622,7 +631,7 @@ class BenchResultBase:
     def map_plot_panes(
         self,
         plot_callback: Callable,
-        hv_dataset: hv.Dataset = None,
+        hv_dataset: hv.Dataset | None = None,
         target_dimension: int = 2,
         result_var: ResultFloat | None = None,
         result_types=None,
@@ -633,7 +642,14 @@ class BenchResultBase:
         **kwargs,
     ) -> pn.Row | None:
         if hv_dataset is None:
-            hv_dataset = self.to_hv_dataset(reduce=reduce)
+            # `reduce=None` historically fell through to_dataset's catch-all arm and got
+            # ReduceType.NONE semantics -- NOT to_hv_dataset's own ReduceType.AUTO default.
+            # Normalizing here preserves that behaviour and keeps the sentinel out of the
+            # enum's domain, which is what lets to_dataset's match be exhaustive.
+            # NOTE (plan 23): that this default disagrees with to_hv_dataset's AUTO is a
+            # real inconsistency; changing it would alter rendering, so it is left for a
+            # phase that can own the behaviour change.
+            hv_dataset = self.to_hv_dataset(reduce=ReduceType.NONE if reduce is None else reduce)
 
         if pane_collection is None:
             pane_collection = pn.Row()
@@ -854,7 +870,7 @@ class BenchResultBase:
     def _to_panes_da(
         self,
         dataset: xr.Dataset,
-        plot_callback: Callable | None = None,
+        plot_callback: Callable,
         target_dimension=1,
         horizontal=False,
         result_var=None,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -60,7 +60,11 @@ class ReduceType(Enum):
 
 
 # ReduceType with AUTO excluded: the return type of _resolve_auto, so that the match in
-# to_dataset is provably exhaustive over four members rather than relying on a catch-all.
+# to_dataset is exhaustive over four members rather than relying on a catch-all.
+# CAVEAT: this only *fully* holds once `invalid-return-type` is enabled (plan 23 P12).
+# That rule is what checks _resolve_auto actually returns a member of this Literal; until
+# it lands, adding a ReduceType member without updating both this alias and the match
+# passes ty and fails at runtime in assert_never instead of at check time.
 ResolvedReduceType = Literal[
     ReduceType.SQUEEZE, ReduceType.REDUCE, ReduceType.MINMAX, ReduceType.NONE
 ]
@@ -203,7 +207,7 @@ class BenchResultBase:
 
     def to_hv_dataset(
         self,
-        reduce: ReduceType = ReduceType.AUTO,
+        reduce: ReduceType | None = ReduceType.AUTO,
         result_var: ResultFloat | None = None,
         subsampling_divisions: int | None = None,
         agg_over_dims: list[str] | None = None,
@@ -241,8 +245,24 @@ class BenchResultBase:
             )
         )
 
-    def _resolve_auto(self, reduce: ReduceType) -> ResolvedReduceType:
-        """Resolve AUTO to a concrete ReduceType based on repeat count."""
+    def _resolve_auto(self, reduce: ReduceType | None) -> ResolvedReduceType:
+        """Resolve AUTO (and the legacy `None` sentinel) to a concrete ReduceType.
+
+        `reduce=None` reaches here from public methods that declare
+        `reduce: ReduceType | None` and forward it unchanged (`map_plot_panes`,
+        `filter`, ...). It has always meant "no reduction": it used to fall through
+        `to_dataset`'s catch-all arm. Mapping it *here* rather than at the callers
+        matters, because `to_hv_dataset` branches on `reduce == ReduceType.NONE`
+        beforehand and `None` deliberately does not match that, which preserves the
+        unit-carrying kdims of its generic arm.
+
+        NOTE (plan 23): `None` and `AUTO` meaning different things on one field is the
+        sentinel smell this plan exists to remove, and `map_plot_panes` defaulting to
+        "no reduction" disagrees with `to_hv_dataset`'s AUTO. Both are behaviour changes
+        that need a phase which can own them.
+        """
+        if reduce is None:
+            return ReduceType.NONE
         if reduce is ReduceType.AUTO:
             return ReduceType.REDUCE if self.bench_cfg.repeats > 1 else ReduceType.SQUEEZE
         return reduce
@@ -266,7 +286,7 @@ class BenchResultBase:
 
     def to_dataset(
         self,
-        reduce: ReduceType = ReduceType.AUTO,
+        reduce: ReduceType | None = ReduceType.AUTO,
         result_var: ResultFloat | str | None = None,
         subsampling_divisions: int | None = None,
         agg_over_dims: list[str] | None = None,
@@ -642,14 +662,7 @@ class BenchResultBase:
         **kwargs,
     ) -> pn.Row | None:
         if hv_dataset is None:
-            # `reduce=None` historically fell through to_dataset's catch-all arm and got
-            # ReduceType.NONE semantics -- NOT to_hv_dataset's own ReduceType.AUTO default.
-            # Normalizing here preserves that behaviour and keeps the sentinel out of the
-            # enum's domain, which is what lets to_dataset's match be exhaustive.
-            # NOTE (plan 23): that this default disagrees with to_hv_dataset's AUTO is a
-            # real inconsistency; changing it would alter rendering, so it is left for a
-            # phase that can own the behaviour change.
-            hv_dataset = self.to_hv_dataset(reduce=ReduceType.NONE if reduce is None else reduce)
+            hv_dataset = self.to_hv_dataset(reduce=reduce)
 
         if pane_collection is None:
             pane_collection = pn.Row()

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -176,7 +176,7 @@ class VideoSummaryResult(BenchResultBase):
     def _to_video_panes_ds(
         self,
         dataset: xr.Dataset,
-        plot_callback: Callable | None = None,
+        plot_callback: Callable,
         target_dimension=0,
         compose_method=ComposeType.right,
         compose_method_list=None,

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -50,7 +50,7 @@ def _sigterm_handler(signum, frame) -> None:
     """Handle SIGTERM so servers are stopped even when the process is killed."""
     _shutdown_all_servers()
     if _prev_sigterm_handler not in (signal.SIG_DFL, signal.SIG_IGN, None):
-        _prev_sigterm_handler(signum, frame)  # type: ignore[misc]
+        _prev_sigterm_handler(signum, frame)  # type: ignore[misc]  # ty: ignore[call-non-callable]
     else:
         sys.exit(128 + signum)
 

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -706,35 +706,70 @@ than silently worked around.
    `# ty: ignore` comments remain, each with its reason inline: the optional `scoop`
    import (the `try/except ImportError` *is* the handling) and the `signal.getsignal`
    result in `run.py` (ty cannot narrow an `IntEnum` by identity against specific members).
-3. **`extra_panels` was discriminated by `callable()`, which cannot exclude the
-   `Viewable` arm.** Now discriminated by `isinstance(ep, pn.viewable.Viewable)`. This is
-   a latent-bug fix as well as a type fix: a `Viewable` that defined `__call__` would have
-   been *called* instead of appended.
+3. **`extra_panels`' `callable()` check cannot exclude the `Viewable` arm**, so the
+   predicate is now `callable(ep) and not isinstance(ep, pn.viewable.Viewable)`.
+   **Corrected during review:** the first attempt used `isinstance(...)` alone with the
+   branches swapped, which *introduced* a regression — the two predicates are not
+   complementary, and an object that is neither callable nor `Viewable` (a `str`, an
+   `hv.Curve`, a `DataFrame`) used to reach `append`, where `Column.append` coerces it.
+   Under the swapped form it was called instead, raising `TypeError` into the surrounding
+   `except Exception` and **silently dropping the panel**. `test_extra_panels.py` only
+   covers `pn.pane.Markdown`, so nothing caught it. Note also that the "latent bug" the
+   change was originally justified by is hypothetical: no panel `Viewable` is callable
+   (`Viewable` has no `__call__` in its MRO). The guard is cheap and kept, but it defends
+   a possibility, not an observed defect.
 4. **`Benchable` is discriminated by `inspect.signature` parameter count**, which no
    checker can narrow. The two call sites now `cast()` to the arm the introspection
    established, so the assumption is stated rather than blanket-ignored. This is the
    shape plan 24 warns about; the `cast` is honest about being unverified.
 5. **`_resolve_auto` now returns `ResolvedReduceType`** — a `Literal` over the four
-   non-`AUTO` members — so `to_dataset`'s `match` is exhaustive by construction and its
-   `assert_never` arm is *provably* dead rather than a catch-all. Verified two ways:
-   forcing `invalid-return-type` on shows the narrowing genuinely holds (`return reduce`
-   after `if reduce is ReduceType.AUTO: return ...`), and deleting one arm produces
+   non-`AUTO` members — so `to_dataset`'s `match` is exhaustive over those members and the
+   `assert_never` arm is not a catch-all. Deleting one arm produces
    `error[type-assertion-failure] … Inferred type of argument is Literal[ReduceType.MINMAX]`,
    naming the forgotten variant.
+   **Scope corrected during review — this is not yet a compile-time guarantee.** The
+   proof rests on `_resolve_auto` really returning a member of that `Literal`, and the only
+   rule that checks it, `invalid-return-type`, is Tier B and still globally ignored.
+   Measured: seeding `return ReduceType.AUTO` into `_resolve_auto` passes `pixi run ty`
+   (it is caught only with `--error invalid-return-type`), and adding a `ReduceType` member
+   without updating the alias or the match also passes ty, then fails at runtime in
+   `assert_never`. So for that scenario P1 moves "silently degrades to NONE" to "crashes,
+   still statically undetected". P12 closes it; a caveat comment records this at the alias.
 6. **Plan 24's warning was confirmed empirically, by this plan breaking on it.**
    Converting the catch-all to `assert_never` turned two green tests red with
    `AssertionError: Expected code to be unreachable, but got: None` — `map_plot_panes`
-   declares `reduce: ReduceType | None = None` and passed that `None` straight into
-   `to_dataset`, whose annotation says `ReduceType`. The old `case _:` had been absorbing
-   it. This is exactly plan 24 §2.1: a *complete* match is type-clean while raising at
-   runtime, because the subject's type was never established.
-   **A behaviour discrepancy fell out of it, and is deliberately NOT fixed here:**
-   `reduce=None` reaching the catch-all meant `ReduceType.NONE`, whereas
-   `to_hv_dataset`'s own default is `ReduceType.AUTO`. So `map_plot_panes(cb)` has always
-   skipped reduction rather than averaging over repeats. P1 normalizes `None` →
-   `ReduceType.NONE` at the boundary to preserve today's behaviour exactly; correcting the
-   default is a rendering change that needs a phase which can own it. Compare
-   `BenchResult.to()`, which handles the same sentinel correctly by omitting the argument.
+   declares `reduce: ReduceType | None = None` and passed that `None` into `to_dataset`,
+   whose annotation says `ReduceType`. The old `case _:` had been absorbing it. This is
+   exactly plan 24 §2.1: a *complete* match is type-clean while raising at runtime,
+   because the subject's type was never established.
+
+   **Where the sentinel is normalized matters, and the first attempt got it wrong.**
+   Mapping `None` → `ReduceType.NONE` in `map_plot_panes` (the obvious place) was **not**
+   behaviour-preserving, and review caught it: `to_hv_dataset` branches on
+   `reduce == ReduceType.NONE` *before* delegating, and `None` deliberately did not match
+   that, so it took the generic arm where holoviews infers kdims from the xarray variables
+   **with their units**. Normalizing early flipped it onto the arm that passes bare
+   strings as `kdims`, silently dropping unit metadata:
+
+   ```
+   reduce=None       -> [('theta', 'rad'), ('repeat', 'repeats')]
+   ReduceType.NONE   -> [('theta', None),  ('repeat', None)]
+   ```
+
+   The normalization therefore lives in **`_resolve_auto`** — the single funnel, reached
+   after every `== ReduceType.NONE` branch has already been decided on the raw value. That
+   preserves behaviour on every path *and* fixes the wider problem: `to_dataset`,
+   `to_hv_dataset`, `to_hv_type`, `to_points` and `filter` all forward `reduce` unchanged,
+   so an early fix in one caller would have left `reduce=None` crashing on all the others.
+   `to_dataset`/`to_hv_dataset` are now annotated `ReduceType | None`, which is the domain
+   they have always accepted.
+
+   **The behaviour discrepancy this exposed is recorded, not fixed:** `map_plot_panes`
+   defaulting to `None` means it has always skipped reduction, whereas `to_hv_dataset`'s own
+   default is `AUTO` (mean/std over repeats). Changing that alters rendering output and
+   needs a phase that can own it. Compare `BenchResult.to()`, which handles the same
+   sentinel correctly by omitting the argument.
+
 7. **`identity.py` was pulled back off the strict list.** It is not clean: it passes
    `list | dict | None` to `plot_sweep`, annotated `list[ParametrizedSweep] | None`. The
    annotation is the wrong one — `convert_vars_to_params` accepts
@@ -746,3 +781,32 @@ than silently worked around.
    does not mistake them for debt: `unused-ignore-comment` and
    `unused-type-ignore-comment`, because the repo deliberately carries 8 `# type: ignore`
    comments for other checkers.
+9. **D1's relaxed override block was dropped entirely, and D1 should be read as amended.**
+   As first written it exempted `test/**`, `bencher/example/**`, `scripts/**`, `docs/**`
+   and `setup.py` from twelve rules. Review measured what actually fires in those paths
+   with nothing silenced: **6 diagnostics**, all addressable inline — 4
+   `unresolved-import` (optional `playwright` ×3, vestigial `setuptools` in `setup.py`) and
+   2 `call-non-callable` in `scripts/benchmark_save.py:190` (a heterogeneous dict literal
+   widens `fdef["cls"]` past `type`). Five of the twelve rules were also **no-ops**, being
+   Tier C and already globally ignored. So the block's real effect was disabling seven
+   Tier-A rules over the largest trees in the repo — including `missing-argument` across
+   `bencher/example/**`, the corpus that doubles as integration tests and doc source, and
+   the very rule that catches a call site omitting a newly-required argument like this
+   phase's `plot_callback`. It is replaced by the two narrowest things that work: one
+   scoped `# ty: ignore[call-non-callable]` in `scripts/benchmark_save.py`, and a
+   **file-precise** override silencing only `unresolved-import` for exactly three files
+   (`generate_examples.py`, `test_docs_scrollbars.py`, `setup.py`). Those three cannot take
+   an inline comment: ruff reflows the import past the line limit and the comment lands on
+   the inner line, where pylint's own `import-error` pragma stops applying — attempting it
+   dropped `pixi run pylint` from 10.00/10. Verified afterwards that `missing-argument`
+   still fires in both `test/` and `bencher/example/`, so **Tier A is now enforced in those
+   trees**. A future phase enabling Tier B/C may need a broader relaxed block; it should
+   size it from measured evidence and list paths explicitly rather than by subtree glob.
+10. **The meta-tests could not detect the bypass they exist to prevent.** Asserting only
+   on `[tool.ty.rules]` missed the override route: review demonstrated adding
+   `"bencher/**"` to a relaxed `include` turned the whole Tier-A gate off for the package
+   with `test_ty_gate.py` still green. There is now a parametrized assertion that no
+   override block silences a protected rule for first-party package code, verified to fail
+   on exactly that seeded bypass. The probe tests also assert ty's **exit code**, not just
+   its output text, so a rule demoted to warning level cannot pass; and their class
+   docstring no longer claims to prove the repo's gate, only the mechanism.

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -679,3 +679,70 @@ and may be reordered or dropped individually.
 - Grep-level checks: no `_LOSSY_KINDS`, no `match_all(`, no bare
   `assert self.res is not None`, no `zip(button_names`, no `nan_to_num(arr, nan=0.0)`
   in `rerun_result.py`, and exactly one definition of the agg-fn vocabulary.
+
+## 10. Amendments discovered during implementation
+
+Recorded per the plans-README rule that claims which stopped holding are stated rather
+than silently worked around.
+
+### P1 (implemented)
+
+1. **The gate was worse than "21 rules ignored" — it ran with no dependency
+   resolution.** The `ty` task was `ty check --respect-ignore-files .` with no
+   `--python`, so *every* third-party import was unresolved (`param`, `panel`, `numpy`,
+   `xarray`, …). That is why `unresolved-import` had to be ignored globally, and it
+   silently degraded every rule that needs a third-party type. The task now passes
+   `--python "$CONDA_PREFIX"`, which resolves the *active* pixi environment so `-e py311`
+   and `-e py313` each check against their own interpreter. **All per-rule counts in §2.1
+   are only reproducible with `--python`**; measured without it they are meaningless. A
+   meta-test now pins the flag.
+2. **Tier A is 17 diagnostics, and all 17 are fixed rather than suppressed except two.**
+   Genuine fixes: `hv_dataset: hv.Dataset = None` → `| None` (annotation contradicted its
+   own default); `plot_callback: Callable | None` narrowed to `Callable` in `_to_panes_da`
+   and `_to_video_panes_ds` (both call it unguarded, so `None` was unanswerable — all four
+   call sites already pass a real callable); `options(self, *_args)` → `*_args, **_kwargs`
+   to match tornado's `RequestHandler.options`; `ExampleEnum.to_class`'s parameter widened
+   to `ClassEnum` (it narrowed a base-class parameter, an LSP violation). Two scoped
+   `# ty: ignore` comments remain, each with its reason inline: the optional `scoop`
+   import (the `try/except ImportError` *is* the handling) and the `signal.getsignal`
+   result in `run.py` (ty cannot narrow an `IntEnum` by identity against specific members).
+3. **`extra_panels` was discriminated by `callable()`, which cannot exclude the
+   `Viewable` arm.** Now discriminated by `isinstance(ep, pn.viewable.Viewable)`. This is
+   a latent-bug fix as well as a type fix: a `Viewable` that defined `__call__` would have
+   been *called* instead of appended.
+4. **`Benchable` is discriminated by `inspect.signature` parameter count**, which no
+   checker can narrow. The two call sites now `cast()` to the arm the introspection
+   established, so the assumption is stated rather than blanket-ignored. This is the
+   shape plan 24 warns about; the `cast` is honest about being unverified.
+5. **`_resolve_auto` now returns `ResolvedReduceType`** — a `Literal` over the four
+   non-`AUTO` members — so `to_dataset`'s `match` is exhaustive by construction and its
+   `assert_never` arm is *provably* dead rather than a catch-all. Verified two ways:
+   forcing `invalid-return-type` on shows the narrowing genuinely holds (`return reduce`
+   after `if reduce is ReduceType.AUTO: return ...`), and deleting one arm produces
+   `error[type-assertion-failure] … Inferred type of argument is Literal[ReduceType.MINMAX]`,
+   naming the forgotten variant.
+6. **Plan 24's warning was confirmed empirically, by this plan breaking on it.**
+   Converting the catch-all to `assert_never` turned two green tests red with
+   `AssertionError: Expected code to be unreachable, but got: None` — `map_plot_panes`
+   declares `reduce: ReduceType | None = None` and passed that `None` straight into
+   `to_dataset`, whose annotation says `ReduceType`. The old `case _:` had been absorbing
+   it. This is exactly plan 24 §2.1: a *complete* match is type-clean while raising at
+   runtime, because the subject's type was never established.
+   **A behaviour discrepancy fell out of it, and is deliberately NOT fixed here:**
+   `reduce=None` reaching the catch-all meant `ReduceType.NONE`, whereas
+   `to_hv_dataset`'s own default is `ReduceType.AUTO`. So `map_plot_panes(cb)` has always
+   skipped reduction rather than averaging over repeats. P1 normalizes `None` →
+   `ReduceType.NONE` at the boundary to preserve today's behaviour exactly; correcting the
+   default is a rendering change that needs a phase which can own it. Compare
+   `BenchResult.to()`, which handles the same sentinel correctly by omitting the argument.
+7. **`identity.py` was pulled back off the strict list.** It is not clean: it passes
+   `list | dict | None` to `plot_sweep`, annotated `list[ParametrizedSweep] | None`. The
+   annotation is the wrong one — `convert_vars_to_params` accepts
+   `param.Parameter | str | dict | tuple` — but widening a public entry point's signature
+   is A5's business, not P1's. The strict list's rule ("a file is added only once it is
+   clean") is honoured instead of loosening the block. Initial strict members are
+   therefore `sample_order.py`, `sweep_timings.py` and `blob_store.py`.
+8. **Two rules stay ignored permanently and are labelled as such**, so a future reader
+   does not mistake them for debt: `unused-ignore-comment` and
+   `unused-type-ignore-comment`, because the repo deliberately carries 8 `# type: ignore`
+   comments for other checkers.

--- a/plans/23-handover.md
+++ b/plans/23-handover.md
@@ -1,0 +1,226 @@
+# Handover — plan 23 after P1
+
+**Ephemeral.** This is working state, not a plan. Delete it when plan 23 P12 lands (or
+fold anything still open into plan 23 §10). Everything here is actionable without the
+conversation that produced it.
+
+**State pinned to:** `main` @ `ee044f0e` plus PR #1026 (`plan/ty-enforcement-floor`,
+head `b9524867`). Per plans-README rule 7, re-confirm every `file:line` before relying on
+it; the symbol is the durable reference.
+
+---
+
+## 1. What has landed
+
+| Change | PR | State |
+|---|---|---|
+| Plan 23 — the audit itself, 12 phases | #1023 | merged |
+| Plan 24 — `assert_never` boundary discipline (amends 23) | — | merged (`7de09227`) |
+| Python floor 3.10 → 3.11 | #1025 | merged (`1aad6bfc`) |
+| **Plan 23 P1 — make the `ty` gate real** | #1026 | 6/7 checks green, RTD pending at handover |
+
+Read in this order before touching anything:
+
+1. `plans/23-constructive-data-modeling.md` — **§10 first**. It records what P1 actually
+   did and, more usefully, three claims that were falsified during implementation.
+2. `plans/24-assert-never-boundary-discipline.md` — its §3 amendments bind 23-P2 and
+   23-P11. Do not implement `assert_never` anywhere without reading its §2.
+3. `plans/README.md` ground rules (pixi-only, `pixi run ci` before commit, cite
+   `file:line` + symbol).
+
+## 2. Read this before you write any `assert_never`
+
+Plan 24's finding is the single most load-bearing thing in this handover, and P1
+confirmed it the hard way — by breaking on it.
+
+**A `match` that is *complete* still raises at runtime if its subject arrives untyped.**
+`ty` reports `All checks passed!`; the `assert_never` arm fires as an `AssertionError`
+whose message ("Expected code to be unreachable") actively misdirects the reader toward a
+missing enum member rather than a bad value at the boundary. No checker closes this —
+`pyrefly` is clean on the same probe. It is a property of gradual typing, not a `ty` gap.
+
+The repo's own config names the vector: `pyproject.toml` says param descriptors "resolve
+as **Unknown**". So **a `match` on a raw `param` field read never qualifies.** Normalize
+at the boundary first — construct the enum (`Executors(value)`, `AggFn(value)`), raising
+on unknown input — and cover that normalization with a *runtime* test, because no static
+check enforces it.
+
+Verified still true at the py311 target with stdlib `typing.assert_never`.
+
+## 3. Next phase: 23-P2
+
+Collection-path live bugs plus executor normalization. Plan 23 §5 has the full spec; the
+deltas you must not miss:
+
+- **B2** `bencher/result_collector.py:463-471` — the `ResultVec` branch stores only when
+  `isinstance(result_value, (list, np.ndarray))` **and** `len(result_value) == rv.size`,
+  with no `else`. A wrong-length vector is silently discarded and left at the NaN fill,
+  indistinguishable from "never sampled". Add the `else` → `TypeError` naming the
+  variable, expected size and actual length.
+- **B3** `bencher/job.py:158-160` + `bencher/result_collector.py:424` — a worker returning
+  `None` trips a bare `assert` on the serial path (absent under `python -O`) but on
+  MULTIPROCESSING/SCOOP the whole `store_results` body is skipped by
+  `if result is not None:` with no `else`, and the sweep completes green with an
+  all-sentinel dataset and `n_failed == 0`. One boundary check raising `TypeError` on
+  **both** paths.
+- **C13** executor normalization. **Read plan 23 C13 before writing the test** — an
+  earlier draft claimed `BenchRunCfg(executor="serial")` diverged between branches and
+  that was **false**: `strenum.auto()` yields the member *name*, so
+  `Executors.SERIAL.value == "SERIAL"`, `"serial"` is rejected by the `Selector` with
+  `ValueError`, and `factory("SERIAL")` returns `None` so even the exact-case string
+  resolves serial everywhere. It is a latent smell (four sites, three comparison styles:
+  `bencher.py:1180`, `:1182`, `job.py:230`, `:355`), not a shipped bug. No pre-fix
+  regression test is possible; write a branch-agreement test instead.
+- **Plan 24 A3 DoD addition:** state in the PR that the `executor` normalization is what
+  *licenses* any later `assert_never` on that field. A2 promotes this from "hardening" to
+  "precondition" — do not skip it on the grounds that C13 is only a smell.
+
+**Owner decision still open (plan 23 §6.2):** raise vs warn for B2/B3. Recommendation on
+file is raise `TypeError`, and explicitly *not* routed through plan 21's `catch=`, because
+a bad return shape is a harness-contract error rather than a sample fault.
+
+## 4. Small items P1 left on the floor
+
+Each is independent and none blocks P2.
+
+- **Plan 24 Q1** (small, self-contained): raise the `ty` ceiling to `<=0.0.65`
+  (`pyproject.toml:80`; env resolves 0.0.56, behaviour identical across 0.0.56/0.0.64/
+  0.0.65), and add plan 24 A5's third probe to `test/test_ty_gate.py` — a **complete**
+  match fed from an unannotated helper asserted *type-clean*. Comment it as pinning
+  current `ty` behaviour, not desired behaviour, so that a future `ty` release closing the
+  hole becomes a test failure that tells us rather than a silent improvement. **P1 did not
+  add this probe.**
+- **Plan 24 A4** was not applied to plan 23 §9: add the DoD line "every `assert_never` in
+  the tree either has a subject `ty` can type, or is preceded by a normalizing parse that
+  is covered by a test", plus a grep check that no `assert_never` subject is an attribute
+  read on a `param.Parameterized` instance.
+- **`to_panes_multi_panel`** (`bencher/results/bench_result_base.py:833`) still declares
+  `plot_callback: Callable | None = None` and forwards it into `_to_panes_da`, which P1
+  narrowed to a required `Callable`. The unanswerable-`None` problem moved up one frame
+  rather than being removed; `ty` cannot see it because `invalid-argument-type` is Tier C.
+- **Seven `pn.pane = None` / `pn.pane.panel = None` parameter defaults** —
+  `bench_result_base.py:658,737`, `video_summary.py:46`, `rerun_summary.py:82`,
+  `heatmap_result.py:35,140`, `line_result.py:35`. Same shape as the
+  `hv_dataset: hv.Dataset = None` bug P1 fixed. They escape `invalid-parameter-default`
+  only because `pn.pane` is a *module* in annotation position and `invalid-type-form` is
+  Tier C — i.e. one Tier-C suppression is currently hiding a Tier-A class of defect.
+- **`bencher/run.py:52-53`** carries a `# ty: ignore[call-non-callable]`. The honest fix
+  is one token: `if callable(_prev_sigterm_handler)` instead of
+  `not in (signal.SIG_DFL, signal.SIG_IGN, None)`, which narrows for `ty` *and* is safer
+  at runtime. Then delete the ignore.
+- **`test/test_extra_panels.py` covers only `pn.pane.Markdown`** (4 references, zero
+  non-Markdown cases). That gap let a P1 regression through CI — see §6. Add cases for a
+  plain `str`, an `hv` element and a callable factory.
+
+## 5. Deferred by design — each needs a phase that can own it
+
+These are **behaviour or public-API changes**. They were found during P1 and deliberately
+not made there. Do not sweep them into an unrelated PR.
+
+1. **`map_plot_panes` defaults to no reduction, disagreeing with `to_hv_dataset`'s
+   `AUTO`.** `map_plot_panes(reduce=None)` has always skipped reduction, because `None`
+   fell through `to_dataset`'s old catch-all; `to_hv_dataset`'s own default averages over
+   repeats. Fixing the default changes rendered output. `_resolve_auto`
+   (`bench_result_base.py`) now maps `None → ReduceType.NONE` in one place and documents
+   this. Compare `BenchResult.to()`, which handles the same sentinel correctly by omitting
+   the argument — that is the shape to converge on.
+2. **`to_hv_dataset`'s `ReduceType.NONE` arm discards kdim units** — a pre-existing bug.
+   It passes `kdims=[name, ...]` as bare strings, where the generic arm lets holoviews
+   infer dimensions from the xarray variables *with* units:
+   ```
+   reduce=None      -> [('theta', 'rad'), ('repeat', 'repeats')]
+   ReduceType.NONE  -> [('theta', None),  ('repeat', None)]
+   ```
+   P1 does **not** route new traffic onto it (an earlier attempt did, and that is why the
+   normalization moved to `_resolve_auto`). Fix by building `hv.Dimension` objects, or by
+   reusing the inferred dims.
+3. **`plot_sweep`'s annotation understates its domain.** `input_vars` is
+   `list[ParametrizedSweep] | None`, but `convert_vars_to_params`
+   (`bencher/sweep_executor.py:242`) accepts `param.Parameter | str | dict | tuple`, and
+   `identity.py:155` passes `list | dict | None`. This is why **`identity.py` is not on
+   the strict `ty` list** — it is not clean, and the wrong side is the annotation.
+   Widening a public entry point is A5's business. Add `identity.py` to the strict block
+   once resolved.
+4. **`strenum` → stdlib `enum.StrEnum` is now possible but is a trap.** The 3.11 floor
+   allows it; they are not drop-in equivalents:
+   ```
+   strenum.StrEnum + auto()  ->  member name verbatim   ('SERIAL')
+   enum.StrEnum    + auto()  ->  lowercased name        ('serial')
+   ```
+   Five of seven StrEnums are unaffected (lowercase member names). **`Executors` and
+   `SampleOrder` would silently change value**, and since `executor` is a
+   `param.Selector(objects=list(Executors))`, that flips which strings callers may pass.
+   Verified **not** a cache-invalidation risk: neither feeds `hash_persistent`, and
+   `sample_order` is in `EXCLUDED_FIELDS` (`identity.py:49`). If done, give those two
+   enums **explicit string values** rather than `auto()`, in its own PR.
+5. **The `ReduceType` exhaustiveness guarantee is incomplete until P12.** `to_dataset`'s
+   match is exhaustive over `ResolvedReduceType`, but the only rule that verifies
+   `_resolve_auto` actually returns a member of that `Literal` — `invalid-return-type` —
+   is Tier B and still globally ignored. Seeding `return ReduceType.AUTO` passes
+   `pixi run ty`. So adding a `ReduceType` member without updating both the alias and the
+   match currently fails at *runtime*, not at check time. A caveat comment records this at
+   the alias. **P12 closes it**; `bench_result_base.py` has 3 other `invalid-return-type`
+   diagnostics (`:202`, `:507`, `:543`) that must be fixed first.
+
+## 6. Traps that cost real time — please read
+
+1. **`ty` is not a no-op gate in the way the old config implied — but measuring it is
+   easy to get wrong.** Every per-rule count in plan 23 §2.1 is only reproducible with
+   `--python` pointing at a resolved environment. Without it, `param`/`panel`/`numpy`/
+   `xarray` are all unresolved and the numbers are meaningless. The `ty` task now passes
+   `--python "$CONDA_PREFIX"`; a meta-test pins the flag.
+2. **A seeded `ty` probe run under the repo's own config silently passes**, because Tier C
+   is globally ignored. `test/test_ty_gate.py` writes a minimal standalone `pyproject.toml`
+   on purpose. This is the exact trap that made this plan's first measurements wrong.
+3. **A regression can pass full CI here.** P1's first commit replaced
+   `if callable(ep)` with `if isinstance(ep, pn.viewable.Viewable)` in `extra_panels` and
+   swapped the branches. The predicates are **not complementary**: a `str`, `hv` element or
+   `DataFrame` — previously appended, where `Column.append` coerces it — was called
+   instead, raising `TypeError` into a surrounding `except Exception`, so the panel
+   vanished from the report with only a log line. 2400+ tests stayed green because
+   `test_extra_panels.py` only covers `Markdown` (§4). Corrected to
+   `callable(ep) and not isinstance(ep, Viewable)`. **Whenever you change a discrimination
+   predicate on a union, enumerate the objects that satisfy neither arm.**
+4. **Three claims made during this work were later falsified** (the executor "bug", the
+   `reduce` normalization being behaviour-preserving, and the `extra_panels` fix). All are
+   recorded in plan 23 §10 with the falsifying evidence rather than quietly amended.
+   Expect to falsify more; prefer running the probe over reasoning about it.
+5. **Sourcery was rate-limited** (weekly 500k diff-char cap) on #1025 and #1026, so
+   neither got an automated review. If it is still limited, budget for a manual or
+   subagent adversarial pass — that is what caught trap 3.
+6. **Do not add a file to the strict `ty` block until it is clean.** The block's whole
+   value is that it only ever grows. Current members: `sample_order.py`,
+   `sweep_timings.py`, `blob_store.py`.
+7. **Do not silence a Tier-A rule with a broad `include` glob.** P1 replaced a five-tree,
+   twelve-rule relaxed block (whose real effect was disabling seven Tier-A rules over
+   `test/` and `bencher/example/`, including `missing-argument` — the rule that catches a
+   call site omitting a newly-required argument) with one inline ignore plus a
+   **file-precise** override for three files. A meta-test now fails on any override
+   silencing a protected rule for first-party package code. Prefer a scoped
+   `# ty: ignore[rule]` with a reason.
+8. Annotating those three files inline is not possible: ruff reflows the import past the
+   line limit and the comment lands on the inner line, where pylint's own
+   `import-error` pragma stops applying — it dropped `pixi run pylint` from 10.00/10.
+
+## 7. Verification recipe
+
+```bash
+pixi run ci                 # format, ruff, pylint, ty, tests+coverage (gate 85%)
+pixi run -e py311 ci        # the other CI matrix entry
+pixi run ty                 # gate only, fast
+pixi run pytest test/test_ty_gate.py -q     # 24 tests, the gate's own meta-tests
+```
+
+Always prefix with `pixi run`. Never bump the version in `pyproject.toml` — a version
+increase on `main` auto-publishes to PyPI (`.github/workflows/publish.yml` publishes only
+on an *increase*, so leaving it alone is safe).
+
+To prove the exhaustiveness gate still bites, delete one `case ReduceType.*` arm from
+`to_dataset` and run `pixi run ty`: expect
+`error[type-assertion-failure] … Inferred type of argument is Literal[ReduceType.<member>]`.
+
+## 8. Remaining phase order
+
+`P2` (§3) → `P3` → `P4` (result-type registry; A6 phase 2 consumes it, so do it before
+that) → `P5`–`P11` (mutually independent, individually droppable) → `P12` (Tier-B ratchet,
+which also closes §5.5). Plan 24's Q1 (§4) is independent and can go any time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,12 @@ format = "ruff format ."
 check-clean-workspace = "git diff --exit-code"
 ruff-lint = "ruff check . --fix"
 pylint = "pylint --version && echo 'running pylint...' && pylint $(git ls-files '*.py')"
-ty = "ty check --respect-ignore-files ."
+# --python $CONDA_PREFIX points ty at the *active* pixi environment, so `-e py311` and
+# `-e py313` each type-check against their own interpreter and installed packages.
+# Without it ty resolves no third-party import at all (param, panel, numpy, xarray all
+# read as unresolved), which silently degrades every rule that depends on knowing a
+# third-party type. See plans/23-constructive-data-modeling.md P1.
+ty = { cmd = "ty check --respect-ignore-files --python \"$CONDA_PREFIX\" ." }
 lint = { depends-on = ["ruff-lint", "ty", "pylint"] }
 style = { depends-on = ["format", "lint"] }
 commit-format = "git commit -a -m'autoformat code' || true"
@@ -240,43 +245,91 @@ exclude_also = [
 [tool.pytest.ini_options]
 tmp_path_retention_count = 0
 
+# Type-check gate. See plans/23-constructive-data-modeling.md D1 for the tier design.
+#
+# The rules below are grouped into tiers by measured cost, and the list is a RATCHET:
+# rules move out of it over time and never back in. Two rules are exempt by design and
+# stay forever (see "Permanently ignored").
+#
+# Tier A (enabled -- plan 23 P1): call-non-callable, call-top-callable, inconsistent-mro,
+#   invalid-method-override, invalid-parameter-default, missing-argument,
+#   too-many-positional-arguments, unresolved-import, unresolved-reference.
+#   Deliberately absent from this file: they are errors everywhere except the paths
+#   relaxed in [[tool.ty.overrides]] below.
+#
+# Tier B (~126 diagnostics, scheduled for plan 23 P12).
+# Tier C (~1068 diagnostics, dominated by param-descriptor dynamism and by test/).
+#   Enabled per-file via the strict override block below as modules are reworked;
+#   every plan 23 phase adds the files it touches.
 [tool.ty.rules]
-# Ignore type errors related to param library descriptors
-invalid-assignment = "ignore"
-# Ignore argument type mismatches (many false positives with param library)
-invalid-argument-type = "ignore"
-# Ignore unresolved attributes (param descriptors create dynamic attributes)
-unresolved-attribute = "ignore"
-# Ignore invalid type forms (pn.panel is a function, not a type)
-invalid-type-form = "ignore"
-# Ignore return type mismatches
+
+# --- Tier B: enable globally in plan 23 P12 -----------------------------------------
+# Return type mismatches. Also the signal a degraded assert_never falls back to, so
+# enabling this hardens the exhaustiveness gate (plan 23 section 2.4).
 invalid-return-type = "ignore"
-# Ignore not-subscriptable errors
-not-subscriptable = "ignore"
-# Ignore possibly missing attributes (Union type issues)
-possibly-missing-attribute = "ignore"
-# Ignore unsupported operator errors
-unsupported-operator = "ignore"
-# Ignore positional argument count errors
-too-many-positional-arguments = "ignore"
-missing-argument = "ignore"
-# Ignore not-iterable errors (Union types)
+# Union types read as non-iterable / no matching overload / unsupported operator.
 not-iterable = "ignore"
-# Ignore overload matching errors
 no-matching-overload = "ignore"
-# Ignore call-non-callable errors
-call-non-callable = "ignore"
-# Ignore call-top-callable errors (callable() guard + call on union types)
-call-top-callable = "ignore"
-# Ignore method override errors
-invalid-method-override = "ignore"
-# Ignore import/reference resolution errors
-unresolved-import = "ignore"
-unresolved-reference = "ignore"
-# Ignore parameter default errors (param library StrEnum/enum descriptors resolve as Unknown)
-invalid-parameter-default = "ignore"
-# Ignore MRO errors (param base classes resolve as Unknown)
-inconsistent-mro = "ignore"
-# Ignore unused type: ignore comments (needed for other type checkers)
+unsupported-operator = "ignore"
+# Possibly missing attributes (union type issues).
+possibly-missing-attribute = "ignore"
+
+# --- Tier C: param-descriptor dynamism; per-file via the strict block ---------------
+# param descriptors: a class-level `x = param.Number(1.0)` reads back as float on
+# instances, which no static checker models. bench_cfg.py alone accounts for 63.
+invalid-assignment = "ignore"
+invalid-argument-type = "ignore"
+unresolved-attribute = "ignore"
+# pn.panel is a function used in annotation position, not a type.
+invalid-type-form = "ignore"
+not-subscriptable = "ignore"
+
+# --- Permanently ignored: not debt, do not "fix" ------------------------------------
+# The repo carries 8 `# type: ignore` comments for OTHER type checkers (mypy/pyright).
+# ty considers them unused; that is expected and must stay silenced.
 unused-ignore-comment = "ignore"
 unused-type-ignore-comment = "ignore" # same rule, renamed in ty >= 0.0.14
+
+# Relaxed paths: tests, generated examples, helper scripts, docs, and the dead
+# setuptools shim. Tier A/B/C are all off here.
+#   - unresolved-import: playwright is optional tooling, only needed on the standalone
+#     screenshot path; setup.py is vestigial (see plans/03-repo-hygiene.md).
+#   - 315 of the ~545 invalid-argument-type diagnostics are in test/ alone, where
+#     deliberately-wrong values are the point of the test.
+[[tool.ty.overrides]]
+include = [
+    "test/**",
+    "bencher/example/**",
+    "scripts/**",
+    "docs/**",
+    "setup.py",
+]
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+invalid-method-override = "ignore"
+too-many-positional-arguments = "ignore"
+missing-argument = "ignore"
+call-non-callable = "ignore"
+call-top-callable = "ignore"
+invalid-parameter-default = "ignore"
+invalid-argument-type = "ignore"
+unresolved-attribute = "ignore"
+invalid-assignment = "ignore"
+not-subscriptable = "ignore"
+invalid-type-form = "ignore"
+
+# STRICT RATCHET. Files here are held to Tier C as well. Only ever append.
+# Every plan 23 phase adds the modules it reworks as part of its Definition of Done;
+# a file is added only once it is clean, so this block can never regress the gate.
+[[tool.ty.overrides]]
+include = [
+    "bencher/sample_order.py",
+    "bencher/sweep_timings.py",
+    "bencher/blob_store.py",
+]
+[tool.ty.overrides.rules]
+invalid-assignment = "error"
+invalid-argument-type = "error"
+unresolved-attribute = "error"
+invalid-type-form = "error"
+not-subscriptable = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,33 +290,19 @@ not-subscriptable = "ignore"
 unused-ignore-comment = "ignore"
 unused-type-ignore-comment = "ignore" # same rule, renamed in ty >= 0.0.14
 
-# Relaxed paths: tests, generated examples, helper scripts, docs, and the dead
-# setuptools shim. Tier A/B/C are all off here.
-#   - unresolved-import: playwright is optional tooling, only needed on the standalone
-#     screenshot path; setup.py is vestigial (see plans/03-repo-hygiene.md).
-#   - 315 of the ~545 invalid-argument-type diagnostics are in test/ alone, where
-#     deliberately-wrong values are the point of the test.
+# Optional/vestigial imports, scoped to the exact files rather than whole trees. These
+# three cannot be annotated inline: ruff reflows the import past the line limit and the
+# comment lands where pylint's own import-error pragma stops applying.
+#   - playwright is optional tooling, needed only on the standalone screenshot path.
+#   - setup.py is a vestigial setuptools shim (see plans/03-repo-hygiene.md).
 [[tool.ty.overrides]]
 include = [
-    "test/**",
-    "bencher/example/**",
-    "scripts/**",
-    "docs/**",
+    "bencher/example/meta/generate_examples.py",
+    "test/test_docs_scrollbars.py",
     "setup.py",
 ]
 [tool.ty.overrides.rules]
 unresolved-import = "ignore"
-invalid-method-override = "ignore"
-too-many-positional-arguments = "ignore"
-missing-argument = "ignore"
-call-non-callable = "ignore"
-call-top-callable = "ignore"
-invalid-parameter-default = "ignore"
-invalid-argument-type = "ignore"
-unresolved-attribute = "ignore"
-invalid-assignment = "ignore"
-not-subscriptable = "ignore"
-invalid-type-form = "ignore"
 
 # STRICT RATCHET. Files here are held to Tier C as well. Only ever append.
 # Every plan 23 phase adds the modules it reworks as part of its Definition of Done;

--- a/scripts/benchmark_save.py
+++ b/scripts/benchmark_save.py
@@ -187,7 +187,8 @@ FIXTURE_DEFS = {
 def build_fixture(fixture_type: str, variant: FixtureVariant) -> bn.Bench:
     """Build a benchmark fixture and return the Bench with populated report."""
     fdef = FIXTURE_DEFS[fixture_type]
-    benchable = fdef["cls"]()
+    # FIXTURE_DEFS values are heterogeneous, so ty widens fdef["cls"] beyond `type`.
+    benchable = fdef["cls"]()  # ty: ignore[call-non-callable]
     run_cfg = bn.BenchRunCfg()
     run_cfg.over_time = fdef["over_time"]
     run_cfg.repeats = fdef["repeats"]

--- a/test/test_ty_gate.py
+++ b/test/test_ty_gate.py
@@ -60,8 +60,8 @@ class TestGateConfiguration:
             f"`{rule}` has been added back to [tool.ty.rules] as 'ignore'. "
             f"It guards {MUST_NOT_BE_IGNORED[rule]}. Silencing it globally makes the "
             f"gate pass while the property it protects is unenforced. Scope the "
-            f"suppression to the offending file with `# ty: ignore[{rule}]`, or relax "
-            f"it for a path in [[tool.ty.overrides]], rather than disabling it here."
+            f"suppression to the offending line with `# ty: ignore[{rule}]` and a "
+            f"reason, rather than disabling it here."
         )
 
     def test_ty_task_resolves_the_environment(self) -> None:
@@ -72,10 +72,43 @@ class TestGateConfiguration:
         the active environment.
         """
         task = _load_ty_task()
+        assert "$CONDA_PREFIX" in task, (
+            "the `ty` task must resolve the *active* pixi environment via $CONDA_PREFIX, "
+            "so that `-e py311` and `-e py313` each check against their own interpreter. "
+            f"A hardcoded or empty path would check the wrong env. Task: {task!r}"
+        )
         assert "--python" in task, (
             "the `ty` pixi task no longer passes --python, so ty will type-check with "
             "no third-party packages resolved. Every rule that depends on knowing an "
             'external type degrades silently. Restore --python "$CONDA_PREFIX".'
+        )
+
+    @pytest.mark.parametrize("rule", sorted(MUST_NOT_BE_IGNORED))
+    def test_rule_not_ignored_for_the_package_via_overrides(self, rule: str) -> None:
+        """The global ignore table is not the only way to disable a rule.
+
+        An ``[[tool.ty.overrides]]`` block with a broad ``include`` silences rules just
+        as effectively, and asserting only on ``[tool.ty.rules]`` would not notice. This
+        caught a real hole in review: a block covering ``bencher/example/**`` had
+        ``missing-argument`` off across the corpus that doubles as integration tests.
+        """
+        offenders = []
+        for block in _ty_config().get("overrides", []):
+            if block.get("rules", {}).get(rule) != "ignore":
+                continue
+            for pattern in block.get("include", []):
+                # Silencing a rule for first-party package code is the regression; the
+                # generated-example tree and helper trees are allowed to be exempted, but
+                # must be listed explicitly rather than swept in by a `bencher/**` glob.
+                if pattern.startswith("bencher/") and not pattern.startswith(
+                    ("bencher/example/", "bencher/_vendor/")
+                ):
+                    offenders.append((pattern, rule))
+        assert not offenders, (
+            f"`{rule}` is disabled for first-party package code by an override block "
+            f"({offenders}). It guards {MUST_NOT_BE_IGNORED[rule]}. Prefer a scoped "
+            f"`# ty: ignore[{rule}]` on the offending line, which is greppable and "
+            f"carries a reason, over an include pattern that silently covers a subtree."
         )
 
     def test_strict_override_block_is_non_empty(self) -> None:
@@ -100,7 +133,11 @@ def _load_ty_task() -> str:
 
 @pytest.mark.skipif(shutil.which("ty") is None, reason="ty binary not on PATH")
 class TestGateActuallyFires:
-    """End-to-end proof that the configured gate rejects real violations.
+    """Proof that `ty` itself enforces exhaustiveness, under a minimal config.
+
+    Scope note: these run against a *standalone* minimal config, so they verify the
+    mechanism plan 23 D2 depends on rather than this repo's full gate. The repo-level
+    properties are asserted by TestGateConfiguration above.
 
     Configuration assertions above can pass while the checker itself is misconfigured,
     so these run ty against seeded violations. They deliberately use a *minimal
@@ -110,7 +147,7 @@ class TestGateActuallyFires:
     """
 
     @staticmethod
-    def _run_ty(tmp_path: Path, source: str) -> str:
+    def _run_ty(tmp_path: Path, source: str) -> tuple[str, int]:
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "probe"\nversion = "0"\nrequires-python = ">=3.11"\n'
         )
@@ -123,10 +160,10 @@ class TestGateActuallyFires:
             cwd=tmp_path,
             check=False,
         )
-        return result.stdout + result.stderr
+        return result.stdout + result.stderr, result.returncode
 
     def test_non_exhaustive_match_is_rejected(self, tmp_path: Path) -> None:
-        output = self._run_ty(
+        output, returncode = self._run_ty(
             tmp_path,
             """
 from enum import Enum, auto
@@ -149,6 +186,10 @@ def handle(k: Kind) -> str:
             assert_never(unreachable)
 """,
         )
+        assert returncode != 0, (
+            f"ty exited 0 on a non-exhaustive match, so the diagnostic is not "
+            f"error-level and would not fail CI. Output:\n{output}"
+        )
         assert "type-assertion-failure" in output, (
             "ty did not reject a match missing one enum member. The exhaustiveness "
             f"mechanism plan 23 D2 relies on is not working. Output:\n{output}"
@@ -160,7 +201,7 @@ def handle(k: Kind) -> str:
 
     def test_exhaustive_match_is_accepted(self, tmp_path: Path) -> None:
         """Guards against a gate that rejects everything (which would be equally useless)."""
-        output = self._run_ty(
+        output, returncode = self._run_ty(
             tmp_path,
             """
 from enum import Enum, auto
@@ -182,6 +223,7 @@ def handle(k: Kind) -> str:
             assert_never(unreachable)
 """,
         )
+        assert returncode == 0, f"ty exited {returncode} on a complete match:\n{output}"
         assert "All checks passed" in output, (
             f"ty rejected a complete match, so the gate has false positives:\n{output}"
         )

--- a/test/test_ty_gate.py
+++ b/test/test_ty_gate.py
@@ -1,0 +1,187 @@
+"""Meta-tests for the ``ty`` type-check gate itself.
+
+The gate is configuration, so it can be weakened by a one-line edit to
+``pyproject.toml`` without any test noticing. Before plan 23 P1 the gate ignored 21
+rules and was effectively a no-op that still reported "All checks passed!". These tests
+assert the *properties that make it a gate*, so that regression cannot happen silently
+again.
+
+See ``plans/23-constructive-data-modeling.md`` sections D1/D2 and P1.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# Rules that must never be silenced globally, with the reason each one matters.
+MUST_NOT_BE_IGNORED = {
+    # The exhaustiveness mechanism. Silencing this turns every `assert_never` arm from a
+    # compile-time proof into a runtime assertion, with no other signal.
+    "type-assertion-failure": "exhaustive `match` checking (plan 23 D2)",
+    # Tier A, enabled in P1. Each was measured at <=6 diagnostics, so a reappearance in
+    # the ignore list is a regression rather than a pragmatic concession.
+    "call-non-callable": "Tier A (plan 23 P1)",
+    "call-top-callable": "Tier A (plan 23 P1)",
+    "inconsistent-mro": "Tier A (plan 23 P1)",
+    "invalid-method-override": "Tier A (plan 23 P1)",
+    "invalid-parameter-default": "Tier A (plan 23 P1)",
+    "missing-argument": "Tier A (plan 23 P1)",
+    "too-many-positional-arguments": "Tier A (plan 23 P1)",
+    "unresolved-import": "Tier A (plan 23 P1)",
+    "unresolved-reference": "Tier A (plan 23 P1)",
+}
+
+
+def _ty_config() -> dict:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["tool"]["ty"]
+
+
+def _global_rules() -> dict[str, str]:
+    return _ty_config().get("rules", {})
+
+
+class TestGateConfiguration:
+    """Properties of the checked-in ty configuration."""
+
+    @pytest.mark.parametrize("rule", sorted(MUST_NOT_BE_IGNORED))
+    def test_rule_not_globally_ignored(self, rule: str) -> None:
+        setting = _global_rules().get(rule)
+        assert setting != "ignore", (
+            f"`{rule}` has been added back to [tool.ty.rules] as 'ignore'. "
+            f"It guards {MUST_NOT_BE_IGNORED[rule]}. Silencing it globally makes the "
+            f"gate pass while the property it protects is unenforced. Scope the "
+            f"suppression to the offending file with `# ty: ignore[{rule}]`, or relax "
+            f"it for a path in [[tool.ty.overrides]], rather than disabling it here."
+        )
+
+    def test_ty_task_resolves_the_environment(self) -> None:
+        """Without ``--python`` ty resolves no third-party import.
+
+        param, panel, numpy and xarray all read as unresolved, which silently degrades
+        every rule that needs a third-party type. The task must therefore point ty at
+        the active environment.
+        """
+        task = _load_ty_task()
+        assert "--python" in task, (
+            "the `ty` pixi task no longer passes --python, so ty will type-check with "
+            "no third-party packages resolved. Every rule that depends on knowing an "
+            'external type degrades silently. Restore --python "$CONDA_PREFIX".'
+        )
+
+    def test_strict_override_block_is_non_empty(self) -> None:
+        """The Tier-C ratchet must actually cover something.
+
+        Plan 23 couples "constructively modeled" to "strictly checked": each phase adds
+        the files it reworked. An empty list means the ratchet has been disengaged.
+        """
+        overrides = _ty_config().get("overrides", [])
+        strict = [o for o in overrides if any(v == "error" for v in o.get("rules", {}).values())]
+        assert strict, "no [[tool.ty.overrides]] block sets any rule to 'error'"
+        covered = [path for block in strict for path in block.get("include", [])]
+        assert covered, "the strict override block covers no files"
+
+
+def _load_ty_task() -> str:
+    with PYPROJECT.open("rb") as fh:
+        tasks = tomllib.load(fh)["tool"]["pixi"]["tasks"]
+    task = tasks["ty"]
+    return task["cmd"] if isinstance(task, dict) else task
+
+
+@pytest.mark.skipif(shutil.which("ty") is None, reason="ty binary not on PATH")
+class TestGateActuallyFires:
+    """End-to-end proof that the configured gate rejects real violations.
+
+    Configuration assertions above can pass while the checker itself is misconfigured,
+    so these run ty against seeded violations. They deliberately use a *minimal
+    standalone* config rather than the repo's: under the repo config the Tier-C rules
+    are ignored and a seeded probe passes, which is exactly the trap that made the
+    original measurements for this plan wrong.
+    """
+
+    @staticmethod
+    def _run_ty(tmp_path: Path, source: str) -> str:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "probe"\nversion = "0"\nrequires-python = ">=3.11"\n'
+        )
+        probe = tmp_path / "probe.py"
+        probe.write_text(source)
+        result = subprocess.run(
+            ["ty", "check", "--python", sys.prefix, str(probe)],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            check=False,
+        )
+        return result.stdout + result.stderr
+
+    def test_non_exhaustive_match_is_rejected(self, tmp_path: Path) -> None:
+        output = self._run_ty(
+            tmp_path,
+            """
+from enum import Enum, auto
+from typing import assert_never
+
+
+class Kind(Enum):
+    A = auto()
+    B = auto()
+    C = auto()
+
+
+def handle(k: Kind) -> str:
+    match k:
+        case Kind.A:
+            return "a"
+        case Kind.B:
+            return "b"
+        case _ as unreachable:
+            assert_never(unreachable)
+""",
+        )
+        assert "type-assertion-failure" in output, (
+            "ty did not reject a match missing one enum member. The exhaustiveness "
+            f"mechanism plan 23 D2 relies on is not working. Output:\n{output}"
+        )
+        assert "Kind.C" in output, (
+            "ty flagged the incomplete match but did not name the missing variant, "
+            f"which is what makes the diagnostic actionable. Output:\n{output}"
+        )
+
+    def test_exhaustive_match_is_accepted(self, tmp_path: Path) -> None:
+        """Guards against a gate that rejects everything (which would be equally useless)."""
+        output = self._run_ty(
+            tmp_path,
+            """
+from enum import Enum, auto
+from typing import assert_never
+
+
+class Kind(Enum):
+    A = auto()
+    B = auto()
+
+
+def handle(k: Kind) -> str:
+    match k:
+        case Kind.A:
+            return "a"
+        case Kind.B:
+            return "b"
+        case _ as unreachable:
+            assert_never(unreachable)
+""",
+        )
+        assert "All checks passed" in output, (
+            f"ty rejected a complete match, so the gate has false positives:\n{output}"
+        )


### PR DESCRIPTION
Implements **plan 23 P1** — the enforcement floor. Follows #1025 (the 3.11 floor), which
was its prerequisite.

## Summary

Enables the 9 Tier-A `ty` rules globally, adds the relaxed/strict override structure from
plan 23 D1, and adds meta-tests so the gate cannot silently regress to a no-op again.

**The gate was worse than "21 rules ignored".** The task ran `ty check` with no `--python`,
so *every* third-party import was unresolved — `param`, `panel`, `numpy`, `xarray`. That is
why `unresolved-import` had to be ignored globally, and it silently degraded every rule
that needs a third-party type. The task now passes `--python "$CONDA_PREFIX"`, resolving
the *active* environment so `-e py311` and `-e py313` each check against their own
interpreter. Every per-rule count in plan 23 §2.1 is only reproducible with that flag.

All 17 Tier-A diagnostics are **fixed rather than suppressed**, except two scoped
`# ty: ignore` comments with inline reasons: the optional `scoop` import (its
`try/except ImportError` *is* the handling) and `signal.getsignal` (ty cannot narrow an
`IntEnum` by identity against specific members).

## Latent bugs fixed on the way

| Fix | Why it mattered |
|---|---|
| `hv_dataset: hv.Dataset = None` → `\| None` | The annotation contradicted its own default |
| `plot_callback` narrowed `Callable \| None` → `Callable` | Both `_to_panes_da` and `_to_video_panes_ds` call it unguarded, so `None` was unanswerable. All four call sites already pass a real callable |
| `extra_panels` discriminated by `isinstance(ep, Viewable)` instead of `callable()` | `callable()` cannot exclude the `Viewable` arm — a `Viewable` defining `__call__` would have been **called instead of appended** |
| `ExampleEnum.to_class` parameter widened to `ClassEnum` | It narrowed a base-class parameter — an LSP violation |
| `options(self, *_args)` → `*_args, **_kwargs` | Did not match tornado's `RequestHandler.options` |
| `agg_callable` branch tests the callable | Was re-deriving `needs_agg`; the correlation is now structural, not duplicated |
| `ResultCollector.__enter__` → `Self` | The 3.10-era workaround #1025 unblocked |

## The exhaustiveness exemplar

`_resolve_auto` now returns `ResolvedReduceType` — a `Literal` over the four non-`AUTO`
members — so `to_dataset`'s `match` is exhaustive **by construction** and its
`assert_never` arm is provably dead rather than a catch-all. Proven both ways: forcing
`invalid-return-type` on shows the narrowing genuinely holds, and deleting one arm yields

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
    |  Inferred type of argument is `Literal[ReduceType.MINMAX]`
```

naming the forgotten variant.

## Plan 24 was confirmed by this PR breaking on it

Converting the catch-all to `assert_never` turned **two green tests red** with
`AssertionError: Expected code to be unreachable, but got: None`. `map_plot_panes` declares
`reduce: ReduceType | None = None` and passed that `None` into `to_dataset`, whose
annotation says `ReduceType`; the old `case _:` had been absorbing it. That is exactly plan
24 §2.1 — a *complete* match is type-clean while raising at runtime, because the subject's
type was never established.

**A behaviour discrepancy fell out and is deliberately NOT fixed here.** `reduce=None`
reaching the catch-all meant `ReduceType.NONE`, whereas `to_hv_dataset`'s own default is
`ReduceType.AUTO` — so `map_plot_panes(cb)` has always **skipped reduction rather than
averaging over repeats**. This PR normalizes `None` → `NONE` at the boundary to preserve
today's behaviour exactly; correcting the default changes rendering output and needs a
phase that can own it. (Compare `BenchResult.to()`, which handles the same sentinel
correctly by omitting the argument.)

## Scope discipline

`identity.py` was pulled back **off** the strict list rather than loosening the block,
honouring its own rule that a file is added only once it is clean. It passes
`list | dict | None` to `plot_sweep`, annotated `list[ParametrizedSweep] | None` — and the
*annotation* is the wrong one, since `convert_vars_to_params` accepts
`Parameter | str | dict | tuple`. Widening a public entry point is A5's business. Initial
strict members: `sample_order.py`, `sweep_timings.py`, `blob_store.py`.

## Test plan

- `pixi run ci` green on the default env: **2417 passed, 3 skipped, 90% coverage** (gate 85%)
- `pixi run -e py311 ty` → `All checks passed!`; `pixi run -e py313` likewise via `ci`
- New `test/test_ty_gate.py` — 14 tests, green on both py311 and py313:
  - `type-assertion-failure` and all 9 Tier-A rules asserted absent from the global ignore list
  - the `--python` flag asserted present, with a message explaining what breaks without it
  - the strict ratchet asserted non-empty
  - two subprocess probes proving ty *actually* rejects a non-exhaustive match (naming the
    missing variant) and *accepts* a complete one, so the gate has neither false negatives
    nor false positives. These use a minimal standalone config on purpose: under the repo
    config the Tier-C rules are ignored and a seeded probe passes clean — the exact trap
    that made this plan's first measurements wrong.

## Review notes

- Plan 23 gains a §10 recording all of the above, per the house convention plan 22 uses.
- The two `cast()` calls in `bench_runner.py` are honest-but-unverified by design:
  `Benchable` is discriminated by `inspect.signature` parameter count, which no checker can
  narrow, so the cast states the arm the introspection established. This is the shape plan
  24 warns about.
- Next phase is P2 (collection-path live bugs B2/B3 plus C13 executor normalization), which
  plan 24 amends with a boundary-normalization precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen and formalize the `ty` type-checking gate by enforcing Tier-A diagnostics, making exhaustiveness checks real, and adding meta-tests and plan documentation so regressions in type-check coverage are prevented.

New Features:
- Introduce a strict type-checking ratchet for selected modules that enables Tier-C `ty` rules as errors once files are clean.
- Add meta-tests that validate the `ty` configuration, environment resolution, and exhaustiveness behavior so the type-check gate itself is tested end-to-end.

Bug Fixes:
- Ensure `ty` runs against the active pixi environment using `--python "$CONDA_PREFIX"` so third-party imports and types are correctly resolved.
- Make match handling over `ReduceType` exhaustive and correct by using a narrowed literal return type, an `assert_never` arm, and explicit handling of the `None` sentinel.
- Align several function signatures and annotations with their actual usage and intended contracts, including `hv_dataset` optionality, `plot_callback` non-nullability, request handler `options` parameters, `ExampleEnum.to_class` input type, optuna aggregation callable semantics, and `ResultCollector.__enter__` return type.
- Fix `extra_panels` dispatch so viewable panels are appended and non-viewable callables are invoked, avoiding incorrect calls on callable `Viewable` instances.
- Handle optional `scoop` imports and `signal` handlers with scoped `ty` ignores instead of global rule suppression.

Enhancements:
- Restructure `ty` rule configuration into cost-based tiers, permanently ignored rules, relaxed paths, and strict per-file overrides to support phased tightening of type checks.
- Update plan 23 documentation with an amendments section capturing configuration changes, discovered inconsistencies, and confirmed interactions with plan 24.
- Use explicit casts in bench execution to document protocol discrimination by runtime introspection rather than relying on unchecked unions.

Tests:
- Add `test/test_ty_gate.py` to assert Tier-A and exhaustiveness rules are not globally ignored, that `ty` uses the correct environment, that the strict override block is non-empty, and that seeded exhaustive/non-exhaustive matches are treated correctly by `ty`.