### PR TITLE
fix: report tab pairing, capability vocabulary, honest rerun missing values (plan 23 P10)

### DIFF
--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -234,27 +234,60 @@ class BenchReport(BenchPlotServer):
                 return tab
         return None
 
+    @staticmethod
+    def _result_title(bench_res: BenchResult) -> str:
+        """Best-effort human title for *bench_res*, for attributing a fallback pane."""
+        cfg = getattr(bench_res, "bench_cfg", None)
+        return getattr(cfg, "title", None) or getattr(bench_res, "title", None) or "unknown sweep"
+
+    def _append_unattributed(self, bench_res: BenchResult, pane: pn.panel) -> None:
+        """Fallback for a result with no tab of its own: append to the last tab.
+
+        The pane lands under a *different* result's heading, so it is labelled
+        with its true owner and a warning is emitted. A silently misattributed
+        pane is worse than a missing one — a reader would otherwise credit this
+        content (a regression verdict, say) to the sweep whose tab it sits in.
+        """
+        title = self._result_title(bench_res)
+        logger.warning(
+            "No tab for result %r (its plot() produced nothing, or it was never "
+            "registered via append_result); appending its content to the last tab "
+            "instead, labelled with its origin",
+            title,
+        )
+        self.append(
+            pn.pane.Markdown(
+                f"**⚠️ From `{title}`** — this sweep produced no tab of its own, "
+                "so its content appears here. It does **not** belong to the sweep "
+                "above.",
+                name=f"{title} (no tab)",
+            )
+        )
+        self.append(pane)
+
     def append_to_result(self, bench_res: BenchResult, pane: pn.panel) -> None:
         """Append *pane* to the tab that belongs to *bench_res*.
 
-        Falls back to :meth:`append` (the last tab) when the result is
-        untracked or its plot() produced no tab.
+        Falls back to the last tab when the result is untracked or its plot()
+        produced no tab; the fallback labels the pane with its true owner (see
+        :meth:`_append_unattributed`).
         """
         tab = self._tab_for_result(bench_res)
         if tab is None:
-            self.append(pane)
+            self._append_unattributed(bench_res, pane)
         else:
             tab.append(pane)
 
     def prepend_to_result(self, bench_res: BenchResult, pane: pn.panel) -> None:
         """Insert *pane* at the beginning of the tab that belongs to *bench_res*.
 
-        Falls back to :meth:`append` (the last tab) when the result is
-        untracked or its plot() produced no tab.
+        Falls back to the last tab when the result is untracked or its plot()
+        produced no tab; the fallback labels the pane with its true owner (see
+        :meth:`_append_unattributed`).
         """
         tab = self._tab_for_result(bench_res)
         if tab is None:
-            self.append(pane)
+            self._append_unattributed(bench_res, pane)
         else:
             tab.insert(0, pane)
 

--- a/bencher/bench_report.py
+++ b/bencher/bench_report.py
@@ -144,7 +144,22 @@ class BenchReport(BenchPlotServer):
         self.bench_name = bench_name
         self.pane = pn.Tabs(tabs_location="above", name=self.bench_name)
         self.last_save_ms: float = 0.0
-        self.bench_results: list[BenchResult] = []
+        # Each result is stored together with the tab that was created for it
+        # (None when its plot() produced nothing), so tab routing can never
+        # resolve into a *different* result's tab (plan 23 C9). The previous
+        # representation — two parallel lists correlated by index — silently
+        # misrouted once a None plot desynced them.
+        self._result_tabs: list[tuple[BenchResult, pn.Column | None]] = []
+
+    @property
+    def bench_results(self) -> tuple[BenchResult, ...]:
+        """The results registered via :meth:`append_result`, in registration order.
+
+        Read-only snapshot: register results through :meth:`append_result` so each
+        one is paired with its tab. (A mutable list here would make direct appends
+        a silent no-op — a tuple fails loudly instead.)
+        """
+        return tuple(res for res, _tab in self._result_tabs)
 
     def clear(self) -> None:
         """Remove all tabs and results so the report can be reused between runs.
@@ -152,7 +167,7 @@ class BenchReport(BenchPlotServer):
         Not safe to call while the report is being served to a live Panel session.
         """
         self.pane.clear()
-        self.bench_results.clear()
+        self._result_tabs.clear()
 
     def append_title(self, title: str, new_tab: bool = True):
         if new_tab:
@@ -201,7 +216,6 @@ class BenchReport(BenchPlotServer):
         return label
 
     def append_result(self, bench_res: BenchResult, render_from: BenchResult | None = None) -> None:
-        self.bench_results.append(bench_res)
         title = bench_res.bench_cfg.title
         label = self._time_event_label(bench_res)
         if label:
@@ -210,30 +224,50 @@ class BenchReport(BenchPlotServer):
         # routing (append_to_result) while building the pane from another — used
         # by the BENCHER_FORCE_SPLIT_RENDER path to render from a deserialized
         # copy without breaking routing. Defaults to bench_res (normal path).
-        self.append_tab((render_from or bench_res).plot(), title)
+        tab = self.append_tab((render_from or bench_res).plot(), title)
+        self._result_tabs.append((bench_res, tab))
+
+    def _tab_for_result(self, bench_res: BenchResult) -> pn.Column | None:
+        """The tab created for *bench_res*, or None when untracked / plot() was None."""
+        for res, tab in self._result_tabs:
+            if res is bench_res:
+                return tab
+        return None
 
     def append_to_result(self, bench_res: BenchResult, pane: pn.panel) -> None:
-        """Append *pane* to the tab that belongs to *bench_res*."""
-        try:
-            idx = self.bench_results.index(bench_res)
-            self.pane[idx].append(pane)
-        except (ValueError, IndexError):
+        """Append *pane* to the tab that belongs to *bench_res*.
+
+        Falls back to :meth:`append` (the last tab) when the result is
+        untracked or its plot() produced no tab.
+        """
+        tab = self._tab_for_result(bench_res)
+        if tab is None:
             self.append(pane)
+        else:
+            tab.append(pane)
 
     def prepend_to_result(self, bench_res: BenchResult, pane: pn.panel) -> None:
-        """Insert *pane* at the beginning of the tab that belongs to *bench_res*."""
-        try:
-            idx = self.bench_results.index(bench_res)
-            self.pane[idx].insert(0, pane)
-        except (ValueError, IndexError):
-            self.append(pane)
+        """Insert *pane* at the beginning of the tab that belongs to *bench_res*.
 
-    def append_tab(self, pane: pn.panel, name: str | None = None) -> None:
-        if pane is not None:
-            if name is None:
-                name = pane.name
-            self.pane.append(pn.Column(pane, name=name))
-            self.pane.active = len(self.pane) - 1
+        Falls back to :meth:`append` (the last tab) when the result is
+        untracked or its plot() produced no tab.
+        """
+        tab = self._tab_for_result(bench_res)
+        if tab is None:
+            self.append(pane)
+        else:
+            tab.insert(0, pane)
+
+    def append_tab(self, pane: pn.panel, name: str | None = None) -> pn.Column | None:
+        """Add *pane* as a new tab and return the created tab column (None if no pane)."""
+        if pane is None:
+            return None
+        if name is None:
+            name = pane.name
+        tab = pn.Column(pane, name=name)
+        self.pane.append(tab)
+        self.pane.active = len(self.pane) - 1
+        return tab
 
     def save_index(self, directory: str = "", filename: str = "index.html") -> Path:
         """Saves the result to index.html in the root folder so that it can be displayed by github pages.

--- a/bencher/plugins/__init__.py
+++ b/bencher/plugins/__init__.py
@@ -13,7 +13,7 @@ built-in chart types onto the plugin mechanism happens in subsequent PRs."""
 from __future__ import annotations
 
 from bencher.plotting.plot_filter import PlotFilter, VarRange
