### PR TITLE
feat: single ResultSpec registry replaces the nine result-type tuples (plan 23 P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which strings `BenchRunCfg(executor=...)` accepts. See plan 23 D4.
 
 ### Added
+- **Single result-type registry: `RESULT_SPECS` in `bencher/variables/results.py`**
+  (plan 23 P4). One ordered `{Result* class: ResultSpec}` mapping now declares each
+  result type's kind, missing fill/sentinels, and family memberships (panel, media,
+  data-var, multidim, scalar, reference-backed). The nine previously hand-maintained
+  registries — `PANEL_TYPES`, `SCALAR_RESULT_TYPES`, `XARRAY_MULTIDIM_RESULT_TYPES`,
+  `ALL_RESULT_TYPES`, `RESULT_KIND_ORDER`, `_REFERENCE_MISSING_TYPES`,
+  `_OBJECT_MISSING_TYPES`, `DATA_VAR_RESULT_TYPES`, and `result_collector`'s
+  `_MEDIA_RESULT_TYPES` — are derived from it under their existing names, so call
+  sites are unchanged and no stored cell value or sentinel changes (no
+  `CACHE_VERSION` bump). Adding a `Result*` class without a spec now fails CI with
+  one clear message, and a parameter class defined in the results module but absent
+  from the registry is refused at sweep-declaration time instead of silently
+  classifying as an *input* variable. A6 phase 2 (the generalized rendering plan)
+  is intended to derive its channel vocabulary from this registry. The deprecated
+  `ResultVar` is exempt by declaration (`RESULT_SPEC_EXEMPT`) and resolves to
+  `ResultFloat`'s spec; `ResultHmap` keeps its historical quirks (registered, but
+  neither a data-var nor a panel type) rather than being "tidied".
 - **Content-addressed blob store: `bencher/blob_store.py`** (plan 22, phase 1 of the A6
   grammar-of-ND-data migration, #1021). Result payloads that cannot live directly in a
   dataset cell are serialized under `cachedir/blobs/` and named by the sha256 of their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is intended to derive its channel vocabulary from this registry. The deprecated
   `ResultVar` is exempt by declaration (`RESULT_SPEC_EXEMPT`) and resolves to
   `ResultFloat`'s spec; `ResultHmap` keeps its historical quirks (registered, but
-  neither a data-var nor a panel type) rather than being "tidied".
+  neither a data-var nor a panel type) rather than being "tidied". Membership of
+  every derived tuple is unchanged, but iteration *order* now follows the registry's
+  most-derived-first order (e.g. `SCALAR_RESULT_TYPES` is now `(ResultBool,
+  ResultFloat)`); every in-repo consumer is an `isinstance()` check, so this is
+  observable only to external code that indexes or orders on the re-exported tuples.
 - **Content-addressed blob store: `bencher/blob_store.py`** (plan 22, phase 1 of the A6
   grammar-of-ND-data migration, #1021). Result payloads that cannot live directly in a
   dataset cell are serialized under `cachedir/blobs/` and named by the sha256 of their

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -41,17 +41,14 @@ from bencher.job import JobFuture, SampleFailure, normalize_catch, require_worke
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
+    _MEDIA_RESULT_TYPES,
     DATA_VAR_RESULT_TYPES,
     XARRAY_MULTIDIM_RESULT_TYPES,
-    _MEDIA_RESULT_TYPES,
     ResultDataSet,
     ResultFloat,
-    ResultImage,
-    ResultPath,
     ResultReference,
     ResultRerun,
     ResultVec,
-    ResultVideo,
     result_missing_fill,
 )
 from bencher.variables.time import TimeEvent, TimeSnapshot

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -43,7 +43,7 @@ from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
     DATA_VAR_RESULT_TYPES,
     XARRAY_MULTIDIM_RESULT_TYPES,
-    ResultContainer,
+    _MEDIA_RESULT_TYPES,
     ResultDataSet,
     ResultFloat,
     ResultImage,
@@ -58,19 +58,6 @@ from bencher.variables.time import TimeEvent, TimeSnapshot
 from bencher.worker_job import WorkerJob
 
 logger = logging.getLogger(__name__)
-
-# Result types whose cell names a file this variable alone owns, so aging the cell
-# out of the over_time history deletes the file too (see ``_null_old_entries``).
-#
-# ``ResultDataSet`` is deliberately NOT here, even though its cells are paths as
-# well: blob-store files are content-addressed, so one file may back cells at other
-# time points, in other result variables, or in another benchmark sharing the cache
-# — identical payloads deduplicate to a single path by design, and this function
-# sees only the variable it is aging. Deleting the file here would strand every
-# other cell still holding that path. Aging therefore only writes the sentinel;
-# reclaiming blob storage belongs to ``bencher.cache_management``, which is the
-# layer that can see the whole cache and tell a dropped payload from a shared one.
-_MEDIA_RESULT_TYPES = (ResultPath, ResultVideo, ResultImage, ResultContainer, ResultRerun)
 
 
 def _sentinel_for_result_var(rv):

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -86,6 +86,18 @@ class ParametrizedSweep(Parameterized):
             ):
                 results[k] = v
             else:
