### PR TITLE
refactor: one AggFn vocabulary; unknown aggregation raises (plan 23 P11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `n_failed > 0`, in the same way the regression report is auto-inserted.
 
 ### Changed
+- **BREAKING (small): one `AggFn` vocabulary, and an unknown `agg_fn` now raises instead
+  of silently meaning `mean`** (plan 23 P11, C11). The aggregation-function vocabulary
+  existed in four independent spellings — the `Literal`s on `to`/`to_dataset`/
+  `to_hv_dataset`/`filter`, `AGG_FN_MAP`, `BenchCfg.agg_fn`'s `ObjectSelector`, and an
+  if/elif ladder in `to_dataset` that consulted none of the others. `AggFn`
+  (`bencher/utils.py`) is now the single definition and the other three derive from it;
+  the ladder normalizes at the boundary (`normalize_agg_fn`) and then matches
+  exhaustively under `assert_never`.
+
+  Two user-visible changes, both on the plotting path:
+
+  1. **An unrecognised `agg_fn` raises `ValueError`.** The ladder's terminal `else` was
+     commented "Fall back to mean if unknown string provided", so `agg_fn="meen"`
+     silently produced a mean-aggregated plot — while `optimize()` raised on the very
+     same input. The two agree now. The raise lands at plot/aggregation time, never
+     mid-sweep: via `plot_sweep`, `BenchCfg`'s `ObjectSelector` rejects the value before
+     any sample is collected; via `to_dataset`/`filter`, results are already collected
+     and cached. Validation is also unconditional now — previously an unknown value was
+     only checked when `agg_over_dims` was non-empty, so whether you got an error
+     depended on the data.
+
+  2. **Uppercase is no longer accepted.** The ladder did `(agg_fn or "mean").lower()`,
+     so `agg_fn="MEAN"` worked in `to`/`to_dataset`/`to_hv_dataset`/`filter` — and
+     nowhere else: `plot_sweep(agg_fn="MEAN")` and `optimize(agg_fn="MEAN")` already
+     raised, because the `ObjectSelector`'s objects are lowercase. That leniency was
+     undocumented, unused anywhere in the tree, and asymmetric across the API, i.e. a
+     fifth partial spelling of the vocabulary rather than a feature. Preserving it
+     inside `normalize_agg_fn` would have recreated exactly the divergence this change
+     deletes; honouring it everywhere would mean widening the accepted set, which is a
+     public-API decision that does not belong in an internal single-sourcing change.
+     The error message names the lowercase spelling
+     (`... (the vocabulary is lowercase; did you mean 'mean'?)`), so the fix is
+     mechanical. Lowercase the string, or pass an `AggFn` member.
+
+  No cache, hash or `CACHE_VERSION` impact: `agg_fn` feeds no persistent hash (it is in
+  `identity.py`'s `EXCLUDED_FIELDS`), the accepted string set is byte-identical, and all
+  five aggregations are numerically unchanged.
+
 - **`BenchRunCfg.executor` is normalized to an `Executors` member at the sweep boundary**
   (plan 23 P2, C13). Because `Executors` is a `StrEnum`,
   `param.Selector(objects=list(Executors))` accepts the bare string `"SERIAL"` and stores a

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -16,6 +16,7 @@ from bencher.cache_management import CACHE_VERSION
 from bencher.job import Executors
 from bencher.results.composable_container.composable_container_base import PaneLayout
 from bencher.results.laxtex_result import to_latex
+from bencher.utils import AggFn
 from bencher.variables.results import OptDir
 from bencher.variables.sweep_base import SUBSAMPLING_DIVISIONS_SAMPLES, describe_variable, hash_sha1
 from bencher.variables.time import TimeEvent, TimeSnapshot
@@ -817,9 +818,13 @@ class BenchCfg(BenchRunCfg):
         "When set, run_sweep will automatically append CurveResult (mean +/- std) "
         "and BandResult (percentile bands) with these dims collapsed.",
     )
+    # The objects derive from AggFn (the single source of the vocabulary, plan 23
+    # C11/P11) but stay plain strings: param stores whatever the caller assigns, so
+    # readers of this field must construct the enum at the boundary via
+    # normalize_agg_fn before matching on it (plan 24 A2/A3).
     agg_fn = param.ObjectSelector(
-        default="mean",
-        objects=["mean", "sum", "max", "min", "median"],
+        default=AggFn.MEAN.value,
+        objects=[m.value for m in AggFn],
         doc="Aggregation function to use when agg_over_dims is set.",
     )
 

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -43,7 +43,7 @@ from bencher.results.optimize_result import OptimizeResult
 from bencher.sample_order import SampleOrder
 from bencher.sweep_executor import SweepExecutor, validate_declared_vars, worker_kwargs_wrapper
 from bencher.sweep_timings import SweepTimings, phase_timer
-from bencher.utils import AGG_FN_MAP, normalize_agg_fn, params_to_str, resolve_aggregate
+from bencher.utils import AGG_FN_MAP, AggFn, normalize_agg_fn, params_to_str, resolve_aggregate
 from bencher.variables.inputs import IntSweep
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import ResultHmap
@@ -328,7 +328,7 @@ class Bench(BenchPlotServer):
         relationship_cb: Callable | None = None,
         plot_callbacks: list[Callable] | bool | None = None,
         aggregate: bool | int | list[str] | None = None,
-        agg_fn: str = "mean",
+        agg_fn: AggFn | str = AggFn.MEAN.value,
     ) -> list[BenchResult]:
         """Run a sequence of benchmarks by sweeping through groups of input variables.
 
@@ -396,7 +396,7 @@ class Bench(BenchPlotServer):
         plot_callbacks: list[Callable] | bool | None = None,
         sample_order: SampleOrder = SampleOrder.INORDER,
         aggregate: bool | int | list[str] | None = None,
-        agg_fn: str = "mean",
+        agg_fn: AggFn | str = AggFn.MEAN.value,
         auto_plot: bool | None = None,
     ) -> BenchResult:
         """The all-in-one function for benchmarking and results plotting.
