### PR TITLE
fix: worker-contract violations warn visibly in the report instead of aborting the sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,32 +8,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **BREAKING (fail-loud): a benchmark that returns `None` now raises instead of producing
-  an empty sweep** (plan 23 P2, B3). A worker that forgot to `return
+- **Fail-loud, not fail-fatal: a benchmark that returns `None` no longer produces a
+  silently empty sweep — and no longer aborts the run either** (plan 23 P2, B3; amended
+  per owner decision before release). A worker that forgot to `return
   super().__call__(**kwargs)` used to trip a bare `assert` on the serial executor — and
   nothing at all on `MULTIPROCESSING`/`SCOOP`, where the future resolved to `None`,
   `store_results` skipped its entire body behind `if result is not None:` with no `else`,
   and the sweep finished green with an all-sentinel dataset and `n_failed == 0`. The same
   user error was loud or silent depending on an unrelated config knob, and the assert
   vanished entirely under `python -O`. Both paths now funnel through one check
-  (`require_worker_result`) raising `TypeError`.
+  (`require_worker_result`, raising `WorkerContractError`), which `store_results`
+  consumes: the sample is recorded in `failed_samples` (so `n_failed` counts it and
+  `fail_on_sample_error` can gate the run at the end), logged at ERROR, announced with a
+  `WorkerContractWarning`, and shown in the report's failed-samples summary — while the
+  sweep continues, because crashing mid-run loses the expensive samples already
+  collected. Strict pipelines can promote the warning:
+  `warnings.filterwarnings("error", category=bn.WorkerContractWarning)`.
 
-- **BREAKING (fail-loud): a `ResultVec` set to the wrong number of elements now raises**
-  (plan 23 P2, B2). The store was guarded by `isinstance(value, (list, np.ndarray)) and
-  len(value) == rv.size` with no `else`, so a length mismatch was silently discarded and
-  the cell kept its NaN fill — indistinguishable downstream from "never sampled".
-  `param.List` validates that the value is a list but not how long it is, so this was
-  reachable from ordinary benchmark code. The error names the variable, the declared size
-  and the actual length.
+- **A `ResultVec` set to the wrong number of elements is recorded and warned, not
+  silently dropped** (plan 23 P2, B2; same amended disposition as B3). The store was
+  guarded by `isinstance(value, (list, np.ndarray)) and len(value) == rv.size` with no
+  `else`, so a length mismatch was silently discarded and the cell kept its NaN fill —
+  indistinguishable downstream from "never sampled". `param.List` validates that the
+  value is a list but not how long it is, so this was reachable from ordinary benchmark
+  code. The warning names the variable, the declared size and the actual length. A
+  raw-dict worker omitting a declared result variable (previously a mid-sweep
+  `KeyError`) is handled the same way.
 
-  Both checks are raised **outside** `store_results`'s `except catch` block on purpose: a
-  bad return shape is a harness-contract error, not a sample fault, so `catch=` does not
-  absorb it (plan 23 decision 2). Previously `catch=Exception` did swallow the serial
-  `assert`, restoring the silent behaviour. Tests pin this. The `Bench.optimize` path is
-  the documented exception — its objective runs under `study.optimize(..., catch=catch)`,
-  so a `catch=` there still absorbs the error. That is pre-existing rather than new: the
-  old code was absorbed at the same point, as an `AssertionError` on serial and a `None`
-  subscript `TypeError` on the pool.
+  Contract violations are handled **outside** `store_results`'s `except catch` block on
+  purpose: a bad return shape is a harness-contract error, not a sample fault, so
+  `catch=` plays no part in it (plan 23 decision 2) — the violation is recorded
+  identically with and without `catch=Exception`, so neither setting nor omitting it
+  restores the old silent skip. The `Bench.optimize` path is the documented exception —
+  its objective runs under `study.optimize(..., catch=catch)`, so a `catch=` there still
+  absorbs the error. That is pre-existing rather than new: the old code was absorbed at
+  the same point, as an `AssertionError` on serial and a `None` subscript `TypeError` on
+  the pool.
+
+- **The report now shows failed samples.** `n_failed`/`failed_samples` existed since
+  plan 21 but never surfaced anywhere a reader would look: a run with failures produced
+  a normal-looking report and only log lines. `to_auto_plots` now auto-inserts a
+  failed-samples summary (inputs + first error line per failure) whenever
+  `n_failed > 0`, in the same way the regression report is auto-inserted.
 
 ### Changed
 - **`BenchRunCfg.executor` is normalized to an `Executors` member at the sweep boundary**

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -44,7 +44,7 @@ from .identity import (
     identity_of,
     sweep_identity,
 )
-from .job import SampleFailure
+from .job import SampleFailure, WorkerContractError, WorkerContractWarning
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -115,6 +115,27 @@ def normalize_catch(catch) -> tuple[type[BaseException], ...]:
     return catch
 
 
+class WorkerContractError(TypeError):
+    """A worker broke the harness contract (returned ``None``, or set a
+    ``ResultVec`` to the wrong shape).
+
+    Distinct from a sample fault: the collector records the sample as failed,
+    emits :class:`WorkerContractWarning`, surfaces it in the report, and the
+    sweep **continues** — a broken sample must never abort a run and lose the
+    expensive samples already collected (owner decision amending plan 23 §6.2,
+    2026-07-31). Subclasses ``TypeError`` so callers that consumed the previous
+    raising behavior still match."""
+
+
+class WorkerContractWarning(UserWarning):
+    """Emitted when a sample is dropped because the worker broke the harness
+    contract (see :class:`WorkerContractError`).
+
+    The sample is counted in ``BenchResult.n_failed`` and listed in the
+    report's failed-samples summary. Promote to an error in strict pipelines
+    with ``warnings.filterwarnings("error", category=bn.WorkerContractWarning)``."""
+
+
 def require_worker_result(result: dict | None, job_id: str) -> dict:
     """Reject a worker that returned ``None`` instead of a result dict.
 
@@ -127,11 +148,13 @@ def require_worker_result(result: dict | None, job_id: str) -> dict:
     unrelated config knob; this is the one check both paths funnel through.
 
     Deliberately **not** routed through ``catch=`` (plan 23 decision 2): a missing
-    return value is a harness-contract error, not a sample fault, so every call site
-    must raise it from *outside* its ``except catch`` block.
-    """
+    return value is a harness-contract error, not a sample fault, so ``catch=``
+    must never decide its fate. The raise is consumed by ``store_results``, which
+    records the sample as failed and warns instead of aborting the sweep (plan 23
+    §6.2 as amended: crashing mid-run loses expensive data; the failure surfaces
+    in the report instead)."""
     if result is None:
-        raise TypeError(
+        raise WorkerContractError(
             f"The benchmark function for job {job_id} returned None. "
             "Make sure you are returning a dict or `super().__call__(**kwargs)` "
             "from your __call__ function."

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import warnings
 from contextlib import suppress
 from datetime import datetime
 from itertools import product
@@ -37,7 +38,14 @@ from bencher.history import (
     project,
     reconcile,
 )
-from bencher.job import JobFuture, SampleFailure, normalize_catch, require_worker_result
+from bencher.job import (
+    JobFuture,
+    SampleFailure,
+    WorkerContractError,
+    WorkerContractWarning,
+    normalize_catch,
+    require_worker_result,
+)
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
 from bencher.variables.results import (
@@ -375,6 +383,32 @@ class ResultCollector:
             failure.exception,
         )
 
+    @staticmethod
+    def record_contract_violation(
+        bench_res: BenchResult, job_id: str, inputs: dict, exc: WorkerContractError
+    ) -> None:
+        """Record a broken worker contract without aborting the sweep.
+
+        Owner decision amending plan 23 §6.2 (2026-07-31): a sweep must never
+        crash mid-run and lose the expensive samples already collected, so a
+        contract violation (worker returned ``None``, wrong-shape ``ResultVec``)
+        is recorded like a caught sample — the cell keeps its missing sentinel,
+        ``n_failed`` counts it, ``fail_on_sample_error`` sees it, and the report
+        shows it in the failed-samples summary — but *louder*: an ERROR log and
+        a :class:`WorkerContractWarning`, unconditionally. ``catch=`` plays no
+        part in this (plan 23 decision 2 still holds): the violation is recorded
+        with or without it, so ``catch=Exception`` cannot restore the old silent
+        skip, and leaving ``catch`` unset cannot turn it back into a crash.
+        """
+        failure = SampleFailure.from_exception(job_id, inputs, exc)
+        bench_res.failed_samples.append(failure)
+        logger.error(
+            "worker contract violation (%s): %s",
+            ", ".join(f"{k}={v}" for k, v in failure.inputs.items()) or "no inputs",
+            exc,
+        )
+        warnings.warn(str(exc), WorkerContractWarning, stacklevel=2)
+
     def store_results(
         self,
         job_result: JobFuture,
@@ -398,7 +432,10 @@ class ResultCollector:
                 precompute_result_arrays(). Falls back to dataset lookup if None.
 
         Raises:
-            RuntimeError: If an unsupported result variable type is encountered
+            TypeError: If an unsupported result variable type is encountered (a
+                bencher-internal invariant; worker-contract violations are
+                recorded and warned instead of raised — see
+                ``record_contract_violation``).
         """
         # No `if catch:` branch: `except ()` matches nothing, so the default empty
         # tuple is already fail-fast, and result() keeps a single call site.
@@ -416,10 +453,19 @@ class ResultCollector:
             return
         # Outside the `except catch` above, deliberately: a worker that returned
         # nothing is a harness-contract error, not a sample fault, so `catch=` must
-        # not absorb it (plan 23 decision 2). This replaces `if result is not None:`
-        # with no `else`, which skipped everything below and left the sweep green with
-        # an all-sentinel dataset -- see require_worker_result for the full B3 story.
-        result = require_worker_result(result, job_result.job.job_id)
+        # not decide its fate (plan 23 decision 2). This replaces `if result is not
+        # None:` with no `else`, which skipped everything below and left the sweep
+        # green with an all-sentinel dataset -- see require_worker_result for the
+        # full B3 story. The violation is recorded and warned, never raised through
+        # the sweep (plan 23 §6.2 as amended): the cells keep their missing
+        # sentinel, and the failed-samples summary makes that visible.
+        try:
+            result = require_worker_result(result, job_result.job.job_id)
+        except WorkerContractError as exc:
+            self.record_contract_violation(
+                bench_res, job_result.job.job_id, worker_job.function_input, exc
+            )
+            return
         logger.info(f"{job_result.job.job_id}:")
         if bench_res.bench_cfg.print_bench_inputs:
             for k, v in worker_job.function_input.items():