+                # A parameter class defined in the results module but absent
+                # from RESULT_SPECS would otherwise silently classify as an
+                # *input* variable — the hole that made the old ResultVolume
+                # class a trap (declared, unstorable, KeyError far from cause).
+                if type(v).__module__ == "bencher.variables.results":
+                    raise TypeError(
+                        f"'{k}' is declared as {type(v).__name__}, which is defined in "
+                        f"bencher.variables.results but is not registered in RESULT_SPECS, "
+                        f"so it cannot be classified as a result variable (and refusing "
+                        f"to treat it as an input). Add a ResultSpec entry for it in "
+                        f"bencher/variables/results.py."
+                    )
                 inputs[k] = v
 
         if not include_name:

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -788,7 +788,7 @@ RESULT_SPECS: dict[type, ResultSpec] = {
         is_media=False,
         is_data_var=True,
         multidim=False,
-        reference_backed=False,
+        reference_backed=True,
     ),
 }
 
@@ -871,30 +871,24 @@ def result_kind(result_var) -> str:
 # aging (``_null_old_entries``) build their arrays from ``result_missing_fill``,
 # and consumers test for missingness with ``result_is_missing`` instead of
 # hardcoding ``np.isnan`` / ``== "NAN"`` / ``== -1`` per call site.
-_REFERENCE_MISSING_TYPES = (ResultReference,)
-_OBJECT_MISSING_TYPES = (
-    ResultPath,
-    ResultVideo,
-    ResultImage,
-    ResultString,
-    ResultContainer,
-    ResultRerun,
-    ResultDataSet,
-)
+_REFERENCE_MISSING_TYPES = _spec_types(lambda s: s.reference_backed)
+_OBJECT_MISSING_TYPES = _spec_types(lambda s: s.fill_dtype is object)
 # Single-column result types that get a data variable in the dataset. ResultVec
 # is handled separately (it expands to one column per element); ResultHmap is
 # stored out-of-band and intentionally gets no data variable.
-DATA_VAR_RESULT_TYPES = SCALAR_RESULT_TYPES + _REFERENCE_MISSING_TYPES + _OBJECT_MISSING_TYPES
+DATA_VAR_RESULT_TYPES = _spec_types(lambda s: s.is_data_var)
 
 
 def result_missing_fill(rv) -> tuple[Any, type]:
-    """Return the ``(fill_value, numpy_dtype)`` used for missing entries of *rv*."""
-    if isinstance(rv, _REFERENCE_MISSING_TYPES):
-        return -1, int
-    if isinstance(rv, _OBJECT_MISSING_TYPES):
-        return "NAN", object
-    # ResultFloat / ResultBool / ResultVec and any future numeric.
-    return float("nan"), float
+    """Return the ``(fill_value, numpy_dtype)`` used for missing entries of *rv*.
+
+    Read from the ResultSpec registry; an unregistered parameter (or a future
+    numeric result type before registration) falls back to the NaN family,
+    matching the pre-registry behavior."""
+    spec = result_spec(rv)
+    if spec is None:
+        return float("nan"), float
+    return spec.missing_fill, spec.fill_dtype
 
 
 def _dataset_cell_is_missing(value) -> bool:

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -32,6 +32,7 @@ import math
 import numbers
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import auto
 from functools import partial
 from typing import Any
@@ -559,71 +560,292 @@ class ResultDataSet(param.Parameter):
         return _hash_slots(self)
 
 
-PANEL_TYPES = (
-    ResultPath,
-    ResultImage,
-    ResultVideo,
-    ResultContainer,
-    ResultRerun,
-    ResultString,
-    ResultReference,
-    ResultDataSet,
-)
+# --- Result-type registry (plan 23 P4) --------------------------------------
+#
+# Single source of truth for how every Result* class is classified and stored.
+# It replaces nine hand-maintained tuples (PANEL_TYPES, SCALAR_RESULT_TYPES,
+# XARRAY_MULTIDIM_RESULT_TYPES, ALL_RESULT_TYPES, RESULT_KIND_ORDER,
+# _REFERENCE_MISSING_TYPES, _OBJECT_MISSING_TYPES, DATA_VAR_RESULT_TYPES and
+# result_collector's _MEDIA_RESULT_TYPES) that each had their own silent
+# failure mode when a new class missed one of them. The original names are
+# all still exported, derived from the registry, so call sites are unchanged.
+# Adding a Result* class without a spec fails CI (test/test_result_missing.py)
+# and is refused at sweep-declaration time (parametrised_sweep.py).
 
 
-SCALAR_RESULT_TYPES = (ResultFloat, ResultBool)
+class ResultKind(StrEnum):
+    """Coarse, serializable classification of a result variable.
 
-XARRAY_MULTIDIM_RESULT_TYPES = (
-    ResultFloat,
-    ResultBool,
-    ResultVideo,
-    ResultImage,
-    ResultString,
-    ResultContainer,
-    ResultRerun,
-    ResultPath,
-)
+    The values feed the A2 plot-selection signatures, so they must stay
+    stable strings. Explicit values rather than ``auto()``: ``strenum``'s
+    ``auto()`` yields the member *name* verbatim, which would silently change
+    these to uppercase (plan 23 D4)."""
 