@@ -1323,7 +1323,7 @@ class Bench(BenchPlotServer):
         sampler: optuna.samplers.BaseSampler | None = None,
         warm_start: bool = True,
         aggregate: bool | int | list[str] | None = None,
-        agg_fn: str = "mean",
+        agg_fn: AggFn | str = AggFn.MEAN.value,
         repeats: int = 1,
         tag: str = "",
         run_cfg: BenchRunCfg | None = None,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -43,7 +43,7 @@ from bencher.results.optimize_result import OptimizeResult
 from bencher.sample_order import SampleOrder
 from bencher.sweep_executor import SweepExecutor, validate_declared_vars, worker_kwargs_wrapper
 from bencher.sweep_timings import SweepTimings, phase_timer
-from bencher.utils import AGG_FN_MAP, params_to_str, resolve_aggregate
+from bencher.utils import AGG_FN_MAP, normalize_agg_fn, params_to_str, resolve_aggregate
 from bencher.variables.inputs import IntSweep
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import ResultHmap
@@ -1346,7 +1346,8 @@ class Bench(BenchPlotServer):
                 first input dim, an *int N* aggregates the last N dims, or a
                 *list[str]* names specific dims.  Aggregated dims are looped
                 over internally so Optuna sees the aggregated value.
-            agg_fn: Aggregation function name (``"mean"``, ``"sum"``, ``"max"``,
+            agg_fn: Aggregation function name — one of the values of
+                :class:`bencher.utils.AggFn` (``"mean"``, ``"sum"``, ``"max"``,
                 ``"min"``, ``"median"``).  Applied when *aggregate* is set or
                 *repeats* > 1.
             repeats: Number of times to evaluate each parameter combination.
@@ -1380,9 +1381,9 @@ class Bench(BenchPlotServer):
 
         needs_agg = bool(agg_vars) or repeats > 1
         if needs_agg:
-            if agg_fn not in AGG_FN_MAP:
-                raise ValueError(f"Unknown agg_fn={agg_fn!r}, must be one of {sorted(AGG_FN_MAP)}")
-            agg_callable = AGG_FN_MAP[agg_fn]
+            # normalize_agg_fn raises ValueError on an unknown value — the same
+            # behaviour this site always had, now shared with the plotting path.
+            agg_callable = AGG_FN_MAP[normalize_agg_fn(agg_fn)]
         else:
             agg_callable = None
 

--- a/bencher/results/bench_result.py
+++ b/bencher/results/bench_result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import panel as pn
 from param import Parameter
@@ -53,7 +53,7 @@ from bencher.results.pane_result import PaneResult
 from bencher.results.rerun_summary import RerunSummaryResult
 from bencher.results.video_summary import VideoSummaryResult
 from bencher.results.volume_result import VolumeResult
-from bencher.utils import listify, resolve_aggregate
+from bencher.utils import AggFn, listify, resolve_aggregate
 
 if TYPE_CHECKING:
     # Runtime import would be circular: identity imports bench_cfg, which this
@@ -203,7 +203,7 @@ class BenchResult(
         reduce: ReduceType | None = None,
         # Aggregation controls (applied in filter())
         aggregate: bool | int | list[str] | None = None,
-        agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
+        agg_fn: AggFn | str = AggFn.MEAN,
         **kwargs: Any,
     ) -> BenchResult:
         """Return the current instance of BenchResult.

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -29,7 +29,14 @@ from bencher.results.composable_container.composable_container_base import (
 from bencher.results.composable_container.composable_container_panel import (
     ComposableContainerPanel,
 )
-from bencher.utils import callable_name, color_tuple_to_css, int_to_col, listify
+from bencher.utils import (
+    AggFn,
+    callable_name,
+    color_tuple_to_css,
+    int_to_col,
+    listify,
+    normalize_agg_fn,
+)
 from bencher.variables.inputs import with_subsampling_divisions
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import (
@@ -211,7 +218,7 @@ class BenchResultBase:
         result_var: ResultFloat | None = None,
         subsampling_divisions: int | None = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["mean", "sum", "max", "min", "median"] | None = None,
+        agg_fn: AggFn | str | None = None,
     ) -> hv.Dataset:
         """Generate a holoviews dataset from the xarray dataset.
 
@@ -273,15 +280,17 @@ class BenchResultBase:
         result_var: ResultFloat | str | None,
         subsampling_divisions: int | None,
         agg_over_dims: list[str] | None,
-        agg_fn: str | None,
+        agg_fn: AggFn | str | None,
     ) -> tuple:
         """Build a hashable cache key from normalized to_dataset() arguments."""
         reduce = self._resolve_auto(reduce)
         rv_key = result_var.name if isinstance(result_var, Parameter) else result_var
         # Normalize dimension order so aggregation over the same set shares cache entries
         dims_key = tuple(sorted(agg_over_dims)) if agg_over_dims else None
