### PR TITLE
fix: fail loudly on a broken worker contract (plan 23 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Both checks are raised **outside** `store_results`'s `except catch` block on purpose: a
   bad return shape is a harness-contract error, not a sample fault, so `catch=` does not
   absorb it (plan 23 decision 2). Previously `catch=Exception` did swallow the serial
-  `assert`, restoring the silent behaviour. Tests pin this.
+  `assert`, restoring the silent behaviour. Tests pin this. The `Bench.optimize` path is
+  the documented exception — its objective runs under `study.optimize(..., catch=catch)`,
+  so a `catch=` there still absorbs the error. That is pre-existing rather than new: the
+  old code was absorbed at the same point, as an `AssertionError` on serial and a `None`
+  subscript `TypeError` on the pool.
 
 ### Changed
 - **`BenchRunCfg.executor` is normalized to an `Executors` member at the sweep boundary**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **BREAKING (fail-loud): a benchmark that returns `None` now raises instead of producing
+  an empty sweep** (plan 23 P2, B3). A worker that forgot to `return
+  super().__call__(**kwargs)` used to trip a bare `assert` on the serial executor — and
+  nothing at all on `MULTIPROCESSING`/`SCOOP`, where the future resolved to `None`,
+  `store_results` skipped its entire body behind `if result is not None:` with no `else`,
+  and the sweep finished green with an all-sentinel dataset and `n_failed == 0`. The same
+  user error was loud or silent depending on an unrelated config knob, and the assert
+  vanished entirely under `python -O`. Both paths now funnel through one check
+  (`require_worker_result`) raising `TypeError`.
+
+- **BREAKING (fail-loud): a `ResultVec` set to the wrong number of elements now raises**
+  (plan 23 P2, B2). The store was guarded by `isinstance(value, (list, np.ndarray)) and
+  len(value) == rv.size` with no `else`, so a length mismatch was silently discarded and
+  the cell kept its NaN fill — indistinguishable downstream from "never sampled".
+  `param.List` validates that the value is a list but not how long it is, so this was
+  reachable from ordinary benchmark code. The error names the variable, the declared size
+  and the actual length.
+
+  Both checks are raised **outside** `store_results`'s `except catch` block on purpose: a
+  bad return shape is a harness-contract error, not a sample fault, so `catch=` does not
+  absorb it (plan 23 decision 2). Previously `catch=Exception` did swallow the serial
+  `assert`, restoring the silent behaviour. Tests pin this.
+
+### Changed
+- **`BenchRunCfg.executor` is normalized to an `Executors` member at the sweep boundary**
+  (plan 23 P2, C13). Because `Executors` is a `StrEnum`,
+  `param.Selector(objects=list(Executors))` accepts the bare string `"SERIAL"` and stores a
+  `str` in a field compared with `==`/`!=` in `Bench` and with `is not` in
+  `FutureCache.submit` — styles that disagree on a raw string. The four sites happened to
+  agree, because `Executors.factory` also used `==`; that was luck, not design. `executor`
+  is now parsed once in `plot_sweep` and in `FutureCache.__init__`, `factory` matches
+  exhaustively via `assert_never`, and an out-of-vocabulary value raises at the parse
+  rather than at a match site. No cache impact: `executor` feeds no persistent hash, and a
+  member's `str()` and `hash()` are identical to the raw string's.
+
+- `Executors.factory` is annotated `-> SupportsSubmit | None` rather than `-> Future |
+  None`, which was the one thing it never returns — a `Future` is what `submit()` hands
+  back. The new `Protocol` (`submit`, `shutdown`) is satisfied by both
+  `ProcessPoolExecutor` and scoop's module.
+
+- `JobFuture.result()` is annotated `-> dict | None`. The `None` is not new behaviour, only
+  newly admitted: `JobFuture` can represent "no result and no future", and callers must
+  reject it. Plan 23 P5's `Ready(dict) | Pending(Future)` split is what makes the state
+  unrepresentable and the `| None` removable.
+
 ### Removed
 - **BREAKING: dropped Python 3.10 support.** `requires-python` is now `>=3.11,<3.14`, and
   the CI matrix runs py311 + py313 (was py310 + py313). The `py310` pixi feature and

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -26,7 +26,15 @@ from bencher.bench_plot_server import BenchPlotServer
 from bencher.bench_report import BenchReport
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES, ensure_cache_version
 from bencher.history import config_summary as history_config_summary
-from bencher.job import Executors, FutureCache, Job, JobFuture, normalize_catch
+from bencher.job import (
+    Executors,
+    FutureCache,
+    Job,
+    JobFuture,
+    normalize_catch,
+    normalize_executor,
+    require_worker_result,
+)
 from bencher.optuna_conversions import sweep_var_to_optuna_dist, sweep_var_to_suggest
 from bencher.regression import RegressionError, detect_regressions
 from bencher.result_collector import ResultCollector
@@ -503,6 +511,11 @@ class Bench(BenchPlotServer):
         # kwarg spelling would give each knob two homes to reconcile.
         run_cfg.catch = normalize_catch(run_cfg.catch)
         validate_sample_error_policy(run_cfg.fail_on_sample_error)
+        # Same reasoning for `executor` (C13): `param.Selector` accepts the bare
+        # string "SERIAL" because Executors is a StrEnum, and the field is then
+        # compared with both `==` and `is` further down. Assigning the member back
+        # makes the field's type true for every reader.
+        run_cfg.executor = normalize_executor(run_cfg.executor)
 
         if run_cfg.only_plot:
             run_cfg.cache_results = True
@@ -1664,7 +1677,10 @@ class Bench(BenchPlotServer):
             job_key=cache_key,
             tag=tag,
         )