-ALL_RESULT_TYPES = (
-    ResultFloat,
-    ResultBool,
-    ResultVec,
-    ResultHmap,
-    ResultPath,
-    ResultVideo,
-    ResultImage,
-    ResultString,
-    ResultContainer,
-    ResultRerun,
-    ResultDataSet,
-    ResultReference,
-)
+    BOOL = "bool"
+    FLOAT = "float"
+    VEC = "vec"
+    IMAGE = "image"
+    VIDEO = "video"
+    PATH = "path"
+    STRING = "string"
+    DATASET = "dataset"
+    RERUN = "rerun"
+    CONTAINER = "container"
+    HMAP = "hmap"
+    REFERENCE = "reference"
 
-# Most-derived first: kind classification takes the first isinstance match
+
+@dataclass(frozen=True)
+class ResultSpec:
+    """Storage and classification contract for one Result* class.
+
+    Attributes:
+        kind: Coarse kind name for plot-selection signatures (A2).
+        missing_fill: Value written for a missing/unrecorded sample.
+        fill_dtype: Numpy dtype of the backing array (float | object | int).
+        missing_sentinels: Exact-equality sentinel values accepted as
+            "missing" on READ. This can be wider than ``{missing_fill}``
+            because missingness is not a pure function of the fill:
+            ``ResultDataSet`` accepts both its cell generations (``"NAN"``
+            blob paths from plan 22 onwards, ``-1`` indices before)
+            permanently. NaN/``None`` missingness is dtype-generic and handled
+            in :func:`result_is_missing`, not listed here (NaN has no useful
+            equality semantics in a set).
+        is_scalar: Continuous/boolean scalar metric (regression, optimization).
+        is_panel: Rendered through the panel pathway rather than holoviews.
+        is_media: Cell values reference media files on disk that over_time
+            aging must delete when entries age out.
+        is_data_var: Gets a single data variable (column) in the dataset.
+            ``ResultVec`` expands to one column per element and ``ResultHmap``
+            is stored out-of-band, so neither is a data var.
+        multidim: Member of the xarray multidim store family
+            (``XARRAY_MULTIDIM_RESULT_TYPES``).
+        reference_backed: Cell stores an ``object_index`` index
+            (``ResultReference`` only).
+    """
+
+    kind: ResultKind
+    missing_fill: Any
+    fill_dtype: type
+    missing_sentinels: frozenset
+    is_scalar: bool
+    is_panel: bool
+    is_media: bool
+    is_data_var: bool
+    multidim: bool
+    reference_backed: bool
+
+
+_NAN = float("nan")
+
+# Insertion order is the isinstance-resolution order: most-derived first
 # (ResultBool subclasses ResultFloat; ResultRerun subclasses ResultContainer).