-        # fn is irrelevant when no agg dims — aggregation is skipped entirely
-        fn_key = (agg_fn or "mean").lower() if agg_over_dims else None
+        # fn is irrelevant when no agg dims — aggregation is skipped entirely.
+        # normalize_agg_fn raises on an unknown value (plan 23 C11): before, an
+        # unknown string silently fell back to mean in the aggregation ladder.
+        fn_key = normalize_agg_fn(agg_fn) if agg_over_dims else None
         return (reduce, rv_key, subsampling_divisions, dims_key, fn_key)
 
     def to_dataset(
@@ -290,7 +299,7 @@ class BenchResultBase:
         result_var: ResultFloat | str | None = None,
         subsampling_divisions: int | None = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["mean", "sum", "max", "min", "median"] | None = None,
+        agg_fn: AggFn | str | None = None,
         deep: bool = True,
     ) -> xr.Dataset:
         """Generate a summarised xarray dataset.
@@ -398,34 +407,34 @@ class BenchResultBase:
                         list(ds_out.dims),
                     )
 
-                # Support basic aggregations; default to mean
-                fn = (agg_fn or "mean").lower()
-                if fn == "sum":
-                    ds_out = ds_out.sum(dim=dims_present, skipna=True)
-                elif fn == "mean":
-                    ds_agg_mean = ds_out.mean(dim=dims_present, skipna=True)
-                    non_std_vars = [v for v in ds_out.data_vars if not v.endswith("_std")]
-                    if non_std_vars:
-                        ds_agg_std = ds_out[non_std_vars].std(dim=dims_present, skipna=True)
-                        ds_agg_std = rename_ds(ds_agg_std, "std")
-                        # Drop pre-existing _std vars that will be replaced by the
-                        # aggregation std (e.g. from repeat reduction) to avoid merge conflicts.
-                        expected_std = {f"{v}_std" for v in non_std_vars}
-                        old_std = [v for v in ds_agg_mean.data_vars if v in expected_std]
-                        if old_std:
-                            ds_agg_mean = ds_agg_mean.drop_vars(old_std)
-                        ds_out = xr.merge([ds_agg_mean, ds_agg_std])
-                    else:
-                        ds_out = ds_agg_mean
-                elif fn == "max":
-                    ds_out = ds_out.max(dim=dims_present, skipna=True)
-                elif fn == "min":
-                    ds_out = ds_out.min(dim=dims_present, skipna=True)
-                elif fn == "median":
-                    ds_out = ds_out.median(dim=dims_present, skipna=True)
-                else:
-                    # Fall back to mean if unknown string provided
-                    ds_out = ds_out.mean(dim=dims_present, skipna=True)
+                # Normalize at the boundary (raises on an unknown value — no more
+                # silent fall-back to mean), then match exhaustively (plan 24 A2/A3).
+                match normalize_agg_fn(agg_fn):
+                    case AggFn.MEAN:
+                        ds_agg_mean = ds_out.mean(dim=dims_present, skipna=True)
+                        non_std_vars = [v for v in ds_out.data_vars if not v.endswith("_std")]
+                        if non_std_vars:
+                            ds_agg_std = ds_out[non_std_vars].std(dim=dims_present, skipna=True)
+                            ds_agg_std = rename_ds(ds_agg_std, "std")
+                            # Drop pre-existing _std vars that will be replaced by the
+                            # aggregation std (e.g. from repeat reduction) to avoid merge conflicts.
+                            expected_std = {f"{v}_std" for v in non_std_vars}
+                            old_std = [v for v in ds_agg_mean.data_vars if v in expected_std]
+                            if old_std:
+                                ds_agg_mean = ds_agg_mean.drop_vars(old_std)
+                            ds_out = xr.merge([ds_agg_mean, ds_agg_std])
+                        else:
+                            ds_out = ds_agg_mean
+                    case AggFn.SUM:
+                        ds_out = ds_out.sum(dim=dims_present, skipna=True)
+                    case AggFn.MAX:
+                        ds_out = ds_out.max(dim=dims_present, skipna=True)
+                    case AggFn.MIN:
+                        ds_out = ds_out.min(dim=dims_present, skipna=True)
+                    case AggFn.MEDIAN:
+                        ds_out = ds_out.median(dim=dims_present, skipna=True)
+                    case _ as unreachable:
+                        assert_never(unreachable)
             else:
                 logger.warning(
                     "Aggregation requested for dims %s but none were found in dataset dims %s; returning unaggregated dataset",
@@ -738,7 +747,7 @@ class BenchResultBase:
         override=False,
         hv_dataset: hv.Dataset | None = None,
         agg_over_dims: list[str] | None = None,
-        agg_fn: Literal["mean", "sum", "max", "min", "median"] = "mean",
+        agg_fn: AggFn | str = AggFn.MEAN,
         pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ) -> pn.panel | None:

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -282,15 +282,27 @@ class BenchResultBase:
         agg_over_dims: list[str] | None,
         agg_fn: AggFn | str | None,
     ) -> tuple:
-        """Build a hashable cache key from normalized to_dataset() arguments."""
+        """Build a hashable cache key from normalized to_dataset() arguments.
+
+        Raises:
+            ValueError: If ``agg_fn`` is outside the ``AggFn`` vocabulary. Validating
+                here is deliberate and load-bearing, not a side effect of key building:
+                ``to_dataset`` returns on a cache hit before reaching its ``match``, so
+                this is the only ``agg_fn`` check on the warm-cache path.
+        """
         reduce = self._resolve_auto(reduce)
         rv_key = result_var.name if isinstance(result_var, Parameter) else result_var
         # Normalize dimension order so aggregation over the same set shares cache entries
         dims_key = tuple(sorted(agg_over_dims)) if agg_over_dims else None
-        # fn is irrelevant when no agg dims — aggregation is skipped entirely.
-        # normalize_agg_fn raises on an unknown value (plan 23 C11): before, an
-        # unknown string silently fell back to mean in the aggregation ladder.
-        fn_key = normalize_agg_fn(agg_fn) if agg_over_dims else None
+        # Validate unconditionally, even though the *key* only needs fn when there are
+        # agg dims (without them aggregation is skipped entirely, so every fn collapses
+        # to the same dataset — hence the None below, which keeps those calls sharing one
+        # cache entry). Gating the *validation* on agg_over_dims would make an unknown
+        # agg_fn raise or not depending on the data ("does this dim exist in the
+        # dataset?"), which is exactly the data-dependent validation plan 23 exists to
+        # remove. normalize_agg_fn is cheap, idempotent and total (None -> MEAN).
+        fn = normalize_agg_fn(agg_fn)
+        fn_key = fn if agg_over_dims else None
         return (reduce, rv_key, subsampling_divisions, dims_key, fn_key)
 
     def to_dataset(
@@ -318,6 +330,10 @@ class BenchResultBase:
             a deep copy is returned so callers can safely mutate the result. Internal
             hot paths pass ``deep=False`` to reuse the cached object directly.
         """