@@ -428,12 +474,39 @@ class ResultCollector:
         result_dict = result if isinstance(result, dict) else result.param.values()
         idx = worker_job.index_tuple
 
+        try:
+            self._store_result_vars(bench_res, result_dict, idx, bench_run_cfg, rv_arrays)
+        except WorkerContractError as exc:
+            # Record-and-continue, like the None-return check above. Result vars
+            # stored before the violating one keep their values; the violating
+            # one (and any after it) keep the missing sentinel, and the failure
+            # record names the sample.
+            self.record_contract_violation(
+                bench_res, job_result.job.job_id, worker_job.function_input, exc
+            )
+            return
+        for rv in bench_res.result_hmaps:
+            bench_res.hmaps[rv.name][worker_job.canonical_input] = result_dict[rv.name]
+
+    @staticmethod
+    def _store_result_vars(
+        bench_res: BenchResult,
+        result_dict: dict,
+        idx: tuple,
+        bench_run_cfg: BenchRunCfg,
+        rv_arrays: dict[str, np.ndarray] | None,
+    ) -> None:
+        """Write one sample's result variables into the dataset (see store_results)."""
         for rv in bench_res.bench_cfg.result_vars:
             try:
                 result_value = result_dict[rv.name]
             except KeyError:
+                # Same contract-error shape as the ResultVec checks below: only a
+                # worker returning a raw dict can omit a declared result var
+                # (benchmark() always emits every declared key), and aborting the
+                # sweep for it would lose the samples already collected.
                 available = list(result_dict.keys())
