### PR TITLE
fix: dedup hits refresh blob mtime so the GC grace period is a real guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,14 +162,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cache_results` and `cache_samples` both default to `False`, so with the defaults nothing
   on disk references the blobs of a plain (non-`over_time`) sweep, and a stored history
   holds paths rather than payload copies. GC is therefore an offline maintenance step, as
-  `clean_orphaned_media` already is. `min_age_seconds=` adds a grace period, but it is a
-  mitigation, not a guarantee: it protects blobs a concurrent sweep *wrote* during the
-  window, yet a sweep that deduplicates onto an existing old blob gets no protection at any
-  grace period — a content hit skips the write and never refreshes the file's mtime
-  (pinned by `test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob`).
-  Run GC only when no sweep is in flight. There is deliberately no size- or age-based
-  eviction of *referenced* blobs, because nothing could restore them. An unreadable cache
-  entry makes
+  `clean_orphaned_media` already is. `min_age_seconds=` adds a grace period, and it covers
+  both ways a concurrent sweep gains a reference: a blob it *wrote*, and an old blob it
+  *deduplicated onto* — a content hit in `materialize_blob` refreshes the blob's mtime, so
+  **a blob's mtime means "last referenced", not "created"** (pinned by
+  `test_min_age_protects_a_new_reference_to_an_old_deduplicated_blob`; the bytes are still
+  never rewritten on a hit). Size the window honestly: the guard holds when
+  `min_age_seconds` exceeds the gap between a sweep materializing a payload and persisting
+  the record that references it — in practice, your longest sweep's runtime — and the
+  default `0` gives no protection at all. The deletion loop stats each blob immediately
+  before its unlink, leaving only the syscall-instant between stat and unlink uncovered,
+  so running GC with no sweep in flight remains the zero-assumption choice. There is
+  deliberately no size- or age-based eviction of *referenced* blobs, because nothing could
+  restore them. An unreadable cache entry makes
   absence-of-reference unprovable, so a corrupt cache collects **nothing** in either mode
   and warns with the offending entries named.
 

--- a/bencher/blob_store.py
+++ b/bencher/blob_store.py
@@ -33,6 +33,7 @@ Supported formats, dispatched on the payload type:
 import hashlib
 import io
 import logging
+import os
 import pickle
 import uuid
 from pathlib import Path
@@ -151,6 +152,14 @@ def materialize_blob(obj: Any, cache_dir: str | Path) -> str:
     serialized bytes plus a format extension, so identical payloads map to
     identical paths (content addressing) and are written only once.
 
+    A content hit (the blob already exists) does not rewrite the file, but it
+    **does** refresh the file's mtime: a hit is a *new reference* to the
+    payload, and ``cache_management.clean_orphaned_blobs`` uses mtime as its
+    ``min_age_seconds`` grace-period signal.  A blob's mtime therefore means
+    "last referenced", not "created" — which is what makes an age-based grace
+    period a sound guard for a sweep that deduplicates onto an old blob, not
+    just for one that writes a new one.
+
     A str/Path payload is pickled like any other object — even when it names
     an existing file — so loading the blob returns exactly what the worker
     stored and every blob lives under *cache_dir*.
@@ -176,12 +185,24 @@ def materialize_blob(obj: Any, cache_dir: str | Path) -> str:
     blobs_dir.mkdir(parents=True, exist_ok=True)
     blob_path = blobs_dir / f"{digest}{extension}"
 
-    if not blob_path.exists():
-        # Write via a unique temp file + atomic rename so concurrent workers
-        # materializing the same payload never observe a partial blob.
-        tmp_path = blob_path.with_suffix(blob_path.suffix + f".tmp-{uuid.uuid4().hex}")
-        tmp_path.write_bytes(data)
-        tmp_path.replace(blob_path)
+    if blob_path.exists():
+        try:
+            # A content hit is a new reference to this payload.  Refresh mtime
+            # (never the bytes) so it reads as "last referenced" and an
+            # age-based GC grace period protects the blob a concurrent sweep
+            # just deduplicated onto, exactly as it protects one just written.
+            os.utime(blob_path)
+            return str(blob_path)
+        except OSError:
+            # The blob vanished between the existence check and the touch
+            # (e.g. a concurrent GC collected it): fall through and rewrite.
+            pass
+
+    # Write via a unique temp file + atomic rename so concurrent workers
+    # materializing the same payload never observe a partial blob.
+    tmp_path = blob_path.with_suffix(blob_path.suffix + f".tmp-{uuid.uuid4().hex}")
+    tmp_path.write_bytes(data)
+    tmp_path.replace(blob_path)
 
     return str(blob_path)
 

--- a/bencher/cache_management.py
+++ b/bencher/cache_management.py
@@ -754,16 +754,22 @@ def clean_orphaned_blobs(
         as placeholders).  Pass such archives as *extra_roots* to protect them.
         The same applies to a result held only in memory by a sweep running
         concurrently with GC: with the default ``cache_results=False`` nothing
-        on disk references its blobs yet.  ``min_age_seconds`` mitigates only
-        part of that exposure — it protects a blob the concurrent sweep *wrote*
-        during the grace window, but **not** a blob the sweep deduplicated
-        onto: a content hit skips the write entirely and never refreshes the
-        file's mtime, so an old blob that just gained a new reference looks
-        old to any grace period, however large
-        (``test_blob_store_races.py::test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob``
-        pins this).  The only sufficient guard is to run GC with no sweep in
+        on disk references its blobs yet.  ``min_age_seconds`` is the guard for
+        that exposure, and it covers **both** ways a concurrent sweep can gain a
+        reference: a blob it *wrote*, and an old blob it *deduplicated onto* —
+        ``materialize_blob`` refreshes mtime on a content hit, so a blob's
+        mtime means "last referenced", not "created"
+        (``test_blob_store_races.py::test_min_age_protects_a_new_reference_to_an_old_deduplicated_blob``
+        pins this).  The guard is exactly as strong as its window: choose
+        ``min_age_seconds`` longer than the gap between a sweep materializing a
+        payload and persisting the record that references it — in practice,
+        longer than your longest sweep's runtime — and note the default ``0``
+        gives no protection at all.  The deletion loop stats each blob
+        immediately before its ``unlink``, so the only residual exposure is a
+        reference landing in the instant between that stat and the unlink
+        syscall, which no grace period can close.  Running GC with no sweep in
         flight — between sessions, as :func:`clean_orphaned_media` is already
-        used.
+        used — avoids relying on the window at all.
 
     An unreadable root makes the scan untrustworthy, since a record that cannot
     be deserialized may name any blob.  In that case **nothing** is reported or
@@ -775,11 +781,12 @@ def clean_orphaned_blobs(
         dry_run: If True (the default), only report unreferenced blobs.
         extra_roots: Saved-result pickles, or directories of them, whose
             references count as live.  See :func:`blob_reachability`.
-        min_age_seconds: Skip blobs modified more recently than this.  A
-            non-zero grace period protects blobs an in-flight sweep has
-            *written* during the window, but not an old blob it deduplicated
-            onto (see the warning above); 0 (the default) collects regardless
-            of age.
+        min_age_seconds: Skip blobs whose mtime is more recent than this.
+            mtime means "last referenced" (a dedup content hit refreshes it),
+            so a non-zero grace period protects every blob an in-flight sweep
+            has written *or* deduplicated onto during the window (see the
+            warning above for how to size it); 0 (the default) collects
+            regardless of age.
 
     Returns:
         (orphan_blobs, total_bytes) — paths of unreferenced blob files and their

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,10 +207,12 @@ cache-clear-media = "python -c 'from bencher.cache_management import clear_media
 cache-clean-orphans = "python -c 'from bencher.cache_management import clean_orphaned_media; clean_orphaned_media(dry_run=False)'"
 # Reachability GC for the content-addressed blob store. Report first (blobs are
 # primary storage, so a mistaken delete is data loss), then reclaim.
-# The reclaim task passes a one-hour grace period so blobs a concurrent sweep just
-# wrote are not collected. This is a mitigation, not a guarantee: no grace period
-# protects a blob a concurrent sweep deduplicated onto (a content hit never
-# refreshes mtime) — run GC only when no sweep is in flight.
+# The reclaim task passes a one-hour grace period. Blob mtime means "last
+# referenced" (a dedup content hit refreshes it), so the grace period protects
+# blobs a concurrent sweep wrote OR deduplicated onto within the window — sound
+# as long as no sweep runs longer than an hour between materializing a payload
+# and recording its reference. For longer sweeps, raise it or run GC between
+# sessions.
 cache-blob-orphans = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs()'"
 cache-blob-gc = "python -c 'from bencher.cache_management import print_orphaned_blobs; print_orphaned_blobs(dry_run=False, min_age_seconds=3600)'"
 

--- a/test/test_blob_store.py
+++ b/test/test_blob_store.py
@@ -1,5 +1,6 @@
 """Tests for the content-addressed blob store (plan 22, design D1, test item 1)."""
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -92,13 +93,18 @@ class TestContentAddressing:
         assert path1 == path2
         assert _blob_files(tmp_path) == [Path(path1)]
 
-    def test_file_written_once(self, tmp_path):
+    def test_file_written_once_but_mtime_refreshed_on_hit(self, tmp_path):
+        """The bytes are written once; a content hit refreshes mtime (it is a new
+        reference — the GC grace period reads mtime as "last referenced").
+        ``test_blob_store_races.py`` pins the no-rewrite half on the mechanism."""
         payload = b"same content"
         path1 = materialize_blob(payload, tmp_path)
-        mtime = Path(path1).stat().st_mtime_ns
+        backdated = 1_000_000_000
+        os.utime(path1, (backdated, backdated))
         path2 = materialize_blob(payload, tmp_path)
         assert path1 == path2
-        assert Path(path2).stat().st_mtime_ns == mtime  # not rewritten
+        assert Path(path2).read_bytes() == payload  # bytes intact
+        assert Path(path2).stat().st_mtime > backdated  # hit refreshed mtime
 
     def test_differing_payloads_differing_paths(self, tmp_path):
         path1 = materialize_blob(b"payload one", tmp_path)

--- a/test/test_blob_store_races.py
+++ b/test/test_blob_store_races.py
@@ -11,9 +11,11 @@ three genuinely concurrent surfaces, and this module pins the behaviour of each:
 2. **GC versus a writer.** ``clean_orphaned_blobs`` computes reachability and
    *then* lists the directory. Anything that becomes referenced inside that window
    is invisible to the snapshot but present in the listing. These tests establish
-   exactly how far the guarantees reach, including the two cases
-   ``min_age_seconds`` does **not** cover — they are the reason GC is documented as
-   a between-sessions operation.
+   exactly how far the guarantees reach: ``min_age_seconds`` protects both a blob
+   the concurrent sweep *wrote* and one it *deduplicated onto* (a content hit
+   refreshes mtime, so mtime means "last referenced"), but the **default**
+   ``min_age_seconds=0`` offers no protection at all — that case stays pinned, and
+   is why GC is still documented as a between-sessions operation.
 3. **GC versus GC, and GC versus a reader.** Both must degrade rather than raise:
    a losing racer sees ``FileNotFoundError`` from its own ``unlink``, and a
    renderer whose blob vanished must produce a placeholder.
@@ -265,16 +267,19 @@ class TestGCRacingAWriter:
         assert orphans == [] and nbytes == 0
         assert len(list((tmp_path / "blobs").iterdir())) == 1
 
-    def test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob(
+    def test_min_age_protects_a_new_reference_to_an_old_deduplicated_blob(
         self, tmp_path, monkeypatch
     ):
-        """**The gap ``min_age_seconds`` cannot close.** Dedup lets a *new* sweep
-        reference an *old* blob without rewriting it: ``materialize_blob`` returns
-        the existing path and leaves mtime untouched. So an age-based grace period —
-        which reasons about write time — offers no protection at all here, however
-        large it is set. Only running GC while nothing sweeps is sufficient."""
+        """**The gap ``min_age_seconds`` used to leave open, now closed.** Dedup
+        lets a *new* sweep reference an *old* blob without rewriting it —
+        ``materialize_blob`` returns the existing path — but a content hit now
+        refreshes the blob's mtime, so mtime means "last referenced" rather than
+        "created" and the grace period protects this blob exactly as it protects
+        a freshly written one. The deletion loop stats each blob immediately
+        before its unlink, so the touch is visible to the age check even though
+        it lands after the reachability scan."""
         old_path = materialize_blob(frame(7.0), tmp_path)
-        os.utime(old_path, (1, 1))  # backdate beyond any plausible grace period
+        os.utime(old_path, (1, 1))  # backdate far beyond the grace period below
 
         def concurrent_sweep_dedups_onto_it() -> None:
             again = materialize_blob(frame(7.0), tmp_path)  # same content -> same name
@@ -282,10 +287,12 @@ class TestGCRacingAWriter:
             write_reference(tmp_path, again)
 
         self._inject_after_scan(monkeypatch, concurrent_sweep_dedups_onto_it)
-        orphans, _ = clean_orphaned_blobs(str(tmp_path), dry_run=False, min_age_seconds=86_400)
+        orphans, nbytes = clean_orphaned_blobs(str(tmp_path), dry_run=False, min_age_seconds=3600)
 
-        assert orphans == [str(old_path)], "a huge grace period does not help here"
-        assert not Path(old_path).exists()
+        assert orphans == [] and nbytes == 0, "the dedup touch must protect the old blob"
+        assert Path(old_path).exists()
+        # The reference the sweep recorded is intact, not dangling.
+        assert blob_reachability(str(tmp_path)).names == {Path(old_path).name}
 
     def test_a_blob_referenced_before_the_scan_is_never_at_risk(self, tmp_path):
         """The ordinary, safe case: reference recorded first, so GC sees it."""
@@ -431,16 +438,40 @@ class TestContentAddressingUnderConcurrency:
             stem = blob.name.split(".")[0]
             assert stem == digest, f"{blob.name} does not match its content digest"
 
-    def test_repeated_materialize_never_rewrites_an_existing_blob(self, tmp_path):
-        """Skipping the write on a content hit is what makes concurrent dedup cheap
-        and keeps mtime stable — the property the dedup/min_age test above relies on."""
+    def test_repeated_materialize_refreshes_mtime_but_never_rewrites_the_bytes(self, tmp_path):
+        """The content-hit contract: the bytes are never rewritten (what makes
+        concurrent dedup cheap and tear-free), but the mtime **is** refreshed —
+        a hit is a new reference, and mtime is the GC grace period's signal for
+        "recently referenced" (see the dedup/min_age test above).
+
+        "Never rewritten" is asserted on the mechanism: publication only ever
+        happens through the temp-file ``Path.replace``, so zero replace calls
+        during the hits means zero writes — mtime can no longer stand in as the
+        no-rewrite witness, since the touch moves it by design.
+        """
         payload = frame(1.5)
         path = Path(materialize_blob(payload, tmp_path))
-        first_mtime = path.stat().st_mtime_ns
+        original_bytes = path.read_bytes()
+        backdated = 1_000_000_000  # far in the past, so a refresh is unmistakable
+        os.utime(path, (backdated, backdated))
 
-        for _ in range(5):
-            assert materialize_blob(payload, tmp_path) == str(path)
-        assert path.stat().st_mtime_ns == first_mtime, "an existing blob was rewritten"
+        replace_calls: list[str] = []
+        real_replace = Path.replace
+
+        def counting_replace(self, target):
+            replace_calls.append(self.name)
+            return real_replace(self, target)
+
+        with mock.patch.object(Path, "replace", counting_replace):
+            for _ in range(5):
+                assert materialize_blob(payload, tmp_path) == str(path)
+
+        assert replace_calls == [], "a content hit must not rewrite the blob"
+        assert path.read_bytes() == original_bytes
+        assert path.stat().st_mtime > backdated, (
+            "a content hit must refresh mtime — it is a new reference, and the GC "
+            "grace period reasons about last-referenced time"
+        )
 
 
 class TestPickleRoundTripUnderConcurrency:


### PR DESCRIPTION
Implements the owner's decision on the open design question from #1022's review ([comment](https://github.com/blooop/bencher/pull/1022#issuecomment-5145597476)): correctness chosen over the pinned status quo.

## The semantics change

**A blob's mtime now means "last referenced", not "created".** `materialize_blob`'s content-hit branch runs `os.utime` on the existing blob before returning its path. The bytes are still never rewritten on a hit — publication still only happens through the unique-temp-file + atomic `Path.replace` — but every materialization, hit or miss, leaves the blob's mtime fresh.

That closes the one hole in `clean_orphaned_blobs(min_age_seconds=...)`: previously a concurrent sweep that deduplicated onto an *old* blob gained a live reference without touching the file, so its mtime stayed ancient and **no grace period, however large, protected it** (the loss was pinned by `test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob`). Now both ways a sweep gains a reference — writing a new blob and dedup-hitting an existing one — refresh mtime, so one grace period covers both.

If the blob vanishes between the existence check and the touch (a concurrent GC won that instant), the `OSError` is caught and the writer falls through to the atomic rewrite, which also closes the pre-existing exists→return race.

## Step-4 precision check: stat time vs delete time

Verified before wording the docs: `_unreferenced_blobs` stats each blob **immediately before its `unlink`, inside the same loop iteration** — delete time, not scan time. So a dedup touch landing after the reachability scan is still seen by the age check; "re-stat before unlink" was already the implementation, and no code change was needed there. The only residual exposure is the syscall-instant between that final stat and the unlink, which re-statting cannot close (any re-stat recreates the same gap). The docstring now states that window exactly. (The loop's single `now = time.time()` snapshot only *understates* ages as the loop runs, which errs protective.)

## Guard strength, stated exactly

`min_age_seconds` is sound when it exceeds the gap between a sweep materializing a payload and persisting the record that references it — in practice, the longest sweep's runtime. The default `0` still protects nothing (that hazard stays pinned unchanged by `test_blob_written_after_the_scan_is_deleted_despite_being_referenced`), and running GC with no sweep in flight remains the zero-assumption choice. The `cache-blob-gc` pixi task keeps its one-hour grace, with the comment updated to say what it now actually guarantees.

## Test pins flipped

- `test_repeated_materialize_never_rewrites_an_existing_blob` → `..._refreshes_mtime_but_never_rewrites_the_bytes`: mtime can no longer witness "not rewritten" (the touch moves it by design), so no-rewrite is asserted on the mechanism — zero `Path.replace` calls during hits — plus byte equality and the mtime refresh.
- `test_min_age_does_not_protect_a_new_reference_to_an_old_deduplicated_blob` → `test_min_age_protects_...`: same injected interleaving, now demonstrating the grace period holding (orphans empty, blob alive, reference intact).
- `test_blob_store.py::test_file_written_once` → `..._but_mtime_refreshed_on_hit`: same flip for the original #1021 pin.
- Module docstring of `test_blob_store_races.py` updated: one uncovered case (`min_age_seconds=0`), not two.

## Docs

`clean_orphaned_blobs` docstring, `materialize_blob`/module docstring, CHANGELOG entry (unreleased, so amended in place), and the pixi task comment all re-tightened to exactly what the code makes true — no stronger.

## Verification

`pixi run pytest test/test_blob_store.py test/test_blob_store_races.py test/test_blob_store_edge_cases.py test/test_cache_management.py` → **161 passed**. `pixi run format` clean, `pixi run lint` (ruff + pylint) **10.00/10**, `pixi run ty` "All checks passed!". No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh blob mtimes on dedup hits so GC’s min_age_seconds grace period reliably protects both newly written and deduplicated blobs, and update tests and documentation to reflect the “mtime = last referenced” semantics.

Bug Fixes:
- Ensure blobs deduplicated onto during a concurrent sweep have their mtime refreshed so they are no longer incorrectly collected despite a configured GC grace period.
- Eliminate the race where a blob disappearing between existence check and touch could bypass the intended atomic rewrite path.

Enhancements:
- Clarify and tighten the semantics and guarantees of clean_orphaned_blobs and materialize_blob, defining blob mtime as “last referenced” and specifying the exact protection window of min_age_seconds.
- Document and parameterize the cache GC pixi task so its one-hour grace period is clearly tied to sweep runtimes and mtime-based guarding behavior.

Documentation:
- Update blob store, GC, and race-test docstrings plus the unreleased CHANGELOG to describe the new mtime-as-last-reference semantics and the precise limits of GC safety.

Tests:
- Adjust blob store and race-condition tests to assert mtime refresh on content hits, verify that min_age_seconds now protects deduplicated old blobs, and pin the no-rewrite guarantee via replace-call counting rather than mtime stability.