+        # NOTE: this call validates agg_fn (normalize_agg_fn, inside), and that is
+        # load-bearing rather than redundant with the match further down: on a cache
+        # hit we return two lines below and never reach the match, so this is the
+        # *only* validation on the warm-cache path. Do not "optimize" it away.
         cache_key = self._to_dataset_cache_key(
             reduce, result_var, subsampling_divisions, agg_over_dims, agg_fn
         )
@@ -409,6 +425,11 @@ class BenchResultBase:
 
                 # Normalize at the boundary (raises on an unknown value — no more
                 # silent fall-back to mean), then match exhaustively (plan 24 A2/A3).
+                # This is the second normalize_agg_fn call on this path (the first is in
+                # _to_dataset_cache_key above) and both are needed: that one is the only
+                # validation when the cache hits and this one is the only thing that
+                # gives the match subject a type ty can check. Neither substitutes for
+                # the other; the function is idempotent, so calling it twice is free.
                 match normalize_agg_fn(agg_fn):
                     case AggFn.MEAN:
                         ds_agg_mean = ds_out.mean(dim=dims_present, skipna=True)

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -394,6 +394,14 @@ class AggFn(StrEnum):
     yields the member *name* verbatim (``'MEAN'``), and these strings are the
     exact values ``BenchCfg.agg_fn`` accepts, so they are pinned here
     (plan 23 D4).
