### PR TITLE
fix: pin that over_time aging never deletes a ResultDataSet blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is gone: the report shows a labelled per-time grid, one pane per snapshot under its
   timestamp, instead of only the latest run. Practical effect: a report over a long history
   gets *N* times wider — bound it with `max_time_events` on the result variable if that
-  matters. Cells cached before this release render real content at the final time event and
-  an explicit labelled placeholder at earlier ones, because the legacy payload list only
-  ever held the final run's samples.
+  matters. Note that unlike an image or video, aging a dataset cell out of the history does
+  not itself delete the payload: blobs are content-addressed, so the same file may still
+  back a cell elsewhere in the cache. `max_time_events` bounds the *report*; reclaiming
+  blob storage is a cache-management operation. Cells cached before this release render
+  real content at the final time event and an explicit labelled placeholder at earlier
+  ones, because the legacy payload list only ever held the final run's samples.
 - **New gallery example `example_result_dataset_1d_over_time`** under
   `reference/meta/result_types/result_dataset/`; no existing example combined
   `ResultDataSet` with `over_time`.

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -59,6 +59,17 @@ from bencher.worker_job import WorkerJob
 
 logger = logging.getLogger(__name__)
 
+# Result types whose cell names a file this variable alone owns, so aging the cell
+# out of the over_time history deletes the file too (see ``_null_old_entries``).
+#
+# ``ResultDataSet`` is deliberately NOT here, even though its cells are paths as
+# well: blob-store files are content-addressed, so one file may back cells at other
+# time points, in other result variables, or in another benchmark sharing the cache
+# — identical payloads deduplicate to a single path by design, and this function
+# sees only the variable it is aging. Deleting the file here would strand every
+# other cell still holding that path. Aging therefore only writes the sentinel;
+# reclaiming blob storage belongs to ``bencher.cache_management``, which is the
+# layer that can see the whole cache and tell a dropped payload from a shared one.
 _MEDIA_RESULT_TYPES = (ResultPath, ResultVideo, ResultImage, ResultContainer, ResultRerun)
 
 

--- a/test/test_result_collector.py
+++ b/test/test_result_collector.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import xarray as xr
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -556,6 +557,58 @@ class TestPerVariableMaxTimeEvents(unittest.TestCase):
             self.assertFalse(os.path.exists(paths[1]))
             self.assertTrue(os.path.exists(paths[2]))
             self.assertTrue(os.path.exists(paths[3]))
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_per_variable_never_deletes_dataset_blobs(self):
+        """Aging a ResultDataSet cell nulls it but must NEVER delete its blob.
+
+        Blobs are content-addressed, so identical payloads at different time points
+        deduplicate to one file: here the aged-out event at index 0 and the still-live
+        event at index 3 carry the same payload and therefore the same path. Deleting
+        the file when the old cell ages out would break the live one, which is why
+        ResultDataSet is excluded from ``_MEDIA_RESULT_TYPES``.
+        """
+        import os
+
+        from bencher.blob_store import materialize_blob
+        from bencher.variables.results import ResultDataSet
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            # Payload of event 3 repeats event 0's, so both cells hold one shared blob.
+            payloads = [
+                pd.DataFrame({"v": [0.0]}),
+                pd.DataFrame({"v": [1.0]}),
+                pd.DataFrame({"v": [2.0]}),
+                pd.DataFrame({"v": [0.0]}),
+            ]
+            paths = [materialize_blob(p, tmpdir) for p in payloads]
+            self.assertEqual(paths[0], paths[3], "content addressing should dedup these")
+
+            slices = [
+                xr.Dataset({"table": (["x", "over_time"], np.array([[p]], dtype=object))})
+                for p in paths
+            ]
+            dataset = xr.concat(slices, "over_time")
+
+            rv = ResultDataSet(max_time_events=2, doc="table")
+            rv.name = "table"
+
+            unique_hash = f"pervar-blob-{uuid.uuid4()}"
+            result = self.collector.load_history_cache(
+                dataset, unique_hash, clear_history=False, result_vars=[rv]
+            )
+
+            # The cells age exactly like any other path-valued result...
+            cells = list(result["table"].values[0])
+            self.assertEqual(cells[:2], ["NAN", "NAN"])
+            self.assertEqual(cells[2:], [paths[2], paths[3]])
+
+            # ...but every blob survives, including the one the aged cell shared with
+            # the live event at index 3, and the one no live cell references at all.
+            for path in paths:
+                self.assertTrue(os.path.exists(path), f"aging deleted blob {path}")
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 


### PR DESCRIPTION
Review follow-up on #1021 (plan 22). No behaviour change — a comment, a regression test, and a changelog correction.

## The invariant

`ResultDataSet` is absent from `_MEDIA_RESULT_TYPES`, so `_null_old_entries` writes the sentinel into an aged-out cell **without** deleting the file it named. That is correct and load-bearing: blob-store files are content-addressed, so one file may back cells at other time points, in other result variables, or in another benchmark sharing the cache — and `_null_old_entries` sees only the variable it is aging. Deleting the file there would strand every other cell holding that path.

Nothing said so and nothing pinned it. A reader who noticed a path-valued result type missing from the path-deleting tuple could reasonably "fix" the apparent omission, and the suite would stay green.

## What changes

- **A comment on `_MEDIA_RESULT_TYPES`** stating why `ResultDataSet` is excluded, and that reclaiming blob storage belongs to `cache_management` — the layer that can see the whole cache and tell a dropped payload from a shared one. (Worded to stay true alongside the reachability GC in #1022.)
- **A regression test**, the mirror of the existing `test_per_variable_deletes_media_files`: the aged-out event and a still-live event carry the same payload, so content addressing gives them the same path. The cells age to `"NAN"` and every blob survives. Verified it fails (`aging deleted blob …`) when `ResultDataSet` is added to the tuple.
- **A changelog correction.** The plan-22 entry tells users to bound a wide `over_time` report with `max_time_events`, which for an image or video also reclaims the disk. For a dataset payload it does not — that bullet now says so.

## Validation

`pytest test/` on py311: **2404 passed, 3 skipped**, 147 subtests. `ruff format --check` and `ruff check` clean; pylint 10.00/10 on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify that aging over_time entries for ResultDataSet must not delete shared blob files and document this invariant in code and changelog.

Bug Fixes:
- Add a regression test ensuring over_time aging does not delete ResultDataSet blobs that may be shared across cache entries.

Enhancements:
- Document why ResultDataSet is intentionally excluded from _MEDIA_RESULT_TYPES and that blob reclamation is handled by cache management.

Documentation:
- Update changelog to explain that max_time_events bounds ResultDataSet over_time reports without reclaiming dataset blob storage and that cleanup is done via cache management.

Tests:
- Add a per-variable regression test verifying that aging ResultDataSet cells nulls the entries but preserves all underlying dataset blob files.