-RESULT_KIND_ORDER = (
-    (ResultBool, "bool"),
-    (ResultFloat, "float"),
-    (ResultVec, "vec"),
-    (ResultImage, "image"),
-    (ResultVideo, "video"),
-    (ResultPath, "path"),
-    (ResultString, "string"),
-    (ResultDataSet, "dataset"),
-    (ResultRerun, "rerun"),
-    (ResultContainer, "container"),
-    (ResultHmap, "hmap"),
-    (ResultReference, "reference"),
-)
+# A test pins that no key precedes one of its own subclasses.
+RESULT_SPECS: dict[type, ResultSpec] = {
+    ResultBool: ResultSpec(
+        kind=ResultKind.BOOL,
+        missing_fill=_NAN,
+        fill_dtype=float,
+        missing_sentinels=frozenset(),
+        is_scalar=True,
+        is_panel=False,
+        is_media=False,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultFloat: ResultSpec(
+        kind=ResultKind.FLOAT,
+        missing_fill=_NAN,
+        fill_dtype=float,
+        missing_sentinels=frozenset(),
+        is_scalar=True,
+        is_panel=False,
+        is_media=False,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultVec: ResultSpec(
+        kind=ResultKind.VEC,
+        missing_fill=_NAN,
+        fill_dtype=float,
+        missing_sentinels=frozenset(),
+        is_scalar=False,
+        is_panel=False,
+        is_media=False,
+        is_data_var=False,
+        multidim=False,
+        reference_backed=False,
+    ),
+    ResultImage: ResultSpec(
+        kind=ResultKind.IMAGE,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=True,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultVideo: ResultSpec(
+        kind=ResultKind.VIDEO,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=True,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultPath: ResultSpec(
+        kind=ResultKind.PATH,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=True,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultString: ResultSpec(
+        kind=ResultKind.STRING,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=False,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultDataSet: ResultSpec(
+        kind=ResultKind.DATASET,
+        missing_fill="NAN",
+        fill_dtype=object,
+        # Dual-generation compatibility (plan 22): "NAN" blob-path cells and
+        # legacy -1 index cells are both missing, permanently. The float
+        # promotion (-1.0) and NaN/None acceptance live in
+        # _dataset_cell_is_missing — do NOT collapse that into this set.
+        missing_sentinels=frozenset({"NAN", -1}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=False,
+        is_data_var=True,
+        multidim=False,
+        reference_backed=False,
+    ),
+    ResultRerun: ResultSpec(
+        kind=ResultKind.RERUN,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=True,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultContainer: ResultSpec(
+        kind=ResultKind.CONTAINER,
+        missing_fill="NAN",
+        fill_dtype=object,
+        missing_sentinels=frozenset({"NAN"}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=True,
+        is_data_var=True,
+        multidim=True,
+        reference_backed=False,
+    ),
+    ResultHmap: ResultSpec(
+        kind=ResultKind.HMAP,
+        missing_fill=_NAN,
+        fill_dtype=float,
+        missing_sentinels=frozenset(),
+        is_scalar=False,
+        is_panel=False,
+        is_media=False,
+        is_data_var=False,
+        multidim=False,
+        reference_backed=False,
+    ),
+    ResultReference: ResultSpec(
+        kind=ResultKind.REFERENCE,
+        missing_fill=-1,
+        fill_dtype=int,
+        missing_sentinels=frozenset({-1}),
+        is_scalar=False,
+        is_panel=True,
+        is_media=False,
+        is_data_var=True,
+        multidim=False,
+        reference_backed=False,
+    ),
+}
+
+
+def result_spec(result_var) -> ResultSpec | None:
+    """Spec for a result-variable instance, resolved most-derived-first.
+
+    Returns ``None`` for parameters that are not registered result types.
+    Deprecated subclasses absent from the registry (``ResultVar``) resolve to
+    their base class's spec via isinstance."""
+    for cls, spec in RESULT_SPECS.items():
+        if isinstance(result_var, cls):
+            return spec
+    return None
+
+
+def _spec_types(predicate) -> tuple[type, ...]:
+    """The registry keys whose spec satisfies *predicate*, in registry order."""
+    return tuple(cls for cls, spec in RESULT_SPECS.items() if predicate(spec))
+
+
+# The nine pre-registry names, derived. Every consumer is an isinstance()
+# check, so membership (not tuple order) is the behavioral contract; only
+# RESULT_KIND_ORDER is order-sensitive and reproduces its original order
+# exactly. A transitional test pins each against its pre-migration literal.
+PANEL_TYPES = _spec_types(lambda s: s.is_panel)
+
+SCALAR_RESULT_TYPES = _spec_types(lambda s: s.is_scalar)
+
+XARRAY_MULTIDIM_RESULT_TYPES = _spec_types(lambda s: s.multidim)
+
+ALL_RESULT_TYPES = tuple(RESULT_SPECS)
+
+# Most-derived first: kind classification takes the first isinstance match.
+RESULT_KIND_ORDER = tuple((cls, spec.kind.value) for cls, spec in RESULT_SPECS.items())
+
+# Result types whose cell names a file this variable alone owns, so aging the
+# cell out of the over_time history deletes the file too (see
+# ``result_collector._null_old_entries``).
+#
+# ``ResultDataSet`` is deliberately not media (``is_media=False``), even though
+# its cells are paths as well: blob-store files are content-addressed, so one
+# file may back cells at other time points, in other result variables, or in
+# another benchmark sharing the cache — identical payloads deduplicate to a
+# single path by design, and the aging path sees only the variable it is aging.
+# Deleting the file there would strand every other cell still holding that
+# path. Aging therefore only writes the sentinel; reclaiming blob storage
+# belongs to ``bencher.cache_management``, which is the layer that can see the
+# whole cache and tell a dropped payload from a shared one.
+_MEDIA_RESULT_TYPES = _spec_types(lambda s: s.is_media)
 
 
 def result_kind(result_var) -> str:
     """Classify a result variable into a coarse, serializable kind name used by
     plot-selection signatures (A2)."""
-    for cls, kind in RESULT_KIND_ORDER:
-        if isinstance(result_var, cls):
-            return kind
-    return "unknown"
+    spec = result_spec(result_var)
+    return spec.kind.value if spec is not None else "unknown"
 
 
 # --- Missing / unrecorded-sample representation ----------------------------
@@ -734,3 +956,12 @@ class ResultVar(ResultFloat):
             stacklevel=2,
         )
         super().__init__(*args, **kwargs)
+
+
+# Result* classes deliberately absent from RESULT_SPECS, so the completeness
+# test can tell "exempt" from "forgotten". An exempt class must resolve to a
+# registered base class via isinstance (result_spec falls through to it) and
+# has never been a member of any registry tuple.
+RESULT_SPEC_EXEMPT: dict[type, str] = {
+    ResultVar: "deprecated alias of ResultFloat; instances resolve to ResultFloat's spec",
+}

--- a/bencher/variables/results.py
+++ b/bencher/variables/results.py
@@ -487,7 +487,7 @@ class ResultReference(param.Parameter):
     def __init__(
         self,
         obj: Any | None = None,
-        container: Callable[Any, pn.pane.panel] | None = None,
+        container: Callable[[Any], Any] | None = None,
         default: Any | None = None,
         units: str = "container",
         max_time_events=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ include = [
     "bencher/sample_order.py",
     "bencher/sweep_timings.py",
     "bencher/blob_store.py",
+    "bencher/variables/results.py",
 ]
 [tool.ty.overrides.rules]
 invalid-assignment = "error"

--- a/test/test_result_missing.py
+++ b/test/test_result_missing.py
@@ -283,6 +283,41 @@ class TestResultSpecRegistry(unittest.TestCase):
         self.assertIsNone(result_spec(param.Number()))
         self.assertIsNone(result_spec(param.String()))
 
+    def test_missing_fill_reads_from_the_spec(self):
+        # Permanent (unlike the transitional literal test below): the fill
+        # helper must resolve each instance to ITS spec, exempt classes must
+        # inherit their base's fill, and unregistered params must fall back to
+        # the NaN family. Guards the isinstance-resolution path end to end.
+        for cls, spec in RESULT_SPECS.items():
+            inst = _instantiate(cls)
+            with self.subTest(cls=cls.__name__):
+                fill, dtype = result_missing_fill(inst)
+                self.assertIs(dtype, spec.fill_dtype)
+                if isinstance(spec.missing_fill, float) and math.isnan(spec.missing_fill):
+                    self.assertTrue(math.isnan(fill))
+                else:
+                    self.assertEqual(fill, spec.missing_fill)
+        for cls in RESULT_SPEC_EXEMPT:
+            fill, dtype = result_missing_fill(_instantiate(cls))
+            self.assertTrue(math.isnan(fill))
+            self.assertIs(dtype, float)
+        fill, dtype = result_missing_fill(param.Number())
+        self.assertTrue(math.isnan(fill))
+        self.assertIs(dtype, float)
+
+    def test_fill_dtype_is_consistent_with_the_fill_value(self):
+        # A spec whose fill and dtype disagree would corrupt the backing array
+        # at setup_dataset time; make the mismatch a registry-level failure.
+        for cls, spec in RESULT_SPECS.items():
+            with self.subTest(cls=cls.__name__):
+                if spec.fill_dtype is float:
+                    self.assertTrue(math.isnan(spec.missing_fill))
+                elif spec.fill_dtype is int:
+                    self.assertIsInstance(spec.missing_fill, int)
+                else:
+                    self.assertIs(spec.fill_dtype, object)
+                    self.assertIsInstance(spec.missing_fill, str)
+
 
 class TestDerivedTuplesMatchPreRegistryLiterals(unittest.TestCase):
     """TRANSITIONAL — delete after one release (added in plan 23 P4).

--- a/test/test_result_missing.py
+++ b/test/test_result_missing.py
@@ -12,11 +12,21 @@ import unittest
 import warnings
 
 import numpy as np
+import param
 
 from bencher.result_collector import _sentinel_for_result_var
+from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import (
+    _MEDIA_RESULT_TYPES,
+    _OBJECT_MISSING_TYPES,
+    _REFERENCE_MISSING_TYPES,
     ALL_RESULT_TYPES,
     DATA_VAR_RESULT_TYPES,
+    PANEL_TYPES,
+    RESULT_KIND_ORDER,
+    RESULT_SPEC_EXEMPT,
+    RESULT_SPECS,
+    SCALAR_RESULT_TYPES,
     XARRAY_MULTIDIM_RESULT_TYPES,
     ResultBool,
     ResultContainer,
@@ -33,6 +43,7 @@ from bencher.variables.results import (
     result_is_missing,
     result_kind,
     result_missing_fill,
+    result_spec,
 )
 
 
@@ -216,6 +227,206 @@ class TestResultIsMissing(unittest.TestCase):
             arr = np.full(3, fill, dtype=dtype)
             with self.subTest(rv=type(rv).__name__):
                 self.assertTrue(result_is_missing(rv, arr[0]))
+
+
+class TestResultSpecRegistry(unittest.TestCase):
+    """Plan 23 P4: RESULT_SPECS is the single source of truth for result-type
+    classification and storage; the nine legacy tuples are derived from it.
+    These tests make "add a Result* class without a spec" a CI failure with
+    one clear message instead of nine scattered silent failure modes."""
+
+    def test_every_result_class_is_registered_or_exempt(self):
+        from test.test_hash_persistent import _discover_all_result_classes
+
+        for cls in _discover_all_result_classes():
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(
+                    cls in RESULT_SPECS or cls in RESULT_SPEC_EXEMPT,
+                    f"{cls.__name__} has no entry in RESULT_SPECS and is not in "
+                    f"RESULT_SPEC_EXEMPT. Every Result* class must declare a "
+                    f"ResultSpec (bencher/variables/results.py) so all nine "
+                    f"derived registries stay complete.",
+                )
+
+    def test_exempt_classes_resolve_to_a_registered_spec(self):
+        # An exempt class must still be classifiable: isinstance resolution
+        # falls through to a registered base (ResultVar -> ResultFloat).
+        for cls in RESULT_SPEC_EXEMPT:
+            with self.subTest(cls=cls.__name__):
+                self.assertIsNotNone(result_spec(_instantiate(cls)))
+                self.assertNotIn(cls, ALL_RESULT_TYPES)
+
+    def test_no_key_precedes_its_own_subclass(self):
+        # Registry insertion order is the isinstance-resolution order, so a
+        # base class listed before its subclass would shadow the subclass.
+        keys = list(RESULT_SPECS)
+        for i, earlier in enumerate(keys):
+            for later in keys[i + 1 :]:
+                self.assertFalse(
+                    issubclass(later, earlier),
+                    f"{later.__name__} subclasses {earlier.__name__} but is listed "
+                    f"after it in RESULT_SPECS; isinstance dispatch would never "
+                    f"reach it. Most-derived classes must come first.",
+                )
+
+    def test_missing_sentinels_agree_with_result_is_missing(self):
+        # The spec's declared fill and sentinels must be judged missing by the
+        # read-side oracle, so the two cannot drift apart.
+        for cls, spec in RESULT_SPECS.items():
+            inst = _instantiate(cls)
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(result_is_missing(inst, spec.missing_fill))
+                for sentinel in spec.missing_sentinels:
+                    self.assertTrue(result_is_missing(inst, sentinel))
+
+    def test_result_spec_is_none_for_non_result_params(self):
+        self.assertIsNone(result_spec(param.Number()))
+        self.assertIsNone(result_spec(param.String()))
+
+
+class TestDerivedTuplesMatchPreRegistryLiterals(unittest.TestCase):
+    """TRANSITIONAL — delete after one release (added in plan 23 P4).
+
+    Pins that the registry-derived tuples are membership-identical to the
+    hand-maintained literals they replaced (copied here verbatim from the
+    pre-P4 module). Every consumer is an ``isinstance()`` check, so membership
+    is the behavioral contract; a single registry order cannot reproduce all
+    nine historic tuple orders (PANEL_TYPES had Image before Video,
+    XARRAY_MULTIDIM_RESULT_TYPES the reverse). RESULT_KIND_ORDER is the one
+    order-sensitive name (most-derived-first isinstance dispatch) and is
+    compared exactly, order included."""
+
+    def test_membership_identical_to_pre_registry_literals(self):
+        literals = {
+            "PANEL_TYPES": (
+                PANEL_TYPES,
+                {
+                    ResultPath,
+                    ResultImage,
+                    ResultVideo,
+                    ResultContainer,
+                    ResultRerun,
+                    ResultString,
+                    ResultReference,
+                    ResultDataSet,
+                },
+            ),
+            "SCALAR_RESULT_TYPES": (SCALAR_RESULT_TYPES, {ResultFloat, ResultBool}),
+            "XARRAY_MULTIDIM_RESULT_TYPES": (
+                XARRAY_MULTIDIM_RESULT_TYPES,
+                {
+                    ResultFloat,
+                    ResultBool,
+                    ResultVideo,
+                    ResultImage,
+                    ResultString,
+                    ResultContainer,
+                    ResultRerun,
+                    ResultPath,
+                },
+            ),
+            "ALL_RESULT_TYPES": (
+                ALL_RESULT_TYPES,
+                {
+                    ResultFloat,
+                    ResultBool,
+                    ResultVec,
+                    ResultHmap,
+                    ResultPath,
+                    ResultVideo,
+                    ResultImage,
+                    ResultString,
+                    ResultContainer,
+                    ResultRerun,
+                    ResultDataSet,
+                    ResultReference,
+                },
+            ),
+            "_REFERENCE_MISSING_TYPES": (_REFERENCE_MISSING_TYPES, {ResultReference}),
+            "_OBJECT_MISSING_TYPES": (
+                _OBJECT_MISSING_TYPES,
+                {
+                    ResultPath,
+                    ResultVideo,
+                    ResultImage,
+                    ResultString,
+                    ResultContainer,
+                    ResultRerun,
+                    ResultDataSet,
+                },
+            ),
+            "DATA_VAR_RESULT_TYPES": (
+                DATA_VAR_RESULT_TYPES,
+                {
+                    ResultFloat,
+                    ResultBool,
+                    ResultReference,
+                    ResultPath,
+                    ResultVideo,
+                    ResultImage,
+                    ResultString,
+                    ResultContainer,
+                    ResultRerun,
+                    ResultDataSet,
+                },
+            ),
+            "_MEDIA_RESULT_TYPES": (
+                _MEDIA_RESULT_TYPES,
+                {ResultPath, ResultVideo, ResultImage, ResultContainer, ResultRerun},
+            ),
+        }
+        for name, (derived, literal) in literals.items():
+            with self.subTest(registry=name):
+                self.assertEqual(set(derived), literal)
+                self.assertEqual(len(derived), len(literal), f"{name} has duplicates")
+
+    def test_result_kind_order_identical_including_order(self):
+        self.assertEqual(
+            RESULT_KIND_ORDER,
+            (
+                (ResultBool, "bool"),
+                (ResultFloat, "float"),
+                (ResultVec, "vec"),
+                (ResultImage, "image"),
+                (ResultVideo, "video"),
+                (ResultPath, "path"),
+                (ResultString, "string"),
+                (ResultDataSet, "dataset"),
+                (ResultRerun, "rerun"),
+                (ResultContainer, "container"),
+                (ResultHmap, "hmap"),
+                (ResultReference, "reference"),
+            ),
+        )
+
+
+class TestUnregisteredResultClassGuard(unittest.TestCase):
+    """A parameter class defined in the results module but missing from
+    RESULT_SPECS must be refused at sweep-declaration time, not silently
+    classified as an input variable (the old ResultVolume trap)."""
+
+    def test_unregistered_results_module_class_raises(self):
+        class ResultBogus(param.Parameter):
+            pass
+
+        # Simulate a class defined in the results module but never registered.
+        ResultBogus.__module__ = "bencher.variables.results"
+
+        class BogusSweep(ParametrizedSweep):
+            out = ResultBogus()
+
+        with self.assertRaises(TypeError) as ctx:
+            BogusSweep.get_input_and_results()
+        self.assertIn("RESULT_SPECS", str(ctx.exception))
+
+    def test_ordinary_inputs_still_classify_as_inputs(self):
+        class PlainSweep(ParametrizedSweep):
+            x = param.Number(1.0)
+            out = ResultFloat()
+
+        io = PlainSweep.get_input_and_results()
+        self.assertIn("x", io.inputs)
+        self.assertIn("out", io.results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements **plan 23 P4** (`plans/23-constructive-data-modeling.md` §D3/§P4): one ordered
`RESULT_SPECS: dict[type, ResultSpec]` mapping in `bencher/variables/results.py` now declares
every `Result*` class's kind, missing fill/sentinels, and family memberships. The nine
hand-maintained registries (C1) are **derived under their existing names** — zero call-site
churn: `PANEL_TYPES`, `SCALAR_RESULT_TYPES`, `XARRAY_MULTIDIM_RESULT_TYPES`,
`ALL_RESULT_TYPES`, `RESULT_KIND_ORDER`, `_REFERENCE_MISSING_TYPES`, `_OBJECT_MISSING_TYPES`,
`DATA_VAR_RESULT_TYPES`, and `result_collector`'s `_MEDIA_RESULT_TYPES` (now imported, not
redeclared; PR #1028's aging-rationale comment moved with it).

This is the prerequisite A6 phase 2 (grammar of ND data) consumes: a closed channel
vocabulary derives from `RESULT_SPECS` rather than nine tuples (plan 23 §8).

## DoD

- **Adding a `Result*` class without a spec fails CI with one clear message** — verified by
  mutation: a probe `ResultProbe` class fails
  `TestResultSpecRegistry::test_every_result_class_is_registered_or_exempt` naming the class
  and the fix.
- The misclassification hole is closed: a parameter class defined in
  `bencher.variables.results` but absent from the registry now **raises at
  sweep-declaration time** (`parametrised_sweep.py`) instead of silently becoming an
  *input* variable (the old `ResultVolume` trap).
- `bencher/variables/results.py` added to the strict ty ratchet after fixing its one Tier-C
  diagnostic (`ResultReference.__init__`'s malformed `Callable[Any, pn.pane.panel]`
  annotation — one of the handover §4 shapes). `pixi run ty`: All checks passed.
- Post-plan-22 fills preserved exactly: `ResultDataSet` keeps its dual-generation sentinels
  (`"NAN"` + legacy `-1`) as a **documented per-spec `missing_sentinels` set plus the
  unchanged `_dataset_cell_is_missing` read path** — not collapsed, per D3.
- `ResultHmap` reproduces its historical quirks (registered; neither data-var nor panel);
  `ResultVar` is exempt by declaration (`RESULT_SPEC_EXEMPT`) and resolves to `ResultFloat`'s
  spec via isinstance — the D3 decision this PR states explicitly.
- No stored cell value or sentinel changes; **no `CACHE_VERSION` bump** (plan 23 §7).

## Deviation from the plan, stated per plans-README rule 7

D3 asked for a transitional test asserting each derived tuple is **value-identical** to its
pre-migration literal. A single registry order cannot reproduce all nine historic tuple
orders (`PANEL_TYPES` had Image before Video; `XARRAY_MULTIDIM_RESULT_TYPES` the reverse).
Every consumer of the eight isinstance-tuples is an `isinstance()` check (verified by grep),
so membership is the behavioral contract; the transitional test therefore pins
**set-identity** for those eight and **exact order** for `RESULT_KIND_ORDER`, the one
order-sensitive registry (most-derived-first dispatch), whose order the registry reproduces
verbatim. The subclass-order test (`test_no_key_precedes_its_own_subclass`) guards the
property that actually matters for isinstance resolution.

## Tests

- `TestResultSpecRegistry` — completeness (reuses `_discover_all_result_classes`), exemption
  resolution, subclass ordering, spec/oracle sentinel agreement.
- `TestDerivedTuplesMatchPreRegistryLiterals` — transitional, delete after one release.
- `TestUnregisteredResultClassGuard` — the new raise, plus a control that ordinary inputs
  still classify as inputs.
- Existing storability/kind tests now run against the derived registries automatically.

`pixi run ci` green locally (py313 env, coverage 90%); rebased on post-#1029/#1028/#1027 main
with `test_collection_contract.py` and collector tests re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a single, ordered ResultSpec registry as the authoritative source of result-type classification and missing-value behavior, and derive all legacy result-type tuples from it while preserving existing semantics.

New Features:
- Add the ResultKind enum and ResultSpec dataclass plus a RESULT_SPECS registry mapping each Result* class to its kind, storage characteristics, and family memberships.
- Expose a result_spec helper to resolve an instance’s ResultSpec via most-derived-first isinstance dispatch, with explicit exemptions for deprecated types via RESULT_SPEC_EXEMPT.
- Enforce at sweep-declaration time that parameters defined in the results module but missing from RESULT_SPECS are rejected with a clear error message instead of being treated as inputs.

Bug Fixes:
- Prevent unregistered result-like parameter classes from silently becoming input variables by requiring registration in RESULT_SPECS.

Enhancements:
- Derive PANEL_TYPES, SCALAR_RESULT_TYPES, XARRAY_MULTIDIM_RESULT_TYPES, ALL_RESULT_TYPES, RESULT_KIND_ORDER, _REFERENCE_MISSING_TYPES, _OBJECT_MISSING_TYPES, DATA_VAR_RESULT_TYPES, and _MEDIA_RESULT_TYPES from the central RESULT_SPECS registry while keeping their previous behavior.
- Tighten type hints on ResultReference.container and add bencher/variables/results.py to the strict type-checking ratchet.
- Document and encode per-type missing-value sentinels in ResultSpec while ensuring they remain consistent with the runtime result_is_missing oracle.
- Add comprehensive tests to validate registry completeness, exemption behavior, subclass ordering, tuple derivation compatibility, and the new guard against unregistered result classes.

Build:
- Extend the type-checking configuration to include bencher/variables/results.py under strict rules.

Documentation:
- Update the changelog to describe the new RESULT_SPECS registry, its role as a single source of truth for result types, and its relationship to existing registries and future rendering work.

Tests:
- Add TestResultSpecRegistry, TestDerivedTuplesMatchPreRegistryLiterals, and TestUnregisteredResultClassGuard to cover registry integrity, compatibility with previous tuple literals, and classification behavior for result-like parameters.