-        return self.sample_cache.submit(job).result()
+        # Same boundary check as store_results: the optimize path consumes the result
+        # dict directly, so a worker returning None must fail here by name rather than
+        # as a downstream subscript error (B3, plan 23 P2).
+        return require_worker_result(self.sample_cache.submit(job).result(), job.job_id)
 
     def _make_optuna_objective(
         self,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -1680,6 +1680,13 @@ class Bench(BenchPlotServer):
         # Same boundary check as store_results: the optimize path consumes the result
         # dict directly, so a worker returning None must fail here by name rather than
         # as a downstream subscript error (B3, plan 23 P2).
+        #
+        # Unlike the sweep path this one *is* inside a `catch=`, because the objective
+        # runs under `study.optimize(..., catch=catch)`. That asymmetry is pre-existing
+        # and not a behaviour change: with `catch=Exception` the old code was absorbed
+        # here too, as an AssertionError on serial and a `None` subscript TypeError on
+        # the pool. Only the message and the serial/parallel agreement improve. Making
+        # optuna's catch selective is its own decision, not B3's.
         return require_worker_result(self.sample_cache.submit(job).result(), job.job_id)
 
     def _make_optuna_objective(

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -537,7 +537,7 @@ class JobFunctionCache(FutureCache):
         self,
         function: Callable,
         overwrite: bool = False,
-        executor: Executors = Executors.SERIAL,
+        executor: Executors | str = Executors.SERIAL,
         cache_name: str = "fcache",
         tag_index: bool = True,
         size_limit: int = int(100e8),

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import Future, ProcessPoolExecutor
 from dataclasses import dataclass
 from enum import auto
+from typing import Protocol, assert_never, runtime_checkable
 
 from diskcache import Cache
 from strenum import StrEnum
@@ -23,6 +24,23 @@ except ImportError as e:
 
 
 _MISSING = object()  # Sentinel for cache.get() miss detection
+
+
+@runtime_checkable
+class SupportsSubmit(Protocol):
+    """The executor surface bencher actually uses.
+
+    ``Executors.factory`` was annotated ``-> Future | None``, which is the one thing
+    it never returns: a ``Future`` is what ``submit()`` *hands back*. The concrete
+    values are a ``ProcessPoolExecutor`` and -- for SCOOP -- a *module*, which is why
+    naming ``concurrent.futures.Executor`` would be a second, smaller lie. Two
+    methods is the whole contract, so a Protocol is both the honest type and the
+    narrow one (plan 23 P2).
+    """
+
+    def submit(self, fn: Callable, /, *args, **kwargs) -> Future: ...
+
+    def shutdown(self, wait: bool = True) -> None: ...
 
 
 class Job:
@@ -97,6 +115,30 @@ def normalize_catch(catch) -> tuple[type[BaseException], ...]:
     return catch
 
 
+def require_worker_result(result: dict | None, job_id: str) -> dict:
+    """Reject a worker that returned ``None`` instead of a result dict.
+
+    B3 (plan 23 P2): this used to be a bare ``assert`` in ``JobFuture.__init__``,
+    which fired only on the serial path -- and not at all under ``python -O``. On
+    MULTIPROCESSING/SCOOP the future was set, ``result()`` returned ``None``, and
+    ``store_results`` skipped its whole body behind ``if result is not None:`` with
+    no ``else``, so the sweep completed green with an all-sentinel dataset and
+    ``n_failed == 0``. The same user error was loud or silent depending on an
+    unrelated config knob; this is the one check both paths funnel through.
+
+    Deliberately **not** routed through ``catch=`` (plan 23 decision 2): a missing
+    return value is a harness-contract error, not a sample fault, so every call site
+    must raise it from *outside* its ``except catch`` block.
+    """
+    if result is None:
+        raise TypeError(
+            f"The benchmark function for job {job_id} returned None. "
+            "Make sure you are returning a dict or `super().__call__(**kwargs)` "
+            "from your __call__ function."
+        )
+    return result
+
+
 @dataclass(frozen=True)
 class SampleFailure:
     """One sample that raised and was tolerated because of ``catch=``.
@@ -149,29 +191,32 @@ class JobFuture:
             res (dict, optional): The immediate result, if available. Defaults to None.
             future (Future, optional): The future representing the pending result. Defaults to None.
             cache (Cache, optional): The cache to store results in. Defaults to None.
-
-        Raises:
-            AssertionError: If neither res nor future is provided
         """
         self.job = job
         self.res = res
         self.future = future
-        # either a result or a future needs to be passed
-        assert self.res is not None or self.future is not None, (
-            "make sure you are returning a dict or super().__call__(**kwargs) from your __call__ function"
-        )
-
+        # No `assert res is not None or future is not None` here any more (B3, plan
+        # 23 P2). It only caught a None worker return on the serial path, where
+        # `submit()` runs inside the caller's `except catch` block and `catch=` would
+        # therefore have absorbed it. Both paths now converge on
+        # require_worker_result() at the point where the result is consumed.
         self.cache = cache
 
-    def result(self) -> dict:
+    def result(self) -> dict | None:
         """Get the job result, waiting for completion if necessary.
 
         If the result is not immediately available (i.e., it's a future),
         this method will wait for the future to complete. Once the result
         is available, it will be cached if a cache is provided.
 
+        Returns ``None`` when the worker returned nothing, which every caller must
+        reject via ``require_worker_result()``. The annotation is deliberately
+        honest rather than narrow: ``JobFuture`` can represent "no result and no
+        future", and only plan 23 P5's ``Ready(dict) | Pending(Future)`` split makes
+        that state unrepresentable and this ``| None`` removable.
+
         Returns:
-            dict: The job result
+            dict | None: The job result, or None if the worker returned nothing
         """
         if self.future is not None:
             self.res = self.future.result()
@@ -220,28 +265,75 @@ class Executors(StrEnum):
     # THREADS=auto() #not that useful as most bench code is cpu bound
 
     @staticmethod
-    def factory(provider: Executors) -> Future | None:
+    def factory(provider: Executors | str) -> SupportsSubmit | None:
         """Create an executor instance based on the specified execution strategy.
 
         Args:
-            provider (Executors): The type of executor to create
+            provider (Executors | str): The type of executor to create. A raw string
+                is normalized to a member first, so the comparisons below can be
+                identity checks -- see ``normalize_executor``.
 
         Returns:
-            Future | None: The executor instance, or None for serial execution
+            SupportsSubmit | None: The executor, or None for serial execution
+
+        Raises:
+            ValueError: If ``provider`` is not an ``Executors`` member or its value
         """
-        if provider == Executors.SERIAL:
-            return None
-        if provider == Executors.MULTIPROCESSING:
-            try:
-                return ProcessPoolExecutor()
-            except (OSError, PermissionError) as exc:  # pragma: no cover - env specific
-                logger.warning(
-                    "Falling back to serial execution; multiprocessing unavailable: %s", exc
-                )
+        # Parse first, so the match below is over a value whose type is established
+        # rather than over a raw string (plan 24 A1/A2). Before C13 this compared with
+        # `==`, which quietly accepted `"SERIAL"` while FutureCache.submit's `is not`
+        # on the same field rejected it.
+        match normalize_executor(provider):
+            case Executors.SERIAL:
                 return None
-        if provider == Executors.SCOOP:
-            return scoop_future_executor
-        raise ValueError(f"Unknown executor provider: {provider}")
+            case Executors.MULTIPROCESSING:
+                try:
+                    return ProcessPoolExecutor()
+                except (OSError, PermissionError) as exc:  # pragma: no cover - env specific
+                    logger.warning(
+                        "Falling back to serial execution; multiprocessing unavailable: %s", exc
+                    )
+                    return None
+            case Executors.SCOOP:
+                return scoop_future_executor
+            case _ as unreachable:
+                assert_never(unreachable)
+
+
+def normalize_executor(executor: Executors | str) -> Executors:
+    """Coerce ``executor`` to an ``Executors`` member.
+
+    C13 (plan 23 P2). ``Executors`` is a ``StrEnum``, so ``"SERIAL" ==
+    Executors.SERIAL`` is True and ``param.Selector(objects=list(Executors))``
+    (``BenchRunCfg.executor``) therefore *accepts* the bare string and stores a
+    ``str`` in a field that is compared three different ways: ``==``/``!=`` in
+    ``Bench._sample_and_store`` and ``is not`` in ``FutureCache.submit``. An identity
+    check against a raw string is False, so those sites disagree the moment one is
+    reached with an un-normalized value. Today they still all land on the serial path,
+    but only because ``factory`` used to compare with ``==`` as well -- that is luck,
+    not design, and it is why plan 23 records C13 as a latent smell rather than a
+    shipped bug.
+
+    Normalizing at each ingress is what makes the field's declared type true. Per plan
+    24 A2 that is not merely hardening: it is the precondition that licenses matching
+    on ``executor`` exhaustively at all, because ``ty`` cannot establish the type of a
+    ``param`` descriptor read, and an ``assert_never`` reached with a raw string reads
+    as a proof while behaving as an assertion.
+
+    Raises:
+        ValueError: for a value outside the vocabulary. ``param.Selector`` rejects
+            those on assignment already, so this fires for hand-built configs and
+            direct calls -- i.e. at the parse, never at a match site.
+    """
+    if isinstance(executor, Executors):
+        return executor
+    try:
+        return Executors(executor)
+    except ValueError:
+        raise ValueError(
+            f"executor must be one of {[e.value for e in Executors]} "
+            f"(or the matching Executors member), got {executor!r}"
+        ) from None
 
 
 class FutureCache:
@@ -265,7 +357,7 @@ class FutureCache:
 
     def __init__(
         self,
-        executor=Executors.SERIAL,
+        executor: Executors | str = Executors.SERIAL,
         overwrite: bool = True,
         cache_name: str = "fcache",
         tag_index: bool = True,
@@ -282,7 +374,10 @@ class FutureCache:
             size_limit (int, optional): Maximum size of the cache in bytes. Defaults to 20GB.
             cache_samples (bool, optional): Whether to cache results at all. Defaults to True.
         """
-        self.executor_type = executor
+        # Normalized here as well as in plot_sweep, because FutureCache is also
+        # constructed directly (SampleCache, and by callers building their own
+        # cache), and `submit()` below discriminates with `is not` (C13).
+        self.executor_type = normalize_executor(executor)
         self.executor = None
         if cache_samples:
             self.cache = Cache(f"cachedir/{cache_name}", tag_index=tag_index, size_limit=size_limit)

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -37,7 +37,7 @@ from bencher.history import (
     project,
     reconcile,
 )
-from bencher.job import JobFuture, SampleFailure, normalize_catch
+from bencher.job import JobFuture, SampleFailure, normalize_catch, require_worker_result
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
@@ -419,59 +419,76 @@ class ResultCollector:
                 bench_res, job_result.job.job_id, worker_job.function_input, exc
             )
             return
-        if result is not None:
-            logger.info(f"{job_result.job.job_id}:")
-            if bench_res.bench_cfg.print_bench_inputs:
-                for k, v in worker_job.function_input.items():
-                    logger.info(f"\t {k}:{v}")
+        # Outside the `except catch` above, deliberately: a worker that returned
+        # nothing is a harness-contract error, not a sample fault, so `catch=` must
+        # not absorb it (plan 23 decision 2). This replaces `if result is not None:`
+        # with no `else`, which skipped everything below and left the sweep green with
+        # an all-sentinel dataset -- see require_worker_result for the full B3 story.
+        result = require_worker_result(result, job_result.job.job_id)
+        logger.info(f"{job_result.job.job_id}:")
+        if bench_res.bench_cfg.print_bench_inputs:
+            for k, v in worker_job.function_input.items():
+                logger.info(f"\t {k}:{v}")
 
-            result_dict = result if isinstance(result, dict) else result.param.values()
-            idx = worker_job.index_tuple
+        result_dict = result if isinstance(result, dict) else result.param.values()
+        idx = worker_job.index_tuple
 
-            for rv in bench_res.bench_cfg.result_vars:
-                try:
-                    result_value = result_dict[rv.name]
-                except KeyError:
-                    available = list(result_dict.keys())
-                    raise KeyError(
-                        f"Result variable '{rv.name}' was not set by the "
-                        f"benchmark function. Available keys: {available}. "
-                        f"Make sure your benchmark() method sets "
-                        f"self.{rv.name}."
-                    ) from None
-                result_value = _materialize_result_value(rv, result_value)
-                if bench_run_cfg.print_bench_results:
-                    logger.info(f"{rv.name}: {result_value}")
+        for rv in bench_res.bench_cfg.result_vars:
+            try:
+                result_value = result_dict[rv.name]
+            except KeyError:
+                available = list(result_dict.keys())
+                raise KeyError(
+                    f"Result variable '{rv.name}' was not set by the "
+                    f"benchmark function. Available keys: {available}. "
+                    f"Make sure your benchmark() method sets "
+                    f"self.{rv.name}."
+                ) from None
+            result_value = _materialize_result_value(rv, result_value)
+            if bench_run_cfg.print_bench_results:
+                logger.info(f"{rv.name}: {result_value}")
 
-                if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):
-                    _set_result_value(bench_res, rv_arrays, rv.name, idx, result_value)
-                elif isinstance(rv, ResultDataSet):
-                    # Plan 22 (D2): the cell stores a blob path, not an index into
-                    # dataset_list.  The list attribute stays, empty, as the read
-                    # path for results collected before path-backed cells.
-                    _set_result_value(
-                        bench_res, rv_arrays, rv.name, idx, _materialize_dataset_value(result_value)
+            if isinstance(rv, XARRAY_MULTIDIM_RESULT_TYPES):
+                _set_result_value(bench_res, rv_arrays, rv.name, idx, result_value)
+            elif isinstance(rv, ResultDataSet):
+                # Plan 22 (D2): the cell stores a blob path, not an index into
+                # dataset_list.  The list attribute stays, empty, as the read
+                # path for results collected before path-backed cells.
+                _set_result_value(
+                    bench_res, rv_arrays, rv.name, idx, _materialize_dataset_value(result_value)
+                )
+            elif isinstance(rv, ResultReference):
+                bench_res.object_index.append(result_value)
+                _set_result_value(
+                    bench_res, rv_arrays, rv.name, idx, len(bench_res.object_index) - 1
+                )
+
+            elif isinstance(rv, ResultVec):
+                # B2 (plan 23 P2): these two conditions used to guard the store with
+                # no `else`, so a vector of the wrong length was silently dropped and
+                # the cell kept its NaN fill -- indistinguishable, downstream, from
+                # "never sampled". The sibling arms of this ladder all raise.
+                if not isinstance(result_value, (list, np.ndarray)):
+                    raise TypeError(
+                        f"Result variable '{rv.name}' is a ResultVec(size={rv.size}), "
+                        f"so the benchmark function must set it to a list or numpy "
+                        f"array; got {type(result_value).__name__} ({result_value!r})."
                     )
-                elif isinstance(rv, ResultReference):
-                    bench_res.object_index.append(result_value)
-                    _set_result_value(
-                        bench_res, rv_arrays, rv.name, idx, len(bench_res.object_index) - 1
+                if len(result_value) != rv.size:
+                    raise TypeError(
+                        f"Result variable '{rv.name}' is a ResultVec(size={rv.size}), "
+                        f"but the benchmark function returned {len(result_value)} "
+                        f"element(s): {result_value!r}. Each element is stored in its "
+                        f"own dataset column, so every sample must return exactly "
+                        f"{rv.size} of them."
                     )
+                for i in range(rv.size):
+                    _set_result_value(bench_res, rv_arrays, rv.index_name(i), idx, result_value[i])
 
-                elif isinstance(rv, ResultVec):
-                    if (
-                        isinstance(result_value, (list, np.ndarray))
-                        and len(result_value) == rv.size
-                    ):
-                        for i in range(rv.size):
-                            _set_result_value(
-                                bench_res, rv_arrays, rv.index_name(i), idx, result_value[i]
-                            )
-
-                else:
-                    raise TypeError(f"Unsupported result type: {type(rv).__name__}")
-            for rv in bench_res.result_hmaps:
-                bench_res.hmaps[rv.name][worker_job.canonical_input] = result_dict[rv.name]
+            else:
+                raise TypeError(f"Unsupported result type: {type(rv).__name__}")
+        for rv in bench_res.result_hmaps:
+            bench_res.hmaps[rv.name][worker_job.canonical_input] = result_dict[rv.name]
 
     def cache_results(
         self, bench_res: BenchResult, bench_cfg_hash: str, bench_cfg_hashes: list[str]

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -468,6 +468,12 @@ class ResultCollector:
                 # no `else`, so a vector of the wrong length was silently dropped and
                 # the cell kept its NaN fill -- indistinguishable, downstream, from
                 # "never sampled". The sibling arms of this ladder all raise.
+                #
+                # The accepted set is deliberately left as-is rather than widened: a
+                # `tuple` would work fine positionally, but which types each result
+                # variable accepts is P4's (the result-type registry) call, not a
+                # side effect of making the drop loud. It now says so instead of
+                # silently NaN-ing.
                 if not isinstance(result_value, (list, np.ndarray)):
                     raise TypeError(
                         f"Result variable '{rv.name}' is a ResultVec(size={rv.size}), "

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -883,7 +883,16 @@ than silently worked around.
    subject under test. The useful implication: for a worker whose return type is
    annotated, B3 is already a **static** error; `require_worker_result` is what covers the
    unannotated case, which is the common one.
-9. **Cache safety confirmed for the C13 normalization** (§7's requirement). `executor`
+9. **The "not routed through `catch=`" guarantee has one documented exception, found by
+   self-review after Sourcery hit its weekly cap again.** It holds on the sweep path,
+   which is what decision 2 is about. It does **not** hold on `Bench.optimize`: that
+   objective runs under `study.optimize(..., catch=catch)`, so a `catch=` there absorbs
+   the `TypeError`. This is pre-existing rather than introduced — with `catch=Exception`
+   the old code was absorbed at the same point, as an `AssertionError` on serial and a
+   `None`-subscript `TypeError` on the pool — so B3 still strictly improves both the
+   message and serial/parallel agreement. Making optuna's catch selective is its own
+   decision. Recorded because the unqualified claim would have been an overstatement.
+10. **Cache safety confirmed for the C13 normalization** (§7's requirement). `executor`
    reaches no persistent hash — it appears in neither `identity.py` nor `worker_job.py` —
    and for the one place it is stringified (`bench_cfg.py`'s sampling summary) a member and
    the raw string are indistinguishable: `str(Executors.SERIAL) == str("SERIAL")` and

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -810,3 +810,82 @@ than silently worked around.
    on exactly that seeded bypass. The probe tests also assert ty's **exit code**, not just
    its output text, so a rule demoted to warning level cannot pass; and their class
    docstring no longer claims to prove the repo's gate, only the mechanism.
+
+### P2 (implemented)
+
+1. **B2 and B3 both landed as `raise TypeError`, per decision 2 — and the "not routed
+   through `catch=`" half of that decision turned out to be the load-bearing half.**
+   Seeding the pre-fix code back to measure what the new tests catch produced this, from a
+   run with `catch=Exception`:
+
+   ```
+   WARNING sample failed and was caught (x=0, repeat=1): AssertionError('old assert')
+   ```
+
+   So the old serial `assert` was not merely absent under `python -O`; with `catch=` set it
+   was **downgraded to a tolerated sample failure**, which is the same silent-empty-dataset
+   outcome as the parallel path. Both checks are therefore raised *outside*
+   `store_results`'s `except catch` block, and `TestCatchDoesNotAbsorbContractErrors` pins
+   it — without that test the fix would have looked complete while the obvious user
+   response (`catch=Exception`) restored the old behaviour.
+2. **The B3 check could not go where it naturally belongs.** `JobFuture.result()` is the
+   one place both executors converge, but it is called *inside* that same `except catch`
+   block (and `FutureCache.submit` is inside the caller's), so raising from either would be
+   absorbed. The check is `require_worker_result(result, job_id)` at the two points where a
+   result is *consumed* — `store_results` and the optimize path (`bencher.py`, which calls
+   `.result()` directly and would otherwise fail as a downstream subscript error).
+   Consequently `JobFuture.result()` is now annotated `-> dict | None`: honest rather than
+   narrow, since `JobFuture` really can hold neither a result nor a future. **P5 removes
+   the `| None`** by making that state unrepresentable; until then the widening is the
+   truthful option, not a regression.
+3. **C13's `assert_never` works on a `strenum.StrEnum` — verified, not assumed.**
+   `Executors.factory` now parses with `normalize_executor` and matches exhaustively.
+   Deleting the SCOOP arm yields
+   `error[type-assertion-failure] … Inferred type of argument is Literal[Executors.SCOOP]`,
+   naming the missing member. This is the first place in the repo where plan 24 A2's claim
+   is realised end to end: the parse is what makes the subject typed, and
+   `test_factory_rejects_an_unknown_value_before_matching` pins that bad input raises
+   `ValueError` at the parse rather than `AssertionError` at the match.
+4. **No pre-fix regression test exists for C13, and the plan was right that none could.**
+   What is testable is the *reason* the normalization exists, so it is pinned as an
+   executable fact: `"SERIAL" == Executors.SERIAL` while `"SERIAL" is not Executors.SERIAL`.
+   That assertion doubles as a tripwire for the stdlib-`StrEnum` migration (D4 / handover
+   §5.4), which would change the vocabulary rather than just the representation.
+5. **Normalization is not visible on the caller's own config, and that is intended.**
+   `to_bench(cfg)` deepcopies, so `plot_sweep` normalizes the copy — asserted via
+   `bench.last_run_cfg`. A config passed directly as `plot_sweep(run_cfg=cfg)` is not
+   copied and *is* normalized in place. A first draft of the test asserted the wrong one of
+   these and failed; both paths are now pinned explicitly so the asymmetry is documented
+   rather than rediscovered.
+6. **`Executors.factory` was annotated `-> Future | None`, the one type it never
+   returns.** A `Future` is what `submit()` hands back. Found by putting `job.py` on the
+   strict list to measure it: `Object of type Future[Unknown] has no attribute submit`. The
+   concrete values are a `ProcessPoolExecutor` and, for SCOOP, a *module*, so naming
+   `concurrent.futures.Executor` would be a second smaller lie; the fix is a two-method
+   `SupportsSubmit` Protocol, which both satisfy.
+7. **Neither reworked file could join the strict ratchet, and the block's rule is honoured
+   rather than loosened** (as in P1 item 7). Measured with `job.py` and
+   `result_collector.py` added to it: 6 diagnostics, 2 of which the Protocol above fixed.
+   The remaining 4 are pre-existing and out of P2's scope:
+   - `job.py` `clear_tag` calls `self.cache.evict(tag)` on `Cache | None` with no guard —
+     a live latent `AttributeError`.
+   - `job.py` `Job.__init__` argument type; `result_collector.py`
+     `record_caught_sample` argument type.
+   - `result_collector.py` iterates `worker_job.function_input.items()` where the field is
+     `dict | None`. The last two are the *same* defect: `WorkerJob.function_input` is
+     `None` until `setup_hashes()` runs, i.e. two-phase init. **That is P5/P9 territory**
+     (`WorkerJob`/`JobFuture` state), and fixing it there should let both files onto the
+     strict list in one step.
+8. **P1's Tier-A gate caught this phase's own test fixture**, which is worth recording as
+   evidence the gate earns its keep: `ReturnsNothing.__call__` is annotated `-> None` and
+   `invalid-method-override` flagged it against `ParametrizedSweep.__call__ -> dict`. It
+   carries a scoped `# ty: ignore` with a reason, because the invalid override *is* the
+   subject under test. The useful implication: for a worker whose return type is
+   annotated, B3 is already a **static** error; `require_worker_result` is what covers the
+   unannotated case, which is the common one.
+9. **Cache safety confirmed for the C13 normalization** (§7's requirement). `executor`
+   reaches no persistent hash — it appears in neither `identity.py` nor `worker_job.py` —
+   and for the one place it is stringified (`bench_cfg.py`'s sampling summary) a member and
+   the raw string are indistinguishable: `str(Executors.SERIAL) == str("SERIAL")` and
+   `hash(Executors.SERIAL) == hash("SERIAL")`, both True, since `StrEnum` inherits `str`.
+   No `CACHE_VERSION` bump.

--- a/plans/23-handover.md
+++ b/plans/23-handover.md
@@ -17,7 +17,8 @@ it; the symbol is the durable reference.
 | Plan 23 — the audit itself, 12 phases | #1023 | merged |
 | Plan 24 — `assert_never` boundary discipline (amends 23) | — | merged (`7de09227`) |
 | Python floor 3.10 → 3.11 | #1025 | merged (`1aad6bfc`) |
-| **Plan 23 P1 — make the `ty` gate real** | #1026 | 6/7 checks green, RTD pending at handover |
+| **Plan 23 P1 — make the `ty` gate real** | #1026 | merged (`3e222307`) |
+| **Plan 23 P2 — collection-path bugs (B2, B3) + executor normalization (C13)** | — | see §3 |
 
 Read in this order before touching anything:
 
@@ -47,10 +48,23 @@ check enforces it.
 
 Verified still true at the py311 target with stdlib `typing.assert_never`.
 
-## 3. Next phase: 23-P2
+## 3. 23-P2 — implemented
 
-Collection-path live bugs plus executor normalization. Plan 23 §5 has the full spec; the
-deltas you must not miss:
+**Done**, on `plan/p2-collection-path-bugs`. Findings are in plan 23 §10 under "P2
+(implemented)"; read those before P3. The four that change what you should expect:
+
+- The old serial `assert` was not just `-O`-fragile — with `catch=` set it was
+  **downgraded to a tolerated sample failure**, so the silent-empty-dataset outcome was
+  reachable on the serial path too. Both new checks raise from *outside* `except catch`.
+- `JobFuture.result()` is now `-> dict | None`. **P5 removes the `| None`**; until then
+  callers use `require_worker_result`.
+- `Executors.factory` matches exhaustively with `assert_never` and this is the first
+  place plan 24 A2 is realised end to end: verified by deleting the SCOOP arm.
+- `job.py` and `result_collector.py` still **cannot** join the strict ratchet; §10 item 7
+  names the exact 4 blockers, two of which are one `WorkerJob.function_input` two-phase-init
+  defect that **P5/P9 should fix, unlocking both files at once**.
+
+The original spec, kept for reference:
 
 - **B2** `bencher/result_collector.py:463-471` — the `ResultVec` branch stores only when
   `isinstance(result_value, (list, np.ndarray))` **and** `len(result_value) == rv.size`,
@@ -75,9 +89,18 @@ deltas you must not miss:
   *licenses* any later `assert_never` on that field. A2 promotes this from "hardening" to
   "precondition" — do not skip it on the grounds that C13 is only a smell.
 
-**Owner decision still open (plan 23 §6.2):** raise vs warn for B2/B3. Recommendation on
-file is raise `TypeError`, and explicitly *not* routed through plan 21's `catch=`, because
-a bad return shape is a harness-contract error rather than a sample fault.
+**Owner decision 6.2 (raise vs warn for B2/B3): resolved as raise `TypeError`**, on the
+recommendation on file, and explicitly not routed through plan 21's `catch=`. Both halves
+are pinned by tests. Flagged in the PR as a breaking fail-loud change; if the owner prefers
+warn-and-skip for parallel users, the change is localized to `require_worker_result` and the
+`ResultVec` arm.
+
+## 3a. Next phase: 23-P3
+
+Reporting/rendering live bugs (B1, B4, B5) — plan 23 §5. Independent of P2. Note B5's
+scope was narrowed during the audit: regressions are still reported correctly, and the
+unit mismatch corrupts only the **improved-vs-unchanged** distinction for non-percentage
+methods.
 
 ## 4. Small items P1 left on the floor
 

--- a/test/test_collection_contract.py
+++ b/test/test_collection_contract.py
@@ -1,0 +1,321 @@
+"""Plan 23 P2 — the collection path must not accept a broken worker silently.
+
+Two shipped bugs and one latent smell, all the same shape: a branch that stored
+nothing and had no ``else``, so a harness-contract error looked exactly like a
+sweep that had not been run yet.
+
+- **B2** a ``ResultVec`` of the wrong length was dropped, leaving the NaN fill.
+- **B3** a worker that returned ``None`` tripped a bare ``assert`` on the serial
+  path and *nothing at all* on MULTIPROCESSING/SCOOP, where the sweep finished
+  green with an all-sentinel dataset and ``n_failed == 0``.
+- **C13** ``executor`` is compared with both ``==`` and ``is``, and
+  ``param.Selector`` accepts a raw string for it, so the two styles can disagree.
+
+These are contract errors, not sample faults, so none of them is routed through
+``catch=`` (plan 23 decision 2) -- ``TestCatchDoesNotAbsorbContractErrors`` pins
+that, since ``catch=Exception`` is the natural thing for a user to reach for and
+would otherwise turn every one of these back into a silent skip.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import ClassVar
+
+import numpy as np
+import pytest
+
+import bencher as bn
+from bencher.job import (
+    Executors,
+    FutureCache,
+    Job,
+    JobFuture,
+    normalize_executor,
+    require_worker_result,
+)
+from bencher.result_collector import ResultCollector
+
+# ---------------------------------------------------------------------------
+# Workers. Module level: MULTIPROCESSING pickles them.
+# ---------------------------------------------------------------------------
+
+
+class WrongLengthVec(bn.ParametrizedSweep):
+    """Sets a ``ResultVec(size=2)`` to ``n_elements`` elements.
+
+    ``param.List`` enforces *that* the value is a list but not how long it is, so
+    a length mismatch reaches the collector -- which is why B2 was reachable at
+    all from ordinary benchmark code.
+    """
+
+    x = bn.IntSweep(default=0, bounds=(0, 1), samples=2)
+    v = bn.ResultVec(size=2)
+
+    n_elements: ClassVar[int] = 2
+
+    def benchmark(self) -> None:
+        self.v = [float(self.x)] * type(self).n_elements
+
+
+class ReturnsNothing(bn.ParametrizedSweep):
+    """A worker with the most common harness-contract mistake: no return value.
+
+    Written on the legacy ``__call__`` path because that is the only way to get
+    here -- ``benchmark()`` cannot cause it, since ``ParametrizedSweep.__call__``
+    returns ``get_results_values_as_dict()`` for you.
+    """
+
+    x = bn.IntSweep(default=0, bounds=(0, 1), samples=2)
+    y = bn.ResultFloat()
+
+    # The override really is invalid -- that is the bug under test -- and the
+    # annotation says so honestly rather than hiding it behind a bare `def`. Worth
+    # noting what this proves: for a worker whose return type is *annotated*, P1's
+    # Tier-A `invalid-method-override` already catches this statically. The runtime
+    # check exists for the untyped case, which is the common one.
+    def __call__(self, **kwargs) -> None:  # ty: ignore[invalid-method-override]
+        self.update_params_from_kwargs(**kwargs)
+        self.y = float(self.x)
+        # Deliberately no `return self.get_results_values_as_dict()`.
+
+
+def _run(worker, *, executor=Executors.SERIAL, **run_kwargs):
+    cfg = bn.BenchRunCfg(executor=executor, **run_kwargs)
+    cfg.auto_plot = False
+    cfg.cache_results = False
+    cfg.cache_samples = False
+    bench = worker.to_bench(cfg)
+    try:
+        return bench.plot_sweep(input_vars=["x"], plot_callbacks=False)
+    finally:
+        bench.close()
+
+
+# ---------------------------------------------------------------------------
+# B2 -- wrong-length ResultVec
+# ---------------------------------------------------------------------------
+
+
+class TestResultVecLength(unittest.TestCase):
+    """B2: the ladder's other arms raise; this one used to just not store."""
+
+    def tearDown(self) -> None:
+        WrongLengthVec.n_elements = 2
+
+    def test_the_control_case_still_stores_every_element(self) -> None:
+        """Guards against a check that rejects correct vectors too."""
+        WrongLengthVec.n_elements = 2
+        res = _run(WrongLengthVec())
+        for name in WrongLengthVec.param.v.index_names():
+            self.assertIn(name, res.ds)
+            self.assertFalse(np.isnan(res.ds[name].values).any(), f"{name} left at the NaN fill")
+
+    def test_a_short_vector_raises_instead_of_being_dropped(self) -> None:
+        WrongLengthVec.n_elements = 1
+        with self.assertRaises(TypeError) as ctx:
+            _run(WrongLengthVec())
+        msg = str(ctx.exception)
+        # The message has to carry all three facts, because the symptom the user
+        # would otherwise see is an all-NaN column with nothing pointing at 'v'.
+        self.assertIn("'v'", msg)
+        self.assertIn("size=2", msg)
+        self.assertIn("1 element", msg)
+
+    def test_a_long_vector_also_raises(self) -> None:
+        WrongLengthVec.n_elements = 3
+        with self.assertRaises(TypeError) as ctx:
+            _run(WrongLengthVec())
+        self.assertIn("3 element", str(ctx.exception))
+
+    def test_a_non_sequence_raises_naming_the_type(self) -> None:
+        """Only reachable from a worker that returns a raw dict.
+
+        Assignment through ``self.v`` cannot get here -- ``param.List`` rejects a
+        float first -- so this goes through ``store_results`` directly, which is
+        also the shape a plain-function worker produces.
+        """
+        res = _run(WrongLengthVec())
+        collector = ResultCollector()
+        job = Job(job_id="vec-job", function=lambda **_: None, job_args={"x": 0})
+
+        class _Worker:
+            function_input: ClassVar[dict] = {"x": 0}
+            index_tuple = (0, 0)
+            canonical_input = ("x", 0)
+
+        with self.assertRaises(TypeError) as ctx:
+            collector.store_results(
+                JobFuture(job=job, res={"v": 3.0}),
+                res,
+                _Worker(),
+                bn.BenchRunCfg(),
+            )
+        msg = str(ctx.exception)
+        self.assertIn("'v'", msg)
+        self.assertIn("float", msg)
+
+
+# ---------------------------------------------------------------------------
+# B3 -- worker returned None
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerReturnedNothing(unittest.TestCase):
+    """B3: loud or silent used to be chosen by an unrelated config knob."""
+
+    def test_serial_raises(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            _run(ReturnsNothing())
+        self.assertIn("returned None", str(ctx.exception))
+
+    def test_multiprocessing_raises_too(self) -> None:
+        """The path that used to complete green with an all-sentinel dataset."""
+        with self.assertRaises(TypeError) as ctx:
+            _run(ReturnsNothing(), executor=Executors.MULTIPROCESSING)
+        self.assertIn("returned None", str(ctx.exception))
+
+    def test_the_message_says_what_to_do(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            require_worker_result(None, "job-42")
+        msg = str(ctx.exception)
+        self.assertIn("job-42", msg)
+        self.assertIn("super().__call__(**kwargs)", msg)
+
+    def test_a_real_result_passes_straight_through(self) -> None:
+        payload = {"y": 1.0}
+        self.assertIs(require_worker_result(payload, "job-1"), payload)
+
+    def test_an_empty_dict_is_not_treated_as_missing(self) -> None:
+        """A worker with no result vars returns ``{}``, which is falsy but valid."""
+        self.assertEqual(require_worker_result({}, "job-1"), {})
+
+
+class TestCatchDoesNotAbsorbContractErrors(unittest.TestCase):
+    """Plan 23 decision 2: ``catch=`` tolerates failing *samples*, not a broken harness.
+
+    Both checks are raised outside ``store_results``'s ``except catch`` block on
+    purpose. Without this test the fix would look complete while
+    ``catch=Exception`` -- the obvious thing to reach for -- silently restored the
+    old behaviour, which is the exact failure mode B2 and B3 are about.
+    """
+
+    def tearDown(self) -> None:
+        WrongLengthVec.n_elements = 2
+
+    def test_catch_does_not_swallow_a_none_return(self) -> None:
+        with self.assertRaises(TypeError):
+            _run(ReturnsNothing(), catch=Exception)
+
+    def test_catch_does_not_swallow_a_wrong_length_vector(self) -> None:
+        WrongLengthVec.n_elements = 1
+        with self.assertRaises(TypeError):
+            _run(WrongLengthVec(), catch=Exception)
+
+
+# ---------------------------------------------------------------------------
+# C13 -- executor normalization
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorNormalization:
+    """C13, and the precondition plan 24 A2 requires for matching on ``executor``.
+
+    No pre-fix regression test is possible here: the four comparison sites happen
+    to agree today, because ``Executors.factory`` also used ``==``. What is
+    testable -- and what actually protects the ``assert_never`` in ``factory`` --
+    is that normalization makes the agreement structural.
+    """
+
+    def test_a_raw_string_is_where_the_two_styles_disagree(self) -> None:
+        """The reason normalization exists, pinned as an executable fact.
+
+        Also a tripwire for the stdlib-``StrEnum`` migration (plan 23 handover
+        §5.4): ``enum.StrEnum`` + ``auto()`` lowercases, so ``"SERIAL"`` would
+        stop comparing equal at all and this assertion would fail loudly rather
+        than the vocabulary changing under callers in silence.
+        """
+        raw = "SERIAL"
+        assert raw == Executors.SERIAL  # every `==`/`!=` site sees serial
+        assert raw is not Executors.SERIAL  # every `is`/`is not` site does not
+
+    @pytest.mark.parametrize("member", list(Executors))
+    def test_normalizing_a_member_is_the_identity(self, member: Executors) -> None:
+        assert normalize_executor(member) is member
+
+    @pytest.mark.parametrize("member", list(Executors))
+    def test_a_raw_value_normalizes_to_its_member(self, member: Executors) -> None:
+        assert normalize_executor(member.value) is member
+
+    @pytest.mark.parametrize("member", list(Executors))
+    def test_every_comparison_style_agrees_after_normalizing(self, member: Executors) -> None:
+        """The property the four sites (`==`, `!=`, `is`, `is not`) rely on."""
+        normalized = normalize_executor(member.value)
+        assert (normalized == Executors.SERIAL) == (normalized is Executors.SERIAL)
+        assert (normalized != Executors.SERIAL) == (normalized is not Executors.SERIAL)
+
+    @pytest.mark.parametrize("bad", ["serial", "threads", "", "Serial"])
+    def test_an_unknown_value_raises_at_the_parse(self, bad: str) -> None:
+        """Plan 24 A3: at normalization, never at a match site."""
+        with pytest.raises(ValueError, match="executor must be one of"):
+            normalize_executor(bad)
+
+    def test_factory_rejects_an_unknown_value_before_matching(self) -> None:
+        """``factory``'s ``assert_never`` must be unreachable from bad input.
+
+        If the parse were removed the match would fall through to
+        ``assert_never`` and raise ``AssertionError: Expected code to be
+        unreachable``, which points the reader at a missing enum member rather
+        than at their own typo (plan 24 A1).
+        """
+        with pytest.raises(ValueError, match="executor must be one of"):
+            Executors.factory("threads")
+
+    def test_factory_resolves_a_raw_string_to_the_serial_path(self) -> None:
+        assert Executors.factory("SERIAL") is None
+        assert Executors.factory(Executors.SERIAL) is None
+
+    def test_future_cache_stores_a_member_not_a_string(self) -> None:
+        """``submit()`` discriminates with ``is not``, so the field must be a member."""
+        cache = FutureCache(executor="SERIAL", cache_samples=False)
+        try:
+            assert cache.executor_type is Executors.SERIAL
+        finally:
+            cache.close()
+
+    @staticmethod
+    def _cfg() -> bn.BenchRunCfg:
+        cfg = bn.BenchRunCfg(executor="SERIAL")
+        # The premise of C13: param.Selector accepts the bare string, because
+        # Executors is a StrEnum and `"SERIAL" in list(Executors)` is therefore True.
+        assert cfg.executor is not Executors.SERIAL, "precondition: param stored a raw str"
+        cfg.auto_plot = False
+        cfg.cache_results = False
+        cfg.cache_samples = False
+        return cfg
+
+    def test_the_config_the_sweep_actually_runs_on_holds_a_member(self) -> None:
+        """``to_bench`` deepcopies, so the normalized field is the one on the copy.
+
+        Asserted via ``last_run_cfg`` rather than the caller's object: the copy is
+        what reaches every comparison site, and leaving the caller's config
+        untouched is the intended behaviour, not a gap.
+        """
+        cfg = self._cfg()
+        bench = WrongLengthVec().to_bench(cfg)
+        try:
+            bench.plot_sweep(input_vars=["x"], plot_callbacks=False)
+            assert bench.last_run_cfg.executor is Executors.SERIAL
+            assert cfg.executor == "SERIAL", "the caller's own config is not mutated"
+        finally:
+            bench.close()
+
+    def test_a_config_passed_to_plot_sweep_is_normalized_in_place(self) -> None:
+        """The direct path does not copy, so the caller sees the member."""
+        cfg = self._cfg()
+        bench = bn.Bench("c13_direct", WrongLengthVec())
+        try:
+            bench.plot_sweep(input_vars=["x"], run_cfg=cfg, plot_callbacks=False)
+            assert cfg.executor is Executors.SERIAL
+        finally:
+            bench.close()


### PR DESCRIPTION
Plan 23 P2 — the collection-path live bugs (B2, B3) plus executor normalization (C13).
Follows #1026 (P1, the `ty` gate). Independent of P3.

## Summary

Three findings, all the same shape: **a branch that stored nothing and had no `else`**, so
a harness-contract error was indistinguishable from a sweep that had not run yet.

**B2 — a wrong-length `ResultVec` was silently discarded.** The store was guarded by
`isinstance(v, (list, np.ndarray)) and len(v) == rv.size` with no `else`, so the cell kept
its NaN fill. `param.List` validates *that* the value is a list but not how long it is, so
this was reachable from ordinary benchmark code. Now raises `TypeError` naming the
variable, the declared size and the actual length.

**B3 — a worker returning `None` was loud or silent depending on an unrelated knob.** It
tripped a bare `assert` on the serial path (absent under `python -O`) and *nothing at all*
on MULTIPROCESSING/SCOOP, where the future resolved to `None`, `store_results` skipped its
entire body behind `if result is not None:`, and the sweep completed green with an
all-sentinel dataset and `n_failed == 0`. Both paths now funnel through
`require_worker_result`.

**C13 — `executor` is normalized to an `Executors` member at both ingresses.** Because
`Executors` is a `StrEnum`, `param.Selector(objects=list(Executors))` accepts the bare
string `"SERIAL"` and stores a `str` in a field compared with `==` in `Bench` and `is not`
in `FutureCache.submit`. The four sites agreed only because `factory` also used `==` —
luck, not design. `factory` now parses first and matches exhaustively.

## Two things worth reviewing specifically

**`catch=` was the load-bearing half of decision 2.** Seeding the pre-fix code back to
check the new tests actually catch something produced this, from a run with
`catch=Exception`:

```
WARNING sample failed and was caught (x=0, repeat=1): AssertionError('old assert')
```

So the old assert was not merely `-O`-fragile — with `catch=` set it was **downgraded to a
tolerated sample failure**, i.e. the silent-empty-dataset outcome was reachable on serial
too. Both new checks are raised from *outside* `store_results`'s `except catch` block, and
`TestCatchDoesNotAbsorbContractErrors` pins it. Without that test the fix would look
complete while `catch=Exception` — the obvious thing for a user to reach for — restored the
old behaviour.

This also forced the check's location: `JobFuture.result()` is where both executors
converge, but it is called *inside* that `except catch` block, so raising there would be
absorbed. Hence the check sits at the two points a result is *consumed*, and
`JobFuture.result()` is now annotated `-> dict | None` — honest rather than narrow, since
`JobFuture` really can hold neither a result nor a future. **P5 removes the `| None`** by
making that state unrepresentable.

**The `assert_never` in `factory` is verified, not assumed.** Deleting the SCOOP arm gives:

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
    |  Inferred type of argument is `Literal[Executors.SCOOP]`
```

This is the first place plan 24 A2's precondition is realised end to end: the parse is what
makes the subject typed, and `test_factory_rejects_an_unknown_value_before_matching` pins
that bad input raises `ValueError` at the parse rather than `AssertionError` at the match.

## Also in here

- `Executors.factory` was annotated `-> Future | None`, the one type it never returns — a
  `Future` is what `submit()` hands back. Found by putting `job.py` on the strict `ty` list
  to measure it. The concrete values are a `ProcessPoolExecutor` and, for SCOOP, a
  *module*, so `concurrent.futures.Executor` would be a second smaller lie; it is now a
  two-method `SupportsSubmit` Protocol that both satisfy.
- **Neither reworked file could join the strict ratchet**, and the block's "only when
  clean" rule is honoured rather than loosened. Measured: 6 diagnostics, 2 fixed by the
  Protocol above. The remaining 4 are pre-existing and out of scope — a missing `None`
  guard in `clear_tag`, two argument-type mismatches, and iterating
  `worker_job.function_input.items()` where the field is `dict | None`. **The last two are
  the same defect** (`WorkerJob.function_input` is `None` until `setup_hashes()` runs —
  two-phase init), which is P5/P9 territory and should unlock both files in one step. Plan
  23 §10 item 7 names them precisely.
- P1's Tier-A gate caught this PR's own test fixture: `ReturnsNothing.__call__ -> None`
  trips `invalid-method-override` against `ParametrizedSweep.__call__ -> dict`. It carries a
  scoped `# ty: ignore` with a reason, because the invalid override *is* the subject under
  test. Useful implication: for a worker whose return type is annotated, B3 is already a
  **static** error; the runtime check covers the unannotated case, which is the common one.

## Breaking changes

Both fail-loud fixes are breaking for anyone whose benchmark is currently wrong: a worker
returning `None`, or a `ResultVec` of the wrong length, previously produced a green run with
missing data. **Owner decision 23 §6.2 is resolved as `raise TypeError`** on the
recommendation on file. If warn-and-skip is preferred for parallel users, the change is
localized to `require_worker_result` and the `ResultVec` arm.

Not breaking: a `tuple` for a `ResultVec` now raises where it was silently dropped. The
accepted-type set is deliberately *not* widened here — which types each result variable
accepts is P4's (the registry's) call, not a side effect of making the drop loud.

## Cache safety

Per plan 23 §7: `executor` reaches no persistent hash (absent from both `identity.py` and
`worker_job.py`), and for the one place it is stringified (`bench_cfg.py`'s sampling
summary) a member and the raw string are indistinguishable —
`str(Executors.SERIAL) == str("SERIAL")` and `hash(Executors.SERIAL) == hash("SERIAL")`,
both True, since `StrEnum` inherits `str`. No `CACHE_VERSION` bump.

## Test plan

`test/test_collection_contract.py`, 30 tests.

- `pixi run ci` — 2457 passed, pylint 10.00/10, `ty` clean, coverage 90% (gate 85%)
- `pixi run test-split` — the split-render pipeline over the whole suite
- `pixi run pytest test/test_ty_gate.py` — 24 gate meta-tests still pass

**Each B2/B3 test was verified to fail on the pre-fix code**, by seeding the old branches
back rather than by inspection (plan 23 §9 DoD):

| Seeded | Failing tests |
|---|---|
| B2's silent guard restored | 4 failed, 1 passed (the control case, correctly still green) |
| B3's silent skip + bare assert restored | 3 failed, 3 passed |

No pre-fix test is possible for C13, as the plan predicted — the four sites happen to agree
today. What is pinned instead is the *reason* the normalization exists, as an executable
fact: `"SERIAL" == Executors.SERIAL` while `"SERIAL" is not Executors.SERIAL`. That
assertion doubles as a tripwire for the stdlib-`StrEnum` migration (§D4), which would change
the accepted vocabulary rather than just the representation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fail loudly on broken worker contracts and normalize executor configuration to use typed enum members across collection and execution paths.

Bug Fixes:
- Raise TypeError when a benchmark worker returns None instead of silently producing an empty sweep across serial and multiprocessing executors.
- Raise TypeError when a ResultVec is set to the wrong number or type of elements instead of silently dropping the value and leaving NaNs.

Enhancements:
- Normalize executor configuration values to Executors enum members at all ingress points and make factory exhaustive with assert_never and a dedicated SupportsSubmit protocol.
- Annotate JobFuture.result to allow None and introduce require_worker_result so callers explicitly validate worker results.
- Clarify plan 23 documentation with an implemented P2 section covering collection-path contract checks, executor normalization, and strict-typing implications.

Documentation:
- Update plan 23 constructive data modeling and handover documents to describe P2 implementation, executor normalization semantics, and contract error handling.
- Extend the changelog with breaking fail-loud behaviour for None returns and ResultVec length mismatches, and with executor normalization and typing changes.

Tests:
- Add test suite test_collection_contract.py to cover ResultVec length enforcement, worker returning None behaviour across executors and catch=, and executor normalization and factory error handling.