+
+    Note for callers that *forward a default into* ``BenchCfg``: pass
+    ``AggFn.MEAN.value``, not ``AggFn.MEAN``. ``param`` stores whatever it is
+    handed, so the member would make ``type(bench_cfg.agg_fn)`` an ``AggFn``
+    where every other path leaves it a plain ``str``. Consumers normalize
+    anyway, but keeping the stored type uniform is what makes the descriptor's
+    contract (plain strings) true. Reading code should call
+    :func:`normalize_agg_fn` and not care which it got.
     """
 
     MEAN = "mean"
@@ -427,9 +435,16 @@ def normalize_agg_fn(agg_fn: AggFn | str | None) -> AggFn:
     try:
         return AggFn(agg_fn)
     except ValueError:
-        raise ValueError(
-            f"Unknown agg_fn={agg_fn!r}, must be one of {sorted(m.value for m in AggFn)}"
-        ) from None
+        msg = f"Unknown agg_fn={agg_fn!r}, must be one of {sorted(m.value for m in AggFn)}"
+        # Case-folding hint: the plotting path used to lowercase agg_fn before
+        # dispatch, so `agg_fn="MEAN"` worked there (and only there — plot_sweep
+        # and optimize always rejected it). That leniency is gone; name the fix
+        # rather than leaving the caller to diff the two spellings.
+        if isinstance(agg_fn, str):
+            folded = agg_fn.lower()
+            if folded in {m.value for m in AggFn}:
+                msg += f" (the vocabulary is lowercase; did you mean {folded!r}?)"
+        raise ValueError(msg) from None
 
 
 AGG_FN_MAP: dict[AggFn, Callable] = {

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 import numpy as np
 import param
 import xarray as xr
+from strenum import StrEnum
 
 logger = logging.getLogger(__name__)
 
@@ -382,12 +383,61 @@ def resolve_aggregate(
     )
 
 
-AGG_FN_MAP: dict[str, Callable] = {
-    "mean": lambda vals: float(np.nanmean(vals)),
-    "sum": lambda vals: float(np.nansum(vals)),
-    "max": lambda vals: float(np.nanmax(vals)),
-    "min": lambda vals: float(np.nanmin(vals)),
-    "median": lambda vals: float(np.nanmedian(vals)),
+class AggFn(StrEnum):
+    """The aggregation-function vocabulary — the single source of truth (plan 23 C11).
+
+    Every other spelling derives from this enum: ``AGG_FN_MAP``'s keys, the
+    ``BenchCfg.agg_fn`` ``param.ObjectSelector``'s objects, and the ``agg_fn``
+    signature annotations on the result classes.
+
+    Explicit lowercase values rather than ``auto()``: ``strenum``'s ``auto()``
+    yields the member *name* verbatim (``'MEAN'``), and these strings are the
+    exact values ``BenchCfg.agg_fn`` accepts, so they are pinned here
+    (plan 23 D4).
+    """
+
+    MEAN = "mean"
+    SUM = "sum"
+    MAX = "max"
+    MIN = "min"
+    MEDIAN = "median"
+
+
+def normalize_agg_fn(agg_fn: AggFn | str | None) -> AggFn:
+    """Coerce ``agg_fn`` to an ``AggFn`` member at the boundary.
+
+    ``None`` means the default (``AggFn.MEAN``) — public signatures declare
+    ``agg_fn: AggFn | str | None`` and forward it unchanged. A raw string read
+    from ``BenchCfg.agg_fn`` (a ``param.ObjectSelector`` holding plain strings)
+    is not a type a checker can establish, so constructing the enum here is
+    what licenses the exhaustive ``match`` downstream (plan 24 A2/A3).
+
+    Args:
+        agg_fn: An ``AggFn`` member, one of its string values, or ``None``.
+
+    Returns:
+        AggFn: The corresponding member.
+
+    Raises:
+        ValueError: If ``agg_fn`` is not an ``AggFn`` member or one of its
+            values. Raised at plot/aggregation call time, never mid-sweep.
+    """
+    if agg_fn is None:
+        return AggFn.MEAN
+    try:
+        return AggFn(agg_fn)
+    except ValueError:
+        raise ValueError(
+            f"Unknown agg_fn={agg_fn!r}, must be one of {sorted(m.value for m in AggFn)}"
+        ) from None
+
+
+AGG_FN_MAP: dict[AggFn, Callable] = {
+    AggFn.MEAN: lambda vals: float(np.nanmean(vals)),
+    AggFn.SUM: lambda vals: float(np.nansum(vals)),
+    AggFn.MAX: lambda vals: float(np.nanmax(vals)),
+    AggFn.MIN: lambda vals: float(np.nanmin(vals)),
+    AggFn.MEDIAN: lambda vals: float(np.nanmedian(vals)),
 }
 
 

--- a/docs/how_to_use_bencher.md
+++ b/docs/how_to_use_bencher.md
@@ -479,9 +479,14 @@ bench.plot_sweep(
     aggregate=True,          # collapse all dimensions except the first
     # aggregate=2,           # collapse the last 2 dimensions
     # aggregate=["method"],  # collapse only the "method" dimension
-    agg_fn="mean",           # aggregation function: mean, sum, max, min, median
+    agg_fn="mean",           # aggregation function: see bencher.utils.AggFn
 )
 ```
+
+- `agg_fn` — one of the values of `bencher.utils.AggFn`, the single definition of
+  this vocabulary: `"mean"`, `"sum"`, `"max"`, `"min"`, `"median"`. The strings are
+  **lowercase and case-sensitive**, and an unrecognised value raises `ValueError`
+  rather than quietly falling back to `"mean"`.
 
 - `aggregate=True` — collapse all dimensions except the first into a single
   aggregated statistic

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -7,6 +7,7 @@ import panel as pn
 import bencher as bn
 from bencher.example.meta.example_meta import BenchableObject
 from bencher.results.bench_result_base import ReduceType
+from bencher.utils import AGG_FN_MAP, AggFn
 
 
 class TstBench(bn.ParametrizedSweep):
@@ -201,10 +202,122 @@ class TestAggOverDimsStd(unittest.TestCase):
         ds = self.res_1d_1rep.to_dataset()
         self.assertNotIn("distance_std", ds.data_vars)
 
-    def test_case_insensitive_agg_fn(self):
-        """agg_fn should be case-insensitive."""
-        ds = self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="MEAN")
-        self.assertIn("distance_std", ds.data_vars)
+    def test_uppercase_agg_fn_raises(self):
+        """The vocabulary is exactly AggFn's lowercase values (case-sensitive).
+
+        Plan 23 P11: the old aggregation ladder lowercased agg_fn before
+        dispatch, so "MEAN" used to be accepted here. That leniency was one
+        more spelling of the vocabulary and is gone — optimize() and
+        BenchCfg.agg_fn always rejected "MEAN".
+        """
+        with self.assertRaises(ValueError):
+            self.res_1d_1rep.to_dataset(agg_over_dims=["float1"], agg_fn="MEAN")
+
+
+class TestAggFnVocabulary(unittest.TestCase):
+    """Plan 23 P11 (C11): one AggFn vocabulary; unknown aggregation raises.
+
+    Plan 24 A3: BenchCfg.agg_fn is a param.ObjectSelector whose objects are raw
+    strings, so these tests drive raw strings through the param field into the
+    shipped code path rather than only calling enum-typed functions directly.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.bench = BenchableObject().to_bench()
+        cls.res = cls.bench.plot_sweep(
+            "agg_fn_vocab",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+        )
+
+    def test_agg_fn_map_covers_every_member(self):
+        """AGG_FN_MAP's keys derive from (and must stay in sync with) AggFn."""
+        self.assertEqual(set(AGG_FN_MAP), set(AggFn))
+
+    def test_bench_cfg_objects_are_agg_fn_values(self):
+        """The ObjectSelector's accepted strings are exactly AggFn's values."""
+        objects = bn.BenchCfg.param.agg_fn.objects
+        self.assertEqual(objects, [m.value for m in AggFn])
+        self.assertEqual(bn.BenchCfg.param.agg_fn.default, AggFn.MEAN.value)
+
+    def test_unknown_agg_fn_raises_instead_of_silently_meaning_mean(self):
+        """Before plan 23 P11 the ladder's terminal else silently meant mean."""
+        with self.assertRaises(ValueError) as ctx:
+            self.res.to_dataset(agg_over_dims=["float1"], agg_fn="bogus")
+        msg = str(ctx.exception)
+        self.assertIn("bogus", msg)
+        for member in AggFn:
+            self.assertIn(member.value, msg)
+
+    def test_each_member_aggregates_as_before(self):
+        """Every valid agg_fn (member or raw string) matches the numpy result."""
+        raw = self.res.to_dataset()["distance"].values
+        expected = {
+            AggFn.MEAN: np.nanmean,
+            AggFn.SUM: np.nansum,
+            AggFn.MAX: np.nanmax,
+            AggFn.MIN: np.nanmin,
+            AggFn.MEDIAN: np.nanmedian,
+        }
+        self.assertEqual(set(expected), set(AggFn))
+        for member, np_fn in expected.items():
+            for spelling in (member, member.value):
+                ds = self.res.to_dataset(agg_over_dims=["float1"], agg_fn=spelling)
+                np.testing.assert_allclose(
+                    float(ds["distance"].values), float(np_fn(raw)), rtol=1e-10
+                )
+
+    # --- plan 24 A3 DoD: drive the raw string through the param field ---
+
+    def test_unknown_agg_fn_through_plot_sweep_raises(self):
+        """plot_sweep routes agg_fn into BenchCfg's ObjectSelector, which
+        rejects an out-of-vocabulary string at config acceptance -- before the
+        sweep runs, so no collected data is ever lost to this raise."""
+        with self.assertRaises(ValueError):
+            self.bench.plot_sweep(
+                "agg_fn_bogus",
+                input_vars=[BenchableObject.param.float1],
+                result_vars=[BenchableObject.param.distance],
+                run_cfg=bn.BenchRunCfg(repeats=1),
+                plot_callbacks=False,
+                aggregate=["float1"],
+                agg_fn="bogus",
+            )
+
+    def test_unknown_agg_fn_param_assignment_raises(self):
+        """Assigning through the param descriptor is also boundary-checked."""
+        with self.assertRaises(ValueError):
+            self.res.bench_cfg.agg_fn = "bogus"
+
+    def test_valid_raw_string_through_param_field_reaches_shipped_path(self):
+        """A valid raw string stored by param (a plain str, not an AggFn
+        member) must survive the shipped read of bench_cfg.agg_fn into the
+        normalize+match pipeline and aggregate correctly."""
+        res = self.bench.plot_sweep(
+            "agg_fn_median_param",
+            input_vars=[BenchableObject.param.float1],
+            result_vars=[BenchableObject.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+            aggregate=["float1"],
+            agg_fn="median",
+        )
+        # param stores the raw string, not an enum member: this is exactly why
+        # normalize_agg_fn must construct the enum at the boundary (plan 24 A3).
+        self.assertIs(type(res.bench_cfg.agg_fn), str)
+        raw = res.to_dataset()["distance"].values
+        ds = res.to_dataset(agg_over_dims=res.bench_cfg.agg_over_dims, agg_fn=res.bench_cfg.agg_fn)
+        np.testing.assert_allclose(
+            float(ds["distance"].values), float(np.nanmedian(raw)), rtol=1e-10
+        )
+        # The shipped consumer itself (reads bench_cfg.agg_fn internally);
+        # calling the private method is the point of this plan-24 A3 test.
+        summary = res._scalar_aggregate_summary()  # pylint: disable=protected-access
+        self.assertIsInstance(summary, pn.pane.Markdown)
+        self.assertNotIn("No result variables found", summary.object)
 
 
 class TestBenchResultBase(unittest.TestCase):

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -10,6 +10,21 @@ from bencher.results.bench_result_base import ReduceType
 from bencher.utils import AGG_FN_MAP, AggFn
 
 
+class CountingWorker(bn.ParametrizedSweep):
+    """Counts benchmark invocations, so a test can assert sampling never started."""
+
+    float1 = bn.FloatSweep(default=0, bounds=[0, 4], samples=3)
+    distance = bn.ResultFloat()
+
+    calls = 0
+
+    def benchmark(self):
+        # Instance attribute: each test builds its own worker, so counts do not
+        # leak between tests the way a class-level counter would.
+        self.calls += 1
+        self.distance = float(self.float1)
+
+
 class TstBench(bn.ParametrizedSweep):
     float_var = bn.FloatSweep(default=0, bounds=[0, 4])
     cat_var = bn.StringSweep(["a", "b", "c", "d", "e"])
@@ -236,12 +251,21 @@ class TestAggFnVocabulary(unittest.TestCase):
     def test_agg_fn_map_covers_every_member(self):
         """AGG_FN_MAP's keys derive from (and must stay in sync with) AggFn."""
         self.assertEqual(set(AGG_FN_MAP), set(AggFn))
+        # Set equality alone would still pass if AGG_FN_MAP reverted to raw-string
+        # keys, because AggFn is a StrEnum and "mean" == AggFn.MEAN. Pin the key
+        # *type* so the derivation cannot silently regress to a fifth spelling.
+        self.assertTrue(all(isinstance(k, AggFn) for k in AGG_FN_MAP))
 
     def test_bench_cfg_objects_are_agg_fn_values(self):
         """The ObjectSelector's accepted strings are exactly AggFn's values."""
         objects = bn.BenchCfg.param.agg_fn.objects
         self.assertEqual(objects, [m.value for m in AggFn])
         self.assertEqual(bn.BenchCfg.param.agg_fn.default, AggFn.MEAN.value)
+        # Plain str, not AggFn members: the descriptor's objects are what gets
+        # stored on and serialized out of BenchCfg, so the shape is pinned here
+        # (and is why readers must construct the enum — plan 24 A3).
+        self.assertTrue(all(type(o) is str for o in objects))
+        self.assertIs(type(bn.BenchCfg.param.agg_fn.default), str)
 
     def test_unknown_agg_fn_raises_instead_of_silently_meaning_mean(self):
         """Before plan 23 P11 the ladder's terminal else silently meant mean."""
@@ -272,20 +296,69 @@ class TestAggFnVocabulary(unittest.TestCase):
 
     # --- plan 24 A3 DoD: drive the raw string through the param field ---
 
-    def test_unknown_agg_fn_through_plot_sweep_raises(self):
-        """plot_sweep routes agg_fn into BenchCfg's ObjectSelector, which
-        rejects an out-of-vocabulary string at config acceptance -- before the
-        sweep runs, so no collected data is ever lost to this raise."""
+    def test_unknown_agg_fn_through_plot_sweep_raises_before_any_sampling(self):
+        """plot_sweep routes agg_fn into BenchCfg's ObjectSelector, which rejects
+        an out-of-vocabulary string at config acceptance.
+
+        The claim that matters is *when*: the raise must land before any sample is
+        collected, so this raise can never lose expensive already-collected data
+        (plan 23 owner decision 2). Asserting only ValueError would still pass if
+        BenchCfg construction moved after sampling, so count worker calls.
+        """
+        worker = CountingWorker()
+        bench = worker.to_bench()
         with self.assertRaises(ValueError):
-            self.bench.plot_sweep(
+            bench.plot_sweep(
                 "agg_fn_bogus",
-                input_vars=[BenchableObject.param.float1],
-                result_vars=[BenchableObject.param.distance],
+                input_vars=[CountingWorker.param.float1],
+                result_vars=[CountingWorker.param.distance],
                 run_cfg=bn.BenchRunCfg(repeats=1),
                 plot_callbacks=False,
                 aggregate=["float1"],
                 agg_fn="bogus",
             )
+        self.assertEqual(worker.calls, 0, "config was rejected only after sampling")
+
+        # Control: the identical sweep with a valid agg_fn *does* sample, proving
+        # the zero above is the raise's doing and not a sweep that never runs.
+        bench.plot_sweep(
+            "agg_fn_ok",
+            input_vars=[CountingWorker.param.float1],
+            result_vars=[CountingWorker.param.distance],
+            run_cfg=bn.BenchRunCfg(repeats=1),
+            plot_callbacks=False,
+            aggregate=["float1"],
+            agg_fn="mean",
+        )
+        self.assertGreater(worker.calls, 0)
+
+    def test_uppercase_agg_fn_error_names_the_lowercase_spelling(self):
+        """The break is small but the fix should not need guessing."""
+        with self.assertRaises(ValueError) as ctx:
+            self.res.to_dataset(agg_over_dims=["float1"], agg_fn="MEAN")
+        msg = str(ctx.exception)
+        self.assertIn("lowercase", msg)
+        self.assertIn("'mean'", msg)
+
+    def test_unknown_agg_fn_raises_without_agg_over_dims(self):
+        """Validation must not be data-dependent.
+
+        The cache key only needs agg_fn when there are agg dims, but gating the
+        *validation* on that would make an unknown value raise or pass depending
+        on the dataset's dims -- the shape plan 23 exists to remove.
+        """
+        with self.assertRaises(ValueError):
+            self.res.to_dataset(agg_fn="bogus")
+        with self.assertRaises(ValueError):
+            self.res.to_dataset(agg_over_dims=[], agg_fn="bogus")
+        with self.assertRaises(ValueError):
+            self.res.to_dataset(agg_over_dims=["nonexistent"], agg_fn="bogus")
+
+    def test_unknown_agg_fn_raises_on_a_warm_cache(self):
+        """The cache-key call is the only validation once _to_dataset_cache hits."""
+        self.res.to_dataset(agg_over_dims=["float1"], agg_fn="mean")
+        with self.assertRaises(ValueError):
+            self.res.to_dataset(agg_over_dims=["float1"], agg_fn="bogus")
 
     def test_unknown_agg_fn_param_assignment_raises(self):
         """Assigning through the param descriptor is also boundary-checked."""


### PR DESCRIPTION
Implements plan 23 P11 (C11), folding in plan 24 A3's `agg_fn` DoD addition.

**This is a small breaking change on the plotting path** — see "Behaviour changes" below.
Both breaks are in the `### Changed` CHANGELOG entry.

## The four spellings, collapsed to one

`AggFn` (`bencher/utils.py:386`, `strenum.StrEnum` with explicit lowercase values per
plan 23 D4 — `strenum`'s `auto()` would yield `'MEAN'`, and these strings are exactly
what `BenchCfg.agg_fn` accepts, so they are pinned) is now the single definition.
Everything else derives from it:

1. **The `Literal`s** — `bench_result.py:206` (`to`), `bench_result_base.py:214`
   (`to_hv_dataset`), `:293` (`to_dataset`), `:741` (`filter`) become
   `AggFn | str [| None]`. `str` is kept in the annotation because every caller in the
   tree (and `bench_cfg.agg_fn` itself) passes a raw string; the type is made true by
   normalizing, not by narrowing the signature.
2. **`AGG_FN_MAP`** (`utils.py:435`) is now keyed by `AggFn` members.
3. **The `ObjectSelector`** (`bench_cfg.py:824`) takes `default=AggFn.MEAN.value`,
   `objects=[m.value for m in AggFn]`. The accepted strings are **byte-identical** to
   before — this is internal single-sourcing only; the knob's *home* stays where it is
   (A5's business).
4. **The if/elif ladder** (`bench_result_base.py:401`) is now
   `match normalize_agg_fn(agg_fn):` over the five members with
   `case _ as unreachable: assert_never(unreachable)`. It no longer disagrees with
   `AGG_FN_MAP` because it no longer has its own vocabulary.

`normalize_agg_fn` (`utils.py:413`) is the boundary: `None` → `AggFn.MEAN` (unchanged
default semantics), otherwise `AggFn(value)` or `ValueError` naming the value and the
full vocabulary. `optimize()` (`bencher.py:1386`) now calls it too, replacing its
hand-rolled `if agg_fn not in AGG_FN_MAP: raise` — same behaviour, one implementation.

## Boundary normalization is what licenses the exhaustive match (plan 24 A2/A3)

`BenchCfg.agg_fn` is a `param.ObjectSelector` whose `objects` are **raw strings**, so a
read of that field is `Unknown` to `ty` and a `match` on it would not be an
exhaustiveness check of anything. Constructing the enum at the boundary — `AggFn(value)`,
raising on unknown input — is the precondition that licenses `assert_never` there, not
merely tidiness (plan 24 A2). Per A3 this field is strictly worse than `executor`, whose
`objects` are already enum members: the enum must be *constructed*, never assumed to be
what the descriptor holds. `test_valid_raw_string_through_param_field_reaches_shipped_path`
asserts `type(res.bench_cfg.agg_fn) is str` to pin that rather than let it drift.

## Behaviour changes

### 1. Unknown `agg_fn` raises instead of silently meaning `mean`

The ladder's terminal `else` was commented "Fall back to mean if unknown string
provided", so `agg_fn="meen"` silently produced a mean-aggregated plot — while
`optimize()` raised on the same input. They agree now.

Validation is also **unconditional**: it was previously gated on `agg_over_dims` being
non-empty, so whether a typo raised depended on the dataset's dims. That is
data-dependent validation, the shape plan 23 exists to remove, and it contradicted the
headline. Now `res.to_dataset(agg_fn="bogus")` raises too.

### 2. Uppercase is no longer accepted on the plotting path

The ladder did `(agg_fn or "mean").lower()`, so `agg_fn="MEAN"` worked in
`to`/`to_dataset`/`to_hv_dataset`/`filter` — and **nowhere else**:
`plot_sweep(agg_fn="MEAN")` and `optimize(agg_fn="MEAN")` already raised, because the
`ObjectSelector`'s objects are lowercase. The leniency was undocumented, unused anywhere
in the tree, and asymmetric across the API — a fifth partial spelling of the vocabulary
rather than a feature. Folding inside `normalize_agg_fn` would recreate the exact
divergence this PR deletes (the `ObjectSelector` would still reject `"MEAN"` while
`to_dataset` accepted it); folding everywhere needs widening the accepted set, which is
A5's call. So the raise stays, and the error message names the fix:
`Unknown agg_fn='MEAN', must be one of [...] (the vocabulary is lowercase; did you mean 'mean'?)`.

## When the raise lands, honestly

Not mid-sweep for the two config ingress points:

- **`plot_sweep(agg_fn=...)`** → `BenchCfg`'s `ObjectSelector` rejects it at config
  acceptance, before any sample is collected.
  `test_unknown_agg_fn_through_plot_sweep_raises_before_any_sampling` asserts this with a
  counting worker (plus a valid-`agg_fn` control proving the count would otherwise move),
  because asserting only `ValueError` would pass if `BenchCfg` construction moved after
  sampling.
- **`to_dataset`/`to_hv_dataset`/`filter`** → raises during report building, after
  results are collected and cached.

**There is a third ingress point, and it is worse than the other two.** A user-supplied
`plot_callbacks` entry that passes `agg_fn="MEAN"` (or a typo) now raises out through
`BenchResult.plot()` → `report.append_result` → `run_sweep` → `plot_sweep` and crashes
the sweep. `bench_result.py:279-281` invokes callbacks with **no** `try`/`except`, unlike
`to_auto`'s plugin loop, so nothing contains it. Measured: `main` returns a result where
this PR crashes.

The mitigation is real but partial: `cache_results` (`bencher.py:901`) runs *before* the
`auto_plot` block (`:910`), so with caching enabled the samples are already on disk and a
re-run replots from cache. But `cache_results` and `cache_samples` both default to
`False` (verified), so **from a default-config user's seat the run's data is lost.**
That is a genuine regression in blast radius for the uppercase case specifically, and it
is stated here rather than buried.

The missing `try`/`except` at `bench_result.py:280` is **pre-existing and not fixed
here** — the coordinator is filing it separately. It is what turns any callback error,
not just this one, into a lost run.

## Tests (`test/test_bench_result_base.py`, class `TestAggFnVocabulary`)

- `test_unknown_agg_fn_raises_instead_of_silently_meaning_mean` — the pre-fix regression:
  on `main` this returns a mean-aggregated dataset.
- `test_unknown_agg_fn_raises_without_agg_over_dims` — validation is not data-dependent
  (bare, empty-list, and nonexistent-dim cases).
- `test_unknown_agg_fn_raises_on_a_warm_cache` — the cache-key call is the *only*
  validation once `_to_dataset_cache` hits, since `to_dataset` returns before the match.
- `test_unknown_agg_fn_through_plot_sweep_raises_before_any_sampling` and
  `test_unknown_agg_fn_param_assignment_raises` — **plan 24 A3 DoD**: the raw string goes
  through the `param` field into the shipped path, not into an enum-typed function.
- `test_valid_raw_string_through_param_field_reaches_shipped_path` — a valid raw string
  stored by `param` survives the shipped read into normalize+match, and
  `_scalar_aggregate_summary()` (a real consumer of `bench_cfg.agg_fn`) renders.
- `test_each_member_aggregates_as_before` — all five members, as member *and* raw string,
  against `np.nanmean/nansum/nanmax/nanmin/nanmedian` of the unaggregated data.
- `test_uppercase_agg_fn_raises` / `test_uppercase_agg_fn_error_names_the_lowercase_spelling`
  — pin the break and the migration hint.
- `test_agg_fn_map_covers_every_member` / `test_bench_cfg_objects_are_agg_fn_values` — the
  derivation is asserted, including key/object *types* (set equality alone would pass if
  `AGG_FN_MAP` reverted to raw-string keys, since `AggFn` is a `StrEnum`).
- `optimize()`'s existing raise behaviour is unchanged: `test/test_optimize.py:255` and
  `:243` pass untouched.

## Plan 23 §9 grep check

`grep -rn 'AGG_FN_MAP\|Literal\["mean"\|"mean", "sum"' bencher/` → exactly one definition
of the vocabulary (`utils.py`'s `AggFn`), plus the derived `AGG_FN_MAP` and its consumers.

## Falsified plan claims

None. Every claim in §3 C11 and §5 P11 held, modulo line drift the brief anticipated: the
`Literal`s are at `bench_result.py:206` and `bench_result_base.py:214`/`:293`/`:741`
(plan says `:175`, `:203`/`:266`/`:712`); the `ObjectSelector` (`bench_cfg.py:820-824`)
and `AGG_FN_MAP` (`utils.py:385-391`) were exact; the ladder was at `:401-428` with the
terminal `# Fall back to mean if unknown string provided` else exactly as described. The
`.lower()` case-folding is one detail C11 does not mention — a fifth spelling, not a
contradiction.

## Notes

- No cache/hash/`CACHE_VERSION` impact: `agg_fn` is in `identity.py`'s
  `EXCLUDED_FIELDS` (`:48`), the accepted set is byte-identical, and all five
  aggregations are numerically unchanged.
- Residual literals at `bencher.py:331`/`:399`/`:1326` now read
  `agg_fn: AggFn | str = AggFn.MEAN.value`. **`.value`, not the member**: `param` stores
  what it is handed, so `AggFn.MEAN` would flip `type(bench_cfg.agg_fn)` from `str` to
  `AggFn` and break the pin above (verified). The reason is recorded in `AggFn`'s
  docstring so a future cleanup does not "simplify" it.
- `docs/how_to_use_bencher.md:482` no longer hand-enumerates the vocabulary.
- Version not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
