### PR TITLE
fix: wire all four video buttons, truthful publish_file, method-aware scorecard verdict (plan 23 P3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Scorecard and A/B verdicts now measure an improvement in the units the detector
+  actually used** (plan 23 P3, B5). `RegressionResult.threshold` means a percent for
+  `regression_method="percentage"`, but **MAD-sigma** for `"adaptive"`, an **absolute
+  delta** for `"delta"`, and an **absolute limit** for `"absolute"` — and the verdict
+  helper compared it against `abs(change_percent)` regardless. Regressions were never
+  affected (both call sites resolve `regressed` from the detector before the comparison
+  is reached); what was corrupted is the **improved-vs-unchanged** split for the three
+  non-percentage methods: a tiny but real improvement on a quiet metric read as
+  "unchanged", and a beneficial move well inside the acceptance band read as "improved"
+  because its percent number happened to exceed a sigma count. Each method is now judged
+  on its own terms — `delta` on `|current - baseline|`, `adaptive` against the MAD
+  acceptance band (plus the percent band when the dual-band gate is configured),
+  `absolute` abstaining because a fixed limit has no baseline to improve on — and a
+  record missing the fields a method needs abstains instead of guessing.
+
+  **This recolours existing scorecards.** `schema_version` is a *structural* version and
+  the discovery pass has no version gate, so every `*.summary.json` already on disk is
+  re-read with the corrected rules on the next scorecard build: cells from `adaptive`,
+  `delta`, and `absolute` gates can move between `improved` and `passed` with no file
+  changing and no benchmark re-running. `regressed` and `trend` cells are unaffected. See
+  `docs/scorecard.md` for the versioning policy this follows.
+
+- **All four video-control buttons exist and each does what its label says** (plan 23 P3,
+  B1). Four button labels were zipped against a two-element callback list, so `zip`
+  truncated the row: only two buttons were ever built, "Pause Videos" was wired to the
+  callback that *unpauses*, and the Loop and Reset buttons did not exist. All four are now
+  built from a single list of `(label, callback)` pairs. Looping is driven by one shared
+  flag so a click moves every video pane to the same state instead of inverting each
+  independently, and the button is labelled "Toggle Looping" because videos start out
+  looping — a button reading "Loop Videos" would have turned looping *off* when first
+  pressed. Note that Reset's rewind is a request panel's client-side model can drop while
+  a video is playing (its `set_time` handler returns without seeking when a recent
+  `timeupdate` armed its internal guard); the docstring records this rather than promising
+  a rewind bencher cannot deliver.
+
+- **`publish_file` no longer claims to return a URL it never returned** (plan 23 P3, B4).
+  It was annotated `-> str` and documented as returning the published file's URL, but the
+  body ends at the `git push` and falls off the end returning `None` — so a caller
+  following the signature got `None`. The annotation and docstring now state that, and
+  document `remote` as the string it is (it was described as a callable returning a pair
+  of URLs, from a signature that no longer exists). Behaviour is unchanged: the viewable
+  URL is provider-specific and not derivable from the arguments, so callers still build it
+  themselves, as `publish_and_view_rrd` already did.
+
+- **A malformed or foreign `*.summary.json` no longer aborts a scorecard build.** JSON
+  integers are arbitrary-precision, so an oversized integer where a metric value was
+  expected raised `OverflowError` (not caught by the `TypeError`/`ValueError` guard) out of
+  the verdict pass and out of the page render; it now degrades to an abstaining verdict.
+  The same gap is closed in the writer (`RegressionResult.to_dict`), which now emits `null`
+  for such a value rather than raising.
+
 - **Fail-loud, not fail-fatal: a benchmark that returns `None` no longer produces a
   silently empty sweep — and no longer aborts the run either** (plan 23 P2, B3; amended
   per owner decision before release). A worker that forgot to `return

--- a/bencher/regression.py
+++ b/bencher/regression.py
@@ -924,10 +924,18 @@ def _clean_1d(a: np.ndarray) -> np.ndarray:
 
 
 def _finite_or_none(value: float | None) -> float | None:
-    """Coerce a float to a strict-JSON-safe value: non-finite (NaN/inf) -> None."""
+    """Coerce a float to a strict-JSON-safe value: non-finite (NaN/inf) -> None.
+
+    An int too large to convert to a float (JSON integers are
+    arbitrary-precision) is not JSON-safe either, so it degrades to ``None``
+    rather than raising ``OverflowError`` out of ``to_dict``.
+    """
     if value is None:
         return None
-    value = float(value)
+    try:
+        value = float(value)
+    except OverflowError:
+        return None
     return value if np.isfinite(value) else None
 
 

--- a/bencher/report_export.py
+++ b/bencher/report_export.py
@@ -187,16 +187,26 @@ def _snapshot_ds(bench_res: BenchResult) -> xr.Dataset:
     return ds
 
 
-def _finite_value(value) -> float | None:
-    """Coerce *value* to a finite float, or None (handles None/NaN/inf/non-numbers)."""
+def _finite_value(value: object) -> float | None:
+    """Coerce *value* to a finite float, or None for anything that isn't one.
+
+    The tolerant *reader* counterpart to
+    :func:`~bencher.regression._finite_or_none` (the strict *writer* used by
+    ``to_dict``): this one is fed records parsed from ``*.summary.json`` files
+    that bencher may not have written, so every non-numeric, non-finite, or
+    unrepresentable input degrades to ``None`` (which the verdict branches treat
+    as "abstain") rather than aborting a scorecard build. ``OverflowError``
+    matters in particular because JSON integers are arbitrary-precision, so a
+    hand-edited or foreign summary can carry an int too large for a float.
+    """
     try:
-        value = float(value)
-    except (TypeError, ValueError):
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
         return None
-    return value if np.isfinite(value) else None
+    return number if np.isfinite(number) else None
 
 
-def _verdict(reg: Mapping) -> str:
+def _verdict(reg: Mapping[str, object]) -> str:
     """Classify a metric movement as improved / regressed / unchanged.
 
     *reg* follows the :meth:`~bencher.regression.RegressionResult.to_dict`
@@ -234,25 +244,30 @@ def _verdict(reg: Mapping) -> str:
     return "improved" if improved else "unchanged"
 
 
-def _beneficial(delta: float, direction) -> bool:
+def _beneficial(delta: float, direction: object) -> bool:
     """True when a signed movement is in the variable's beneficial direction."""
     return (direction == OptDir.minimize.value and delta < 0) or (
         direction == OptDir.maximize.value and delta > 0
     )
 
 
-def _delta_improved(reg: Mapping) -> bool:
-    """delta method: gate the improvement on |current - baseline| in absolute units."""
+def _delta_improved(reg: Mapping[str, object]) -> bool:
+    """delta method: gate the improvement on |current - baseline| in absolute units.
+
+    Strict ``>`` to mirror :func:`~bencher.regression.detect_delta`'s
+    ``delta > max_delta`` exactly (contrast :func:`_percent_improved`, which keeps
+    the pre-existing inclusive convention).
+    """
     current = _finite_value(reg.get("current_value"))
     baseline = _finite_value(reg.get("baseline_value"))
     threshold = _finite_value(reg.get("threshold"))
     if current is None or baseline is None or threshold is None:
         return False
     delta = current - baseline
-    return _beneficial(delta, reg.get("direction")) and abs(delta) >= threshold
+    return _beneficial(delta, reg.get("direction")) and abs(delta) > threshold
 
 
-def _adaptive_improved(reg: Mapping) -> bool:
+def _adaptive_improved(reg: Mapping[str, object]) -> bool:
     """adaptive method: improved iff outside the MAD band (and any percent band)."""
     current = _finite_value(reg.get("current_value"))
     baseline = _finite_value(reg.get("baseline_value"))
@@ -267,10 +282,17 @@ def _adaptive_improved(reg: Mapping) -> bool:
     # Dual-band AND gate: when the percent band is present, being inside it suppresses.
     pct_lower = _finite_value(reg.get("percent_band_lower"))
     pct_upper = _finite_value(reg.get("percent_band_upper"))
-    return pct_lower is None or pct_upper is None or not pct_lower <= current <= pct_upper
+    if pct_lower is None or pct_upper is None:
+        return True
+    # detect_adaptive derives the band as baseline*(1 ± pct/100), which INVERTS the
+    # endpoints for a negative baseline (baseline=-100, pct=5 -> (-95, -105)); sort so
+    # the membership test still holds there. The detector itself is unaffected because
+    # it gates on _safe_change_percent, which divides by abs(baseline).
+    pct_lower, pct_upper = sorted((pct_lower, pct_upper))
+    return not pct_lower <= current <= pct_upper
 
 
-def _percent_improved(reg: Mapping) -> bool:
+def _percent_improved(reg: Mapping[str, object]) -> bool:
     """percentage method (and unknown-method fallback, mirroring method_cells)."""
     change_percent = _finite_value(reg.get("change_percent"))
     threshold = _finite_value(reg.get("threshold"))

--- a/bencher/report_export.py
+++ b/bencher/report_export.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import warnings
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -186,25 +187,96 @@ def _snapshot_ds(bench_res: BenchResult) -> xr.Dataset:
     return ds
 
 
-def _verdict(
-    change_percent: float | None, direction: str, regressed: bool, threshold: float
-) -> str:
+def _finite_value(value) -> float | None:
+    """Coerce *value* to a finite float, or None (handles None/NaN/inf/non-numbers)."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if np.isfinite(value) else None
+
+
+def _verdict(reg: Mapping) -> str:
     """Classify a metric movement as improved / regressed / unchanged.
 
-    ``regressed`` comes straight from the detector (direction- and
-    threshold-aware). An improvement is the mirror image: a beneficial-direction
-    move whose magnitude clears the same threshold.
+    *reg* follows the :meth:`~bencher.regression.RegressionResult.to_dict`
+    contract. ``regressed`` comes straight from the detector (direction- and
+    threshold-aware). An improvement is the mirror image — a beneficial-direction
+    move that clears the detector's gate — measured in each method's own units,
+    because ``threshold`` means percent, absolute delta, MAD-sigma, or an
+    absolute limit depending on ``method``:
+
+    * ``percentage`` (and unknown methods, mirroring the fallback in
+      :func:`~bencher.regression.method_cells`): ``|change_percent|`` clears
+      ``threshold`` (a percent).
+    * ``delta``: ``|current_value - baseline_value|`` clears ``threshold``
+      (absolute units).
+    * ``adaptive``: ``current_value`` lies outside the MAD acceptance band
+      (``band_lower``/``band_upper``) and, when the dual-band percent gate is
+      present, outside ``percent_band_lower``/``percent_band_upper`` too —
+      mirroring :func:`~bencher.regression.detect_adaptive`'s AND gate.
+      Abstains to "unchanged" when the bands are absent from the record.
+    * ``absolute``: a fixed limit with no baseline to improve against
+      (``change_percent`` is always NaN/None), so a non-regressed check is
+      explicitly "unchanged".
     """
-    if regressed:
+    if reg.get("regressed"):
         return "regressed"
-    if change_percent is None or not np.isfinite(change_percent):
-        return "unchanged"
-    beneficial = (direction == OptDir.minimize.value and change_percent < 0) or (
-        direction == OptDir.maximize.value and change_percent > 0
+    method = reg.get("method")
+    if method == "absolute":
+        improved = False
+    elif method == "delta":
+        improved = _delta_improved(reg)
+    elif method == "adaptive":
+        improved = _adaptive_improved(reg)
+    else:
+        improved = _percent_improved(reg)
+    return "improved" if improved else "unchanged"
+
+
+def _beneficial(delta: float, direction) -> bool:
+    """True when a signed movement is in the variable's beneficial direction."""
+    return (direction == OptDir.minimize.value and delta < 0) or (
+        direction == OptDir.maximize.value and delta > 0
     )
-    if beneficial and abs(change_percent) >= threshold:
-        return "improved"
-    return "unchanged"
+
+
+def _delta_improved(reg: Mapping) -> bool:
+    """delta method: gate the improvement on |current - baseline| in absolute units."""
+    current = _finite_value(reg.get("current_value"))
+    baseline = _finite_value(reg.get("baseline_value"))
+    threshold = _finite_value(reg.get("threshold"))
+    if current is None or baseline is None or threshold is None:
+        return False
+    delta = current - baseline
+    return _beneficial(delta, reg.get("direction")) and abs(delta) >= threshold
+
+
+def _adaptive_improved(reg: Mapping) -> bool:
+    """adaptive method: improved iff outside the MAD band (and any percent band)."""
+    current = _finite_value(reg.get("current_value"))
+    baseline = _finite_value(reg.get("baseline_value"))
+    band_lower = _finite_value(reg.get("band_lower"))
+    band_upper = _finite_value(reg.get("band_upper"))
+    if current is None or baseline is None or band_lower is None or band_upper is None:
+        return False  # bands absent from the record: abstain.
+    if not _beneficial(current - baseline, reg.get("direction")):
+        return False
+    if band_lower <= current <= band_upper:
+        return False
+    # Dual-band AND gate: when the percent band is present, being inside it suppresses.
+    pct_lower = _finite_value(reg.get("percent_band_lower"))
+    pct_upper = _finite_value(reg.get("percent_band_upper"))
+    return pct_lower is None or pct_upper is None or not pct_lower <= current <= pct_upper
+
+
+def _percent_improved(reg: Mapping) -> bool:
+    """percentage method (and unknown-method fallback, mirroring method_cells)."""
+    change_percent = _finite_value(reg.get("change_percent"))
+    threshold = _finite_value(reg.get("threshold"))
+    if change_percent is None or threshold is None:
+        return False
+    return _beneficial(change_percent, reg.get("direction")) and abs(change_percent) >= threshold
 
 
 def compare_results(baseline: BenchResult, candidate: BenchResult, *, run_cfg=None) -> dict:
@@ -257,7 +329,7 @@ def compare_results(baseline: BenchResult, candidate: BenchResult, *, run_cfg=No
     metrics = []
     counts = {"improved": 0, "regressed": 0, "unchanged": 0}
     for r in report.results:
-        verdict = _verdict(r.change_percent, r.direction, r.regressed, r.threshold)
+        verdict = _verdict(r.to_dict())
         counts[verdict] += 1
         metrics.append(
             {

--- a/bencher/results/video_controls.py
+++ b/bencher/results/video_controls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import panel as pn
@@ -7,7 +8,7 @@ import panel as pn
 
 class VideoControls:
     def __init__(self) -> None:
-        self.vid_p = []
+        self.vid_p: list[pn.pane.Video] = []
 
     def video_container(self, path, **kwargs):
         if path is not None and Path(path).exists():
@@ -17,24 +18,39 @@ class VideoControls:
             return vid
         return pn.pane.Markdown(f"video does not exist {path}")
 
-    def video_controls(self) -> pn.Column | None:
-        def play_vid(_):  # pragma: no cover
-            for r in self.vid_p:
-                r.paused = False
+    def play_videos(self, _event=None) -> None:
+        """Unpause every registered video."""
+        for vid in self.vid_p:
+            vid.paused = False
 
-        def reset_vid(_):  # pragma: no cover
-            for r in self.vid_p:
-                r.paused = False
-                r.time = 0
+    def pause_videos(self, _event=None) -> None:
+        """Pause every registered video."""
+        for vid in self.vid_p:
+            vid.paused = True
 
-        button_names = ["Play Videos", "Pause Videos", "Loop Videos", "Reset Videos"]
-        buttom_cb = [play_vid, reset_vid]
+    def loop_videos(self, _event=None) -> None:
+        """Toggle looping on every registered video."""
+        for vid in self.vid_p:
+            vid.loop = not vid.loop
+
+    def reset_videos(self, _event=None) -> None:
+        """Rewind every registered video to the start and play it."""
+        for vid in self.vid_p:
+            vid.time = 0
+            vid.paused = False
+
+    def video_controls(self) -> pn.Column:
+        button_specs: list[tuple[str, Callable]] = [
+            ("Play Videos", self.play_videos),
+            ("Pause Videos", self.pause_videos),
+            ("Loop Videos", self.loop_videos),
+            ("Reset Videos", self.reset_videos),
+        ]
 
         buttons = pn.Row()
-
-        for name, cb in zip(button_names, buttom_cb):
+        for name, cb in button_specs:
             button = pn.widgets.Button(label=name)
-            pn.bind(cb, button, watch=True)
+            button.on_click(cb)
             buttons.append(button)
 
         return pn.Column(buttons)

--- a/bencher/results/video_controls.py
+++ b/bencher/results/video_controls.py
@@ -9,11 +9,14 @@ import panel as pn
 class VideoControls:
     def __init__(self) -> None:
         self.vid_p: list[pn.pane.Video] = []
+        # One shared flag rather than per-pane state: a per-pane toggle would
+        # invert each video independently and never converge once they differ.
+        self.loop_enabled: bool = True
 
     def video_container(self, path, **kwargs):
         if path is not None and Path(path).exists():
             vid = pn.pane.Video(path, autoplay=True, **kwargs)
-            vid.loop = True
+            vid.loop = self.loop_enabled
             self.vid_p.append(vid)
             return vid
         return pn.pane.Markdown(f"video does not exist {path}")
@@ -28,13 +31,29 @@ class VideoControls:
         for vid in self.vid_p:
             vid.paused = True
 
-    def loop_videos(self, _event=None) -> None:
-        """Toggle looping on every registered video."""
+    def toggle_looping(self, _event=None) -> None:
+        """Flip looping on/off for every registered video, together.
+
+        Videos start looping (:meth:`video_container`), so the first press turns
+        looping *off* — hence the button reads "Toggle Looping" rather than
+        "Loop Videos", which would have described the opposite of what a first
+        click does.
+        """
+        self.loop_enabled = not self.loop_enabled
         for vid in self.vid_p:
-            vid.loop = not vid.loop
+            vid.loop = self.loop_enabled
 
     def reset_videos(self, _event=None) -> None:
-        """Rewind every registered video to the start and play it."""
+        """Request a rewind to the start of every registered video, and play it.
+
+        Unpausing is reliable. The rewind is a *request*: panel's client-side
+        ``Video`` model (``panel/models/video.ts``) arms a ``_blocked`` flag on
+        every throttled ``ontimeupdate`` and its ``set_time`` handler clears that
+        flag and returns **without seeking**, so a ``time`` write that lands
+        while the video is playing can be swallowed in the browser. Bokeh also
+        only transmits *changed* properties, so writing ``0`` over an existing
+        ``0`` sends nothing. The python-side state below is always updated.
+        """
         for vid in self.vid_p:
             vid.time = 0
             vid.paused = False
@@ -43,7 +62,7 @@ class VideoControls:
         button_specs: list[tuple[str, Callable]] = [
             ("Play Videos", self.play_videos),
             ("Pause Videos", self.pause_videos),
-            ("Loop Videos", self.loop_videos),
+            ("Toggle Looping", self.toggle_looping),
             ("Reset Videos", self.reset_videos),
         ]
 

--- a/bencher/scorecard/model.py
+++ b/bencher/scorecard/model.py
@@ -66,9 +66,10 @@ def cell_verdict(reg: dict | None) -> str:
     there too: the baseline is younger than ``regression_min_history``, so
     bencher reports the regression but never blocks on it — colouring it like a
     real regression would overstate a verdict its own gate treats as advisory.
-    Otherwise defer to bencher's 3-state core verdict and render its
-    ``"unchanged"`` as ``"passed"`` (the gate ran and did not flag). A gate with
-    no threshold can only have "passed".
+    Otherwise defer to bencher's 3-state core verdict (method-aware: it
+    measures the improvement in the record's own threshold units) and render
+    its ``"unchanged"`` as ``"passed"`` (the gate ran and did not flag). A gate
+    with no threshold can only have "passed".
     """
     if reg is None:
         return "trend"
@@ -79,7 +80,9 @@ def cell_verdict(reg: dict | None) -> str:
     threshold = reg.get("threshold")
     if threshold is None:
         return "passed"
-    core = _core_verdict(reg.get("change_percent"), reg.get("direction", "none"), False, threshold)
+    # reg["regressed"] is falsy past the guard above, so _core_verdict can never
+    # return "regressed" here — it only decides improved vs unchanged.
+    core = _core_verdict(reg)
     return "passed" if core == "unchanged" else core
 
 

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -474,22 +474,23 @@ def label_with_units(var: Any) -> str:
     return f"{var.name} [{units}]" if units and units != "ul" else var.name
 
 
-def publish_file(filepath: str, remote: str, branch_name: str) -> str:  # pragma: no cover
-    """Publish a file to an orphan git branch:
+def publish_file(filepath: str, remote: str, branch_name: str) -> None:  # pragma: no cover
+    """Publish a file by force-pushing it to a branch of a git remote.
 
-    .. code-block:: python
+    Creates a fresh single-commit repository in a temporary directory containing
+    only *filepath* and force-pushes it to *branch_name* on *remote*, so no
+    existing repository data needs to be downloaded.
 
-        def publish_args(branch_name) -> tuple[str, str]:
-            return (
-                "https://github.com/blooop/bencher.git",
-                f"https://github.com/blooop/bencher/blob/{branch_name}")
-
+    This function does not return a URL: the address at which the pushed file is
+    viewable depends on the git provider, so callers construct it themselves from
+    *remote* and *branch_name* (see ``publish_and_view_rrd`` in
+    ``bencher/utils_rrd.py``, whose ``content_callback`` does exactly that).
 
     Args:
-        remote (Callable): A function the returns a tuple of the publishing urls. It must follow the signature def publish_args(branch_name) -> tuple[str, str].  The first url is the git repo name, the second url needs to match the format for viewable html pages on your git provider.  The second url can use the argument branch_name to point to the file on a specified branch.
-
-    Returns:
-        str: the url of the published file
+        filepath (str): Path of the local file to publish.
+        remote (str): URL of the git remote to push to, e.g.
+            ``"https://github.com/user/repo.git"``.
+        branch_name (str): Branch to force-push the file to.
     """
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/docs/scorecard.md
+++ b/docs/scorecard.md
@@ -15,6 +15,16 @@ It reads the machine-readable `*.summary.json` written by
 {func}`bencher.result_to_json` (with `include_series=True`) for every benchmark
 under a reports directory and groups them by category.
 
+```{note}
+`schema_version` in those files is a **structural** version: it changes when the
+JSON's shape changes (fields added, removed, renamed, or retyped), not when the
+meaning of a value changes. Verdict semantics — how a recorded threshold, delta,
+or band is turned into `regressed` / `improved` / `passed` / `trend` — can be
+corrected within a version, and the scorecard applies the current rules to every
+summary it finds, including ones written by an earlier release. So a bug fix in
+the verdict logic can recolour historical cells without any file changing.
+```
+
 Within each category the same cells can be read two ways, switched by a control
 in the page header (the choice is remembered across visits):
 

--- a/test/test_report_export.py
+++ b/test/test_report_export.py
@@ -117,6 +117,22 @@ class TestRegressionDataclassToDict(unittest.TestCase):
         )
         self.assertIsNone(r.to_dict()["change_percent"])
 
+    def test_oversized_int_becomes_none(self):
+        # JSON ints are arbitrary-precision; float(10**400) raises OverflowError,
+        # which must not escape to_dict.
+        r = RegressionResult(
+            variable="x",
+            method="percentage",
+            regressed=False,
+            current_value=10**400,
+            baseline_value=1.0,
+            change_percent=0.0,
+            threshold=10.0,
+            direction="minimize",
+            details="",
+        )
+        self.assertIsNone(r.to_dict()["current_value"])
+
     def test_report_to_dict_parity_with_markdown(self):
         regressed = RegressionResult(
             "a", "percentage", True, 12.0, 10.0, 20.0, 10.0, "minimize", ""

--- a/test/test_report_export.py
+++ b/test/test_report_export.py
@@ -133,6 +133,62 @@ class TestRegressionDataclassToDict(unittest.TestCase):
             self.assertIn(r.variable, {x["variable"] for x in d["results"]})
 
 
+class TestVerdictMethodUnits(unittest.TestCase):
+    """_verdict must measure improvements in each method's own threshold units
+    (percent / absolute delta / MAD band), driven by real detector output."""
+
+    def test_delta_verdict_uses_absolute_units(self):
+        from bencher.regression import detect_delta
+        from bencher.report_export import _verdict
+        from bencher.variables.results import OptDir
+
+        hist = np.full(6, 10.0)
+        # Improvement of 3 absolute units (-30%): below max_delta=5 -> unchanged,
+        # even though |change_percent| (30) dwarfs the threshold number (5).
+        small = detect_delta("m", hist, np.array([7.0]), max_delta=5.0, direction=OptDir.minimize)
+        self.assertFalse(small.regressed)
+        self.assertEqual(_verdict(small.to_dict()), "unchanged")
+        # Improvement of 6 absolute units clears max_delta=5 -> improved.
+        big = detect_delta("m", hist, np.array([4.0]), max_delta=5.0, direction=OptDir.minimize)
+        self.assertEqual(_verdict(big.to_dict()), "improved")
+
+    def test_adaptive_verdict_uses_mad_band(self):
+        from bencher.regression import detect_adaptive
+        from bencher.report_export import _verdict
+        from bencher.variables.results import OptDir
+
+        rng = np.random.default_rng(42)
+        hist = 100.0 + rng.normal(0.0, 0.01, size=20)
+        # A -1% move is tiny in percent terms but far outside the MAD band of a
+        # near-noiseless history -> improved despite |change| < the sigma number.
+        improved = detect_adaptive(
+            "m", hist, np.array([99.0]), regression_mad=3.5, direction=OptDir.minimize
+        )
+        self.assertFalse(improved.regressed)
+        self.assertLess(abs(improved.change_percent), improved.threshold)
+        self.assertEqual(_verdict(improved.to_dict()), "improved")
+        # A beneficial move inside a wide MAD band must not be called improved
+        # just because |change_percent| exceeds the sigma threshold number.
+        noisy = 100.0 + rng.normal(0.0, 10.0, size=20)
+        inside = detect_adaptive(
+            "m", noisy, np.array([95.0]), regression_mad=3.5, direction=OptDir.minimize
+        )
+        self.assertFalse(inside.regressed)
+        d = inside.to_dict()
+        self.assertGreaterEqual(d["band_upper"], 95.0)
+        self.assertLessEqual(d["band_lower"], 95.0)
+        self.assertEqual(_verdict(d), "unchanged")
+
+    def test_absolute_verdict_abstains(self):
+        from bencher.regression import detect_absolute
+        from bencher.report_export import _verdict
+        from bencher.variables.results import OptDir
+
+        res = detect_absolute("m", np.array([40.0]), limit=50.0, direction=OptDir.minimize)
+        self.assertFalse(res.regressed)
+        self.assertEqual(_verdict(res.to_dict()), "unchanged")
+
+
 class TestCompareResults(unittest.TestCase):
     def test_regression_detected(self):
         # offset shifts out_sin upward; direction=minimize => increase regresses.

--- a/test/test_scorecard.py
+++ b/test/test_scorecard.py
@@ -307,6 +307,55 @@ class TestCellVerdictMethodUnits:
         assert cell_verdict(reg) == "improved"
 
 
+class TestCellVerdictHostileRecords:
+    """Summary records may be hand-edited or written by another tool: a scorecard
+    build must degrade to a verdict, never raise out of the page render."""
+
+    def test_oversized_json_integer_does_not_raise(self):
+        # JSON integers are arbitrary-precision; float() on one raises
+        # OverflowError, which is not a ValueError/TypeError.
+        reg = _reg("v", "minimize", False, 10**400, 1.0, -50.0, threshold=10**400)
+        assert cell_verdict(reg) == "passed"
+
+    def test_non_numeric_values_do_not_raise(self):
+        reg = _reg("v", "minimize", False, "n/a", None, "lots", threshold=15.0)
+        assert cell_verdict(reg) == "passed"
+
+    def test_negative_baseline_percent_band_still_suppresses(self):
+        """detect_adaptive derives the percent band as baseline*(1 ± pct/100),
+        which inverts the endpoints for a negative baseline — the dual-band gate
+        must still suppress there, exactly as it does for a positive mirror."""
+        negative = _reg(
+            "v",
+            "minimize",
+            False,
+            -100.0,
+            -100.5,
+            -0.5,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=-100.1,
+            band_upper=-99.9,
+            percent_band_lower=-100.0 * (1 - 0.05),  # -95.0
+            percent_band_upper=-100.0 * (1 + 0.05),  # -105.0
+        )
+        positive = _reg(
+            "v",
+            "maximize",
+            False,
+            100.0,
+            100.5,
+            0.5,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=99.9,
+            band_upper=100.1,
+            percent_band_lower=95.0,
+            percent_band_upper=105.0,
+        )
+        assert cell_verdict(negative) == cell_verdict(positive) == "passed"
+
+
 class TestDiscover:
     def test_finds_benches_across_categories(self, mock_reports: Path):
         names = {r["bench_name"] for r in discover_summaries(mock_reports, CONFIG)}

--- a/test/test_scorecard.py
+++ b/test/test_scorecard.py
@@ -52,16 +52,27 @@ def _pt(time_event, mean, std, n=4):
     return {"time_event": time_event, "mean": mean, "std": std, "n": n}
 
 
-def _reg(variable, direction, regressed, baseline, current, change, threshold=15.0):
+def _reg(
+    variable,
+    direction,
+    regressed,
+    baseline,
+    current,
+    change,
+    threshold=15.0,
+    method="percentage",
+    **extra,
+):
     return {
         "variable": variable,
-        "method": "percentage",
+        "method": method,
         "regressed": regressed,
         "current_value": current,
         "baseline_value": baseline,
         "change_percent": change,
         "threshold": threshold,
         "direction": direction,
+        **extra,
     }
 
 
@@ -193,6 +204,107 @@ class TestCellVerdict:
     def test_passed_when_threshold_none(self):
         reg = _reg("v", "maximize", False, 1.0, 1.2, 20.0, threshold=None)
         assert cell_verdict(reg) == "passed"
+
+
+class TestCellVerdictMethodUnits:
+    """threshold is percent ONLY for method='percentage' — MAD-sigma for
+    'adaptive', an absolute delta for 'delta', an absolute limit for
+    'absolute'. The verdict must measure improvements in the record's own
+    units, not compare |change_percent| against a non-percent threshold."""
+
+    def test_adaptive_small_percent_outside_mad_band_is_improved(self):
+        # 1% improvement on a very quiet metric: far outside the MAD band even
+        # though |change| (1.0) is below the sigma threshold number (3.5).
+        reg = _reg(
+            "v",
+            "minimize",
+            False,
+            100.0,
+            99.0,
+            -1.0,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=99.9,
+            band_upper=100.1,
+        )
+        assert cell_verdict(reg) == "improved"
+
+    def test_adaptive_inside_band_not_improved_by_sigma_number(self):
+        # 5% beneficial move but inside the MAD acceptance band: |change| (5.0)
+        # >= the sigma threshold number (3.5) must NOT make it "improved".
+        reg = _reg(
+            "v",
+            "minimize",
+            False,
+            100.0,
+            95.0,
+            -5.0,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=90.0,
+            band_upper=110.0,
+        )
+        assert cell_verdict(reg) == "passed"
+
+    def test_adaptive_dual_band_gate_requires_both(self):
+        # Outside the MAD band but inside the percent band: the detector's
+        # dual-band AND gate would not have fired, so no "improved" either.
+        inside_pct = _reg(
+            "v",
+            "minimize",
+            False,
+            100.0,
+            99.0,
+            -1.0,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=99.9,
+            band_upper=100.1,
+            percent_band_lower=95.0,
+            percent_band_upper=105.0,
+        )
+        assert cell_verdict(inside_pct) == "passed"
+        outside_both = _reg(
+            "v",
+            "minimize",
+            False,
+            100.0,
+            90.0,
+            -10.0,
+            threshold=3.5,
+            method="adaptive",
+            band_lower=99.9,
+            band_upper=100.1,
+            percent_band_lower=95.0,
+            percent_band_upper=105.0,
+        )
+        assert cell_verdict(outside_both) == "improved"
+
+    def test_adaptive_missing_bands_abstains(self):
+        reg = _reg("v", "minimize", False, 100.0, 90.0, -10.0, threshold=3.5, method="adaptive")
+        assert cell_verdict(reg) == "passed"
+
+    def test_delta_threshold_is_absolute_units(self):
+        # -30% change but the absolute delta (3) is below max_delta (5):
+        # comparing |change_percent| against the threshold used to say improved.
+        small_delta = _reg("v", "minimize", False, 10.0, 7.0, -30.0, threshold=5.0, method="delta")
+        assert cell_verdict(small_delta) == "passed"
+        # -0.6% change but the absolute delta (6) clears max_delta (5).
+        big_delta = _reg("v", "minimize", False, 1000.0, 994.0, -0.6, threshold=5.0, method="delta")
+        assert cell_verdict(big_delta) == "improved"
+
+    def test_delta_adverse_move_not_improved(self):
+        reg = _reg("v", "minimize", False, 10.0, 14.0, 40.0, threshold=5.0, method="delta")
+        assert cell_verdict(reg) == "passed"
+
+    def test_absolute_abstains_to_passed(self):
+        # detect_absolute has no baseline: change_percent serializes to None.
+        reg = _reg("v", "minimize", False, 50.0, 40.0, None, threshold=50.0, method="absolute")
+        assert cell_verdict(reg) == "passed"
+
+    def test_unknown_method_falls_back_to_percentage(self):
+        reg = _reg("v", "maximize", False, 1.0, 1.2, 20.0, method="mystery")
+        assert cell_verdict(reg) == "improved"
 
 
 class TestDiscover:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,3 +1,6 @@
+import ast
+import inspect
+import textwrap
 import unittest
 from functools import partial
 
@@ -13,6 +16,7 @@ from bencher.utils import (
     lerp,
     listify,
     mult_tuple,
+    publish_file,
     tabs_in_markdown,
 )
 
@@ -176,3 +180,24 @@ class TestBencherUtils(unittest.TestCase):
         input_str = ""
         expected_output = ""
         self.assertEqual(tabs_in_markdown(input_str), expected_output)
+
+
+class TestPublishFileContract(unittest.TestCase):
+    """publish_file's declared return type must match what it actually returns.
+
+    It was annotated ``-> str`` and documented to return the published file's
+    URL, but the body ends at the ``git push`` and returns ``None`` (plan 23 B4).
+    Asserted via the signature rather than by calling it, so no git remote is
+    touched. ``from __future__ import annotations`` in ``bencher/utils.py`` makes
+    annotations strings, hence the comparison against ``"None"``.
+    """
+
+    def test_return_annotation_is_none(self):
+        annotation = inspect.signature(publish_file).return_annotation
+        self.assertIn(annotation, (None, "None"), f"publish_file claims -> {annotation}")
+
+    def test_body_has_no_return_value(self):
+        # No `return <expr>` anywhere: nothing for a caller to consume.
+        tree = ast.parse(textwrap.dedent(inspect.getsource(publish_file)))
+        returns = [n for n in ast.walk(tree) if isinstance(n, ast.Return) and n.value is not None]
+        self.assertEqual(returns, [])

--- a/test/test_video_controls.py
+++ b/test/test_video_controls.py
@@ -42,3 +42,76 @@ class TestVideoControls(unittest.TestCase):
         self.assertIsInstance(result, pn.Column)
         # Should have a Row of buttons
         self.assertGreater(len(result), 0)
+
+    def _make_video(self, vc: VideoControls) -> pn.pane.Video:
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            tmp_path = tmp.name
+        self.addCleanup(os.remove, tmp_path)
+        vid = vc.video_container(tmp_path)
+        self.assertIsInstance(vid, pn.pane.Video)
+        return vid
+
+    def test_all_four_buttons_created_with_correct_labels(self):
+        """Regression test: zip over a 2-element callback list used to truncate
+        the button row to two buttons (and wired 'Pause Videos' to a callback
+        that unpaused)."""
+        vc = VideoControls()
+        column = vc.video_controls()
+        buttons = list(column[0])
+        self.assertEqual(
+            [b.label for b in buttons],
+            ["Play Videos", "Pause Videos", "Loop Videos", "Reset Videos"],
+        )
+        for button in buttons:
+            self.assertIsInstance(button, pn.widgets.Button)
+
+    def test_play_callback_unpauses(self):
+        vc = VideoControls()
+        vid = self._make_video(vc)
+        vid.paused = True
+        vc.play_videos()
+        self.assertFalse(vid.paused)
+
+    def test_pause_callback_pauses(self):
+        vc = VideoControls()
+        vid = self._make_video(vc)
+        vid.paused = False
+        vc.pause_videos()
+        self.assertTrue(vid.paused)
+
+    def test_loop_callback_toggles(self):
+        vc = VideoControls()
+        vid = self._make_video(vc)
+        self.assertTrue(vid.loop)  # video_container turns looping on
+        vc.loop_videos()
+        self.assertFalse(vid.loop)
+        vc.loop_videos()
+        self.assertTrue(vid.loop)
+
+    def test_reset_callback_rewinds_and_plays(self):
+        vc = VideoControls()
+        vid = self._make_video(vc)
+        vid.time = 12.5
+        vid.paused = True
+        vc.reset_videos()
+        self.assertEqual(vid.time, 0)
+        self.assertFalse(vid.paused)
+
+    def test_buttons_clicks_drive_the_matching_callback(self):
+        """End-to-end: clicking each button changes the recorded video state."""
+        vc = VideoControls()
+        vid = self._make_video(vc)
+        column = vc.video_controls()
+        play, pause, loop, reset = list(column[0])
+
+        pause.param.trigger("clicks")
+        self.assertTrue(vid.paused)
+        play.param.trigger("clicks")
+        self.assertFalse(vid.paused)
+        loop.param.trigger("clicks")
+        self.assertFalse(vid.loop)
+        vid.time = 3.0
+        vid.paused = True
+        reset.param.trigger("clicks")
+        self.assertEqual(vid.time, 0)
+        self.assertFalse(vid.paused)

--- a/test/test_video_controls.py
+++ b/test/test_video_controls.py
@@ -60,7 +60,7 @@ class TestVideoControls(unittest.TestCase):
         buttons = list(column[0])
         self.assertEqual(
             [b.label for b in buttons],
-            ["Play Videos", "Pause Videos", "Loop Videos", "Reset Videos"],
+            ["Play Videos", "Pause Videos", "Toggle Looping", "Reset Videos"],
         )
         for button in buttons:
             self.assertIsInstance(button, pn.widgets.Button)
@@ -79,16 +79,34 @@ class TestVideoControls(unittest.TestCase):
         vc.pause_videos()
         self.assertTrue(vid.paused)
 
-    def test_loop_callback_toggles(self):
+    def test_toggle_looping_flips_every_video_together(self):
         vc = VideoControls()
         vid = self._make_video(vc)
-        self.assertTrue(vid.loop)  # video_container turns looping on
-        vc.loop_videos()
+        self.assertTrue(vid.loop)  # video_container starts videos looping
+        vc.toggle_looping()
         self.assertFalse(vid.loop)
-        vc.loop_videos()
+        vc.toggle_looping()
         self.assertTrue(vid.loop)
 
-    def test_reset_callback_rewinds_and_plays(self):
+    def test_toggle_looping_converges_on_mixed_state(self):
+        """A per-pane toggle would invert each video independently and never
+        converge; one shared flag drives them all to the same value."""
+        vc = VideoControls()
+        first = self._make_video(vc)
+        second = self._make_video(vc)
+        second.loop = False  # desynchronise, e.g. set by caller/kwargs
+        vc.toggle_looping()
+        self.assertEqual(first.loop, second.loop)
+        self.assertFalse(first.loop)
+        vc.toggle_looping()
+        self.assertEqual(first.loop, second.loop)
+        self.assertTrue(first.loop)
+
+    def test_reset_callback_sets_python_state_and_plays(self):
+        """Asserts only the python-side state: the ``time`` write is a request
+        panel's client-side ``set_time`` can swallow while playing (see
+        ``VideoControls.reset_videos``), so this is not evidence of a browser
+        rewind. Unpausing has no such guard and is reliable."""
         vc = VideoControls()
         vid = self._make_video(vc)
         vid.time = 12.5


### PR DESCRIPTION
Implements **plan 23 §5 P3** (`plans/23-constructive-data-modeling.md`) — the reporting/rendering live bugs **B1**, **B4**, **B5** from §3.

## B1 — all four video buttons now exist and do what they say

`bencher/results/video_controls.py:30-35` (pre-fix) zipped four button names against a **two**-element callback list, so `zip` truncated: "Pause Videos" was bound to `reset_vid` (which *unpauses*), and "Loop Videos"/"Reset Videos" were never constructed at all.

Fixed in `VideoControls.video_controls` (`bencher/results/video_controls.py:42`): one `list[tuple[str, Callable]]` of `(label, callback)` pairs, and the callbacks are now named methods on the class, each doing what its label says:

- `VideoControls.play_videos` — `paused = False`
- `VideoControls.pause_videos` — `paused = True` (the actual bug: pause never paused)
- `VideoControls.toggle_looping` — flips one shared `loop_enabled` flag and applies it to every pane
- `VideoControls.reset_videos` — `time = 0` then `paused = False`

Two review-driven corrections to this button set:

- **The button is labelled "Toggle Looping", not "Loop Videos".** `video_container` starts every video looping, so a button reading "Loop Videos" would turn looping *off* on its first press — the opposite of its label. Looping is also driven from a single `loop_enabled` flag rather than per-pane `not vid.loop`, because a per-pane toggle inverts each video independently and never reconverges once two panes differ (`test_toggle_looping_converges_on_mixed_state`).
- **Reset's rewind is documented as a request, not a guarantee.** Panel's client-side model (`panel/models/video.ts`) arms `_blocked` on every throttled `ontimeupdate` and its `set_time` handler clears that flag and returns **without seeking**, so a `time` write landing during playback is swallowed in the browser; bokeh also only transmits *changed* properties, so writing `0` over an existing `0` sends nothing. The docstring says so, and the test is named/commented to make clear it asserts python-side state only. Unpausing has no such guard and is reliable. This is not a regression — pre-fix `reset_vid` had the same defect and was not even wired to a button — but the original wording here overstated it. The two-write nudge (`time = 1e-6; time = 0`) was deliberately **not** shipped: whether bokeh coalesces two writes to the same property in one callback cannot be verified headlessly, so shipping it would have been another unverified claim.

Buttons are built with `pn.widgets.Button(label=...)` and `button.on_click(cb)` (panel deprecates `Widget.name` in favour of `label`).

Satisfies the §9 grep-level check "no `zip(button_names`".

**Tests** (`test/test_video_controls.py`): `test_all_four_buttons_created_with_correct_labels` asserts the exact four labels in order; one test per callback drives it directly against a recorded headless `pn.pane.Video` and asserts the state change; `test_buttons_clicks_drive_the_matching_callback` round-trips through `button.param.trigger("clicks")` so the wiring (not just the callbacks) is covered.

## B4 — `publish_file` is now honestly `-> None`

`bencher/utils.py:477` `publish_file` was declared `-> str` and documented as "Returns: str: the url of the published file", but the body ends with `git("push", ...)` and returns `None`.

**Decision: annotate `-> None`, do not synthesize a URL.** Rationale from the call sites:

- `bencher/utils_rrd.py:63` (`publish_and_view_rrd`) is the **only** call site and ignores the return value entirely — it builds the viewable URL itself via its `content_callback(remote, branch_name, file_path)` parameter.
- The docstring's example advertised a two-URL scheme (git remote URL + a provider-specific viewable-HTML URL template) that the current `remote: str, branch_name: str` signature **cannot** construct — the viewable-page URL format is provider-specific and is not an input to this function. Returning a fabricated URL would be a guess.

So the fix is the truthful annotation plus a docstring that describes what the function does, states that no URL is returned and why, and documents `remote` as the `str` it actually is (the old docstring wrongly called it a `Callable` returning a tuple — a leftover from a signature that no longer exists). No behaviour change; no call site needed updating.

## B5 — method-aware verdict (improved-vs-unchanged only)

`RegressionResult.threshold` (`bencher/regression.py:59`) means percent for `method="percentage"`, **MAD-sigma** for `"adaptive"`, an **absolute delta** for `"delta"`, and an **absolute limit** for `"absolute"` — but `_verdict` (`bencher/report_export.py:189` pre-fix) compared it against `abs(change_percent)` regardless.

**Scope, as the plan specifies:** regressions were always reported correctly — `_verdict` returns `"regressed"` from `reg["regressed"]` at the top, and `bencher/scorecard/model.py:77` returns `"regressed"` before `_verdict` is even called. The unit mismatch corrupted only the **improved-vs-unchanged** distinction for non-percentage methods, and that is all this change touches.

**Design chosen: `_verdict` takes the record `Mapping` directly** rather than growing to 8 positional parameters — `_verdict(reg: Mapping) -> str` (`bencher/report_export.py:199`). This works because the shape it needs is exactly `RegressionResult.to_dict()` (`bencher/regression.py:106`), which already serializes `method`, `current_value`, `baseline_value`, `threshold`, `direction` and the four band fields when set. Both call sites feed it that shape:

- `bencher/report_export.py:332` (`compare_results`) → `_verdict(r.to_dict())`
- `bencher/scorecard/model.py:82` (`cell_verdict`) → `_core_verdict(reg)`, where `reg` is already a `to_dict()` record parsed from `summary.json`

Per-method dispatch, in helpers so each rule reads on its own:

| method | improved iff | helper |
|---|---|---|
| `percentage` + unknown fallback (mirrors `method_cells`, `regression.py:317`) | beneficial and `abs(change_percent) >= threshold` — unchanged from before | `_percent_improved` (`:273`) |
| `delta` | beneficial and `abs(current_value - baseline_value) > threshold` (absolute units; strict `>` mirrors `detect_delta`) | `_delta_improved` (`:244`) |
| `adaptive` | beneficial **and** `current_value` outside `band_lower..band_upper`, **and** — when the dual-band percent gate is present — outside `percent_band_lower..percent_band_upper` too, mirroring `detect_adaptive`'s AND gate (`regression.py:1172`). Abstains to `"unchanged"` when the bands are absent from the record. | `_adaptive_improved` (`:255`) |
| `absolute` | never — a fixed limit has no baseline to improve against (`change_percent` is NaN→`None`); now explicit rather than incidental | inline (`:203`) |

`_finite_value` (`bencher/report_export.py:190`) coerces each field to a finite float or `None`, so a missing/NaN/serialized-`None` field abstains instead of raising. Review-driven additions here:

- **`OverflowError` is now caught** — a reachable crash out of the scorecard render, which the owner never-crash principle forbids. JSON integers are arbitrary-precision, and `float(10**400)` raises `OverflowError`, which `except (TypeError, ValueError)` does not cover; a foreign or hand-edited `*.summary.json` carrying an oversized int for `current_value`/`threshold` therefore aborted the page build. Closed in the reader and in `regression._finite_or_none` (`bencher/regression.py:926`), the writer side, where the same gap made `to_dict` raise instead of emitting `null`.
- **The adaptive percent band is sorted before the membership test.** `detect_adaptive` derives it as `baseline*(1 ± pct/100)`, which **inverts** the endpoints for a negative baseline (`baseline=-100, pct=5` → `(-95.0, -105.0)`), so `pct_lower <= current <= pct_upper` could never be true and the dual-band AND gate was silently a no-op. Measured before the fix: a 0.5% beneficial move outside the MAD band but inside the 5% percent band returned `"improved"` for a negative baseline and `"passed"` for its positive mirror. The detector itself is correct because it gates on `_safe_change_percent`, which divides by `abs(baseline)` — so the pre-fix code was not the exact mirror its docstring claimed. Only the percent band is affected; the MAD band is always correctly ordered.
- `_finite_value` is kept separate from `_finite_or_none` on purpose (rather than collapsing them): the former is the **tolerant reader** for records bencher may not have written, the latter the **strict writer** for values handed to `to_dict`, where a non-numeric input is a construction-time programming error. Both are now documented as such, and the `Mapping[str, object]` / `value: object` annotations are filled in for the ty hardening this plan is doing.

**The hardcoded `regressed=False` at `scorecard/model.py:82` was correct — verified, not changed.** `cell_verdict` returns `"regressed"` at `:77` from `bool(reg.get("regressed"))` before reaching the `_verdict` call, so past that guard `reg["regressed"]` is always falsy and `_verdict` can only decide improved-vs-unchanged. Passing the record straight through now makes the flag redundant (it is read from the record), which removes the duplicated-truth smell entirely; a comment at `:81-82` records why the core verdict can never return `"regressed"` there.

**Tests:**

- `test/test_report_export.py::TestVerdictMethodUnits` — driven by **real detector output**, not hand-built dicts: `detect_delta` proves a -30% / 3-absolute-unit move stays `"unchanged"` under `max_delta=5` while a -0.6% / 6-unit move is `"improved"`; `detect_adaptive` proves a -1% move on a near-noiseless history is `"improved"` even though `abs(change_percent) < threshold` (the sigma number), and that a beneficial -5% move **inside** a wide MAD band is **not** misclassified `"improved"` just because `abs(change_percent) >= 3.5`; `detect_absolute` abstains.
- `test/test_scorecard.py::TestCellVerdictMethodUnits` — the same distinctions at the `cell_verdict` layer, plus the dual-band gate (outside MAD but inside the percent band → `"passed"`; outside both → `"improved"`), missing-bands abstention, and unknown-method → percentage fallback. `_reg` (`test/test_scorecard.py:55`) gained `method=` and `**extra` so band fields can be supplied; every existing percentage-method test keeps passing unchanged.

All new tests were confirmed to fail on the pre-fix code (13 failures with `bencher/` reverted). **To be precise about how much of that is behavioural evidence:** 7 of the 13 are vacuous — the 3 `TestVerdictMethodUnits` cases fail with `TypeError: _verdict() missing 3 required positional arguments` (the signature changed, so the old function cannot be called at all) and the 4 video-callback cases fail with `AttributeError` (the methods did not exist). The genuinely behavioural evidence is `test_all_four_buttons_created_with_correct_labels`, `test_buttons_clicks_drive_the_matching_callback`, and all 4 `TestCellVerdictMethodUnits` cases, which go through `cell_verdict` (unchanged signature) and therefore demonstrate real improved→passed / passed→improved verdict diffs. The plan §9 DoD is satisfied; the wording above simply should not be read as 13 independent behavioural findings.

## Historical-record impact (no schema bump)

`SCHEMA_VERSION` is deliberately **not** bumped: the JSON structure is byte-identical, and nothing reads the field — `bencher/scorecard/discover.py:56-64` has no version gate. But that also means **every `*.summary.json` already on disk is re-read with the corrected rules on the next scorecard build**, so `adaptive`, `delta`, and `absolute` cells can move between `improved` and `passed` with no file changing and no benchmark re-running (`regressed` and `trend` cells are unaffected). `test_adaptive_missing_bands_abstains` fails pre-fix precisely because of this. Recorded in `CHANGELOG.md` so a maintainer seeing recoloured cells has something to point at, and `docs/scorecard.md` now states the policy behind it: `schema_version` is a **structural** version covering the JSON's shape, not the meaning of its values, so verdict semantics may be corrected within a version.

## Missing B4 regression test (plan §9 DoD)

Added `test/test_utils.py::TestPublishFileContract`. `publish_file` is `# pragma: no cover` and nothing else references it, so the contract is asserted without executing git: `inspect.signature(...).return_annotation` is `"None"` (a string, since `bencher/utils.py` uses `from __future__ import annotations`), plus an AST walk asserting no `return <expr>` exists in the body. Verified failing against the pre-fix `-> str` at `398bdd96`.

## Falsified plan claims

None. Every B1/B4/B5 claim in §3 held exactly as written, including the precise B5 scoping (regressions unaffected; only improved-vs-unchanged corrupted) and the note that `scorecard/model.py:82`'s `regressed=False` is likely correct.

## Verification

`pixi run ci` passes: format clean, ruff clean, pylint 10.00/10, `ty` clean, 2615 passed / 3 skipped, coverage 90%.

One environment note, not a code issue: an initial `pixi run ci` reported 88 setup **errors**, all `FileNotFoundError: /tmp/pytest-of-kinisi-ci/pytest-1` — a concurrent agent sharing this user's pytest tmp base had garbage-collected the numbered basetemp mid-run. Re-running with a private `TMPDIR` gives a fully green suite; the affected tests also pass in isolation. No version bump in `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
