### PR TITLE
fix: surface render failures instead of only logging them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ResultDataSet` with `over_time`.
 
 ### Changed
+- **A plot that fails to render now leaves a visible mark instead of vanishing.** Report
+  building stays best-effort — one bad plot still never aborts a whole report — but the
+  failure was previously recorded with `logger.exception` and nothing else. Loggers are off
+  by default in library use, so a report could be written *missing whole plots* while every
+  caller-visible signal still said success: no warning, a zero exit code, and an HTML file
+  that looks complete unless you already know which plot should have been there.
+
+  Each swallowed failure now leaves two marks: a `bencher.RenderFailedWarning`, so an
+  embedding test runner (pytest's warnings summary, `-W error`) sees it without configuring
+  logging; and a pane in the report naming what failed and why, so the gap is legible to
+  whoever opens the HTML. The `logger` call is kept for callers already capturing it, though
+  render-failure records now come from the `bencher.results.render_failure` logger rather
+  than from each calling module's logger — code filtering on
+  `bencher.results.bench_result` to catch plot failures should filter on the new name.
+
+  Applied to every best-effort render site: plot plugins, legacy plot callbacks, and
+  user-injected `extra_panels` in `to_auto`/`to_auto_plots`; regression overlays; and the
+  optuna analysis plots, which previously hand-rolled their own differently-formatted
+  failure pane and are now unified on the shared helper.
+
+  Reports that were silently short will now show these panes. That is the point — but a
+  caller whose test run cannot tolerate the new warning can silence that half of it (the
+  report pane is not affected):
+
+  ```python
+  import warnings
+  import bencher as bn
+  warnings.filterwarnings("ignore", category=bn.RenderFailedWarning)
+  ```
+
 - **BREAKING: a `ResultDataSet` dataset cell holds a blob path string, not an index.**
   Cells were `int` indices into `BenchResult.dataset_list`, valid only inside the process
   that produced them; they are now absolute `str` paths into the blob store, so any process

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -179,6 +179,7 @@ from .regression import (
 from .results.bench_result import BenchResult
 from .results.optimize_result import OptimizeResult
 from .results.pane_result import PaneResult
+from .results.render_failure import RenderFailedWarning
 from .sample_order import SampleOrder
 from .variables.parametrised_sweep import ParametrizedSweep
 from .variables.singleton_parametrized_sweep import ParametrizedSweepSingleton

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -9,6 +9,7 @@ import param
 # NOTE: `optuna.visualization` pulls in sklearn's fANOVA evaluator (~3s at
 # import). It is only needed by param_importance(), so import it lazily there.
 from bencher.bench_cfg import BenchCfg
+from bencher.results.render_failure import report_render_failure
 from bencher.variables.inputs import BoolSweep, EnumSweep, FloatSweep, IntSweep, StringSweep
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.time import TimeEvent, TimeSnapshot
@@ -166,13 +167,12 @@ def cfg_from_optuna_trial(
 
 
 def _append_safe(row, plot_fn, *args, **kwargs):
-    """Append a plot to *row*, logging any exception instead of propagating."""
+    """Append a plot to *row*, surfacing any exception instead of propagating."""
     try:
         row.append(plot_fn(*args, **kwargs))
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         fn_name = getattr(plot_fn, "__name__", str(plot_fn))
-        logger.exception("Optuna plot %s failed", fn_name)
-        row.append(pn.pane.Markdown(f"**Plot failed** (`{fn_name}`): {e}"))
+        row.append(report_render_failure(f"Optuna plot '{fn_name}'", exc))
 
 
 def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
@@ -182,7 +182,6 @@ def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
         if hasattr(fig, "update_layout"):
             fig.update_layout(width=width)
         row.append(fig)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         fn_name = getattr(plot_fn, "__name__", str(plot_fn))
-        logger.exception("Optuna plot %s failed", fn_name)
-        row.append(pn.pane.Markdown(f"**Plot failed** (`{fn_name}`): {e}"))
+        row.append(report_render_failure(f"Optuna plot '{fn_name}'", exc))

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -444,8 +444,10 @@ class BenchResult(
                     continue
                 try:
                     plot_cols.append(pn.pane.HoloViews(r.render_overlay()))
-                except Exception:  # pylint: disable=broad-except
-                    logger.exception("Failed to render regression overlay for %s", r.variable)
+                except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                    plot_cols.append(
+                        report_render_failure(f"Regression overlay for '{r.variable}'", exc)
+                    )
 
         # --- Extra panels (user-injected) ---
         if extra_panels:

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -323,12 +323,12 @@ class BenchResult(
         ):
             try:
                 row.append(plugin.render(data))
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 row.append(report_render_failure(f"Plot plugin '{plugin.name}'", exc))
         for plot_callback in extra_callbacks:
             try:
                 row.append(plot_callback(self, override=override, **kwargs))
-            except Exception as exc:  # pylint: disable=broad-except
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 row.append(report_render_failure(f"Plot callback '{plot_callback.__name__}'", exc))
 
         self.plt_cnt_cfg.print_debug = True
@@ -455,7 +455,7 @@ class BenchResult(
                         plot_cols.append(ep(self))
                     else:
                         plot_cols.append(ep)
-                except Exception as exc:  # pylint: disable=broad-except
+                except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                     name = getattr(ep, "__name__", repr(ep))
                     plot_cols.append(report_render_failure(f"Extra panel '{name}'", exc))
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -8,6 +8,7 @@ import panel as pn
 from param import Parameter
 
 from bencher.results.bench_result_base import EmptyContainer, ReduceType
+from bencher.results.render_failure import report_render_failure
 
 try:
     from bencher.results.rerun_result import RerunResult
@@ -322,13 +323,13 @@ class BenchResult(
         ):
             try:
                 row.append(plugin.render(data))
-            except Exception:  # pylint: disable=broad-except
-                logger.exception("Plot plugin %s failed", plugin.name)
+            except Exception as exc:  # pylint: disable=broad-except
+                row.append(report_render_failure(f"Plot plugin '{plugin.name}'", exc))
         for plot_callback in extra_callbacks:
             try:
                 row.append(plot_callback(self, override=override, **kwargs))
-            except Exception:  # pylint: disable=broad-except
-                logger.exception("Plot callback %s failed", plot_callback.__name__)
+            except Exception as exc:  # pylint: disable=broad-except
+                row.append(report_render_failure(f"Plot callback '{plot_callback.__name__}'", exc))
 
         self.plt_cnt_cfg.print_debug = True
         if len(row.pane) == 0:
@@ -454,9 +455,9 @@ class BenchResult(
                         plot_cols.append(ep(self))
                     else:
                         plot_cols.append(ep)
-                except Exception:  # pylint: disable=broad-except
+                except Exception as exc:  # pylint: disable=broad-except
                     name = getattr(ep, "__name__", repr(ep))
-                    logger.exception("Extra panel %s failed", name)
+                    plot_cols.append(report_render_failure(f"Extra panel '{name}'", exc))
 
         # --- Dimension aggregation (orthogonal to over_time) ---
         if self.bench_cfg.agg_over_dims and self.bench_cfg.show_aggregate_plots:

--- a/bencher/results/render_failure.py
+++ b/bencher/results/render_failure.py
@@ -1,0 +1,53 @@
+"""Surfacing for render failures that must not silently shrink a report.
+
+A plot that raises used to be recorded with ``logger.exception`` and nothing
+else.  Loggers are off by default in library use, so the report was written
+*missing whole plots* while every caller-visible signal still said success: no
+warning, a zero exit code, and an HTML file that looks complete unless you
+already know which plot should have been there.
+
+Every failure now leaves two marks instead of one:
+
+* a :mod:`warnings` warning, so an embedding test runner (pytest's warnings
+  summary, ``-W error``) sees it without configuring logging;
+* a visible pane in the report itself, so the gap is legible to whoever opens
+  the HTML rather than only to whoever re-runs it.
+
+The logger call is kept for callers that already capture it.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+import warnings
+
+import panel as pn
+
+logger = logging.getLogger(__name__)
+
+
+class RenderFailedWarning(UserWarning):
+    """A plot could not be rendered; the report is missing it."""
+
+
+def report_render_failure(what: str, exc: BaseException) -> pn.pane.Markdown:
+    """Log, warn about, and build a visible pane for a failed render of *what*.
+
+    Returns the pane to append in place of the plot that failed, so a caller can
+    keep rendering the rest of the report.
+    """
+    logger.exception("%s failed", what)
+    warnings.warn(
+        f"{what} failed to render ({type(exc).__name__}: {exc}); the report is missing this plot",
+        RenderFailedWarning,
+        stacklevel=3,
+    )
+    detail = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    return pn.pane.Markdown(
+        f"### ⚠️ {what} failed to render\n\n"
+        f"```\n{detail}\n```\n\n"
+        "The rest of this report rendered normally. This pane marks a plot that "
+        "is missing, so an incomplete report cannot be mistaken for a complete one.",
+        name=f"{what} (failed)",
+    )

--- a/bencher/results/render_failure.py
+++ b/bencher/results/render_failure.py
@@ -36,8 +36,13 @@ def report_render_failure(what: str, exc: BaseException) -> pn.pane.Markdown:
 
     Returns the pane to append in place of the plot that failed, so a caller can
     keep rendering the rest of the report.
+
+    The traceback comes from *exc* rather than from the ambient
+    ``sys.exc_info()``, so a caller that has already left its ``except`` block
+    (or never had one) still gets the real traceback in the log instead of
+    ``NoneType: None``.
     """
-    logger.exception("%s failed", what)
+    logger.error("%s failed", what, exc_info=exc)
     warnings.warn(
         f"{what} failed to render ({type(exc).__name__}: {exc}); the report is missing this plot",
         RenderFailedWarning,

--- a/bencher/run.py
+++ b/bencher/run.py
@@ -12,6 +12,7 @@ from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any
 
 from bencher.bench_cfg import BenchCfg, BenchRunCfg, ShowMode, normalize_show
+from bencher.results.render_failure import report_render_failure
 from bencher.utils import UNSET
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
@@ -197,11 +198,8 @@ def run(
                 for res in bench.results:
                     try:
                         bench.report.append_to_result(res, res.to_optuna_plots())
-                    except Exception as e:  # pylint: disable=broad-except
-                        logger.exception("Optuna plot generation failed")
-                        bench.report.append(
-                            _pn.pane.Markdown(f"**Optuna plot generation failed**: {e}")
-                        )
+                    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                        bench.report.append(report_render_failure("Optuna plot generation", exc))
             return bench
 
         _with_optimise.__name__ = getattr(_original_target, "__name__", "optimised")

--- a/test/test_bench_result.py
+++ b/test/test_bench_result.py
@@ -125,10 +125,12 @@ class TestBenchResultToAuto(unittest.TestCase):
         self.assertIn("No Plotters are able to represent these results", panes[0].object)
 
     def test_to_auto_failing_callback_surfaced_not_raised(self):
-        with self.assertLogs(level="ERROR") as captured:
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                panes = self.res.to_auto(plot_list=[_failing_cb, LineResult.to_plot])
+        with (
+            self.assertLogs(level="ERROR") as captured,
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            panes = self.res.to_auto(plot_list=[_failing_cb, LineResult.to_plot])
         self.assertTrue(any("_failing_cb" in msg for msg in captured.output))
         # A failure warns, so a caller that never configured logging still sees it.
         self.assertTrue(

--- a/test/test_bench_result.py
+++ b/test/test_bench_result.py
@@ -1,6 +1,7 @@
 """Tests for BenchResult container behavior (bencher/results/bench_result.py)."""
 
 import unittest
+import warnings
 
 import numpy as np
 import panel as pn
@@ -8,6 +9,7 @@ import panel as pn
 import bencher as bn
 from bencher.results.bench_result import BenchResult
 from bencher.results.holoview_results.line_result import LineResult
+from bencher.results.render_failure import RenderFailedWarning
 
 
 class Linear(bn.ParametrizedSweep):
@@ -122,13 +124,26 @@ class TestBenchResultToAuto(unittest.TestCase):
         self.assertIsInstance(panes[0], pn.pane.Markdown)
         self.assertIn("No Plotters are able to represent these results", panes[0].object)
 
-    def test_to_auto_failing_callback_logged_not_raised(self):
+    def test_to_auto_failing_callback_surfaced_not_raised(self):
         with self.assertLogs(level="ERROR") as captured:
-            panes = self.res.to_auto(plot_list=[_failing_cb, LineResult.to_plot])
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                panes = self.res.to_auto(plot_list=[_failing_cb, LineResult.to_plot])
         self.assertTrue(any("_failing_cb" in msg for msg in captured.output))
-        # The failing callback is skipped but the working one still renders.
-        self.assertEqual(len(panes), 1)
+        # A failure warns, so a caller that never configured logging still sees it.
+        self.assertTrue(
+            any(issubclass(w.category, RenderFailedWarning) for w in caught),
+            "expected a RenderFailedWarning for the failing callback",
+        )
+        # The working callback still renders, and the failure leaves a visible
+        # marker in its place rather than silently shrinking the report.
+        self.assertEqual(len(panes), 2)
         self.assertGreater(len(collect_hv_elements(panes)), 0)
+        markers = [p for p in panes if isinstance(p, pn.pane.Markdown)]
+        self.assertTrue(
+            any("_failing_cb" in m.object and "failed to render" in m.object for m in markers),
+            "expected a visible failure pane naming the failing callback",
+        )
 
 
 class TestBenchResultToAutoPlots(unittest.TestCase):

--- a/test/test_extra_panels.py
+++ b/test/test_extra_panels.py
@@ -1,9 +1,11 @@
 import unittest
+import warnings
 
 import panel as pn
 
 import bencher as bn
 from bencher.example.meta.example_meta import BenchableObject
+from bencher.results.render_failure import RenderFailedWarning
 
 
 class TestExtraPanels(unittest.TestCase):
@@ -55,21 +57,36 @@ class TestExtraPanels(unittest.TestCase):
         # Should be before the last element (post_description)
         self.assertLess(idx, len(plots) - 1)
 
-    def test_extra_panels_callable_error_is_caught(self):
-        """A failing callable logs the error and does not crash to_auto_plots."""
+    def test_extra_panels_callable_error_is_surfaced(self):
+        """A failing callable is surfaced, and does not crash to_auto_plots."""
         res = self._make_result()
 
         def bad_panel(_bench_res):
             raise RuntimeError("boom")
 
-        # Should not raise; the error is logged and skipped.
-        with self.assertLogs(level="ERROR") as cm:
+        # Should not raise; the failure is logged, warned about, and marked in place.
+        with (
+            self.assertLogs(level="ERROR") as cm,
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
             plots = res.to_auto_plots(extra_panels=[bad_panel])
 
-        # The broken panel is omitted, but the rest of the output is still produced.
+        # The rest of the output is still produced.
         self.assertGreater(len(plots), 0)
         # Verify the error was actually logged.
         self.assertTrue(any("bad_panel" in msg for msg in cm.output))
+        # A caller that never configured logging still sees the failure.
+        self.assertTrue(
+            any(issubclass(w.category, RenderFailedWarning) for w in caught),
+            "expected a RenderFailedWarning for the failing panel",
+        )
+        # The broken panel leaves a visible marker rather than vanishing.
+        objs = [str(getattr(p, "object", "")) for p in plots]
+        self.assertTrue(
+            any("bad_panel" in o and "failed to render" in o for o in objs),
+            "expected a visible failure pane naming the failing panel",
+        )
 
     def test_extra_panels_in_plot_callback(self):
         """extra_panels works when used inside a named plot_callbacks function."""

--- a/test/test_plugins_builtins.py
+++ b/test/test_plugins_builtins.py
@@ -2,6 +2,7 @@
 (A1 Phase 2: built-ins wrapped as plugins, no renderer logic changes)."""
 
 import unittest
+import warnings
 
 import panel as pn
 
@@ -15,6 +16,7 @@ from bencher.plugins.builtins import (
 )
 from bencher.results.bench_result import BenchResult
 from bencher.results.holoview_results.line_result import LineResult
+from bencher.results.render_failure import RenderFailedWarning
 
 BUILTIN_ORDER = ["bar", "box_whisker", "curve", "line", "heatmap", "histogram", "volume", "panes"]
 
@@ -244,15 +246,30 @@ class TestUserPluginsInToAuto(unittest.TestCase):
         finally:
             unregister_plugin("line", backend="alt")
 
-    def test_failing_user_plugin_logged_not_raised(self):
+    def test_failing_user_plugin_surfaced_not_raised(self):
         @plot_plugin(name="user.extra")
         def _boom(_: BenchData) -> pn.viewable.Viewable:
             raise RuntimeError("intentional plugin failure")
 
-        with self.assertLogs(level="ERROR") as captured:
+        with (
+            self.assertLogs(level="ERROR") as captured,
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
             panes = self.res.to_auto()
         self.assertTrue(any("user.extra" in msg for msg in captured.output))
         self.assertGreater(len(panes), 0)
+        # A caller that never configured logging still sees the failure.
+        self.assertTrue(
+            any(issubclass(w.category, RenderFailedWarning) for w in caught),
+            "expected a RenderFailedWarning for the failing plugin",
+        )
+        # The failed plugin leaves a visible marker rather than vanishing.
+        objs = [str(getattr(p, "object", "")) for p in panes]
+        self.assertTrue(
+            any("user.extra" in o and "failed to render" in o for o in objs),
+            "expected a visible failure pane naming the failing plugin",
+        )
 
 
 class TestNamedOnlyPlugins(unittest.TestCase):

--- a/test/test_render_failure_visibility.py
+++ b/test/test_render_failure_visibility.py
@@ -25,6 +25,28 @@ def _working_plot(_res, **_kwargs):
     return pn.pane.Markdown("WORKING_PLOT")
 
 
+def _raise_overlay_failure(*_args, **_kwargs):
+    raise RuntimeError("synthetic overlay failure")
+
+
+def _already_handled_exception() -> ValueError:
+    """An exception whose ``except`` block has been left, so ``sys.exc_info()`` is clear."""
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        return exc
+
+
+class _OverTimeSweep(bn.ParametrizedSweep):
+    """Categorical input over time — gives the regression report some history."""
+
+    endpoint = bn.StringSweep(["a", "b"], doc="endpoint")
+    latency = bn.ResultFloat(units="ms", direction=bn.OptDir.minimize)
+
+    def benchmark(self):
+        self.latency = 10.0 if self.endpoint == "a" else 20.0
+
+
 class Sweep(bn.ParametrizedSweep):
     x = bn.FloatSweep(default=0, bounds=[0, 2])
     y = bn.ResultFloat()
@@ -110,6 +132,80 @@ class TestReportRenderFailureHelper(unittest.TestCase):
             warnings.simplefilter("always")
             report_render_failure("Thing 'y'", ValueError("boom"))
         self.assertTrue(any("Thing 'y'" in m for m in captured.output))
+
+    def test_logged_traceback_comes_from_the_exception(self):
+        """The traceback must not depend on the caller still being in ``except``.
+
+        The helper takes the exception explicitly, so it is legitimate to call it
+        after the ``except`` block has been left. Deriving the traceback from the
+        ambient ``sys.exc_info()`` instead logs a bare "no exception" placeholder
+        with no traceback header at all.
+        """
+        exc = _already_handled_exception()
+        with (
+            self.assertLogs(level="ERROR") as captured,
+            warnings.catch_warnings(record=True),
+        ):
+            warnings.simplefilter("always")
+            report_render_failure("Thing 'z'", exc)
+        joined = "\n".join(captured.output)
+        self.assertIn("ValueError: boom", joined)
+        # Only a real traceback renders this header; the sys.exc_info() fallback
+        # would emit a placeholder line instead.
+        self.assertIn("Traceback (most recent call last)", joined)
+
+    def test_warning_is_publicly_importable(self):
+        """Filtering the warning is the point, so the class must be public API."""
+        self.assertIs(bn.RenderFailedWarning, RenderFailedWarning)
+
+
+class TestRegressionOverlayFailureIsVisible(unittest.TestCase):
+    """The regression overlay shares ``to_auto_plots``' best-effort contract.
+
+    It sits ten lines above the ``extra_panels`` handler in the same function and
+    had the same silent-skip problem: a regression overlay that raised vanished
+    from the report with no caller-visible signal.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        run_cfg = bn.BenchRunCfg()
+        run_cfg.over_time = True
+        run_cfg.regression_detection = True
+        run_cfg.auto_plot = False
+        run_cfg.headless = True
+        bench = bn.Bench("render_failure_overlay", _OverTimeSweep(), run_cfg=run_cfg)
+        for i in range(2):
+            run_cfg.clear_history = i == 0
+            run_cfg.clear_cache = True
+            bench.plot_sweep(
+                input_vars=["endpoint"],
+                result_vars=["latency"],
+                run_cfg=run_cfg,
+                time_src=f"2026-0{i + 1}-01 renderfail{i}",
+            )
+        cls.res = bench.results[-1]
+
+    def test_failing_overlay_warns_and_leaves_a_visible_pane(self):
+        report = self.res.regression_report
+        self.assertIsNotNone(report, "fixture should produce a regression report")
+        for r in report.results:
+            self.assertIsNotNone(r.historical, "fixture needs history for the overlay path")
+            r.render_overlay = _raise_overlay_failure
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            panel = self.res.to_auto_plots()
+
+        msgs = [str(w.message) for w in caught if issubclass(w.category, RenderFailedWarning)]
+        self.assertTrue(msgs, "expected a RenderFailedWarning for the failing overlay")
+        self.assertIn("synthetic overlay failure", " ".join(msgs))
+        self.assertIsNotNone(panel, "one bad overlay must not abort the report")
+        objs = [str(getattr(p, "object", "")) for p in panel]
+        self.assertTrue(
+            any("Regression overlay" in o and "failed to render" in o for o in objs),
+            "expected a visible failure pane naming the failing overlay",
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_render_failure_visibility.py
+++ b/test/test_render_failure_visibility.py
@@ -1,0 +1,114 @@
+"""A plot that fails to render must leave a mark the caller can see.
+
+``to_auto`` catches every plugin/callback failure so one bad plot cannot abort a
+whole report. That is the right call, but recording it with ``logger.exception``
+alone made it invisible: loggers are off by default in library use, so the report
+was written *missing plots* while every caller-visible signal still said success
+— no warning, a zero exit code, and an HTML file that looks complete unless you
+already know which plot should have been there.
+"""
+
+import unittest
+import warnings
+
+import panel as pn
+
+import bencher as bn
+from bencher.results.render_failure import RenderFailedWarning, report_render_failure
+
+
+def _failing_plot(_res, **_kwargs):
+    raise RuntimeError("synthetic plot failure")
+
+
+def _working_plot(_res, **_kwargs):
+    return pn.pane.Markdown("WORKING_PLOT")
+
+
+class Sweep(bn.ParametrizedSweep):
+    x = bn.FloatSweep(default=0, bounds=[0, 2])
+    y = bn.ResultFloat()
+
+    def __call__(self, **kwargs):
+        self.update_params_from_kwargs(**kwargs)
+        self.y = self.x * 2
+        return self.get_results_values_as_dict()
+
+
+def _sweep_result():
+    bench = bn.Bench("render_failure_visibility", Sweep())
+    return bench.plot_sweep(
+        "vis",
+        input_vars=[Sweep.param.x],
+        result_vars=[Sweep.param.y],
+        run_cfg=bn.BenchRunCfg(repeats=1, cache_samples=False),
+        plot_callbacks=False,
+    )
+
+
+class TestFailureIsVisible(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.res = _sweep_result()
+
+    def _to_auto(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            panes = self.res.to_auto(plot_list=[_failing_plot, _working_plot])
+        return panes, caught
+
+    def test_failure_warns(self):
+        """A warning reaches a test runner that never configured logging."""
+        _, caught = self._to_auto()
+        msgs = [str(w.message) for w in caught if issubclass(w.category, RenderFailedWarning)]
+        self.assertTrue(msgs, "expected a RenderFailedWarning")
+        self.assertIn("synthetic plot failure", " ".join(msgs))
+
+    def test_failure_leaves_a_visible_pane(self):
+        """The gap is legible to whoever opens the HTML, not only whoever re-runs it."""
+        panes, _ = self._to_auto()
+        markers = [p for p in panes if isinstance(p, pn.pane.Markdown)]
+        self.assertTrue(
+            any("failed to render" in m.object for m in markers),
+            "expected a visible failure pane",
+        )
+        self.assertTrue(
+            any("_failing_plot" in m.object for m in markers),
+            "failure pane should name what failed",
+        )
+
+    def test_working_plot_still_renders(self):
+        """One failure must not cost the plots that did work."""
+        panes, _ = self._to_auto()
+        objs = [getattr(p, "object", "") for p in panes]
+        self.assertIn("WORKING_PLOT", objs)
+
+    def test_failure_does_not_raise(self):
+        """Unchanged contract: a bad plot never aborts the report."""
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            self.res.to_auto(plot_list=[_failing_plot])
+
+
+class TestReportRenderFailureHelper(unittest.TestCase):
+    def test_helper_warns_and_returns_a_pane(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pane = report_render_failure("Thing 'x'", ValueError("boom"))
+        self.assertIsInstance(pane, pn.pane.Markdown)
+        self.assertIn("Thing 'x'", pane.object)
+        self.assertIn("boom", pane.object)
+        self.assertEqual(1, len(caught))
+        self.assertTrue(issubclass(caught[0].category, RenderFailedWarning))
+
+    def test_helper_still_logs(self):
+        """Callers already capturing the logger keep working."""
+        with self.assertLogs(level="ERROR") as captured:
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                report_render_failure("Thing 'y'", ValueError("boom"))
+        self.assertTrue(any("Thing 'y'" in m for m in captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_render_failure_visibility.py
+++ b/test/test_render_failure_visibility.py
@@ -103,10 +103,12 @@ class TestReportRenderFailureHelper(unittest.TestCase):
 
     def test_helper_still_logs(self):
         """Callers already capturing the logger keep working."""
-        with self.assertLogs(level="ERROR") as captured:
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter("always")
-                report_render_failure("Thing 'y'", ValueError("boom"))
+        with (
+            self.assertLogs(level="ERROR") as captured,
+            warnings.catch_warnings(record=True),
+        ):
+            warnings.simplefilter("always")
+            report_render_failure("Thing 'y'", ValueError("boom"))
         self.assertTrue(any("Thing 'y'" in m for m in captured.output))
 
 


### PR DESCRIPTION
## Problem

`to_auto` catches every plugin/callback failure so one bad plot cannot abort a whole report. That is the right call — but the failure was recorded with `logger.exception` and nothing else. Loggers are off by default in library use, so the report gets written **missing whole plots** while every caller-visible signal still says success: no warning, a zero exit code, and an HTML file that looks complete unless you already know which plot should have been there.

I hit this downstream: a benchmark's published report lost **both** its headline scatter and its rerun recording. CI was green, the pytest warnings summary was clean, and the out-of-process renderer exited 0. The only record of the failure was a log line nobody was capturing — so from the outside it was indistinguishable from "that plot was never configured".

The report is the artifact people actually read. A silently short one is worse than a loud failure.

## Change

Every failure now leaves two marks instead of one:

- a **`RenderFailedWarning`**, so an embedding test runner (pytest's warnings summary, `-W error`) sees it without configuring logging;
- a **visible pane in the report**, naming what failed and the exception, so the gap is legible to whoever opens the HTML rather than only to whoever re-runs it.

The `logger.exception` call is kept for callers already capturing it, and the swallowing contract is unchanged: one bad plot still never aborts a whole report.

Applied to all three handlers in `to_auto` / `to_auto_plots`: plot plugins, legacy plot callbacks, and user-injected `extra_panels`.

New `bencher/results/render_failure.py` holds the shared helper and the warning class.

## Tests

- `test/test_render_failure_visibility.py` — new: a failure warns, leaves a named visible pane, does not raise, and does not cost the plots that did work; plus the helper's own contract (warns, returns a pane, still logs).
- `test/test_bench_result.py` — `test_to_auto_failing_callback_logged_not_raised` renamed to `..._surfaced_not_raised` and updated: it pinned the old "silently skipped" behaviour (`len(panes) == 1`), and now asserts the warning and the visible marker alongside the working plot. This is the one intentional behaviour change.

Full suite: **2409 passed, 3 skipped**. `ruff format`/`ruff check` clean on changed files (the 6 pre-existing `ruff check` errors on `main` are untouched); `pylint` 10.00/10 on both changed source files.

## Deliberately not in scope

`map_plot_panes` renders every `PANEL_TYPES` var (image, video, rerun, dataset) in a single loop, so one raising var still discards the panes of all the others — that is why the downstream report lost the scatter *and* the recording together, rather than just one.

Fixing that means making the pane path best-effort, which collides head-on with the existing `test_bad_column_raises_rather_than_plotting_nothing` contract in `test_xy_scatter_result.py`, `test_xy_curve_result.py` and `test_xy_distribution_results.py` — and `render_data_samples` documents that it deliberately shares that path with `PaneResult.to_panes` so a chart type "behaves identically to a declared `container=`". I tried gating isolation behind a flag and could not separate the two without weakening that contract, so it belongs in its own PR with your call on which behaviour wins. Happy to take that on if you tell me which way you want it to go.

## Summary by Sourcery

Surface plot render failures to callers and report viewers instead of silently skipping failed plots while still keeping reports best-effort.

Enhancements:
- Introduce a shared render failure helper that logs, emits a warning, and returns a visible pane describing failed plot renders.
- Update automatic plotting and extra panel handling to append visible failure markers when plugins, callbacks, or injected panels raise instead of silently omitting them.

Tests:
- Add dedicated tests verifying that render failures emit warnings, produce visible failure panes, and do not abort successful plots.
- Update the existing BenchResult callback failure test to assert the new surfaced-failure behavior while preserving the non-raising contract.