-                raise KeyError(
+                raise WorkerContractError(
                     f"Result variable '{rv.name}' was not set by the "
                     f"benchmark function. Available keys: {available}. "
                     f"Make sure your benchmark() method sets "
@@ -470,13 +543,13 @@ class ResultCollector:
                 # side effect of making the drop loud. It now says so instead of
                 # silently NaN-ing.
                 if not isinstance(result_value, (list, np.ndarray)):
-                    raise TypeError(
+                    raise WorkerContractError(
                         f"Result variable '{rv.name}' is a ResultVec(size={rv.size}), "
                         f"so the benchmark function must set it to a list or numpy "
                         f"array; got {type(result_value).__name__} ({result_value!r})."
                     )
                 if len(result_value) != rv.size:
-                    raise TypeError(
+                    raise WorkerContractError(
                         f"Result variable '{rv.name}' is a ResultVec(size={rv.size}), "
                         f"but the benchmark function returned {len(result_value)} "
                         f"element(s): {result_value!r}. Each element is stored in its "
@@ -488,8 +561,6 @@ class ResultCollector:
 
             else:
                 raise TypeError(f"Unsupported result type: {type(rv).__name__}")
-        for rv in bench_res.result_hmaps:
-            bench_res.hmaps[rv.name][worker_job.canonical_input] = result_dict[rv.name]
 
     def cache_results(
         self, bench_res: BenchResult, bench_cfg_hash: str, bench_cfg_hashes: list[str]

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -158,8 +158,10 @@ class BenchResult(
         of_attempted = f" of {attempted} executed" if attempted else ""
         lines = [
             "### ⚠ Failed samples\n",
-            f"**{self.n_failed}{of_attempted} sample(s) failed.** Their cells hold "
-            f"the missing-value sentinel and are excluded from reductions.\n",
+            (
+                f"**{self.n_failed}{of_attempted} sample(s) failed.** Their cells hold "
+                f"the missing-value sentinel and are excluded from reductions.\n"
+            ),
             "| Inputs | Error |",
             "|--------|-------|",
         ]

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -108,8 +108,9 @@ class BenchResult(
         HoloviewResult.__init__(self, bench_cfg)
         # DataSetResult.__init__(self.bench_cfg)
         self.timings = None  # Populated by Bench.run_sweep() with SweepTimings
-        # Samples that raised and were tolerated because of run_cfg.catch. Empty
-        # unless catch was set, so a run with no catch is byte-identical to before.
+        # Samples that failed without aborting the sweep: raised and tolerated
+        # because of run_cfg.catch, or dropped for breaking the worker contract
+        # (None return / wrong-shape ResultVec — recorded unconditionally).
         self.failed_samples: list = []
         # Samples this run actually executed, set by calculate_benchmark_results.
         # Needed because neither the dataset's own size nor the job count is the
@@ -144,6 +145,33 @@ class BenchResult(
         """
         attempted = getattr(self, "n_attempted", 0)  # absent on pre-plan-21 pickles
         return self.n_failed / attempted if attempted else 0.0
+
+    def failed_samples_markdown(self, max_rows: int = 20) -> str:
+        """Markdown summary of this run's failed samples, for the report.
+
+        Bencher's contract is that a failing or contract-breaking sample never
+        aborts a sweep (the expensive samples already collected must survive),
+        so the report has to carry the loudness instead: this block is
+        auto-inserted by :meth:`to_auto_plots` whenever ``n_failed > 0``.
+        """
+        attempted = getattr(self, "n_attempted", 0)
+        of_attempted = f" of {attempted} executed" if attempted else ""
+        lines = [
+            "### ⚠ Failed samples\n",
+            f"**{self.n_failed}{of_attempted} sample(s) failed.** Their cells hold "
+            f"the missing-value sentinel and are excluded from reductions.\n",
+            "| Inputs | Error |",
+            "|--------|-------|",
+        ]
+        failures = getattr(self, "failed_samples", ())
+        for failure in failures[:max_rows]:
+            inputs = ", ".join(f"{k}={v}" for k, v in failure.inputs.items()) or "—"
+            # First line of the exception repr; the full traceback is in the log.
+            error = failure.exception.splitlines()[0] if failure.exception else "—"
+            lines.append(f"| {inputs} | {error} |")
+        if len(failures) > max_rows:
+            lines.append(f"\n*… and {len(failures) - max_rows} more (see the run log).*")
+        return "\n".join(lines)
 
     @property
     def identity(self) -> SweepIdentity:
@@ -425,6 +453,19 @@ class BenchResult(
         """
         plot_cols = pn.Column()
         plot_cols.append(self.to_sweep_summary(name="Plots View"))
+
+        # --- Failed samples (auto-inserted whenever any sample failed) ---
+        # Failures never abort a sweep (caught samples and worker-contract
+        # violations alike), so the report is where they must be impossible to
+        # miss — a log line is not a surface anyone reads after the fact.
+        if self.n_failed:
+            plot_cols.append(
+                pn.pane.Markdown(
+                    self.failed_samples_markdown(),
+                    name="Failed Samples",
+                    width=800,
+                )
+            )
 
         # --- Regression report (auto-inserted when regression detection is enabled) ---
         # Summary table surfaces whenever a regression fires (including the

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -607,10 +607,17 @@ and may be reordered or dropped individually.
    **delete** — `result_vars` already carries `# todo remove`; only a test writes them;
    their gates have never fired. The phase must first report what would start being
    filtered if populated.
-2. **B2/B3 (P2): raise vs warn.** Recommendation: **raise `TypeError`**, and *not*
-   routed through plan 21's `catch=` — a `None` return or wrong-length vector is a
-   harness-contract error, not a sample fault. Alternative (warn + skip) preserves the
-   current silent behavior for parallel users.
+2. **B2/B3 (P2): raise vs warn.** ~~Recommendation: raise `TypeError`~~ — **RESOLVED by
+   the owner (2026-07-31): record + warn visibly, never raise through the sweep.** A core
+   bencher principle is that a run must not crash mid-way and lose expensive
+   already-collected data; a visible warning in the report is the correct loudness. P2
+   first landed as raise (per the original recommendation); the follow-up amendment
+   converts contract violations to `WorkerContractError` consumed by `store_results`:
+   recorded in `failed_samples` (so `n_failed` counts them and `fail_on_sample_error`
+   gates them at run end), an ERROR log, a `WorkerContractWarning`, and an auto-inserted
+   failed-samples summary in the report. The "*not* routed through `catch=`" half of the
+   original decision **still holds**: the violation is recorded unconditionally, with or
+   without `catch=`, so neither setting can silence it (see §10 P2-amendment).
 3. ~~**D2: take the `typing_extensions` dependency**~~ — **RESOLVED, no longer a
    decision.** The owner raised the floor to `>=3.11`, so `assert_never` is stdlib and no
    dependency is needed (§2.3). Kept as a numbered entry so later references to
@@ -810,6 +817,23 @@ than silently worked around.
    on exactly that seeded bypass. The probe tests also assert ty's **exit code**, not just
    its output text, so a rule demoted to warning level cannot pass; and their class
    docstring no longer claims to prove the repo's gate, only the mechanism.
+
+### P2-amendment (owner decision, 2026-07-31)
+
+Decision 2 was re-resolved by the owner after P2 merged: **warn visibly, never crash the
+sweep**. Rationale: bencher's core contract is that a run must not abort mid-way and lose
+expensive already-collected samples; the report is where loudness belongs. The amendment
+(branch `plan/p2-amendment-warn-not-crash`) keeps every loud property P2 established while
+removing the abort: `require_worker_result` and the ResultVec checks raise
+`WorkerContractError` (a `TypeError` subclass), which `store_results` consumes —
+recording a `SampleFailure` (counted by `n_failed`, gated by `fail_on_sample_error` at
+run end), logging at ERROR, emitting `WorkerContractWarning`, and leaving the cells at
+the missing sentinel. `to_auto_plots` auto-inserts a failed-samples summary whenever
+`n_failed > 0` (previously failures were counted but never shown in any report). The
+missing-result-key `KeyError` — the same contract shape, reachable only from raw-dict
+workers — was converted with them. `catch=` still plays no part: violations are recorded
+identically with and without it. P1's `invalid-method-override` static catch (below)
+is unaffected.
 
 ### P2 (implemented)
 

--- a/test/test_collection_contract.py
+++ b/test/test_collection_contract.py
@@ -11,10 +11,14 @@ sweep that had not been run yet.
 - **C13** ``executor`` is compared with both ``==`` and ``is``, and
   ``param.Selector`` accepts a raw string for it, so the two styles can disagree.
 
-These are contract errors, not sample faults, so none of them is routed through
-``catch=`` (plan 23 decision 2) -- ``TestCatchDoesNotAbsorbContractErrors`` pins
-that, since ``catch=Exception`` is the natural thing for a user to reach for and
-would otherwise turn every one of these back into a silent skip.
+Disposition (plan 23 §6.2, owner-amended 2026-07-31): a contract violation is
+**recorded and warned, never raised through the sweep** — bencher must not crash
+mid-run and lose expensive already-collected data. Loudness comes from the
+``WorkerContractWarning``, ``n_failed``, the report's failed-samples summary, and
+(opt-in) ``fail_on_sample_error`` at the end of the run. ``catch=`` still plays
+no part in it (plan 23 decision 2): the violation is recorded with or without
+``catch=Exception``, so neither setting nor omitting it restores the old silent
+skip — ``TestCatchDoesNotChangeContractHandling`` pins that.
 """
 
 from __future__ import annotations
@@ -31,6 +35,8 @@ from bencher.job import (
     FutureCache,
     Job,
     JobFuture,
+    WorkerContractError,
+    WorkerContractWarning,
     normalize_executor,
     require_worker_result,
 )
@@ -80,6 +86,14 @@ class ReturnsNothing(bn.ParametrizedSweep):
         # Deliberately no `return self.get_results_values_as_dict()`.
 
 
+def _contract_messages(record) -> list[str]:
+    """The WorkerContractWarning messages out of a pytest.warns record.
+
+    ``record[0]`` is unreliable: unrelated warnings (deprecations, fork) share
+    the capture."""
+    return [str(w.message) for w in record if issubclass(w.category, WorkerContractWarning)]
+
+
 def _run(worker, *, executor=Executors.SERIAL, **run_kwargs):
     cfg = bn.BenchRunCfg(executor=executor, **run_kwargs)
     cfg.auto_plot = False
@@ -98,7 +112,8 @@ def _run(worker, *, executor=Executors.SERIAL, **run_kwargs):
 
 
 class TestResultVecLength(unittest.TestCase):
-    """B2: the ladder's other arms raise; this one used to just not store."""
+    """B2: a wrong-shape vector used to be silently dropped; now it is recorded,
+    warned, and left at the sentinel — without aborting the sweep."""
 
     def tearDown(self) -> None:
         WrongLengthVec.n_elements = 2
@@ -110,25 +125,32 @@ class TestResultVecLength(unittest.TestCase):
         for name in WrongLengthVec.param.v.index_names():
             self.assertIn(name, res.ds)
             self.assertFalse(np.isnan(res.ds[name].values).any(), f"{name} left at the NaN fill")
+        self.assertEqual(res.n_failed, 0)
 
-    def test_a_short_vector_raises_instead_of_being_dropped(self) -> None:
+    def test_a_short_vector_warns_and_is_recorded_not_dropped(self) -> None:
         WrongLengthVec.n_elements = 1
-        with self.assertRaises(TypeError) as ctx:
-            _run(WrongLengthVec())
-        msg = str(ctx.exception)
+        with pytest.warns(WorkerContractWarning) as record:
+            res = _run(WrongLengthVec())
+        # The sweep completed; the bad samples are counted, not fatal.
+        self.assertEqual(res.n_failed, 2)
+        msg = _contract_messages(record)[0]
         # The message has to carry all three facts, because the symptom the user
         # would otherwise see is an all-NaN column with nothing pointing at 'v'.
         self.assertIn("'v'", msg)
         self.assertIn("size=2", msg)
         self.assertIn("1 element", msg)
+        # The cells stay at the missing sentinel — failed, not fabricated.
+        for name in WrongLengthVec.param.v.index_names():
+            self.assertTrue(np.isnan(res.ds[name].values).all())
 
-    def test_a_long_vector_also_raises(self) -> None:
+    def test_a_long_vector_is_also_recorded(self) -> None:
         WrongLengthVec.n_elements = 3
-        with self.assertRaises(TypeError) as ctx:
-            _run(WrongLengthVec())
-        self.assertIn("3 element", str(ctx.exception))
+        with pytest.warns(WorkerContractWarning) as record:
+            res = _run(WrongLengthVec())
+        self.assertEqual(res.n_failed, 2)
+        self.assertIn("3 element", _contract_messages(record)[0])
 
-    def test_a_non_sequence_raises_naming_the_type(self) -> None:
+    def test_a_non_sequence_is_recorded_naming_the_type(self) -> None:
         """Only reachable from a worker that returns a raw dict.
 
         Assignment through ``self.v`` cannot get here -- ``param.List`` rejects a
@@ -144,16 +166,20 @@ class TestResultVecLength(unittest.TestCase):
             index_tuple = (0, 0)
             canonical_input = ("x", 0)
 
-        with self.assertRaises(TypeError) as ctx:
+        n_failed_before = res.n_failed
+        with pytest.warns(WorkerContractWarning) as record:
             collector.store_results(
                 JobFuture(job=job, res={"v": 3.0}),
                 res,
                 _Worker(),
                 bn.BenchRunCfg(),
             )
-        msg = str(ctx.exception)
+        self.assertEqual(res.n_failed, n_failed_before + 1)
+        msg = _contract_messages(record)[0]
         self.assertIn("'v'", msg)
         self.assertIn("float", msg)
+        # The recorded failure is distinguishable from a catch= sample fault.
+        self.assertIn("WorkerContractError", res.failed_samples[-1].exception)
 
 
 # ---------------------------------------------------------------------------
@@ -162,25 +188,39 @@ class TestResultVecLength(unittest.TestCase):
 
 
 class TestWorkerReturnedNothing(unittest.TestCase):
-    """B3: loud or silent used to be chosen by an unrelated config knob."""
+    """B3: loud or silent used to be chosen by an unrelated config knob.
 
-    def test_serial_raises(self) -> None:
-        with self.assertRaises(TypeError) as ctx:
-            _run(ReturnsNothing())
-        self.assertIn("returned None", str(ctx.exception))
+    Now it is uniformly loud-but-nonfatal on both execution paths: recorded,
+    warned, counted — never a green run with ``n_failed == 0``, and never an
+    aborted run that loses the samples already collected."""
 
-    def test_multiprocessing_raises_too(self) -> None:
+    def test_serial_records_and_warns(self) -> None:
+        with pytest.warns(WorkerContractWarning) as record:
+            res = _run(ReturnsNothing())
+        self.assertEqual(res.n_failed, 2)
+        self.assertIn("returned None", _contract_messages(record)[0])
+        # Nothing fabricated: the cells hold the missing sentinel.
+        self.assertTrue(np.isnan(res.ds["y"].values).all())
+
+    def test_multiprocessing_records_and_warns_too(self) -> None:
         """The path that used to complete green with an all-sentinel dataset."""
-        with self.assertRaises(TypeError) as ctx:
-            _run(ReturnsNothing(), executor=Executors.MULTIPROCESSING)
-        self.assertIn("returned None", str(ctx.exception))
+        with pytest.warns(WorkerContractWarning) as record:
+            res = _run(ReturnsNothing(), executor=Executors.MULTIPROCESSING)
+        self.assertEqual(res.n_failed, 2)
+        self.assertIn("returned None", _contract_messages(record)[0])
 
     def test_the_message_says_what_to_do(self) -> None:
-        with self.assertRaises(TypeError) as ctx:
+        # require_worker_result itself still raises (a pure check); the
+        # record-and-continue disposition lives in store_results.
+        with self.assertRaises(WorkerContractError) as ctx:
             require_worker_result(None, "job-42")
         msg = str(ctx.exception)
         self.assertIn("job-42", msg)
         self.assertIn("super().__call__(**kwargs)", msg)
+
+    def test_contract_error_is_a_type_error(self) -> None:
+        """Callers that matched the previous raising behavior still match."""
+        self.assertTrue(issubclass(WorkerContractError, TypeError))
 
     def test_a_real_result_passes_straight_through(self) -> None:
         payload = {"y": 1.0}
@@ -191,26 +231,86 @@ class TestWorkerReturnedNothing(unittest.TestCase):
         self.assertEqual(require_worker_result({}, "job-1"), {})
 
 
-class TestCatchDoesNotAbsorbContractErrors(unittest.TestCase):
+class TestCatchDoesNotChangeContractHandling(unittest.TestCase):
     """Plan 23 decision 2: ``catch=`` tolerates failing *samples*, not a broken harness.
 
-    Both checks are raised outside ``store_results``'s ``except catch`` block on
-    purpose. Without this test the fix would look complete while
-    ``catch=Exception`` -- the obvious thing to reach for -- silently restored the
-    old behaviour, which is the exact failure mode B2 and B3 are about.
+    A contract violation is recorded and warned identically with and without
+    ``catch=Exception``. Without this test the fix would look complete while
+    ``catch=`` either silently absorbed the violation (the old B2/B3 failure
+    mode) or its absence turned the violation back into a mid-run crash.
     """
 
     def tearDown(self) -> None:
         WrongLengthVec.n_elements = 2
 
     def test_catch_does_not_swallow_a_none_return(self) -> None:
-        with self.assertRaises(TypeError):
-            _run(ReturnsNothing(), catch=Exception)
+        with pytest.warns(WorkerContractWarning):
+            res = _run(ReturnsNothing(), catch=Exception)
+        self.assertEqual(res.n_failed, 2)
+        self.assertIn("WorkerContractError", res.failed_samples[0].exception)
 
     def test_catch_does_not_swallow_a_wrong_length_vector(self) -> None:
         WrongLengthVec.n_elements = 1
-        with self.assertRaises(TypeError):
-            _run(WrongLengthVec(), catch=Exception)
+        with pytest.warns(WorkerContractWarning):
+            res = _run(WrongLengthVec(), catch=Exception)
+        self.assertEqual(res.n_failed, 2)
+
+
+class TestContractViolationSurfaces(unittest.TestCase):
+    """The loudness contract: visible in the report, and gateable at run end."""
+
+    def tearDown(self) -> None:
+        WrongLengthVec.n_elements = 2
+
+    def test_failed_samples_appear_in_the_report(self) -> None:
+        WrongLengthVec.n_elements = 1
+        with pytest.warns(WorkerContractWarning):
+            res = _run(WrongLengthVec())
+        md = res.failed_samples_markdown()
+        self.assertIn("Failed samples", md)
+        self.assertIn("x=0", md)
+        self.assertIn("WorkerContractError", md)
+        # And the auto-plot report actually carries the pane.
+        panes = res.to_auto_plots()
+        names = [getattr(p, "name", "") for p in panes]
+        self.assertIn("Failed Samples", names)
+
+    def test_a_clean_run_gets_no_failure_pane(self) -> None:
+        res = _run(WrongLengthVec())
+        panes = res.to_auto_plots()
+        names = [getattr(p, "name", "") for p in panes]
+        self.assertNotIn("Failed Samples", names)
+
+    def test_fail_on_sample_error_gates_contract_violations_at_run_end(self) -> None:
+        """Opt-in hard failure still exists — after collection, not mid-run."""
+        from bencher.bencher import SampleErrorPolicyError
+
+        WrongLengthVec.n_elements = 1
+        with pytest.warns(WorkerContractWarning), self.assertRaises(SampleErrorPolicyError):
+            _run(WrongLengthVec(), fail_on_sample_error=True)
+
+    def test_a_missing_result_key_is_recorded_not_fatal(self) -> None:
+        """A raw-dict worker omitting a declared result var is the same contract
+        shape; it used to abort the sweep with a KeyError."""
+        res = _run(WrongLengthVec())
+        collector = ResultCollector()
+        job = Job(job_id="missing-key", function=lambda **_: None, job_args={"x": 0})
+
+        class _Worker:
+            function_input: ClassVar[dict] = {"x": 0}
+            index_tuple = (0, 0)
+            canonical_input = ("x", 0)
+
+        n_failed_before = res.n_failed
+        with pytest.warns(WorkerContractWarning) as record:
+            collector.store_results(
+                JobFuture(job=job, res={"other": 1.0}),
+                res,
+                _Worker(),
+                bn.BenchRunCfg(),
+            )
+        self.assertEqual(res.n_failed, n_failed_before + 1)
+        self.assertIn("'v'", _contract_messages(record)[0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Amends the disposition of plan 23 P2 (#1029) per owner decision (2026-07-31), recorded in
plan 23 §6.2 and §10: **bencher must not crash mid-run and lose expensive
already-collected data; a visible warning in the report is the correct loudness.**

## What changes

- `require_worker_result` and the `ResultVec` shape checks raise `WorkerContractError`
  (a `TypeError` subclass), which `store_results` consumes instead of letting it abort
  the sweep: the sample is recorded as a `SampleFailure` (so `n_failed` counts it and
  the opt-in `fail_on_sample_error` gate still hard-fails **at run end**, after
  collection/caching/report), logged at ERROR, and announced with a new
  `WorkerContractWarning` (exported; promote with
  `warnings.filterwarnings("error", category=bn.WorkerContractWarning)`).
- The missing-result-key case (raw-dict worker omitting a declared result var) —
  previously a mid-sweep `KeyError` abort, the same contract shape — is converted with
  them.
- **The report now shows failed samples.** `n_failed` existed since plan 21 but surfaced
  nowhere: `to_auto_plots` now auto-inserts a failed-samples summary (inputs + first
  error line, capped) whenever `n_failed > 0`, alongside the auto-inserted regression
  report.

## What does NOT change

- Everything P2 made loud stays loud — the old failure mode was *silence* (green run,
  `n_failed == 0`, all-sentinel dataset), and nothing here restores it.
- `catch=` still plays no part in contract errors (plan 23 decision 2): violations are
  recorded identically with and without `catch=Exception` — pinned by
  `TestCatchDoesNotChangeContractHandling`.
- `require_worker_result` itself still raises (pure check); the record-and-continue
  disposition lives at the one consume point.
- C13 executor normalization and the `assert_never` licensing from #1029 are untouched.

## Tests

All P2 contract tests rewritten to pin the new disposition (completes + warns + counts +
sentinel cells, on SERIAL and MULTIPROCESSING), plus new coverage: the report pane
appears exactly when `n_failed > 0`, `fail_on_sample_error=True` gates contract
violations at run end (`SampleErrorPolicyError`), and the recorded failure is
distinguishable (`WorkerContractError` in `failed_samples[].exception`) from a `catch=`
sample fault. `pixi run ci` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle worker contract violations by recording them as failed samples and warning instead of aborting sweeps, and surface these failures prominently in results and documentation.

Bug Fixes:
- Prevent sweeps from aborting when workers return None, wrong-shaped ResultVecs, or omit declared result keys by treating these as recorded contract violations that increment n_failed and emit WorkerContractWarning.

Enhancements:
- Introduce WorkerContractError/WorkerContractWarning types and plumb contract violations through store_results so they are logged, counted, and accessible via failed_samples.
- Extend BenchResult with a failed_samples_markdown helper and have to_auto_plots auto-insert a Failed Samples pane whenever n_failed > 0 to make failures visible in reports.

Documentation:
- Update plan 23 and the changelog to document the amended disposition for contract violations (record + warn, never crash the sweep).

Tests:
- Rewrite and extend collection-contract tests to assert the new record-and-warn behavior, unchanged catch= semantics, report surfacing of failed samples, and fail_on_sample_error gating at run end.