-from bencher.plugins.bench_data import BenchData, CacheHandle, RunMeta
+from bencher.plugins.bench_data import BenchData, CacheHandle, Capability, RunMeta, to_capability
 from bencher.plugins.plugin import PlotPlugin, plot_plugin
 from bencher.plugins.registry import (
     ENTRY_POINT_GROUP,
@@ -29,6 +29,7 @@ __all__ = [
     "ENTRY_POINT_GROUP",
     "BenchData",
     "CacheHandle",
+    "Capability",
     "PlotFilter",
     "PlotPlugin",
     "PluginDecision",
@@ -39,5 +40,6 @@ __all__ = [
     "get_registry",
     "plot_plugin",
     "register_plugin",
+    "to_capability",
     "unregister_plugin",
 ]

--- a/bencher/plugins/bench_data.py
+++ b/bencher/plugins/bench_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from datetime import datetime
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, assert_never, runtime_checkable
 
 import xarray as xr
 from strenum import StrEnum
@@ -79,17 +79,26 @@ class BenchData:
 
         Used by ``Plugin.requires`` (plugin.py) to gate plugins that need fields
         beyond dataset+vars. Raises ValueError on a capability name outside the
-        :class:`Capability` vocabulary instead of silently returning False."""
+        :class:`Capability` vocabulary instead of silently returning False.
+
+        The match is exhaustive over :class:`Capability` and ends in
+        ``assert_never``, so a new member added without a branch here is a
+        ``ty`` **check-time** error rather than a runtime abort. This is the
+        licensed case of plan 24 A1: the subject comes from
+        :func:`to_capability`, whose return type is established as
+        ``Capability`` (it is not a ``param`` descriptor read)."""
         cap = to_capability(capability)
-        if cap is Capability.OPTIMIZER_STUDY:
-            return self.optimizer_study is not None
-        if cap is Capability.BASELINE_RUNS:
-            return len(self.baseline_runs) > 0
-        if cap is Capability.CACHE:
-            return self.cache is not None
-        if cap is Capability.LEGACY_RESULT:
-            return self.legacy_result is not None
-        raise AssertionError(f"unhandled capability {cap!r}")  # exhaustiveness guard
+        match cap:
+            case Capability.OPTIMIZER_STUDY:
+                return self.optimizer_study is not None
+            case Capability.BASELINE_RUNS:
+                return len(self.baseline_runs) > 0
+            case Capability.CACHE:
+                return self.cache is not None
+            case Capability.LEGACY_RESULT:
+                return self.legacy_result is not None
+            case unreachable:
+                assert_never(unreachable)
 
     def with_changes(self, **kwargs) -> BenchData:
         return replace(self, **kwargs)

--- a/bencher/plugins/bench_data.py
+++ b/bencher/plugins/bench_data.py
@@ -5,8 +5,35 @@ from datetime import datetime
 from typing import Any, Protocol, runtime_checkable
 
 import xarray as xr
+from strenum import StrEnum
 
 from bencher.plotting.plt_cnt_cfg import PltCntCfg
+
+
+class Capability(StrEnum):
+    """The full vocabulary of optional BenchData context fields a plugin may require.
+
+    A plugin's ``requires`` (see ``Plugin`` in plugin.py) names capabilities from this
+    enum (plain strings with these exact values are accepted and normalized). Unknown
+    names raise at plugin registration time — a misspelled capability would otherwise
+    make the plugin permanently, silently unselectable (plan 23 C10)."""
+
+    OPTIMIZER_STUDY = "optimizer_study"
+    BASELINE_RUNS = "baseline_runs"
+    CACHE = "cache"
+    LEGACY_RESULT = "legacy_result"
+
+
+def to_capability(value: str | Capability) -> Capability:
+    """Normalize *value* to a :class:`Capability`.
+
+    Raises ValueError naming the bad string and the valid vocabulary when *value*
+    is not a known capability."""
+    try:
+        return Capability(value)
+    except ValueError:
+        valid = ", ".join(sorted(c.value for c in Capability))
+        raise ValueError(f"Unknown capability {value!r}; valid capabilities are: {valid}") from None
 
 
 @runtime_checkable
@@ -47,19 +74,22 @@ class BenchData:
     legacy_result: Any | None = None
     render_kwargs: dict = field(default_factory=dict)
 
-    def has(self, capability: str) -> bool:
+    def has(self, capability: str | Capability) -> bool:
         """True when an optional context field is populated.
 
-        Used by PlotFilter.requires to gate plugins that need fields beyond dataset+vars."""
-        if capability == "optimizer_study":
+        Used by ``Plugin.requires`` (plugin.py) to gate plugins that need fields
+        beyond dataset+vars. Raises ValueError on a capability name outside the
+        :class:`Capability` vocabulary instead of silently returning False."""
+        cap = to_capability(capability)
+        if cap is Capability.OPTIMIZER_STUDY:
             return self.optimizer_study is not None
-        if capability == "baseline_runs":
+        if cap is Capability.BASELINE_RUNS:
             return len(self.baseline_runs) > 0
-        if capability == "cache":
+        if cap is Capability.CACHE:
             return self.cache is not None
-        if capability == "legacy_result":
+        if cap is Capability.LEGACY_RESULT:
             return self.legacy_result is not None
-        return False
+        raise AssertionError(f"unhandled capability {cap!r}")  # exhaustiveness guard
 
     def with_changes(self, **kwargs) -> BenchData:
         return replace(self, **kwargs)

--- a/bencher/plugins/registry.py
+++ b/bencher/plugins/registry.py
@@ -8,7 +8,7 @@ from importlib import metadata
 
 import panel as pn
 
-from bencher.plugins.bench_data import BenchData
+from bencher.plugins.bench_data import BenchData, to_capability
 from bencher.plugins.plugin import PlotPlugin
 
 ENTRY_POINT_GROUP = "bencher.plot_plugins"
@@ -68,6 +68,16 @@ class PluginRegistry:
             raise ValueError("Plugin must have a non-empty string name")
         if not isinstance(plugin.backend, str) or not plugin.backend:
             raise ValueError("Plugin must have a non-empty string backend")
+        # Validate the capability vocabulary at registration: a misspelled entry in
+        # `requires` would otherwise make the plugin permanently, silently unselectable
+        # (plan 23 C10). Registration-time errors may raise.
+        for cap in getattr(plugin, "requires", None) or ():
+            try:
+                to_capability(cap)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Plugin {plugin.name!r} (backend {plugin.backend!r}): {exc}"
+                ) from None
         self._plugins[(plugin.name, plugin.backend)] = plugin
 
     def unregister(self, name: str, backend: str | None = None) -> None:
@@ -128,7 +138,14 @@ class PluginRegistry:
             except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
                 log.warning("Skipping plugin entry-point %r: %s", ep.name, exc)
                 continue
-            self._register_loaded(ep.name, obj)
+            try:
+                self._register_loaded(ep.name, obj)
+            except ValueError as exc:
+                # Entry-point loading is lazy: it happens on the first lookup, which
+                # can be mid-run. A third-party plugin that fails validation (e.g. a
+                # bad capability in `requires`) is skipped with a visible warning
+                # rather than aborting the run; explicit register() calls still raise.
+                log.warning("Skipping invalid plugin entry-point %r: %s", ep.name, exc)
 
     def _register_loaded(self, ep_name: str, obj) -> None:
         # Entry points may resolve to a single plugin instance, a plugin class (no-arg

--- a/bencher/plugins/registry.py
+++ b/bencher/plugins/registry.py
@@ -255,7 +255,17 @@ class PluginRegistry:
             if plugin.name in exc:
                 reject(plugin, "excluded by name")
                 continue
-            missing = [cap for cap in plugin.requires if not data.has(cap)]
+            # register() validates `requires`, so an invalid capability should be
+            # unreachable here. Selection nonetheless runs mid-run, after an
+            # expensive sweep, and a plugin object could be mutated after
+            # registration — so a bad capability is reported as a rejection reason
+            # rather than propagating out of the report build (never crash mid-run).
+            try:
+                missing = [cap for cap in plugin.requires if not data.has(cap)]
+            except ValueError as exc:
+                log.warning("Plugin %r has an invalid capability: %s", plugin.name, exc)
+                reject(plugin, f"invalid capability: {exc}")
+                continue
             if missing:
                 reject(plugin, f"missing capability: {', '.join(sorted(missing))}")
                 continue

--- a/bencher/results/rerun_result.py
+++ b/bencher/results/rerun_result.py
@@ -337,10 +337,19 @@ def _log_tensor(rr, recording, dataset: xr.Dataset, entity_path: str, rv, dims: 
     rv_name, path = _rv_name_and_path(entity_path, rv)
     try:
         data_array = dataset[rv_name]
-        # Transpose to requested dim order and extract numpy array
-        arr = data_array.transpose(*dims).values.astype(np.float32)
-        # Never-sampled points stay NaN so the viewer shows genuine gaps instead
-        # of fabricated zeros (plan 23 C12).
+        # Transpose to requested dim order, then blank every missing cell BEFORE
+        # coercing to float. `result_is_missing` is the only oracle that knows a
+        # type's sentinel, and the sentinel is not always NaN: the -1 family
+        # (ResultReference, pre-plan-22 ResultDataSet cells) is *finite*, so an
+        # np.isfinite filter alone would plot -1 as real data and drag
+        # value_range's floor down to it (plan 23 C12).
+        raw = data_array.transpose(*dims).values
+        arr = np.array(
+            [float("nan") if result_is_missing(rv, v) else v for v in raw.ravel()],
+            dtype=np.float32,
+        ).reshape(raw.shape)
+        # Surviving NaNs stay NaN so the viewer shows genuine gaps instead of
+        # fabricated zeros.
         finite = arr[np.isfinite(arr)]
         if finite.size == 0:
             logger.warning(

--- a/bencher/results/rerun_result.py
+++ b/bencher/results/rerun_result.py
@@ -6,13 +6,14 @@ from pathlib import Path
 import numpy as np
 import panel as pn
 import xarray as xr
-from param import Parameter
+from param import Number, Parameter
 
 from bencher.results.bench_result_base import BenchResultBase, ReduceType
 from bencher.variables.results import (
     ResultImage,
     ResultString,
     ResultVideo,
+    result_is_missing,
 )
 
 logger = logging.getLogger(__name__)
@@ -305,12 +306,15 @@ def _log_line_graph(rr, recording, dataset: xr.Dataset, entity_path: str, rv, fl
     rv_name, path = _rv_name_and_path(entity_path, rv)
     try:
         for i, coord_val in enumerate(dataset.coords[float_dim].values):
-            recording.set_time("log_tick", sequence=i)
             val = _extract_scalar(dataset, rv_name, {float_dim: coord_val})
-            if val is not None and not (isinstance(val, float) and np.isnan(val)):
-                recording.log(path, rr.Scalars(float(val)))
+            if result_is_missing(rv, val):
+                # Never-sampled point: skip the tick so the plot shows a genuine
+                # gap instead of a fabricated value (plan 23 C12).
+                continue
+            recording.set_time("log_tick", sequence=i)
+            recording.log(path, rr.Scalars(float(val)))
     except (KeyError, ValueError, TypeError) as e:
-        logger.debug("Could not log line graph for %s: %s", rv_name, e)
+        logger.warning("Could not log line graph for %s at %r: %s", rv_name, path, e)
 
 
 def _log_bar_chart(rr, recording, dataset: xr.Dataset, entity_path: str, rv, cat_dim: str):
@@ -320,10 +324,12 @@ def _log_bar_chart(rr, recording, dataset: xr.Dataset, entity_path: str, rv, cat
         values = []
         for coord_val in dataset.coords[cat_dim].values:
             val = _extract_scalar(dataset, rv_name, {cat_dim: coord_val})
-            values.append(float(val) if val is not None else 0.0)
+            # A never-sampled category stays NaN (rendered as a gap) rather than
+            # being fabricated as a real zero-height bar (plan 23 C12).
+            values.append(float("nan") if result_is_missing(rv, val) else float(val))
         recording.log(path, rr.BarChart(values))
     except (KeyError, ValueError, TypeError) as e:
-        logger.debug("Could not log bar chart for %s: %s", rv_name, e)
+        logger.warning("Could not log bar chart for %s at %r: %s", rv_name, path, e)
 
 
 def _log_tensor(rr, recording, dataset: xr.Dataset, entity_path: str, rv, dims: list[str]):
@@ -333,15 +339,21 @@ def _log_tensor(rr, recording, dataset: xr.Dataset, entity_path: str, rv, dims: 
         data_array = dataset[rv_name]
         # Transpose to requested dim order and extract numpy array
         arr = data_array.transpose(*dims).values.astype(np.float32)
-        # Replace NaN with 0 so the tensor renders cleanly
-        arr = np.nan_to_num(arr, nan=0.0)
+        # Never-sampled points stay NaN so the viewer shows genuine gaps instead
+        # of fabricated zeros (plan 23 C12).
+        finite = arr[np.isfinite(arr)]
+        if finite.size == 0:
+            logger.warning(
+                "Tensor for %s at %r contains no recorded values; skipping", rv_name, path
+            )
+            return
         # Pass value_range so the viewer maps the colormap to the actual data range
-        vmin, vmax = float(arr.min()), float(arr.max())
+        vmin, vmax = float(finite.min()), float(finite.max())
         if vmin == vmax:
             vmax = vmin + 1.0
         recording.log(path, rr.Tensor(arr, dim_names=dims, value_range=[vmin, vmax]))
     except (KeyError, ValueError, TypeError) as e:
-        logger.debug("Could not log tensor for %s: %s", rv_name, e)
+        logger.warning("Could not log tensor for %s at %r: %s", rv_name, path, e)
 
 
 def _log_result_var(rr, recording, dataset: xr.Dataset, entity_path: str, rv):
@@ -349,31 +361,41 @@ def _log_result_var(rr, recording, dataset: xr.Dataset, entity_path: str, rv):
     rv_name, path = _rv_name_and_path(entity_path, rv)
 
     try:
+        val = _extract_scalar(dataset, rv_name)
+        if result_is_missing(rv, val):
+            # Never-sampled point: nothing to log — a genuine gap (plan 23 C12).
+            return
+
         if isinstance(rv, ResultImage):
-            val = _extract_scalar(dataset, rv_name)
-            if val is not None and val and Path(str(val)).exists():
+            if val and Path(str(val)).exists():
                 recording.log(path, rr.EncodedImage(path=str(val)))
             return
 
         if isinstance(rv, ResultVideo):
-            val = _extract_scalar(dataset, rv_name)
-            if val is not None and val and Path(str(val)).exists():
+            if val and Path(str(val)).exists():
                 recording.log(path, rr.AssetVideo(path=str(val)))
             return
 
         if isinstance(rv, ResultString):
-            val = _extract_scalar(dataset, rv_name)
-            if val is not None:
-                recording.log(path, rr.TextDocument(str(val)))
+            recording.log(path, rr.TextDocument(str(val)))
             return
 
-        # Default: ResultVar, ResultBool, or any numeric result -> Scalars
-        val = _extract_scalar(dataset, rv_name)
-        if val is not None and not (isinstance(val, float) and np.isnan(val)):
+        # Numeric family (ResultFloat/ResultBool/param.Number subclasses) -> Scalars.
+        if isinstance(rv, Number):
             recording.log(path, rr.Scalars(float(val)))
+            return
+
+        # No blind float() fallthrough: a type without a rerun mapping (e.g.
+        # ResultPath) surfaces visibly instead of being coerced (plan 23 C12).
+        logger.warning(
+            "No rerun mapping for result var %s of type %s at %r; skipping",
+            rv_name,
+            type(rv).__name__,
+            path,
+        )
 
     except (KeyError, ValueError, TypeError) as e:
-        logger.debug("Could not log result var %s: %s", rv_name, e)
+        logger.warning("Could not log result var %s at %r: %s", rv_name, path, e)
 
 
 def _build_blueprint(rrb, result_vars, float_dims, cat_dims, time_dim, dim_values):

--- a/docs/plot_plugin_design.md
+++ b/docs/plot_plugin_design.md
@@ -518,6 +518,11 @@ plugins = registry.select(data,
   capability-gated (every name in `plugin.requires` must satisfy
   `data.has(name)`), and matched against `data.plt_cnt_cfg` via the
   existing `PlotFilter.matches_result(...)` rule.
+- **Capability vocabulary**: the names accepted in `requires` are exactly the
+  members of `bencher.plugins.Capability` (`optimizer_study`, `baseline_runs`,
+  `cache`, `legacy_result`). Plain strings with those values are accepted and
+  normalised; an unknown name raises `ValueError` at `register()` time rather
+  than yielding a plugin that is permanently, silently never selected.
 - **Named-only plugins** (`auto=False`) are dropped from the candidate set
   when `include is None` — they exist in the registry (addressable, listable,
   overridable) but never render in a default report. Naming them via

--- a/test/test_bench_report.py
+++ b/test/test_bench_report.py
@@ -136,13 +136,14 @@ class TestBenchReport(unittest.TestCase):
         self.assertNotIn(optuna1, report.pane[0].objects)
 
     def test_append_to_result_fallback_when_untracked(self):
-        """append_to_result() falls back to append() for untracked results."""
+        """append_to_result() falls back to the last tab for untracked results."""
         report = BenchReport("fallback")
         report.append_tab(pn.pane.Markdown("existing"), "existing")
 
         unknown = _FakeBenchResult("unknown")
         extra = pn.pane.Markdown("orphan content")
-        report.append_to_result(unknown, extra)
+        with self.assertLogs("bencher.bench_report", level="WARNING"):
+            report.append_to_result(unknown, extra)
 
         # Falls back to append, which targets the last tab
         self.assertIn(extra, report.pane[-1].objects)
@@ -199,7 +200,9 @@ class TestBenchReport(unittest.TestCase):
         self.assertIs(report.pane[0].objects[0], pane)
 
     def test_append_to_none_plot_result_falls_back_to_append(self):
-        """Content for a result with no tab falls back to append() (last tab)."""
+        """Content for a result with no tab falls back to the last tab, but is labelled
+        with its true owner and warned about — a silently misattributed pane is worse
+        than a missing one (plan 23 C9 review item 3)."""
         report = BenchReport("no_tab")
         res_none = _FakeBenchResult("no plot", plot_pane=None)
         res = _FakeBenchResult("real sweep")
@@ -207,8 +210,25 @@ class TestBenchReport(unittest.TestCase):
         report.append_result(res)
 
         pane = pn.pane.Markdown("orphan")
-        report.append_to_result(res_none, pane)
+        with self.assertLogs("bencher.bench_report", level="WARNING") as cm:
+            report.append_to_result(res_none, pane)
         self.assertIn(pane, report.pane[-1].objects)
+        self.assertIn("no plot", "\n".join(cm.output))
+        # A visible attribution note precedes the misplaced pane in the tab
+        objects = report.pane[-1].objects
+        note = objects[objects.index(pane) - 1]
+        self.assertIn("no plot", note.object)
+
+    def test_prepend_to_untracked_result_is_attributed(self):
+        """The same attribution applies to prepend_to_result's fallback."""
+        report = BenchReport("untracked")
+        report.append_result(_FakeBenchResult("real sweep"))
+
+        pane = pn.pane.Markdown("orphan")
+        with self.assertLogs("bencher.bench_report", level="WARNING") as cm:
+            report.prepend_to_result(_FakeBenchResult("ghost"), pane)
+        self.assertIn(pane, report.pane[-1].objects)
+        self.assertIn("ghost", "\n".join(cm.output))
 
     def test_clear_resets_results_and_tabs(self):
         report = BenchReport("clearable")

--- a/test/test_bench_report.py
+++ b/test/test_bench_report.py
@@ -116,14 +116,12 @@ class TestBenchReport(unittest.TestCase):
         """append_to_result() routes content to the tab matching a tracked result."""
         report = BenchReport("targeted")
 
-        # Simulate two results being added via append_result
         res0 = _FakeBenchResult("sweep A")
         res1 = _FakeBenchResult("sweep B")
-        report.bench_results.append(res0)
-        report.append_tab(pn.pane.Markdown("Sweep A plot"), "sweep A")
-        report.bench_results.append(res1)
-        report.append_tab(pn.pane.Markdown("Sweep B plot"), "sweep B")
+        report.append_result(res0)
+        report.append_result(res1)
         self.assertEqual(len(report.pane), 2)
+        self.assertEqual([r.bench_cfg.title for r in report.bench_results], ["sweep A", "sweep B"])
 
         optuna0 = pn.pane.Markdown("optuna for A")
         optuna1 = pn.pane.Markdown("optuna for B")
@@ -153,8 +151,7 @@ class TestBenchReport(unittest.TestCase):
         """Multiple append_to_result calls on the same result accumulate in the same tab."""
         report = BenchReport("accum")
         res = _FakeBenchResult("single")
-        report.bench_results.append(res)
-        report.append_tab(pn.pane.Markdown("base"), "single")
+        report.append_result(res)
 
         items = [pn.pane.Markdown(f"item {i}") for i in range(3)]
         for item in items:
@@ -163,9 +160,90 @@ class TestBenchReport(unittest.TestCase):
         for item in items:
             self.assertIn(item, report.pane[0].objects)
 
+    def test_none_plot_does_not_misroute_following_results(self):
+        """A result whose plot() returned None (so no tab) must not shift routing:
+        content for a later result lands in *that* result's tab, never a neighbour's
+        (plan 23 C9 — fails on the parallel-lists representation)."""
+        report = BenchReport("desync")
+        res_none = _FakeBenchResult("no plot", plot_pane=None)
+        res_a = _FakeBenchResult("sweep A")
+        res_b = _FakeBenchResult("sweep B")
+        report.append_result(res_none)  # creates no tab
+        report.append_result(res_a)  # tab 0
+        report.append_result(res_b)  # tab 1
+        self.assertEqual(len(report.pane), 2)
 
-class _FakeBenchResult:
-    """Minimal stand-in for BenchResult so we can test identity-based lookup."""
+        extra_a = pn.pane.Markdown("extra for A")
+        report.append_to_result(res_a, extra_a)
+        self.assertIn(extra_a, report.pane[0].objects)
+        self.assertNotIn(extra_a, report.pane[1].objects)
 
+        prep_a = pn.pane.Markdown("prepended for A")
+        report.prepend_to_result(res_a, prep_a)
+        self.assertIs(report.pane[0].objects[0], prep_a)
+        self.assertNotIn(prep_a, report.pane[1].objects)
+
+    def test_none_plot_then_prepend_to_second_result(self):
+        """Prepending to the result after a None-plot result lands at the start of the
+        second result's own tab (plan 23 C9 — fails on the parallel-lists code, which
+        fell through to append() and put the pane at the end)."""
+        report = BenchReport("prepend")
+        res_none = _FakeBenchResult("no plot", plot_pane=None)
+        res = _FakeBenchResult("real sweep")
+        report.append_result(res_none)
+        report.append_result(res)
+        self.assertEqual(len(report.pane), 1)
+
+        pane = pn.pane.Markdown("prepended")
+        report.prepend_to_result(res, pane)
+        self.assertIs(report.pane[0].objects[0], pane)
+
+    def test_append_to_none_plot_result_falls_back_to_append(self):
+        """Content for a result with no tab falls back to append() (last tab)."""
+        report = BenchReport("no_tab")
+        res_none = _FakeBenchResult("no plot", plot_pane=None)
+        res = _FakeBenchResult("real sweep")
+        report.append_result(res_none)
+        report.append_result(res)
+
+        pane = pn.pane.Markdown("orphan")
+        report.append_to_result(res_none, pane)
+        self.assertIn(pane, report.pane[-1].objects)
+
+    def test_clear_resets_results_and_tabs(self):
+        report = BenchReport("clearable")
+        report.append_result(_FakeBenchResult("sweep"))
+        self.assertEqual(len(report.bench_results), 1)
+        report.clear()
+        self.assertEqual(report.bench_results, ())
+        self.assertEqual(len(report.pane), 0)
+
+    def test_bench_results_is_read_only_snapshot(self):
+        """bench_results is an immutable snapshot, so an out-of-band append cannot
+        silently desync result/tab pairing (plan 23 C9). Callers register through
+        append_result, which pairs each result with its tab."""
+        report = BenchReport("readonly")
+        report.append_result(_FakeBenchResult("sweep"))
+        self.assertIsInstance(report.bench_results, tuple)
+
+
+class _FakeBenchCfg:
     def __init__(self, title: str):
         self.title = title
+        self.over_time = False
+
+
+class _FakeBenchResult:
+    """Minimal stand-in for BenchResult so we can test identity-based tab routing."""
+
+    _UNSET = object()
+
+    def __init__(self, title: str, plot_pane=_UNSET):
+        self.title = title
+        self.bench_cfg = _FakeBenchCfg(title)
+        if plot_pane is self._UNSET:
+            plot_pane = pn.pane.Markdown(f"{title} plot")
+        self._plot_pane = plot_pane
+
+    def plot(self):
+        return self._plot_pane

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -10,6 +10,7 @@ from bencher.plotting.plot_filter import PlotFilter, VarRange
 from bencher.plotting.plt_cnt_cfg import PltCntCfg
 from bencher.plugins import (
     BenchData,
+    Capability,
     PluginRegistry,
     RunMeta,
     get_registry,
@@ -43,11 +44,25 @@ class TestBenchData(unittest.TestCase):
         self.assertFalse(data.has("optimizer_study"))
         self.assertFalse(data.has("baseline_runs"))
         self.assertFalse(data.has("cache"))
-        self.assertFalse(data.has("nonexistent"))
 
         data2 = data.with_changes(optimizer_study=object())
         self.assertTrue(data2.has("optimizer_study"))
         self.assertFalse(data.has("optimizer_study"), "with_changes must not mutate original")
+
+    def test_has_capability_accepts_enum(self) -> None:
+        data = BenchData.fake().with_changes(cache=object())
+        self.assertTrue(data.has(Capability.CACHE))
+        self.assertTrue(data.has("cache"))
+
+    def test_has_unknown_capability_raises(self) -> None:
+        """An unknown capability name raises (with the valid vocabulary) instead of
+        silently reading as 'absent' (plan 23 C10)."""
+        data = BenchData.fake()
+        with self.assertRaises(ValueError) as ctx:
+            data.has("nonexistent")
+        self.assertIn("nonexistent", str(ctx.exception))
+        for cap in Capability:
+            self.assertIn(cap.value, str(ctx.exception))
 
     def test_frozen(self) -> None:
         data = BenchData.fake()
@@ -81,6 +96,43 @@ class TestRegistry(unittest.TestCase):
         _stub.name = ""
         with self.assertRaises(ValueError):
             self.reg.register(_stub)
+
+    def test_register_typoed_capability_raises(self) -> None:
+        """A misspelled capability in requires raises at registration, naming the bad
+        string and the valid vocabulary, instead of yielding a plugin that is
+        permanently, silently unselectable (plan 23 C10)."""
+
+        @plot_plugin(
+            name="typo",
+            backend="t",
+            requires={"legacy_resutl"},  # cspell:disable-line
+            register=False,
+        )
+        def _stub(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("x")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.reg.register(_stub)
+        msg = str(ctx.exception)
+        self.assertIn("legacy_resutl", msg)  # cspell:disable-line
+        self.assertIn("typo", msg)
+        for cap in Capability:
+            self.assertIn(cap.value, msg)
+
+    def test_register_valid_capability_strings_accepted(self) -> None:
+        """External plugins passing valid plain strings keep working."""
+
+        @plot_plugin(
+            name="valid_caps",
+            backend="t",
+            requires={"legacy_result", "cache"},
+            register=False,
+        )
+        def _stub(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("x")
+
+        self.reg.register(_stub)
+        self.assertIs(self.reg.get("valid_caps"), _stub)
 
     def test_override_same_name_and_backend_replaces(self) -> None:
         @plot_plugin(name="dup", backend="a", register=False)
@@ -433,6 +485,29 @@ class TestEntryPointDiscovery(unittest.TestCase):
             # Second call must not re-scan.
             reg.all()
             ep_mock.assert_called_once()
+
+    def test_skip_entry_point_with_bad_capability(self) -> None:
+        """Entry-point loading is lazy (first lookup, possibly mid-run), so a
+        third-party plugin with an invalid capability is skipped with a visible
+        warning instead of aborting the run; explicit register() still raises
+        (plan 23 C10 + the never-crash-mid-run principle)."""
+
+        @plot_plugin(name="ep_typo", backend="t", requires={"nope"}, register=False)
+        def _stub(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("x")
+
+        class FakeEP:
+            name = "ep_typo"
+
+            def load(self):
+                return _stub
+
+        reg = PluginRegistry()
+        with patch("bencher.plugins.registry.metadata.entry_points") as ep_mock:
+            ep_mock.return_value = [FakeEP()]
+            with self.assertLogs("bencher.plugins.registry", level="WARNING") as cm:
+                self.assertEqual(reg.all(), ())
+        self.assertIn("nope", "\n".join(cm.output))
 
     def test_skip_on_load_failure(self) -> None:
         reg = PluginRegistry()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -119,6 +119,35 @@ class TestRegistry(unittest.TestCase):
         for cap in Capability:
             self.assertIn(cap.value, msg)
 
+    def test_select_does_not_abort_on_post_registration_capability_mutation(self) -> None:
+        """Selection runs mid-run, after an expensive sweep, and both production call
+        sites leave select() outside their try/except. A plugin whose `requires` went
+        bad after registration is rejected with a reason, not raised (never crash
+        mid-run)."""
+
+        @plot_plugin(
+            name="mutated",
+            backend="t",
+            match=PlotFilter(
+                float_range=VarRange(0, None),
+                cat_range=VarRange(0, None),
+                repeats_range=VarRange(0, None),
+                input_range=VarRange(0, None),
+            ),
+            register=False,
+        )
+        def _stub(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("x")
+
+        self.reg.register(_stub)
+        _stub.requires = frozenset({"bogus_capability"})  # mutate after registration
+
+        data = _data_with_floats(1)
+        with self.assertLogs("bencher.plugins.registry", level="WARNING"):
+            self.assertEqual(self.reg.select(data), ())
+        reasons = [d.reason for d in self.reg.explain(data) if d.name == "mutated"]
+        self.assertIn("invalid capability", reasons[0])
+
     def test_register_valid_capability_strings_accepted(self) -> None:
         """External plugins passing valid plain strings keep working."""
 

--- a/test/test_rerun_result.py
+++ b/test/test_rerun_result.py
@@ -23,7 +23,13 @@ from bencher.results.rerun_result import (
     _log_result_var,
     _log_tensor,
 )
-from bencher.variables.results import ResultFloat, ResultPath, ResultString
+from bencher.variables.results import (
+    ResultDataSet,
+    ResultFloat,
+    ResultPath,
+    ResultReference,
+    ResultString,
+)
 
 LOGGER = "bencher.results.rerun_result"
 
@@ -34,6 +40,8 @@ class _Vars(param.Parameterized):
     metric = ResultFloat()
     label = ResultString()
     file_out = ResultPath()
+    ref = ResultReference()
+    data_out = ResultDataSet()
 
 
 def _fake_rr() -> SimpleNamespace:
@@ -104,6 +112,37 @@ class TestTensorMissing(unittest.TestCase):
         _path, (_kind, arr, _dims, value_range) = rec.logged[0]
         self.assertTrue(np.isnan(arr[0, 1]), "missing cell must stay NaN, not become 0.0")
         self.assertEqual(value_range, [1.0, 4.0])
+
+    def test_minus_one_sentinel_is_a_gap_not_data(self):
+        """The -1 missing sentinel (ResultReference, and legacy ResultDataSet cells) is
+        finite, so an np.isfinite filter alone would plot it as real data and drag
+        value_range's floor to -1. It must become a NaN gap (plan 23 C12)."""
+        rec = _FakeRecording()
+        ds = xr.Dataset(
+            {"ref": (("x", "y"), [[-1.0, 1.0], [2.0, 3.0]])},
+            coords={"x": [0, 1], "y": [0, 1]},
+        )
+        _log_tensor(_fake_rr(), rec, ds, "", _Vars.param.ref, ["x", "y"])
+
+        self.assertEqual(len(rec.logged), 1)
+        _path, (_kind, arr, _dims, value_range) = rec.logged[0]
+        self.assertTrue(np.isnan(arr[0, 0]), "the -1 sentinel must become a NaN gap")
+        self.assertNotIn(-1.0, arr.ravel().tolist())
+        self.assertEqual(value_range, [1.0, 3.0], "value_range must exclude the sentinel")
+
+    def test_dataset_legacy_minus_one_sentinel_is_a_gap(self):
+        """ResultDataSet accepts both sentinel generations; the legacy -1 int cells are
+        missing too and must not be plotted."""
+        rec = _FakeRecording()
+        ds = xr.Dataset(
+            {"data_out": (("x",), [-1.0, 4.0, 6.0])},
+            coords={"x": [0, 1, 2]},
+        )
+        _log_tensor(_fake_rr(), rec, ds, "", _Vars.param.data_out, ["x"])
+
+        _path, (_kind, arr, _dims, value_range) = rec.logged[0]
+        self.assertTrue(np.isnan(arr[0]))
+        self.assertEqual(value_range, [4.0, 6.0])
 
     def test_all_missing_tensor_skipped_with_warning(self):
         rec = _FakeRecording()

--- a/test/test_rerun_result.py
+++ b/test/test_rerun_result.py
@@ -1,0 +1,159 @@
+"""Regression tests for honest missing-value handling in the rerun renderer.
+
+Plan 23 C12: never-sampled points must render as genuine gaps, never as
+fabricated zeros; result types without a rerun mapping surface visibly instead
+of being coerced through ``float()``; failures log at WARNING, not DEBUG.
+
+The ``_log_*`` helpers take the ``rr`` module and the recording as parameters,
+so these tests drive them with lightweight fakes — no rerun-sdk dependency and
+no viewer round-trip.
+"""
+
+import math
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+import param
+import xarray as xr
+
+from bencher.results.rerun_result import (
+    _log_bar_chart,
+    _log_line_graph,
+    _log_result_var,
+    _log_tensor,
+)
+from bencher.variables.results import ResultFloat, ResultPath, ResultString
+
+LOGGER = "bencher.results.rerun_result"
+
+
+class _Vars(param.Parameterized):
+    """Owner class so the result-var parameters carry their names."""
+
+    metric = ResultFloat()
+    label = ResultString()
+    file_out = ResultPath()
+
+
+def _fake_rr() -> SimpleNamespace:
+    return SimpleNamespace(
+        Scalars=lambda value: ("Scalars", value),
+        BarChart=lambda values: ("BarChart", values),
+        Tensor=lambda arr, dim_names=None, value_range=None: (
+            "Tensor",
+            arr,
+            dim_names,
+            value_range,
+        ),
+        TextDocument=lambda text: ("TextDocument", text),
+    )
+
+
+class _FakeRecording:
+    def __init__(self):
+        self.logged = []
+        self.times = []
+
+    def set_time(self, timeline, sequence=None, **_kwargs):
+        self.times.append((timeline, sequence))
+
+    def log(self, path, payload):
+        self.logged.append((path, payload))
+
+
+class TestLineGraphMissing(unittest.TestCase):
+    def test_missing_point_is_a_gap_not_zero(self):
+        """A never-sampled point is skipped (a gap), not logged as any value."""
+        rec = _FakeRecording()
+        ds = xr.Dataset({"metric": ("x", [1.0, np.nan, 3.0])}, coords={"x": [0, 1, 2]})
+        _log_line_graph(_fake_rr(), rec, ds, "", _Vars.param.metric, "x")
+
+        self.assertEqual(len(rec.logged), 2)
+        values = [payload[1] for _path, payload in rec.logged]
+        self.assertEqual(values, [1.0, 3.0])
+        self.assertNotIn(0.0, values)
+        # The tick sequence keeps its coordinate position, leaving a hole at 1
+        self.assertEqual([seq for _tl, seq in rec.times], [0, 2])
+
+
+class TestBarChartMissing(unittest.TestCase):
+    def test_missing_category_is_nan_not_zero(self):
+        """A never-sampled category stays NaN instead of a fabricated 0-height bar."""
+        rec = _FakeRecording()
+        ds = xr.Dataset({"metric": ("c", [2.0, np.nan])}, coords={"c": ["a", "b"]})
+        _log_bar_chart(_fake_rr(), rec, ds, "", _Vars.param.metric, "c")
+
+        self.assertEqual(len(rec.logged), 1)
+        _path, (_kind, values) = rec.logged[0]
+        self.assertEqual(values[0], 2.0)
+        self.assertTrue(math.isnan(values[1]), f"expected NaN gap, got {values[1]!r}")
+
+
+class TestTensorMissing(unittest.TestCase):
+    def test_nan_preserved_and_range_from_recorded_values(self):
+        """NaN cells are kept as gaps; value_range comes from the recorded values."""
+        rec = _FakeRecording()
+        ds = xr.Dataset(
+            {"metric": (("x", "y"), [[1.0, np.nan], [3.0, 4.0]])},
+            coords={"x": [0, 1], "y": [0, 1]},
+        )
+        _log_tensor(_fake_rr(), rec, ds, "", _Vars.param.metric, ["x", "y"])
+
+        self.assertEqual(len(rec.logged), 1)
+        _path, (_kind, arr, _dims, value_range) = rec.logged[0]
+        self.assertTrue(np.isnan(arr[0, 1]), "missing cell must stay NaN, not become 0.0")
+        self.assertEqual(value_range, [1.0, 4.0])
+
+    def test_all_missing_tensor_skipped_with_warning(self):
+        rec = _FakeRecording()
+        ds = xr.Dataset(
+            {"metric": (("x", "y"), [[np.nan, np.nan], [np.nan, np.nan]])},
+            coords={"x": [0, 1], "y": [0, 1]},
+        )
+        with self.assertLogs(LOGGER, level="WARNING") as cm:
+            _log_tensor(_fake_rr(), rec, ds, "", _Vars.param.metric, ["x", "y"])
+        self.assertEqual(rec.logged, [])
+        self.assertIn("no recorded values", "\n".join(cm.output))
+
+
+class TestResultVarDispatch(unittest.TestCase):
+    def test_missing_scalar_not_logged(self):
+        rec = _FakeRecording()
+        ds = xr.Dataset({"metric": xr.DataArray(np.nan)})
+        _log_result_var(_fake_rr(), rec, ds, "", _Vars.param.metric)
+        self.assertEqual(rec.logged, [])
+
+    def test_present_scalar_logged(self):
+        rec = _FakeRecording()
+        ds = xr.Dataset({"metric": xr.DataArray(1.5)})
+        _log_result_var(_fake_rr(), rec, ds, "", _Vars.param.metric)
+        self.assertEqual(rec.logged, [("metric", ("Scalars", 1.5))])
+
+    def test_missing_string_sentinel_not_logged(self):
+        rec = _FakeRecording()
+        ds = xr.Dataset({"label": xr.DataArray("NAN")})
+        _log_result_var(_fake_rr(), rec, ds, "", _Vars.param.label)
+        self.assertEqual(rec.logged, [])
+
+    def test_present_string_logged(self):
+        rec = _FakeRecording()
+        ds = xr.Dataset({"label": xr.DataArray("hello")})
+        _log_result_var(_fake_rr(), rec, ds, "", _Vars.param.label)
+        self.assertEqual(rec.logged, [("label", ("TextDocument", "hello"))])
+
+    def test_unmapped_type_warns_instead_of_float_coercion(self):
+        """A ResultPath must not fall through to float("/path/..."); it surfaces
+        visibly as a warning and is skipped."""
+        rec = _FakeRecording()
+        ds = xr.Dataset({"file_out": xr.DataArray("/tmp/result.csv")})
+        with self.assertLogs(LOGGER, level="WARNING") as cm:
+            _log_result_var(_fake_rr(), rec, ds, "", _Vars.param.file_out)
+        self.assertEqual(rec.logged, [])
+        out = "\n".join(cm.output)
+        self.assertIn("ResultPath", out)
+        self.assertIn("file_out", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements plan 23 §5 **P10** — the three small constructive fixes C9, C10, C12
(`plans/23-constructive-data-modeling.md` §3).

> **Review round 2 applied.** Independent review returned DO-NOT-MERGE on two
> real defects, both now fixed with regression tests that fail on the previously
> pushed commit: `_log_tensor` still rendered the **`-1` sentinel** as real data
> (C12's own acceptance criterion), and `has()`'s "exhaustiveness guard" enforced
> nothing statically while its runtime form could **abort a report build**. The
> two smaller carry-overs and all four PR-body accuracy corrections are applied
> below. Details in the *Review round 2* section.

## C9 — report tabs: pair each result with its tab

`BenchReport.__init__` kept two parallel lists correlated by index —
`bench_results` (appended in `append_result`) and `pane` (appended in
`append_tab`, which skips `None` panes). `append_to_result` /
`prepend_to_result` resolved `self.bench_results.index(bench_res)` into
`self.pane[idx]`, so once a result whose `plot()` returned `None` desynced them,
an in-range `idx` silently wrote into a **different result's tab**. The
`except (ValueError, IndexError)` guard only caught the trailing out-of-range
case, never the misroute.

- `bencher/bench_report.py:152` `BenchReport._result_tabs` — one list of
  `(BenchResult, tab | None)` pairs replaces the two parallel lists, so
  misrouting is unrepresentable.
- `bencher/bench_report.py:230` `BenchReport._tab_for_result` — identity lookup
  over the pairs; `append_to_result` (`:268`) and `prepend_to_result` (`:281`)
  use it.
- `bencher/bench_report.py:243` `BenchReport._append_unattributed` — the fallback
  for a result with no tab of its own. It appends to the last tab (as before) but
  now **labels the pane with its true owner** and logs a WARNING, because a
  silently misattributed pane is worse than a missing one: a reader would
  otherwise credit a regression verdict to the sweep whose tab it happens to sit
  in. (Review carry-over 3.)
- `bencher/bench_report.py:294` `BenchReport.append_tab` now **returns** the tab
  column it created (`None` when `pane is None`), which is what makes the pairing
  possible. Additive return type; every existing caller ignores it. Note this
  also changes `append_title` (`:172`), which returns `append_tab(...)` in its
  `new_tab=True` branch and so now returns the tab instead of `None` — also a
  public-contract widening, also ignored by every in-tree caller.
- `bencher/bench_report.py:155` `BenchReport.bench_results` is now a read-only
  `tuple` property derived from the pairs, so an out-of-band `append` can no
  longer desync the pairing. Every in-tree read only iterates it (`save()`
  timings loop, `_emit_json`, `test/test_render.py:342`).

Normal-path behavior is unchanged: `append_result` still registers the result,
builds the tab from `render_from or bench_res`, and routes by identity.

## C10 — capability vocabulary raises at registration

`BenchData.has` dispatched on raw strings with a `return False` fallthrough, so a
misspelled capability in a plugin's `requires` produced a plugin that was
permanently, silently never selected — indistinguishable from one whose
capability is genuinely absent.

- `bencher/plugins/bench_data.py:13` `Capability` (strenum `StrEnum`, lowercase
  values) is now the single source of the four capability names.
- `bencher/plugins/bench_data.py:27` `to_capability` normalises
  `str | Capability` and raises `ValueError` naming the bad string and the valid
  vocabulary.
- `bencher/plugins/registry.py:66` `PluginRegistry.register` validates every
  entry of `plugin.requires` — this is where `requires` is first seen, so a typo
  raises at **registration** time (registration/config-time errors may raise per
  the owner principle) instead of at silent selection time.
- `bencher/plugins/bench_data.py:77` `BenchData.has` is a complete `match` over
  `Capability` ending in `typing.assert_never` (`:101`), so a member added
  without a branch is a **check-time** `ty` error. See *Review round 2* for the
  verification and for why this is plan 24 A1's *licensed* case.
- Docstring fix: `bench_data.py:53` misattributed `requires` to `PlotFilter`; it
  lives on the plugin protocol (`bencher/plugins/plugin.py:25`
  `PlotPlugin.requires`).
- The existing correctly-spelled sites (`bencher/plugins/builtins.py:161,174`,
  `requires=frozenset({"legacy_result"})`) and external plugins passing valid
  plain strings keep working unchanged.
- `Capability` / `to_capability` exported from `bencher.plugins`;
  `docs/plot_plugin_design.md` documents the vocabulary and the raise.
- **Two never-crash-mid-run carve-outs.** Registration-time raises are licensed;
  *selection*-time ones are not, and selection runs after the expensive sweep:
  - `registry.py:125` `_ensure_entry_points_loaded` — entry-point registration is
    *lazy*, firing on the first registry lookup, so a third-party plugin failing
    validation is skipped with a visible `log.warning` (matching the existing
    "Skipping plugin entry-point" handling) rather than aborting the run.
    Explicit `register()` / `@plot_plugin(register=True)` still raises.
  - `registry.py:258-267` `explain()` — `register()` makes an invalid capability
    unreachable here, but a plugin object could be mutated post-registration, and
    both production call sites leave `select(...)` **outside** their try/except
    (`results/bench_result.py:351-357`, `registry.py:318-327`). A bad capability
    is therefore reported as a rejection *reason* plus a warning.
- **Behavior change worth recording:** `only=` bypasses the capability gate
  (`registry.py:227-241` returns before it), so a third-party plugin with an
  out-of-vocabulary `requires` was previously reachable via `only="name"` and now
  fails to register at all. Acceptable — such a plugin could never be
  automatically selected, and the failure is now loud instead of silent — but it
  is a real narrowing of what a mis-specified plugin can do.

## C12 — rerun renderer: honest missing values

`bencher/results/rerun_result.py` rendered never-sampled points as real data and
swallowed failures at DEBUG.

- Every value read goes through `result_is_missing`
  (`bencher/variables/results.py:914`), the single missing-value oracle, in
  **all four** value-reading helpers: `_log_line_graph` (`:310`),
  `_log_bar_chart` (`:329`), `_log_tensor` (`:348`) and `_log_result_var`
  (`:374`).
- `_log_line_graph` skips a missing point (logs no tick) so the line shows a
  genuine gap; surviving ticks keep their coordinate sequence numbers.
- `_log_bar_chart`'s `float(val) if val is not None else 0.0` is replaced with
  `float("nan")` for missing entries.
- `_log_tensor`'s `np.nan_to_num(arr, nan=0.0)` is **gone**. Every cell is now
  tested with `result_is_missing` and blanked to NaN **before** the float
  coercion, so both sentinel families are handled: NaN cells stay gaps, and the
  *finite* `-1` sentinel (`ResultReference`, legacy `ResultDataSet` cells) becomes
  a gap instead of plotting as real data. `value_range` is then computed from the
  surviving finite values, so no sentinel can drag the colormap floor. An
  all-missing tensor is skipped with a WARNING rather than logged as a uniform
  zero plane.
- `_log_result_var`'s `# Default:` numeric fallthrough — which a `ResultPath`
  reached as `float("/path/to/x.csv")` — is replaced with explicit dispatch on
  `param.Number` (`ResultFloat`/`ResultBool` and any future numeric); an unmapped
  type logs a WARNING naming the var and its type and is skipped.
- All four `except (KeyError, ValueError, TypeError)` handlers now log at
  **WARNING** with the entity path as context.
- Render errors still never abort — visible degradation only, per the owner
  principle.
- Plan §9 grep check: no `nan_to_num(arr, nan=0.0)` remains in
  `rerun_result.py`.

## Review round 2 — the two required fixes

### 1. HIGH — `_log_tensor` rendered the `-1` sentinel as real data

`_log_tensor` was the **fourth** value-reading helper and the only one not routed
through `result_is_missing`; P10 mandates *every* value read. The old
`np.isfinite` filter catches the NaN family only, and `-1` is finite, so a
`ResultReference` sweep with a failed sample produced:

```
ref tensor -> [[-1. 0. 1.] [2. 3. 4.] [5. 6. 7.]]   value_range [-1.0, 7.0]
```

This also **falsified this PR body's own earlier claim** that value_range was
computed "from the finite values only, so one missing cell no longer drags the
colormap to include a fabricated 0" — it stopped including a fabricated `0` and
started including a fabricated `-1`. Doubly so because the falsified-claims
section below correctly identifies `-1` as *the* real fabrication family, and the
first pass then fixed it in three places out of four.

Fixed by masking per cell with `result_is_missing` before coercing to float.
Two new tests (`test_minus_one_sentinel_is_a_gap_not_data`,
`test_dataset_legacy_minus_one_sentinel_is_a_gap`) both **fail on the previously
pushed commit** (verified by restoring `9840fc20`'s `rerun_result.py`) — the existing tensor tests used only ResultFloat/NaN, which is
exactly why this slipped through.

### 2. MEDIUM — `has()`'s guard enforced nothing, and could abort a report

The previous `raise AssertionError(...)  # exhaustiveness guard` claimed a
static guarantee it did not provide (adding a fifth `Capability` member left
`pixi run ty` reporting `All checks passed!`), and the runtime `AssertionError`
was an unguarded report abort reachable from `explain()`.

Now a complete `match` + `typing.assert_never`. This is plan 24 **A1's licensed
case, not its excluded one**: the subject comes from `to_capability(...)`, whose
return type is established as `Capability` — it is *not* a `param` descriptor
read. Verified by seeding a fifth member into the real file and running the
repo's own gate:

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> bencher/plugins/bench_data.py:102:17
    |             assert_never(unreachable)
    |                          Inferred type of argument is `Literal[Capability.SEEDED_PROBE]`
```

The member was then removed and `pixi run ty` is clean again. The failure now
lives at check time; the residual runtime `ValueError` path at the `explain()`
call site is caught there (see the C10 carve-outs).

### Carry-overs applied

3. The no-tab fallback no longer misattributes silently — see
   `_append_unattributed` under C9. (`plot_callbacks = param.List(None, ...)` at
   `bench_cfg.py:809` does make the None-plot path more reachable than the plan
   implies.)
4. All four PR-body accuracy corrections are applied (see below).

### Noted, not fixed (deliberately out of scope)

5. `_log_line_graph` / `_log_bar_chart` still coerce every *present* value, so a
   present `ResultReference` plots its storage **index** as a value
   (`Scalars(0.0), Scalars(2.0)`) — the 0-D path warns while the 1-D path
   fabricates. Pre-existing, orthogonal to missingness, and a fix belongs with
   the reference-dereferencing work rather than P10. **Follow-up.**
6. The fake `rr` omits `EncodedImage`/`AssetVideo`, so the ResultImage/ResultVideo
   branches of `_log_result_var` are untested. Their behavior is unchanged by this
   PR. The reviewer independently drove the **real** rerun SDK 0.35.0 and
   confirmed `Scalars(nan)`, `BarChart([2.0, nan])`, `BarChart([nan, nan])` and
   `Tensor(nan cell, value_range=...)` all work, so the fake is not masking an API
   mismatch.

## Tests

`test/test_bench_report.py`
- `test_none_plot_does_not_misroute_following_results` — a `None`-plot result
  followed by two real ones; content for the *second* result lands in its own
  tab. **Fails on the pre-fix file** (it landed in the third result's tab — the
  silent misroute).
- `test_none_plot_then_prepend_to_second_result` — prepending to the result after
  a `None`-plot result lands at position 0 of that result's own tab. **Fails
  pre-fix** (fell through to `append()`, landing at the end).
- `test_append_to_none_plot_result_falls_back_to_append` and
  `test_prepend_to_untracked_result_is_attributed` — the fallback warns and
  labels the pane with its owning sweep.
- `test_clear_resets_results_and_tabs`,
  `test_bench_results_is_read_only_snapshot`.
- `_FakeBenchResult` gained `bench_cfg` + `plot()` so the pre-existing routing
  tests drive the real `append_result` instead of hand-appending to the two lists.

`test/test_plugins.py`
- `test_register_typoed_capability_raises` — `requires={"legacy_resutl"}` raises
  at `register()`, naming the bad string, the plugin, and every valid capability.
- `test_register_valid_capability_strings_accepted` — external plugins passing
  valid plain strings still register.
- `test_skip_entry_point_with_bad_capability` — a lazily loaded entry-point
  plugin with a bad capability is skipped with a WARNING, not raised.
- `test_select_does_not_abort_on_post_registration_capability_mutation` — a
  plugin whose `requires` went bad after registration is rejected with a reason
  instead of killing the report build.
- `test_has_unknown_capability_raises`, `test_has_capability_accepts_enum`.

`test/test_rerun_result.py` (new; drives the module-level `_log_*` helpers with a
fake `rr` module and recording, so it needs no rerun viewer round-trip and is not
optional-dep-gated) — 11 tests, covering NaN gaps in the line/bar/tensor/scalar
paths, both `-1`-sentinel cases, the `"NAN"` string sentinel, the all-missing
tensor warning, the unmapped-type warning, and the two present-value happy paths.

**Pre-fix verification, measured (not asserted).** Restoring the original
`bench_report.py` + `rerun_result.py` from `origin/main` and running the two test
files: **14 fail** — 7 in `test_bench_report.py`, 7 in `test_rerun_result.py`.
Restoring only the *round-1 pushed commit* (`9840fc20`) and running all three:
**6 fail**, exactly the six round-2 tests — the two `-1`-sentinel tensor tests,
the three fallback-attribution tests, and the post-registration-mutation test.

`pixi run ci` passes: 2614 passed, 3 skipped, pylint 10.00/10, `ty` clean, run
with a private `TMPDIR`/`PYTEST_DEBUG_TEMPROOT` so a concurrent pytest cannot
delete the numbered temp dir out from under it.

## Falsified / narrowed plan claims

Per plans-README rule 7:

1. **C12's `float(val) if val is not None else 0.0` (`:323`) was dead code, not
   merely narrow.** The plan says it "turn[s] never-sampled points into plotted
   zeros". In fact the `else 0.0` branch appears **unreachable**: xarray coerces a
   literal `None` to `nan` when building the array, in both `float` and `object`
   dtype, so `_extract_scalar` never returns `None` and `float(nan)`/`float("NAN")`
   already yielded NaN. The real fabrication on that line was the **`-1`
   sentinel** family (`ResultReference`, pre-plan-22 `ResultDataSet` cells):
   `float(-1)` is `-1.0`, plotted as a real bar. Routing through
   `result_is_missing` fixes that and makes the NaN cases explicit rather than
   accidental. Consequently `test_missing_category_is_nan_not_zero` passes
   pre-fix.
2. **`nan_to_num(arr, nan=0.0)` (`:337`) is confirmed exactly as stated** — real,
   shipped, and now removed. The plan's framing of it as a *NaN*-only problem was
   itself incomplete: the same helper also rendered the finite `-1` sentinel as
   data, which no amount of NaN handling would have caught.
3. **C9's misroute is confirmed exactly as stated.** Correction to this PR's
   earlier claim of "2 tests fail pre-fix": the true figure is **7**
   `test_bench_report.py` tests, of which only
   `test_none_plot_does_not_misroute_following_results` and
   `test_none_plot_then_prepend_to_second_result` demonstrate the misroute itself;
   the rest exercise the new tuple API and the new fallback attribution. The
   substance was right, the count was not.
4. **C10 is confirmed as a latent footgun, not a shipped defect** — as the plan
   itself says; no misspelled `requires` exists in the tree.
5. **Plan 23's C12 wording "route every value read through `result_is_missing`"
   is load-bearing and was under-delivered in the first pass** — three of four
   helpers. Recorded here because the acceptance criterion, not the plan, was at
   fault.

## Not changed (noted, out of scope)

`bencher/bench_runner.py:259` `_merge_reports` copies `source.pane` tabs into
`target` without carrying result registrations, so before this PR the target's two
lists were *guaranteed* desynced after a merge. The pairing fix makes post-merge
routing safe (merged-in source results are simply untracked and take the fallback,
which now labels itself), but carrying the pairs across a merge would change
`save(emit_json=...)` output for merged reports, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
