### PR TITLE
refactor: JobFuture Ready|Pending sum type and always-hashed WorkerJob (plan 23 P5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   back. The new `Protocol` (`submit`, `shutdown`) is satisfied by both
   `ProcessPoolExecutor` and scoop's module.
 
-- `JobFuture.result()` is annotated `-> dict | None`. The `None` is not new behaviour, only
-  newly admitted: `JobFuture` can represent "no result and no future", and callers must
-  reject it. Plan 23 P5's `Ready(dict) | Pending(Future)` split is what makes the state
-  unrepresentable and the `| None` removable.
+- `JobFuture.result()` was annotated `-> dict | None` by P2 (the `None` was not new
+  behaviour, only newly admitted: `JobFuture` could represent "no result and no future").
+  **Superseded before release by P5 below**, which makes that state unrepresentable and
+  the method total.
+
+- **`JobFuture` holds one state field instead of two optionals** (plan 23 P5, C2). `res`
+  and `future` were independent optionals that `result()` *mutated* — it assigned to
+  `self.res` and left `self.future` set — so `future is not None` stopped meaning
+  "pending" after the first call, and both-set and neither-set were both representable
+  while neither was meaningful. The field is now a single
+  `Ready(res) | Pending(future) | Broken(error)` sum of frozen dataclasses, parsed once in
+  the constructor (whose keyword signature is unchanged, so every construction site and
+  hand-built test object reads as before); passing both a result and a future now raises
+  `ValueError`. `result()` matches exhaustively with `assert_never` — verified by deleting
+  an arm and measuring `error[type-assertion-failure] … Inferred type of argument is
+  'Broken & ~Ready & ~Pending'` — and is **total**: the `| None` return is gone. The
+  order-dependent `job_future.future is not None` dispatch in `Bench.calculate_benchmark_results`
+  reads the variant instead.
+
+  `Broken` is the constructive replacement for the one meaningful half of "neither set": a
+  serial worker that returned `None`. The error is *stored* rather than raised at
+  construction, because the serial site is inside the caller's `except catch` block —
+  raising there is exactly the original B3 failure mode where `catch=Exception` absorbed a
+  contract violation. **The record-and-continue disposition is unchanged** (plan 23 §6.2
+  as amended): `result()` raises `WorkerContractError` at the consume point on *either*
+  executor path, `store_results` records a `SampleFailure`, logs at ERROR, emits
+  `WorkerContractWarning`, and the sweep continues. A `None` return never aborts a run.
+  Caching semantics are also unchanged: the pre-P5 `res is not None` guard on `cache.set`
+  is now enforced by construction — a worker that returned nothing cannot reach the cache.
+
+- **`WorkerJob`'s derived inputs and hashes are `cached_property`s, not two-phase init**
+  (plan 23 P5, C8). `function_input`, `canonical_input`, `fn_inputs_sorted` and
+  `function_input_signature_pure` defaulted to `None` and were filled by a `setup_hashes()`
+  call every construction site had to remember, so nothing prevented caching a sample under
+  `job_key=None`. `setup_hashes()` is gone; the four values are computed on demand from the
+  constructor fields, so a `WorkerJob` with unset hashes no longer exists. The unused
+  `found_in_cache` and `msgs` fields (written nowhere in the package) are removed. Hash
+  values are byte-identical — the same `hash_sha1((sorted_inputs, tag))` over the same
+  inputs — so no cached sample is invalidated, and pickling across a process boundary still
+  works (computed values travel in `__dict__`; unaccessed ones recompute deterministically).
+
+- `FutureCache.clear_tag` no longer raises `AttributeError` on `None` when the cache is
+  disabled (`cache_samples=False`), and `JobFunctionCache.call` passes its counter as a
+  `str`, matching `Job.job_id`'s declared type. Both were latent defects surfaced by putting
+  `job.py` on the strict `ty` list (recorded as out-of-scope in plan 23 P2 item 7).
+  `bencher/job.py`, `bencher/worker_job.py` and `bencher/result_collector.py` are all on
+  that list now — the last one because C8 removed the `function_input`-is-`None` diagnostics
+  that were holding it off, exactly as P2 predicted.
 
 ### Removed
 - **BREAKING: dropped Python 3.10 support.** `requires-python` is now `>=3.11,<3.14`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,12 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reads the variant instead.
 
   `Broken` is the constructive replacement for the one meaningful half of "neither set": a
-  serial worker that returned `None`. The error is *stored* rather than raised at
-  construction, because the serial site is inside the caller's `except catch` block —
-  raising there is exactly the original B3 failure mode where `catch=Exception` absorbed a
-  contract violation. **The record-and-continue disposition is unchanged** (plan 23 §6.2
-  as amended): `result()` raises `WorkerContractError` at the consume point on *either*
-  executor path, `store_results` records a `SampleFailure`, logs at ERROR, emits
+  job that yielded no result. The error is *stored* rather than raised at construction,
+  because the serial site is inside the caller's `except catch` block — raising there is
+  exactly the original B3 failure mode where `catch=Exception` absorbed a contract
+  violation. It is supplied by whichever caller *knows* the cause (the serial site in
+  `FutureCache.submit`, having just watched `run_job` return `None`) rather than inferred
+  from the shape of the constructor call, which cannot tell a `None`-returning worker from
+  a cache entry holding `None`. **The record-and-continue disposition is unchanged** (plan
+  23 §6.2 as amended): `result()` raises at the consume point on *either* executor path,
+  `store_results` records a `SampleFailure`, logs at ERROR, emits
   `WorkerContractWarning`, and the sweep continues. A `None` return never aborts a run.
   Caching semantics are also unchanged: the pre-P5 `res is not None` guard on `cache.set`
   is now enforced by construction — a worker that returned nothing cannot reach the cache.
@@ -117,6 +120,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that list now — the last one because C8 removed the `function_input`-is-`None` diagnostics
   that were holding it off, exactly as P2 predicted.
 
+  Both fixes go past what the type checker asked for, because in both cases satisfying it
+  would have hidden the defect it pointed at. `FutureCache.call_count` was initialised to 0
+  and incremented **nowhere**, so every `JobFunctionCache.call()` produced the same job id —
+  the string every log line and contract message identifies a sample by; it is now
+  incremented, and ids read `call 1`, `call 2`, …. And `clear_tag` on a cache-less
+  `FutureCache` now logs a WARNING rather than returning silently: not crashing is right, but
+  on a public path (`Bench.clear_tag_from_sample_cache`) "nothing happened" must not read as
+  "the tag was cleared".
+
 ### Removed
 - **BREAKING: dropped Python 3.10 support.** `requires-python` is now `>=3.11,<3.14`, and
   the CI matrix runs py311 + py313 (was py310 + py313). The `py310` pixi feature and
@@ -137,6 +149,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which strings `BenchRunCfg(executor=...)` accepts. See plan 23 D4.
 
 ### Added
+- **`bencher.WorkerReturnedNothingError`**, a narrow subclass of `WorkerContractError`
+  meaning *the harness itself* determined a job produced no result (plan 23 P5). Only this
+  subclass is exempt from `catch=`; a `WorkerContractError` raised by a **worker** — the
+  class is public, so a worker or plugin can raise it, e.g. to signal a hard config error
+  and abort with `catch=()` — is an ordinary sample fault and is routed through `catch=` as
+  before. Without the split, a worker-raised `WorkerContractError` was silently tolerated on
+  MULTIPROCESSING even with `catch=()` while still aborting on SERIAL: loud or silent chosen
+  by the executor, which is the defect shape plan 23 B3 exists to eliminate. Existing
+  `except WorkerContractError` handlers keep matching, by subclassing.
+
 - **Single result-type registry: `RESULT_SPECS` in `bencher/variables/results.py`**
   (plan 23 P4). One ordered `{Result* class: ResultSpec}` mapping now declares each
   result type's kind, missing fill/sentinels, and family memberships (panel, media,

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -44,7 +44,12 @@ from .identity import (
     identity_of,
     sweep_identity,
 )
-from .job import SampleFailure, WorkerContractError, WorkerContractWarning
+from .job import (
+    SampleFailure,
+    WorkerContractError,
+    WorkerContractWarning,
+    WorkerReturnedNothingError,
+)
 from .render import load_result, render_report, save_result
 from .report_export import (
     compare_results,

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -31,9 +31,9 @@ from bencher.job import (
     FutureCache,
     Job,
     JobFuture,
+    Pending,
     normalize_catch,
     normalize_executor,
-    require_worker_result,
 )
 from bencher.optuna_conversions import sweep_var_to_optuna_dist, sweep_var_to_suggest
 from bencher.regression import RegressionError, detect_regressions
@@ -1127,7 +1127,6 @@ class Bench(BenchPlotServer):
                     bench_cfg_sample_hash,
                     bench_tag,
                 )
-                job.setup_hashes()
                 jobs.append(job)
 
                 cache_jobs.append(
@@ -1198,10 +1197,16 @@ class Bench(BenchPlotServer):
                 # remaining computation.
                 pending = {}  # concurrent.futures.Future -> (WorkerJob, JobFuture)
                 for job, job_future in submitted:
-                    if job_future.future is not None:
-                        pending[job_future.future] = (job, job_future)
-                    else:
-                        self.store_results(job_future, bench_res, job, bench_run_cfg, rv_arrays)
+                    # No assert_never arm: job_future arrives via an untyped tuple, so
+                    # exhaustiveness would be an assertion, not a proof (plan 24 A1);
+                    # the default arm is a real behavior anyway -- Ready (a cache hit)
+                    # and Broken (a fallen-back-to-serial worker that returned None,
+                    # recorded by store_results) are both stored immediately.
+                    match job_future.state:
+                        case Pending(future=future):
+                            pending[future] = (job, job_future)
+                        case _:
+                            self.store_results(job_future, bench_res, job, bench_run_cfg, rv_arrays)
                 for done in as_completed(pending):
                     worker_job, job_future = pending.pop(done)
                     self.store_results(job_future, bench_res, worker_job, bench_run_cfg, rv_arrays)
@@ -1665,7 +1670,7 @@ class Bench(BenchPlotServer):
         full_input["repeat"] = repeat
 
         cache_key = self._build_cache_key(full_input, tag)
-        # Mirror the sweep path (WorkerJob.setup_hashes): constants must reach the
+        # Mirror the sweep path (WorkerJob.function_input): constants must reach the
         # worker, not just the cache key. Collisions with input_vars are already
         # stripped in _resolve_optimize_vars, so suggested values are never clobbered.
         # deepcopy for the same mutation safety worker_kwargs_wrapper gives the sweep
@@ -1679,7 +1684,9 @@ class Bench(BenchPlotServer):
         )
         # Same boundary check as store_results: the optimize path consumes the result
         # dict directly, so a worker returning None must fail here by name rather than
-        # as a downstream subscript error (B3, plan 23 P2).
+        # as a downstream subscript error (B3, plan 23 P2). Since P5 the check lives
+        # inside `result()` itself, which is total and raises WorkerContractError for
+        # a worker that returned nothing -- on either executor path.
         #
         # Unlike the sweep path this one *is* inside a `catch=`, because the objective
         # runs under `study.optimize(..., catch=catch)`. That asymmetry is pre-existing
@@ -1687,7 +1694,7 @@ class Bench(BenchPlotServer):
         # here too, as an AssertionError on serial and a `None` subscript TypeError on
         # the pool. Only the message and the serial/parallel agreement improve. Making
         # optuna's catch selective is its own decision, not B3's.
-        return require_worker_result(self.sample_cache.submit(job).result(), job.job_id)
+        return self.sample_cache.submit(job).result()
 
     def _make_optuna_objective(
         self,

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -226,14 +226,14 @@ class Broken:
     error: WorkerContractError
 
 
+# The three states a submitted job can be in (plan 23 P5, C2). Previously JobFuture
+# held res/future as two optionals and mutated res on the first result() call, so
+# both-set and neither-set were representable and `future is not None` stopped meaning
+# "pending". Broken is the constructive replacement for the meaningful half of
+# "neither-set": the one production path that reached it was a serial worker returning
+# None. (A comment rather than a docstring: check-docstring-first reads a bare string
+# after a module-level assignment as a misplaced module docstring.)
 JobState = Ready | Pending | Broken
-"""The three states a submitted job can be in (plan 23 P5, C2).
-
-Previously ``JobFuture`` held ``res``/``future`` as two optionals and mutated
-``res`` on the first ``result()`` call, so both-set and neither-set were
-representable and ``future is not None`` stopped meaning "pending". ``Broken``
-is the constructive replacement for the meaningful half of "neither-set": the
-one production path that reached it was a serial worker returning ``None``."""
 
 
 class JobFuture:

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -136,17 +136,49 @@ class WorkerContractWarning(UserWarning):
     with ``warnings.filterwarnings("error", category=bn.WorkerContractWarning)``."""
 
 
-def _returned_none_error(job_id: str) -> WorkerContractError:
-    """Build the contract error for a worker that returned ``None``.
+class WorkerReturnedNothingError(WorkerContractError):
+    """A job yielded no result at all -- **the harness's own diagnosis**, never a
+    worker's.
 
-    Factored out so the two places that can *discover* the violation -- the
-    ``JobFuture`` constructor on the serial path (which stores it as a
-    :class:`Broken` state) and ``require_worker_result`` on the pooled path --
-    produce the identical message."""
-    return WorkerContractError(
+    Exists to keep "the framework decided a job produced nothing" separable from
+    "a worker raised ``WorkerContractError`` itself", which it can: the class is
+    public API (``bencher.WorkerContractError``). ``store_results`` catches *this*
+    subclass ahead of ``except catch``, so a framework-minted no-result is always
+    recorded-and-continued, while a worker-raised ``WorkerContractError`` keeps
+    reaching ``catch=`` exactly as it did before P5.
+
+    Without the split, P5's move of the handler inside the ``try`` silently
+    tolerated a worker-raised ``WorkerContractError`` on the pooled path even with
+    ``catch=()`` -- loud on SERIAL, silent on MULTIPROCESSING, which is the very
+    executor-dependent divergence B3 exists to kill (review finding, 2026-07-31)."""
+
+
+def _returned_none_error(job_id: str) -> WorkerReturnedNothingError:
+    """The contract error for a worker whose call returned ``None``.
+
+    Minted only where that cause is actually *known*: ``require_worker_result``
+    (the pooled path, holding the worker's return value) and ``FutureCache.submit``
+    at the serial site (which has just called ``run_job``). Both produce the
+    identical message."""
+    return WorkerReturnedNothingError(
         f"The benchmark function for job {job_id} returned None. "
         "Make sure you are returning a dict or `super().__call__(**kwargs)` "
         "from your __call__ function."
+    )
+
+
+def _no_result_error(job_id: str) -> WorkerReturnedNothingError:
+    """The contract error for a ``JobFuture`` built with neither result nor future.
+
+    Deliberately does **not** blame the benchmark function: unlike
+    :func:`_returned_none_error` this path does not know the cause. It is reached
+    by a cache entry holding ``None`` and by a ``JobFuture`` constructed with no
+    arguments at all, both of which the pre-review wording mislabelled as a
+    worker bug."""
+    return WorkerReturnedNothingError(
+        f"No result was produced for job {job_id}: it was constructed with neither "
+        "a result nor a pending future. Either a cache entry holds None, or the "
+        "JobFuture was built without one of `res=` / `future=` / `error=`."
     )
 
 
@@ -165,10 +197,13 @@ def require_worker_result(result: dict | None, job_id: str) -> dict:
 
     Deliberately **not** routed through ``catch=`` (plan 23 decision 2): a missing
     return value is a harness-contract error, not a sample fault, so ``catch=``
-    must never decide its fate. The raise is consumed by ``store_results``, which
-    records the sample as failed and warns instead of aborting the sweep (plan 23
-    §6.2 as amended: crashing mid-run loses expensive data; the failure surfaces
-    in the report instead)."""
+    must never decide its fate. That exemption is why the error is the narrow
+    :class:`WorkerReturnedNothingError` rather than its public base class -- it must
+    apply to the harness's own diagnosis only, never to a ``WorkerContractError`` a
+    worker raises. The raise is consumed by ``store_results``, which records the
+    sample as failed and warns instead of aborting the sweep (plan 23 §6.2 as
+    amended: crashing mid-run loses expensive data; the failure surfaces in the
+    report instead)."""
     if result is None:
         raise _returned_none_error(job_id)
     return result
@@ -214,16 +249,21 @@ class Pending:
 
 @dataclass(frozen=True)
 class Broken:
-    """A serial worker that returned nothing, i.e. broke the harness contract.
+    """A job that yielded no result, carrying the harness's diagnosis of why.
 
     The error is *stored*, not raised, because the serial path constructs the
-    ``JobFuture`` inside the caller's ``except catch`` block -- raising here would
+    ``JobFuture`` inside the caller's ``except catch`` block -- raising there would
     let ``catch=`` absorb a contract violation (the original B3 failure mode).
     ``result()`` raises it at the consume point instead, where ``store_results``
     records the sample as failed, warns, and continues (plan 23 §6.2 as amended:
-    a broken sample must never abort the sweep and lose collected data)."""
+    a broken sample must never abort the sweep and lose collected data).
 
-    error: WorkerContractError
+    The error is supplied by whoever *knows* the cause -- ``FutureCache.submit``
+    at the serial site, having just seen ``run_job`` return ``None`` -- rather
+    than inferred from the syntactic shape of the constructor call, which cannot
+    tell a ``None``-returning worker from a cache entry holding ``None``."""
+
+    error: WorkerReturnedNothingError
 
 
 # The three states a submitted job can be in (plan 23 P5, C2). Previously JobFuture
@@ -255,35 +295,47 @@ class JobFuture:
         res: dict | None = None,
         future: Future | None = None,
         cache: Cache | None = None,
+        error: WorkerReturnedNothingError | None = None,
     ) -> None:
-        """Initialize a JobFuture with either an immediate result or a future.
+        """Initialize a JobFuture with a result, a pending future, or an error.
 
         The keyword signature is kept from the two-optional era so the four
         construction sites (and tests that build one directly) read unchanged;
         the arguments are parsed into a single :data:`JobState` here, at the
-        boundary. Passing *both* ``res`` and ``future`` -- previously
-        representable, never meaningful -- is rejected. Passing *neither* means
-        a serial worker returned ``None`` (the only production path that gets
-        here) and becomes :class:`Broken`, resolved at the consume point.
+        boundary. One argument at most may be given -- previously ``res`` and
+        ``future`` together were representable and never meaningful. ``error=``
+        exists so a caller that *knows* why a job produced nothing (the serial
+        site in ``FutureCache.submit``, which has just seen ``run_job`` return
+        ``None``) can say so; with none of the three, the state is still
+        :class:`Broken`, but with a diagnosis that does not guess at the cause.
 
         Args:
             job (Job): The job this future corresponds to
             res (dict, optional): The immediate result, if available. Defaults to None.
             future (Future, optional): The future representing the pending result. Defaults to None.
             cache (Cache, optional): The cache to store results in. Defaults to None.
+            error (WorkerReturnedNothingError, optional): Why this job produced no
+                result, when the caller knows. Defaults to None.
         """
         self.job = job
-        if res is not None and future is not None:
+        # `is not None`, not truthiness: `res={}` is a *valid* result (a worker with
+        # no result vars) and must still count as "given" for this check.
+        given = [
+            name
+            for name, val in (("res", res), ("future", future), ("error", error))
+            if val is not None
+        ]
+        if len(given) > 1:
             raise ValueError(
-                f"JobFuture for job {job.job_id} was given both a result and a future; "
-                "a job is either already resolved or still pending, never both"
+                f"JobFuture for job {job.job_id} was given {' and '.join(given)}; a job is "
+                "resolved, still pending, or broken -- never more than one of the three"
             )
         if res is not None:
             self.state: JobState = Ready(res)
         elif future is not None:
             self.state = Pending(future)
         else:
-            self.state = Broken(_returned_none_error(job.job_id))
+            self.state = Broken(error or _no_result_error(job.job_id))
         self.cache = cache
 
     def result(self) -> dict:
@@ -297,17 +349,19 @@ class JobFuture:
 
         Total over :data:`JobState` (plan 23 P5): the pre-P5 ``dict | None``
         return is gone. A worker that returned nothing surfaces as a
-        :class:`WorkerContractError` raised here -- on *either* executor path --
-        and is consumed by ``store_results``, which records the failure and
-        continues rather than aborting the sweep (plan 23 §6.2 as amended).
+        :class:`WorkerReturnedNothingError` raised here -- on *either* executor
+        path -- and is consumed by ``store_results``, which records the failure
+        and continues rather than aborting the sweep (plan 23 §6.2 as amended).
 
         Returns:
             dict: The job result
 
         Raises:
-            WorkerContractError: If the worker returned ``None`` instead of a
-                result dict (`Broken`, or a `Pending` future that resolves to
-                ``None``).
+            WorkerReturnedNothingError: If the job produced no result (`Broken`,
+                or a `Pending` future that resolves to ``None``). Note this is
+                the *narrow* subclass: a ``WorkerContractError`` a worker raises
+                itself propagates untouched, and ``store_results`` routes it
+                through ``catch=`` like any other sample fault.
         """
         match self.state:
             case Ready(res=res):
@@ -451,7 +505,9 @@ class FutureCache:
         executor: The executor instance, created on demand
         cache (Cache): Cache for storing job results
         overwrite (bool): Whether to overwrite existing cached results
-        call_count (int): Counter for job calls
+        call_count (int): Number of ``JobFunctionCache.call()`` invocations, used to
+            label their job ids. Only that subclass increments it; the counters below
+            are what a ``FutureCache`` used directly tracks.
         size_limit (int): Maximum size of the cache in bytes
         worker_wrapper_call_count (int): Number of job submissions
         worker_fn_call_count (int): Number of actual function executions
@@ -562,9 +618,16 @@ class FutureCache:
                 cache=self.cache,
             )
         self.overwrite_msg(job, " starting serial job...")
+        # The one place that can distinguish "the worker returned None" from any
+        # other route to a result-less job, so it is the place that names the cause
+        # (review finding 4). Passing `res=None` and letting the constructor guess
+        # would relabel a cached None as a benchmark-function bug.
+        res = run_job(job)
+        if res is None:
+            return JobFuture(job=job, error=_returned_none_error(job.job_id), cache=self.cache)
         return JobFuture(
             job=job,
-            res=run_job(job),
+            res=res,
             cache=self.cache,
         )
 
@@ -602,7 +665,15 @@ class FutureCache:
         # Guarded like every other cache access here: with cache_samples=False this
         # used to be a live AttributeError on None (found by the strict ty ratchet,
         # plan 23 P2 item 7; fixed in P5 when this file joined the strict list).
+        # WARNING rather than a silent return: the public entry point
+        # (Bench.clear_tag_from_sample_cache) is reachable from user code, and
+        # "nothing happened" must not look like "the tag was cleared".
         if self.cache is None:
+            logger.warning(
+                "asked to clear tag %r from a sample cache that does not exist "
+                "(cache_samples=False); nothing to clear",
+                tag,
+            )
             return
         logger.info(f"clearing the sample cache for tag: {tag}")
         removed_vals = self.cache.evict(tag)
@@ -680,6 +751,12 @@ class JobFunctionCache(FutureCache):
         Returns:
             JobFuture: A future representing the function call
         """
-        # str() because job_id is declared (and everywhere else used as) a string;
-        # this call site passed the raw counter, caught by the strict ty ratchet.
-        return self.submit(Job(str(self.call_count), self.function, kwargs))
+        # `call_count` is incremented here, which is what makes the job_id below
+        # identify a call. It was initialised to 0 in FutureCache.__init__ and
+        # incremented nowhere, so every call produced job_id=0 -- indistinguishable
+        # in logs and in every contract-violation message. The strict ty ratchet
+        # flagged only the type (int passed as a str job_id); casting alone would
+        # have made the annotation true while preserving the defect it pointed at
+        # (review finding 2).
+        self.call_count += 1
+        return self.submit(Job(f"call {self.call_count}", self.function, kwargs))

--- a/bencher/job.py
+++ b/bencher/job.py
@@ -136,6 +136,20 @@ class WorkerContractWarning(UserWarning):
     with ``warnings.filterwarnings("error", category=bn.WorkerContractWarning)``."""
 
 
+def _returned_none_error(job_id: str) -> WorkerContractError:
+    """Build the contract error for a worker that returned ``None``.
+
+    Factored out so the two places that can *discover* the violation -- the
+    ``JobFuture`` constructor on the serial path (which stores it as a
+    :class:`Broken` state) and ``require_worker_result`` on the pooled path --
+    produce the identical message."""
+    return WorkerContractError(
+        f"The benchmark function for job {job_id} returned None. "
+        "Make sure you are returning a dict or `super().__call__(**kwargs)` "
+        "from your __call__ function."
+    )
+
+
 def require_worker_result(result: dict | None, job_id: str) -> dict:
     """Reject a worker that returned ``None`` instead of a result dict.
 
@@ -145,7 +159,9 @@ def require_worker_result(result: dict | None, job_id: str) -> dict:
     ``store_results`` skipped its whole body behind ``if result is not None:`` with
     no ``else``, so the sweep completed green with an all-sentinel dataset and
     ``n_failed == 0``. The same user error was loud or silent depending on an
-    unrelated config knob; this is the one check both paths funnel through.
+    unrelated config knob; this is the one check both paths funnel through --
+    since P5 it is applied *inside* ``JobFuture.result()``, so a ``None`` can no
+    longer leak past the resolve at all.
 
     Deliberately **not** routed through ``catch=`` (plan 23 decision 2): a missing
     return value is a harness-contract error, not a sample fault, so ``catch=``
@@ -154,11 +170,7 @@ def require_worker_result(result: dict | None, job_id: str) -> dict:
     §6.2 as amended: crashing mid-run loses expensive data; the failure surfaces
     in the report instead)."""
     if result is None:
-        raise WorkerContractError(
-            f"The benchmark function for job {job_id} returned None. "
-            "Make sure you are returning a dict or `super().__call__(**kwargs)` "
-            "from your __call__ function."
-        )
+        raise _returned_none_error(job_id)
     return result
 
 
@@ -186,6 +198,44 @@ class SampleFailure:
         )
 
 
+@dataclass(frozen=True)
+class Ready:
+    """A result already in hand: a cache hit, or a serial worker that returned one."""
+
+    res: dict
+
+
+@dataclass(frozen=True)
+class Pending:
+    """A submitted job whose result has not been collected from its executor yet."""
+
+    future: Future
+
+
+@dataclass(frozen=True)
+class Broken:
+    """A serial worker that returned nothing, i.e. broke the harness contract.
+
+    The error is *stored*, not raised, because the serial path constructs the
+    ``JobFuture`` inside the caller's ``except catch`` block -- raising here would
+    let ``catch=`` absorb a contract violation (the original B3 failure mode).
+    ``result()`` raises it at the consume point instead, where ``store_results``
+    records the sample as failed, warns, and continues (plan 23 §6.2 as amended:
+    a broken sample must never abort the sweep and lose collected data)."""
+
+    error: WorkerContractError
+
+
+JobState = Ready | Pending | Broken
+"""The three states a submitted job can be in (plan 23 P5, C2).
+
+Previously ``JobFuture`` held ``res``/``future`` as two optionals and mutated
+``res`` on the first ``result()`` call, so both-set and neither-set were
+representable and ``future is not None`` stopped meaning "pending". ``Broken``
+is the constructive replacement for the meaningful half of "neither-set": the
+one production path that reached it was a serial worker returning ``None``."""
+
+
 class JobFuture:
     """A wrapper for a job result or future that handles caching.
 
@@ -195,8 +245,7 @@ class JobFuture:
 
     Attributes:
         job (Job): The job this future corresponds to
-        res (dict): The result, if available immediately
-        future (Future): The future representing the pending job, if executed asynchronously
+        state (JobState): ``Ready(res)`` | ``Pending(future)`` | ``Broken(error)``
         cache: The cache to store results in when they become available
     """
 
@@ -209,6 +258,14 @@ class JobFuture:
     ) -> None:
         """Initialize a JobFuture with either an immediate result or a future.
 
+        The keyword signature is kept from the two-optional era so the four
+        construction sites (and tests that build one directly) read unchanged;
+        the arguments are parsed into a single :data:`JobState` here, at the
+        boundary. Passing *both* ``res`` and ``future`` -- previously
+        representable, never meaningful -- is rejected. Passing *neither* means
+        a serial worker returned ``None`` (the only production path that gets
+        here) and becomes :class:`Broken`, resolved at the consume point.
+
         Args:
             job (Job): The job this future corresponds to
             res (dict, optional): The immediate result, if available. Defaults to None.
@@ -216,36 +273,59 @@ class JobFuture:
             cache (Cache, optional): The cache to store results in. Defaults to None.
         """
         self.job = job
-        self.res = res
-        self.future = future
-        # No `assert res is not None or future is not None` here any more (B3, plan
-        # 23 P2). It only caught a None worker return on the serial path, where
-        # `submit()` runs inside the caller's `except catch` block and `catch=` would
-        # therefore have absorbed it. Both paths now converge on
-        # require_worker_result() at the point where the result is consumed.
+        if res is not None and future is not None:
+            raise ValueError(
+                f"JobFuture for job {job.job_id} was given both a result and a future; "
+                "a job is either already resolved or still pending, never both"
+            )
+        if res is not None:
+            self.state: JobState = Ready(res)
+        elif future is not None:
+            self.state = Pending(future)
+        else:
+            self.state = Broken(_returned_none_error(job.job_id))
         self.cache = cache
 
-    def result(self) -> dict | None:
+    def result(self) -> dict:
         """Get the job result, waiting for completion if necessary.
 
-        If the result is not immediately available (i.e., it's a future),
-        this method will wait for the future to complete. Once the result
-        is available, it will be cached if a cache is provided.
+        If the result is not immediately available (i.e., it's ``Pending``),
+        this method will wait for the future to complete. Once the result is
+        available, it will be cached if a cache is provided; a worker that
+        returned nothing is never cached (the pre-P5 ``res is not None`` guard,
+        now enforced by construction).
 
-        Returns ``None`` when the worker returned nothing, which every caller must
-        reject via ``require_worker_result()``. The annotation is deliberately
-        honest rather than narrow: ``JobFuture`` can represent "no result and no
-        future", and only plan 23 P5's ``Ready(dict) | Pending(Future)`` split makes
-        that state unrepresentable and this ``| None`` removable.
+        Total over :data:`JobState` (plan 23 P5): the pre-P5 ``dict | None``
+        return is gone. A worker that returned nothing surfaces as a
+        :class:`WorkerContractError` raised here -- on *either* executor path --
+        and is consumed by ``store_results``, which records the failure and
+        continues rather than aborting the sweep (plan 23 §6.2 as amended).
 
         Returns:
-            dict | None: The job result, or None if the worker returned nothing
+            dict: The job result
+
+        Raises:
+            WorkerContractError: If the worker returned ``None`` instead of a
+                result dict (`Broken`, or a `Pending` future that resolves to
+                ``None``).
         """
-        if self.future is not None:
-            self.res = self.future.result()
-        if self.cache is not None and self.res is not None:
-            self.cache.set(self.job.job_key, self.res, tag=self.job.tag)
-        return self.res
+        match self.state:
+            case Ready(res=res):
+                return self._cache_and_return(res)
+            case Pending(future=future):
+                return self._cache_and_return(
+                    require_worker_result(future.result(), self.job.job_id)
+                )
+            case Broken(error=error):
+                raise error
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def _cache_and_return(self, res: dict) -> dict:
+        """Cache a resolved (never-``None``) result and hand it back."""
+        if self.cache is not None:
+            self.cache.set(self.job.job_key, res, tag=self.job.tag)
+        return res
 
 
 def run_job(job: Job) -> dict:
@@ -519,6 +599,11 @@ class FutureCache:
         Args:
             tag (str): The tag identifying entries to remove from the cache
         """
+        # Guarded like every other cache access here: with cache_samples=False this
+        # used to be a live AttributeError on None (found by the strict ty ratchet,
+        # plan 23 P2 item 7; fixed in P5 when this file joined the strict list).
+        if self.cache is None:
+            return
         logger.info(f"clearing the sample cache for tag: {tag}")
         removed_vals = self.cache.evict(tag)
         logger.info(f"removed: {removed_vals} items from the cache")
@@ -595,4 +680,6 @@ class JobFunctionCache(FutureCache):
         Returns:
             JobFuture: A future representing the function call
         """
-        return self.submit(Job(self.call_count, self.function, kwargs))
+        # str() because job_id is declared (and everywhere else used as) a string;
+        # this call site passed the raw counter, caught by the strict ty ratchet.
+        return self.submit(Job(str(self.call_count), self.function, kwargs))

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -44,7 +44,6 @@ from bencher.job import (
     WorkerContractError,
     WorkerContractWarning,
     normalize_catch,
-    require_worker_result,
 )
 from bencher.results.bench_result import BenchResult
 from bencher.variables.inputs import IntSweep
@@ -444,25 +443,26 @@ class ResultCollector:
         catch = normalize_catch(getattr(bench_run_cfg, "catch", ()))
         try:
             result = job_result.result()
+        # Ordered *before* `except catch`, deliberately: a worker that returned
+        # nothing is a harness-contract error, not a sample fault, so `catch=` must
+        # not decide its fate (plan 23 decision 2) -- WorkerContractError subclasses
+        # TypeError, so a later `except catch` with catch=Exception would otherwise
+        # absorb it. Since P5, JobFuture.result() is total (Ready|Pending|Broken)
+        # and raises this itself on either executor path, replacing the separate
+        # require_worker_result step that used to live after the try -- see
+        # require_worker_result for the full B3 story. The violation is recorded
+        # and warned, never raised through the sweep (plan 23 §6.2 as amended):
+        # the cells keep their missing sentinel, and the failed-samples summary
+        # makes that visible.
+        except WorkerContractError as exc:
+            self.record_contract_violation(
+                bench_res, job_result.job.job_id, worker_job.function_input, exc
+            )
+            return
         # catch is a runtime tuple of exception types, which pylint cannot see into.
         # pylint: disable-next=catching-non-exception
         except catch as exc:
             self.record_caught_sample(
-                bench_res, job_result.job.job_id, worker_job.function_input, exc
-            )
-            return
-        # Outside the `except catch` above, deliberately: a worker that returned
-        # nothing is a harness-contract error, not a sample fault, so `catch=` must
-        # not decide its fate (plan 23 decision 2). This replaces `if result is not
-        # None:` with no `else`, which skipped everything below and left the sweep
-        # green with an all-sentinel dataset -- see require_worker_result for the
-        # full B3 story. The violation is recorded and warned, never raised through
-        # the sweep (plan 23 §6.2 as amended): the cells keep their missing
-        # sentinel, and the failed-samples summary makes that visible.
-        try:
-            result = require_worker_result(result, job_result.job.job_id)
-        except WorkerContractError as exc:
-            self.record_contract_violation(
                 bench_res, job_result.job.job_id, worker_job.function_input, exc
             )
             return

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -43,6 +43,7 @@ from bencher.job import (
     SampleFailure,
     WorkerContractError,
     WorkerContractWarning,
+    WorkerReturnedNothingError,
     normalize_catch,
 )
 from bencher.results.bench_result import BenchResult
@@ -445,16 +446,24 @@ class ResultCollector:
             result = job_result.result()
         # Ordered *before* `except catch`, deliberately: a worker that returned
         # nothing is a harness-contract error, not a sample fault, so `catch=` must
-        # not decide its fate (plan 23 decision 2) -- WorkerContractError subclasses
-        # TypeError, so a later `except catch` with catch=Exception would otherwise
-        # absorb it. Since P5, JobFuture.result() is total (Ready|Pending|Broken)
-        # and raises this itself on either executor path, replacing the separate
-        # require_worker_result step that used to live after the try -- see
-        # require_worker_result for the full B3 story. The violation is recorded
-        # and warned, never raised through the sweep (plan 23 §6.2 as amended):
-        # the cells keep their missing sentinel, and the failed-samples summary
-        # makes that visible.
-        except WorkerContractError as exc:
+        # not decide its fate (plan 23 decision 2) -- WorkerReturnedNothingError
+        # subclasses TypeError, so a later `except catch` with catch=Exception would
+        # otherwise absorb it. Since P5, JobFuture.result() is total
+        # (Ready|Pending|Broken) and raises this itself on either executor path,
+        # replacing the separate require_worker_result step that used to live after
+        # the try -- see require_worker_result for the full B3 story. The violation
+        # is recorded and warned, never raised through the sweep (plan 23 §6.2 as
+        # amended): the cells keep their missing sentinel, and the failed-samples
+        # summary makes that visible.
+        #
+        # The narrow subclass, NOT WorkerContractError: that base class is public, so
+        # a worker or plugin can raise it, and catching it here would silently
+        # tolerate a worker-raised one on the pooled path even with catch=() --
+        # raising on SERIAL but completing on MULTIPROCESSING, exactly the
+        # executor-dependent divergence B3 exists to kill. A worker-raised
+        # WorkerContractError falls through to `except catch` below instead, which is
+        # what it did before P5.
+        except WorkerReturnedNothingError as exc:
             self.record_contract_violation(
                 bench_res, job_result.job.job_id, worker_job.function_input, exc
             )

--- a/bencher/worker_job.py
+++ b/bencher/worker_job.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from functools import cached_property
 from typing import Any
 
 from bencher.utils import hmap_canonical_input
@@ -16,50 +17,62 @@ class WorkerJob:
     including input variables, dimension information, and caching metadata. It handles
     the preparation of function inputs and calculation of hash signatures for caching.
 
+    The derived inputs and hash signatures are ``cached_property``s computed from the
+    constructor fields, so a ``WorkerJob`` with *unset* hashes is unrepresentable
+    (plan 23 P5, C8). They used to be four ``None``-default fields filled by a
+    ``setup_hashes()`` method every constructor site had to remember to call --
+    two-phase init, with nothing preventing caching under a ``None`` job key.
+
+    Pickling (a ``WorkerJob`` may cross a process boundary under the pooled
+    executors) is unaffected: any already-computed properties travel in
+    ``__dict__``; ones not yet accessed are recomputed on demand, deterministically,
+    because ``hash_sha1`` is content-based.
+
     Attributes:
         function_input_vars (list): The values of the input variables to pass to the function
         index_tuple (tuple[int]): The indices of these values in the N-dimensional result array
         dims_name (list[str]): The names of the input dimensions
-        constant_inputs (dict): Dictionary of any constant input values
+        constant_inputs (dict | None): Dictionary of any constant input values
         bench_cfg_sample_hash (str): Hash of the benchmark configuration without repeats
         tag (str): Tag for grouping related jobs
-        function_input (dict): Complete input as a dictionary with dimension names as keys
-        canonical_input (tuple[Any]): Canonical representation of inputs for caching
-        fn_inputs_sorted (list[tuple[str, Any]]): Sorted representation of function inputs
-        function_input_signature_pure (str): Hash of the function inputs and tag
-        found_in_cache (bool): Whether this job result was found in cache
-        msgs (list[str]): Messages related to this job's execution
     """
 
     function_input_vars: list[Any]
     index_tuple: tuple[int, ...]
     dims_name: list[str]
-    constant_inputs: dict
+    constant_inputs: dict | None
     bench_cfg_sample_hash: str
     tag: str
 
-    function_input: dict | None = None
-    canonical_input: tuple[Any] | None = None
-    fn_inputs_sorted: list[tuple[str, Any]] | None = None
-    function_input_signature_pure: str | None = None
-    found_in_cache: bool = False
-    msgs: list[str] = field(default_factory=list)
+    @cached_property
+    def canonical_input(self) -> tuple[Any, ...]:
+        """Canonical representation of the swept inputs, used as a holomap key.
 
-    def setup_hashes(self) -> None:
-        """Set up the function inputs and calculate hash signatures for caching.
-
-        This method prepares the function inputs by combining function input variables
-        with dimensions and constant inputs. It also calculates hash signatures used
-        for caching results and tracking job execution.
+        Computed from the swept dimensions only -- constant inputs are deliberately
+        excluded (they are merged into :attr:`function_input`, not here).
         """
-        self.function_input = dict(zip(self.dims_name, self.function_input_vars))
+        return hmap_canonical_input(dict(zip(self.dims_name, self.function_input_vars)))
 
-        self.canonical_input = hmap_canonical_input(self.function_input)
-
+    @cached_property
+    def function_input(self) -> dict:
+        """Complete input as a dictionary with dimension names as keys."""
+        function_input = dict(zip(self.dims_name, self.function_input_vars))
         if self.constant_inputs is not None:
-            self.function_input = self.function_input | self.constant_inputs
+            function_input = function_input | self.constant_inputs
+        return function_input
 
-        # store a tuple of the inputs as keys for a holomap
-        # the signature is the hash of the inputs to to the function + meta variables such as repeat and time + the hash of the benchmark sweep as a whole (without the repeats hash)
-        self.fn_inputs_sorted = sorted(self.function_input.items())
-        self.function_input_signature_pure = hash_sha1((self.fn_inputs_sorted, self.tag))
+    @cached_property
+    def fn_inputs_sorted(self) -> list[tuple[str, Any]]:
+        """Sorted representation of the function inputs."""
+        return sorted(self.function_input.items())
+
+    @cached_property
+    def function_input_signature_pure(self) -> str:
+        """Hash of the function inputs and tag.
+
+        The signature is the hash of the inputs to the function + meta variables
+        such as repeat and time. The hash of the benchmark sweep as a whole
+        (without the repeats hash) is kept separately in
+        :attr:`bench_cfg_sample_hash` and deliberately not folded in here.
+        """
+        return hash_sha1((self.fn_inputs_sorted, self.tag))

--- a/bencher/worker_job.py
+++ b/bencher/worker_job.py
@@ -23,10 +23,13 @@ class WorkerJob:
     ``setup_hashes()`` method every constructor site had to remember to call --
     two-phase init, with nothing preventing caching under a ``None`` job key.
 
-    Pickling (a ``WorkerJob`` may cross a process boundary under the pooled
-    executors) is unaffected: any already-computed properties travel in
-    ``__dict__``; ones not yet accessed are recomputed on demand, deterministically,
-    because ``hash_sha1`` is content-based.
+    Picklability is preserved and pinned by ``test/test_multiprocessing_executor.py``,
+    though **not** because a ``WorkerJob`` crosses a process boundary -- it does not.
+    Only ``Job`` (function + ``job_args``) is sent to an executor
+    (``bencher.py``'s submit loop); a ``WorkerJob`` is built and consumed entirely in
+    the parent process. It survives a round trip anyway: already-computed properties
+    travel in ``__dict__``, and ones not yet accessed recompute on demand,
+    deterministically, because ``hash_sha1`` is content-based.
 
     Attributes:
         function_input_vars (list): The values of the input variables to pass to the function

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -922,3 +922,79 @@ is unaffected.
    the raw string are indistinguishable: `str(Executors.SERIAL) == str("SERIAL")` and
    `hash(Executors.SERIAL) == hash("SERIAL")`, both True, since `StrEnum` inherits `str`.
    No `CACHE_VERSION` bump.
+
+### P5 (implemented)
+
+1. **P5's spec had to be reconciled with the P2-amendment, and the reconciliation is the
+   phase's main design decision.** The spec says "the worker-`None` check from P2 moves
+   into the factory that constructs `Ready`". Read literally that reinstates the original
+   B3 bug: the serial construction site (`FutureCache.submit`) runs *inside* the caller's
+   `except catch` block, so a `raise` there is absorbed by `catch=Exception` — exactly the
+   failure mode P2 item 1 measured and `TestCatchDoesNotAbsorbContractErrors` pins. The
+   check therefore lives at construction as a **discovery**, not a disposition: "neither
+   result nor future" parses to a third variant, `Broken(WorkerContractError)`, which
+   stores the error and raises it from `result()` at the consume point. `store_results`
+   consumes it unchanged — `SampleFailure`, ERROR log, `WorkerContractWarning`, sweep
+   continues. A `None` return still cannot abort a run on either executor path (§6.2 as
+   amended). `Broken` is not an invented state: it is the one meaningful half of the
+   "neither set" case the old two-optional shape allowed, given a name.
+2. **The union is three arms, not the two the spec names**, and the third is what lets
+   `result()` be total. With only `Ready | Pending` the None case would have to be either a
+   `Ready(None)` (the sentinel back again) or a raise at construction (item 1). The
+   `assert_never` in `result()` is licensed by plan 24 A1 — the subject is
+   `JobFuture.state`, a field this module writes and annotates, not a `param` read.
+   Measured rather than assumed: deleting the `Broken` arm yields
+   `error[type-assertion-failure] … Inferred type of argument is
+   'Broken & ~Ready & ~Pending'`, naming the forgotten variant.
+3. **`bencher.py`'s dispatch deliberately does *not* end in `assert_never`.** It matches
+   `Pending` and falls through on the default arm, because `job_future` arrives from an
+   untyped `list[tuple]` (plan 24 A1: exhaustiveness there would be an assertion, not a
+   proof) and because the default arm is real behaviour rather than a residual — `Ready`
+   (a cache hit) and `Broken` (a pool that fell back to serial and got `None`) both need
+   storing immediately.
+4. **The constructor keyword signature is kept**, so `FutureCache.submit`'s four call
+   sites and the two hand-built `JobFuture(job=…, res=…)` objects in
+   `test/test_collection_contract.py` (`:172`, `:307`) and one in
+   `test/test_sample_fault_tolerance.py:176` read unchanged. Both files stay **green
+   unmodified**, which is the point: they pin the #1032 disposition and would have been
+   the first thing to break if `Broken` had been given raise-at-construction semantics.
+   The one thing that changed at the boundary is that `res` **and** `future` together now
+   raises `ValueError`; nothing in the repo did that.
+5. **One ordering change was required in `store_results` and it is load-bearing.**
+   `require_worker_result` used to run *after* the `try/except catch` around
+   `job_result.result()`; now `result()` raises the violation itself, from inside that
+   `try`. Since `WorkerContractError` subclasses `TypeError`, an `except catch` with
+   `catch=Exception` listed first would absorb it — so `except WorkerContractError` is
+   ordered **before** `except catch`. `TestCatchDoesNotChangeContractHandling` fails
+   without that ordering, which is how it was found.
+6. **C8: `cached_property`, not a factory classmethod.** A factory leaves the plain
+   constructor reachable (`WorkerJob(...)` without `.setup_hashes()` was the defect), and
+   `__post_init__` would recompute hashes on every unpickle. `cached_property` makes the
+   unset state unrepresentable *and* keeps pickling working: computed values travel in
+   `__dict__`, unaccessed ones recompute deterministically because `hash_sha1` is
+   content-based. Verified against `TestWorkerJobPickle`.
+7. **Cache safety: hashes are byte-identical, no `CACHE_VERSION` bump.**
+   `function_input_signature_pure` is still `hash_sha1((sorted(function_input.items()),
+   tag))` over the same `function_input`, and `canonical_input` is still computed from the
+   swept dims *before* constants are merged — the ordering the old imperative
+   `setup_hashes()` relied on, now expressed as two independent properties that each
+   rebuild the pre-merge dict. `test/test_worker_job.py`'s hash assertions cover it.
+8. **`found_in_cache` and `msgs` were dead and are deleted.** Nothing in `bencher/` reads
+   or writes either; the only references were `test_worker_job.py`'s own default-checking
+   test. That test is replaced by one asserting the hashes exist from construction (the C8
+   property), and `test_msgs_lists_are_independent` — a `field(default_factory=list)`
+   regression test for a field that no longer exists — is dropped with it.
+9. **Both files are on the strict `ty` list, and getting them there fixed two live
+   defects P2 item 7 had recorded as out of scope.** `FutureCache.clear_tag` called
+   `self.cache.evict(tag)` unguarded on `Cache | None` (an `AttributeError` for anyone
+   with `cache_samples=False` clearing a tag), and `JobFunctionCache.call` passed
+   `self.call_count` — an `int` — as `Job.job_id`, declared `str`.
+10. **P2 item 7's prediction is confirmed exactly, so `result_collector.py` joins the
+   strict list too — three files, not the two P5's DoD names.** P2 measured 4 remaining
+   diagnostics and predicted "fixing [`WorkerJob`'s two-phase init] in P5 should let both
+   files onto the strict list in one step". Measured after this phase: adding
+   `bencher/result_collector.py` alongside the two P5 files gives `All checks passed!`.
+   Both `function_input`-is-`None` diagnostics (the `.items()` iteration and the
+   `record_caught_sample` argument) were the *same* defect C8 removed — `function_input`
+   is now `dict`, never `None`. It is added rather than deferred to P9/P12 because the
+   block's rule is "a file is added once it is clean", and it is.

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -849,7 +849,7 @@ is unaffected.
    So the old serial `assert` was not merely absent under `python -O`; with `catch=` set it
    was **downgraded to a tolerated sample failure**, which is the same silent-empty-dataset
    outcome as the parallel path. Both checks are therefore raised *outside*
-   `store_results`'s `except catch` block, and `TestCatchDoesNotAbsorbContractErrors` pins
+   `store_results`'s `except catch` block, and `TestCatchDoesNotChangeContractHandling` pins
    it — without that test the fix would have looked complete while the obvious user
    response (`catch=Exception`) restored the old behaviour.
 2. **The B3 check could not go where it naturally belongs.** `JobFuture.result()` is the
@@ -930,7 +930,7 @@ is unaffected.
    into the factory that constructs `Ready`". Read literally that reinstates the original
    B3 bug: the serial construction site (`FutureCache.submit`) runs *inside* the caller's
    `except catch` block, so a `raise` there is absorbed by `catch=Exception` — exactly the
-   failure mode P2 item 1 measured and `TestCatchDoesNotAbsorbContractErrors` pins. The
+   failure mode P2 item 1 measured and `TestCatchDoesNotChangeContractHandling` pins. The
    check therefore lives at construction as a **discovery**, not a disposition: "neither
    result nor future" parses to a third variant, `Broken(WorkerContractError)`, which
    stores the error and raises it from `result()` at the consume point. `store_results`
@@ -998,3 +998,62 @@ is unaffected.
    `record_caught_sample` argument) were the *same* defect C8 removed — `function_input`
    is now `dict`, never `None`. It is added rather than deferred to P9/P12 because the
    block's rule is "a file is added once it is clean", and it is.
+
+#### P5 review round (findings addressed before merge)
+
+Independent review returned MERGE WITH NITS after re-proving the §6.2 disposition across a
+12-case matrix (SERIAL/MULTIPROCESSING × `catch=()`/`catch=Exception` × `cache_samples`
+false/true) byte-for-byte against `main`, and proving cache keys identical two independent
+ways (cross-branch comparison of all four derived values over 10 edge cases; plus a 6-job
+sweep written by `main`'s code and read by P5's → 6/6 hits). One MEDIUM finding was real:
+
+11. **Moving the contract handler inside the `try` created a new serial↔parallel
+   divergence — the exact defect shape B3 exists to kill.** `except WorkerContractError`
+   around `result()` catches *any* such error surfacing from it, not only the one the
+   harness mints. `WorkerContractError` is public (`bencher/__init__.py`), so a worker can
+   raise it; measured, a worker doing so with `catch=()` **aborted on `main` and on SERIAL,
+   but completed with `n_failed=2` on MULTIPROCESSING** under P5 as first written. Loud or
+   silent chosen by an unrelated knob — here the executor rather than `catch=`.
+
+   Fixed by splitting the vocabulary: `WorkerReturnedNothingError(WorkerContractError)` is
+   the harness's *own* diagnosis, and `store_results` catches that narrow subclass ahead of
+   `except catch`. A worker-raised `WorkerContractError` falls through to `except catch`
+   exactly as before P5. Every existing `assertRaises(WorkerContractError)` still passes by
+   subclassing. `TestAWorkerRaisedContractErrorIsStillASampleFault` pins all four matrix
+   cells and was verified to fail on precisely the `pool` + `catch=()` cell when the
+   handler is widened back to the base class.
+
+   Worth recording as a general lesson: **the disposition split is a property of the
+   exception vocabulary, not of handler placement.** P5 moved a handler and silently
+   changed which errors it governed, because one class was doing two jobs.
+
+12. **Two of P5's own strict-ty fixes were type-true but defect-preserving, which is a
+   failure mode the ratchet invites.** `JobFunctionCache.call` passed `self.call_count`
+   (an `int`) as a `str` job id; P5 cast it to `str`. But `call_count` is initialised to 0
+   and was incremented **nowhere**, so every call produced the same id — and job ids are how
+   every log line and contract message identifies a sample. The cast made the annotation
+   true while hiding what it pointed at. Now incremented, ids read `call 1`, `call 2`, …
+   Likewise `clear_tag`'s `if self.cache is None: return` turned a live `AttributeError`
+   into a *silent* no-op on a public path; it now logs a WARNING. Both are pinned by tests
+   — a latent defect fixed without a pin can regress silently.
+
+13. **`Broken` was inferring a cause from a syntactic condition.** "Neither `res` nor
+   `future`" was mapped to an error reading "The benchmark function for job X returned
+   None", but that branch is also reached by a cache entry holding `None`. The constructor
+   now takes an optional `error=`, so `FutureCache.submit`'s serial site — the only place
+   that has actually watched `run_job` return `None` — names the cause, and the fallback
+   diagnosis says only what is known. The conflict check across the three arms uses
+   `is not None`, not truthiness, because `res={}` is a valid result.
+
+14. **Two justifications in P5 were factually wrong and are corrected (the code stands).**
+   Item 6 above rested the `cached_property`-over-`__post_init__` choice partly on
+   `WorkerJob` crossing a process boundary. **It does not** — only `Job` (function +
+   `job_args`) is pickled to an executor; a `WorkerJob` is built and consumed in the parent.
+   The choice is still right for the other reasons given (a factory leaves the plain
+   constructor reachable; `__post_init__` rehashes on every unpickle), and picklability
+   remains a worthwhile property test, but the claim was overstated in the docstring, in
+   `test/test_multiprocessing_executor.py`'s section comment, and here. Also fixed: this
+   plan cited `TestCatchDoesNotAbsorbContractErrors` at two places (one pre-existing at
+   §10 P2 item 1, one added by P5); the class is `TestCatchDoesNotChangeContractHandling`.
+   Per plans-README rule 7 the symbol is the durable reference, so a plan whose thesis is
+   "claims are measured" should not cite one that does not exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,9 @@ include = [
     "bencher/sweep_timings.py",
     "bencher/blob_store.py",
     "bencher/variables/results.py",
+    "bencher/job.py",
+    "bencher/worker_job.py",
+    "bencher/result_collector.py",
 ]
 [tool.ty.overrides.rules]
 invalid-assignment = "error"

--- a/test/test_collection_contract.py
+++ b/test/test_collection_contract.py
@@ -86,6 +86,22 @@ class ReturnsNothing(bn.ParametrizedSweep):
         # Deliberately no `return self.get_results_values_as_dict()`.
 
 
+class RaisesContractError(bn.ParametrizedSweep):
+    """A worker that raises ``WorkerContractError`` *itself*.
+
+    The class is public API (``bn.WorkerContractError``), so a worker or plugin can
+    raise it — e.g. to signal a hard configuration error and have ``catch=()``
+    abort the run. The harness must therefore not confuse it with its *own*
+    diagnosis that a job produced nothing, which is exempt from ``catch=``.
+    """
+
+    x = bn.IntSweep(default=0, bounds=(0, 1), samples=2)
+    y = bn.ResultFloat()
+
+    def benchmark(self) -> None:
+        raise bn.WorkerContractError("raised by the worker, not by the harness")
+
+
 def _contract_messages(record) -> list[str]:
     """The WorkerContractWarning messages out of a pytest.warns record.
 
@@ -247,13 +263,57 @@ class TestCatchDoesNotChangeContractHandling(unittest.TestCase):
         with pytest.warns(WorkerContractWarning):
             res = _run(ReturnsNothing(), catch=Exception)
         self.assertEqual(res.n_failed, 2)
-        self.assertIn("WorkerContractError", res.failed_samples[0].exception)
+        # The narrow subclass by name: this is the harness's own diagnosis, which is
+        # what earns the exemption from `catch=`. A worker-raised
+        # WorkerContractError would record as a plain sample fault instead --
+        # see TestAWorkerRaisedContractErrorIsStillASampleFault.
+        self.assertIn("WorkerReturnedNothingError", res.failed_samples[0].exception)
 
     def test_catch_does_not_swallow_a_wrong_length_vector(self) -> None:
         WrongLengthVec.n_elements = 1
         with pytest.warns(WorkerContractWarning):
             res = _run(WrongLengthVec(), catch=Exception)
         self.assertEqual(res.n_failed, 2)
+
+
+class TestAWorkerRaisedContractErrorIsStillASampleFault:
+    """The converse of the class above, and the reason ``store_results`` catches
+    ``WorkerReturnedNothingError`` rather than its public base class.
+
+    ``catch=`` must not decide the fate of the harness's *own* diagnosis that a job
+    produced nothing. It must still decide the fate of a ``WorkerContractError`` a
+    **worker** raises — that is an ordinary sample fault as far as dispositions go,
+    and it aborted with ``catch=()`` before plan 23 P5.
+
+    Pinned on **both** executors because the regression this guards against was
+    visible on only one of them: P5 first moved the handler inside the ``try``
+    around ``result()``, which caught every ``WorkerContractError`` surfacing from
+    it — so a worker-raised one aborted on SERIAL (where it is raised inside
+    ``submit()``, outside that ``try``) while being silently tolerated on
+    MULTIPROCESSING with ``catch=()``. Loud or silent chosen by an unrelated knob
+    is precisely the defect shape B3 exists to kill.
+    """
+
+    @pytest.mark.parametrize(
+        "executor", [Executors.SERIAL, Executors.MULTIPROCESSING], ids=["serial", "pool"]
+    )
+    def test_no_catch_aborts_on_either_executor(self, executor) -> None:
+        with pytest.raises(WorkerContractError, match="raised by the worker"):
+            _run(RaisesContractError(), executor=executor, catch=())
+
+    @pytest.mark.parametrize(
+        "executor", [Executors.SERIAL, Executors.MULTIPROCESSING], ids=["serial", "pool"]
+    )
+    def test_catch_tolerates_it_on_either_executor(self, executor) -> None:
+        """With ``catch=`` it is a tolerated sample fault, like any other raise."""
+        res = _run(RaisesContractError(), executor=executor, catch=Exception)
+        assert res.n_failed == 2
+        assert "raised by the worker" in res.failed_samples[0].exception
+
+    def test_the_harness_diagnosis_is_a_narrow_subclass(self) -> None:
+        """What makes the two dispositions separable at all."""
+        assert issubclass(bn.WorkerReturnedNothingError, bn.WorkerContractError)
+        assert not issubclass(bn.WorkerContractError, bn.WorkerReturnedNothingError)
 
 
 class TestContractViolationSurfaces(unittest.TestCase):

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import unittest
 from concurrent.futures import Future
@@ -9,12 +10,14 @@ from hypothesis import strategies as st
 import bencher as bn
 from bencher.job import (
     Broken,
+    FutureCache,
     Job,
     JobFunctionCache,
     JobFuture,
     Pending,
     Ready,
     WorkerContractError,
+    WorkerReturnedNothingError,
 )
 
 
@@ -133,11 +136,29 @@ class TestJobFutureState:
         future: Future = Future()
         assert JobFuture(job=_job(), future=future).state == Pending(future)
 
-    def test_both_at_once_is_rejected(self) -> None:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"res": {"y": 1.0}, "future": "future"},
+            {"res": {"y": 1.0}, "error": "error"},
+            {"future": "future", "error": "error"},
+        ],
+        ids=["res+future", "res+error", "future+error"],
+    )
+    def test_more_than_one_variant_at_once_is_rejected(self, kwargs) -> None:
         """Previously representable, never meaningful."""
-        future: Future = Future()
-        with pytest.raises(ValueError, match="both a result and a future"):
-            JobFuture(job=_job(), res={"y": 1.0}, future=future)
+        placeholders = {
+            "future": Future(),
+            "error": WorkerReturnedNothingError("boom"),
+        }
+        kwargs = {k: placeholders.get(v, v) if isinstance(v, str) else v for k, v in kwargs.items()}
+        with pytest.raises(ValueError, match="never more than one of the three"):
+            JobFuture(job=_job(), **kwargs)
+
+    def test_an_empty_dict_result_still_counts_as_given(self) -> None:
+        """`res={}` is falsy but a valid result, so the conflict check must see it."""
+        with pytest.raises(ValueError, match="never more than one of the three"):
+            JobFuture(job=_job(), res={}, future=Future())
 
     def test_resolving_does_not_change_the_variant(self) -> None:
         """The order-dependent read `bencher.py` used to do is now stable.
@@ -168,8 +189,8 @@ class TestJobFutureState:
 class TestJobFutureNoneReturn:
     """B3's disposition, preserved through the new type (plan 23 §6.2 as amended).
 
-    ``result()`` is total -- it no longer returns ``dict | None`` -- so a worker
-    that returned nothing raises ``WorkerContractError`` on *either* executor
+    ``result()`` is total -- it no longer returns ``dict | None`` -- so a job that
+    produced nothing raises ``WorkerReturnedNothingError`` on *either* executor
     path. ``store_results`` consumes that and records-and-continues; nothing
     here may abort a sweep on its own.
     """
@@ -177,25 +198,46 @@ class TestJobFutureNoneReturn:
     def test_neither_result_nor_future_is_broken(self) -> None:
         state = JobFuture(job=_job()).state
         assert isinstance(state, Broken)
-        assert isinstance(state.error, WorkerContractError)
+        assert isinstance(state.error, WorkerReturnedNothingError)
 
     def test_broken_raises_at_the_consume_point_not_at_construction(self) -> None:
         """Construction must stay quiet: the serial site is inside `except catch`."""
         job_future = JobFuture(job=_job("job-42"))  # no raise here
-        with pytest.raises(WorkerContractError, match="job-42"):
+        with pytest.raises(WorkerReturnedNothingError, match="job-42"):
             job_future.result()
+
+    def test_the_generic_diagnosis_does_not_blame_the_benchmark_function(self) -> None:
+        """This path cannot know the cause -- a cached None reaches it too.
+
+        Only ``FutureCache.submit``'s serial site and ``require_worker_result``
+        have actually observed a worker return ``None``, so only they say so.
+        """
+        with pytest.raises(WorkerReturnedNothingError) as exc_info:
+            JobFuture(job=_job()).result()
+        msg = str(exc_info.value)
+        assert "neither a result nor a pending future" in msg
+        assert "benchmark function" not in msg
+
+    def test_an_explicit_error_is_kept_verbatim(self) -> None:
+        """How the serial site names the cause it alone can see."""
+        error = WorkerReturnedNothingError("the worker returned None, and I saw it")
+        job_future = JobFuture(job=_job(), error=error)
+        assert job_future.state == Broken(error)
+        with pytest.raises(WorkerReturnedNothingError) as exc_info:
+            job_future.result()
+        assert exc_info.value is error
 
     def test_a_future_resolving_to_none_raises_too(self) -> None:
         """The pooled path: same error, same message, same job id."""
         future: Future = Future()
         future.set_result(None)
-        with pytest.raises(WorkerContractError, match="job-42"):
+        with pytest.raises(WorkerReturnedNothingError, match="job-42"):
             JobFuture(job=_job("job-42"), future=future).result()
 
     def test_a_broken_serial_result_is_never_cached(self) -> None:
         """Pre-P5 semantics preserved: `cache.set` only for a non-None result."""
         cache = _RecordingCache()
-        with pytest.raises(WorkerContractError):
+        with pytest.raises(WorkerReturnedNothingError):
             JobFuture(job=_job(), cache=cache).result()
         assert cache.sets == []
 
@@ -203,13 +245,70 @@ class TestJobFutureNoneReturn:
         cache = _RecordingCache()
         future: Future = Future()
         future.set_result(None)
-        with pytest.raises(WorkerContractError):
+        with pytest.raises(WorkerReturnedNothingError):
             JobFuture(job=_job(), future=future, cache=cache).result()
         assert cache.sets == []
 
     def test_an_empty_dict_is_a_valid_result(self) -> None:
         """A worker with no result vars returns ``{}`` -- falsy but not missing."""
         assert JobFuture(job=_job(), res={}).state == Ready({})
+
+    def test_a_worker_raised_contract_error_is_not_the_harness_diagnosis(self) -> None:
+        """The distinction store_results' handler ordering depends on.
+
+        A ``WorkerContractError`` from the worker propagates out of ``result()``
+        untouched; only ``WorkerReturnedNothingError`` is the harness's own verdict,
+        and only that one is exempt from ``catch=``.
+        """
+        future: Future = Future()
+        future.set_exception(WorkerContractError("raised by the worker"))
+        with pytest.raises(WorkerContractError, match="raised by the worker") as exc_info:
+            JobFuture(job=_job(), future=future).result()
+        assert not isinstance(exc_info.value, WorkerReturnedNothingError)
+
+
+class TestJobFunctionCacheJobIds:
+    """``call_count`` was initialised to 0 and incremented nowhere, so every
+    ``JobFunctionCache.call()`` produced the same job id -- and job ids are what
+    every log line and contract-violation message identifies a sample by."""
+
+    def test_each_call_gets_a_distinct_job_id(self) -> None:
+        seen = []
+        cache = JobFunctionCache(lambda **kw: dict(kw), cache_name="test_job_ids")
+        try:
+            cache.clear_cache()
+            for i in range(3):
+                seen.append(cache.call(var1=i).job.job_id)
+        finally:
+            cache.close()
+        assert len(set(seen)) == 3, seen
+        assert all(isinstance(job_id, str) for job_id in seen)
+
+
+class TestClearTagWithoutACache:
+    """``clear_tag`` on a cache-less FutureCache used to be an AttributeError.
+
+    Not crashing is right -- but it must not be *silent* either: the public route
+    (``Bench.clear_tag_from_sample_cache``) is reachable from user code, where
+    "nothing happened" must not read as "the tag was cleared".
+    """
+
+    def test_it_does_not_raise(self) -> None:
+        cache = FutureCache(cache_samples=False)
+        try:
+            cache.clear_tag("some_tag")  # used to be AttributeError on None
+        finally:
+            cache.close()
+
+    def test_it_warns_that_there_was_nothing_to_clear(self, caplog) -> None:
+        cache = FutureCache(cache_samples=False)
+        try:
+            with caplog.at_level(logging.WARNING, logger="bencher.job"):
+                cache.clear_tag("some_tag")
+        finally:
+            cache.close()
+        assert "some_tag" in caplog.text
+        assert "does not exist" in caplog.text
 
 
 if __name__ == "__main__":

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -1,11 +1,21 @@
 import random
 import unittest
+from concurrent.futures import Future
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import bencher as bn
-from bencher.job import JobFunctionCache
+from bencher.job import (
+    Broken,
+    Job,
+    JobFunctionCache,
+    JobFuture,
+    Pending,
+    Ready,
+    WorkerContractError,
+)
 
 
 class CachedParamExample(bn.ParametrizedSweep):
@@ -92,6 +102,114 @@ class TestJob(unittest.TestCase):
         bench_run.add_bench(CachedParamExample())
 
         bench_run.run(subsampling_divisions=2)
+
+
+class _RecordingCache:
+    """Minimal stand-in for diskcache.Cache recording only what was written."""
+
+    def __init__(self) -> None:
+        self.sets: list[tuple] = []
+
+    def set(self, key, value, tag=None) -> None:
+        self.sets.append((key, value, tag))
+
+
+def _job(job_id: str = "job-1") -> Job:
+    return Job(job_id=job_id, function=lambda **_: None, job_args={"x": 1}, tag="t")
+
+
+class TestJobFutureState:
+    """C2 (plan 23 P5): one field holding ``Ready | Pending | Broken``.
+
+    ``res``/``future`` used to be two independent optionals that ``result()``
+    *mutated*, so ``future is not None`` stopped meaning "pending" after the
+    first call, and both-set / neither-set were both representable.
+    """
+
+    def test_a_result_parses_to_ready(self) -> None:
+        assert JobFuture(job=_job(), res={"y": 1.0}).state == Ready({"y": 1.0})
+
+    def test_a_future_parses_to_pending(self) -> None:
+        future: Future = Future()
+        assert JobFuture(job=_job(), future=future).state == Pending(future)
+
+    def test_both_at_once_is_rejected(self) -> None:
+        """Previously representable, never meaningful."""
+        future: Future = Future()
+        with pytest.raises(ValueError, match="both a result and a future"):
+            JobFuture(job=_job(), res={"y": 1.0}, future=future)
+
+    def test_resolving_does_not_change_the_variant(self) -> None:
+        """The order-dependent read `bencher.py` used to do is now stable.
+
+        Pre-P5, ``result()`` assigned to ``self.res`` but left ``self.future``
+        set, so the meaning of a state read depended on whether ``result()``
+        had already been called.
+        """
+        future: Future = Future()
+        future.set_result({"y": 1.0})
+        job_future = JobFuture(job=_job(), future=future)
+        assert job_future.result() == {"y": 1.0}
+        assert job_future.state == Pending(future)
+
+    def test_a_ready_result_is_cached(self) -> None:
+        cache = _RecordingCache()
+        JobFuture(job=_job(), res={"y": 1.0}, cache=cache).result()
+        assert cache.sets == [(_job().job_key, {"y": 1.0}, "t")]
+
+    def test_a_pending_result_is_cached_on_resolve(self) -> None:
+        cache = _RecordingCache()
+        future: Future = Future()
+        future.set_result({"y": 2.0})
+        JobFuture(job=_job(), future=future, cache=cache).result()
+        assert cache.sets == [(_job().job_key, {"y": 2.0}, "t")]
+
+
+class TestJobFutureNoneReturn:
+    """B3's disposition, preserved through the new type (plan 23 §6.2 as amended).
+
+    ``result()`` is total -- it no longer returns ``dict | None`` -- so a worker
+    that returned nothing raises ``WorkerContractError`` on *either* executor
+    path. ``store_results`` consumes that and records-and-continues; nothing
+    here may abort a sweep on its own.
+    """
+
+    def test_neither_result_nor_future_is_broken(self) -> None:
+        state = JobFuture(job=_job()).state
+        assert isinstance(state, Broken)
+        assert isinstance(state.error, WorkerContractError)
+
+    def test_broken_raises_at_the_consume_point_not_at_construction(self) -> None:
+        """Construction must stay quiet: the serial site is inside `except catch`."""
+        job_future = JobFuture(job=_job("job-42"))  # no raise here
+        with pytest.raises(WorkerContractError, match="job-42"):
+            job_future.result()
+
+    def test_a_future_resolving_to_none_raises_too(self) -> None:
+        """The pooled path: same error, same message, same job id."""
+        future: Future = Future()
+        future.set_result(None)
+        with pytest.raises(WorkerContractError, match="job-42"):
+            JobFuture(job=_job("job-42"), future=future).result()
+
+    def test_a_broken_serial_result_is_never_cached(self) -> None:
+        """Pre-P5 semantics preserved: `cache.set` only for a non-None result."""
+        cache = _RecordingCache()
+        with pytest.raises(WorkerContractError):
+            JobFuture(job=_job(), cache=cache).result()
+        assert cache.sets == []
+
+    def test_a_future_resolving_to_none_is_never_cached(self) -> None:
+        cache = _RecordingCache()
+        future: Future = Future()
+        future.set_result(None)
+        with pytest.raises(WorkerContractError):
+            JobFuture(job=_job(), future=future, cache=cache).result()
+        assert cache.sets == []
+
+    def test_an_empty_dict_is_a_valid_result(self) -> None:
+        """A worker with no result vars returns ``{}`` -- falsy but not missing."""
+        assert JobFuture(job=_job(), res={}).state == Ready({})
 
 
 if __name__ == "__main__":

--- a/test/test_multiprocessing_executor.py
+++ b/test/test_multiprocessing_executor.py
@@ -295,12 +295,18 @@ class TestJobMultiprocessing:
 
 
 # ---------------------------------------------------------------------------
-# 3. WorkerJob hash + pickle (the dataclass sent alongside the Job)
+# 3. WorkerJob hash + pickle (the dataclass that accompanies the Job in-process)
 # ---------------------------------------------------------------------------
 
 
 class TestWorkerJobPickle:
-    """WorkerJob dataclass must be picklable with all value types."""
+    """WorkerJob dataclass must be picklable with all value types.
+
+    Note a ``WorkerJob`` is **not** actually sent to an executor -- only ``Job``
+    (function + ``job_args``) crosses the process boundary, and the ``WorkerJob``
+    is built and consumed in the parent. This is a property test on the dataclass
+    (it must hold every value type a sweep can produce without one of them
+    breaking pickling), not a test of a production serialization path."""
 
     def _make_worker_job(self, dims_name, function_input_vars, constant_inputs=None):
         job = WorkerJob(

--- a/test/test_multiprocessing_executor.py
+++ b/test/test_multiprocessing_executor.py
@@ -311,7 +311,9 @@ class TestWorkerJobPickle:
             bench_cfg_sample_hash="abc123",
             tag="test",
         )
-        job.setup_hashes()
+        # Touch the derived hashes so the pickle round-trip below covers them as
+        # populated cached_property values, not just lazy recomputation.
+        assert job.function_input_signature_pure
         return job
 
     def test_worker_job_with_string_values(self):

--- a/test/test_worker_job.py
+++ b/test/test_worker_job.py
@@ -14,8 +14,8 @@ def make_job(
     bench_cfg_sample_hash="sample_hash",
     tag="",
 ) -> WorkerJob:
-    """Construct a WorkerJob with setup_hashes() already applied."""
-    job = WorkerJob(
+    """Construct a WorkerJob."""
+    return WorkerJob(
         function_input_vars=list(function_input_vars),
         index_tuple=(0, 0),
         dims_name=list(dims_name),
@@ -23,15 +23,19 @@ def make_job(
         bench_cfg_sample_hash=bench_cfg_sample_hash,
         tag=tag,
     )
-    job.setup_hashes()
-    return job
 
 
-# ── construction defaults ───────────────────────────────────────────────────
+# ── construction ─────────────────────────────────────────────────────────────
 
 
-class TestWorkerJobDefaults:
-    def test_defaults_before_setup(self):
+class TestWorkerJobConstruction:
+    def test_hashes_exist_from_construction(self):
+        """C8 (plan 23 P5): no WorkerJob with unset hashes can exist.
+
+        These four used to be ``None``-default fields filled by a
+        ``setup_hashes()`` call every constructor site had to remember,
+        so nothing prevented caching under a ``None`` job key.
+        """
         job = WorkerJob(
             function_input_vars=[1],
             index_tuple=(0,),
@@ -40,21 +44,13 @@ class TestWorkerJobDefaults:
             bench_cfg_sample_hash="h",
             tag="",
         )
-        assert job.function_input is None
-        assert job.canonical_input is None
-        assert job.fn_inputs_sorted is None
-        assert job.function_input_signature_pure is None
-        assert job.found_in_cache is False
-        assert job.msgs == []
-
-    def test_msgs_lists_are_independent(self):
-        job_a = make_job()
-        job_b = make_job()
-        job_a.msgs.append("only on a")
-        assert job_b.msgs == []
+        assert job.function_input == {"x": 1}
+        assert job.canonical_input == (1,)
+        assert job.fn_inputs_sorted == [("x", 1)]
+        assert isinstance(job.function_input_signature_pure, str)
 
 
-# ── setup_hashes: function input construction ───────────────────────────────
+# ── derived inputs: function input construction ──────────────────────────────
 
 
 class TestFunctionInputConstruction:
@@ -86,7 +82,7 @@ class TestFunctionInputConstruction:
         assert job.fn_inputs_sorted == [("a", 3), ("x", 1), ("y", 2)]
 
 
-# ── setup_hashes: hash behavior ─────────────────────────────────────────────
+# ── derived hashes: hash behavior ─────────────────────────────────────────────
 
 
 class TestFunctionInputSignature:


### PR DESCRIPTION
Implements plan 23 P5 (C2 + C8) — `plans/23-constructive-data-modeling.md:207` (C2), `:247` (C8), `:513` (P5). Implementation notes recorded in that plan's §10 as `### P5 (implemented)`.

## C2 — `JobFuture` holds one state, not two optionals

`JobFuture.__init__` stored `res` and `future` as independent optionals and `result()` *mutated* `res` while leaving `future` set, so `future is not None` stopped meaning "pending" after the first call and both-set / neither-set were both representable.

- `bencher/job.py:233-268` — `Ready(res: dict)` | `Pending(future: Future)` | `Broken(error: WorkerReturnedNothingError)`, frozen dataclasses, aliased as `JobState`.
- `bencher/job.py:292` `JobFuture.__init__` — the keyword signature is preserved (`job`, `res`, `future`, `cache`), so `FutureCache.submit`'s sites and the three hand-built test objects read as before; the arguments are parsed into one `state` field at the boundary. At most one arm may be given — previously `res` and `future` together were representable and never meaningful.
- `bencher/job.py:341` `JobFuture.result()` — exhaustive `match` + `assert_never`, and **total**: the P2-era `-> dict | None` is gone.
- `bencher/bencher.py:1205` `Bench.calculate_benchmark_results` — the order-dependent `job_future.future is not None` read now matches on `job_future.state`.

### How this reconciles with #1029/#1032 (the part of P5's spec that had to change)

P5 says *"the worker-`None` check from P2 moves into the factory that constructs `Ready`"*. **Taken literally that reinstates the original B3 bug** and I did not do it: the serial construction site (`FutureCache.submit`) runs *inside* the caller's `except catch` block, so a `raise` at construction is absorbed by `catch=Exception` — precisely the failure mode plan 23 P2 item 1 measured and `TestCatchDoesNotChangeContractHandling` pins.

So the check lives at construction as a **discovery**, never as a disposition: a job with no result parses to `Broken`, which *stores* the error and raises it from `result()` at the consume point. **The #1032 disposition is unchanged** — `store_results` records a `SampleFailure`, logs at ERROR, emits `WorkerContractWarning`, leaves the cells at the missing sentinel, and the sweep continues. A `None` return still cannot abort a run on either executor path.

Two consequences worth flagging for review:

1. **`Broken` is a third arm the plan text does not name.** With only `Ready | Pending` the None case has to be either `Ready(None)` (the sentinel back again) or a raise at construction (above). `Broken` isn't invented state — it is the one *meaningful* half of the "neither set" case the old shape allowed, given a name. Its error is *supplied* by whichever caller knows the cause (`FutureCache.submit`'s serial site at `bencher/job.py:625`, having just watched `run_job` return `None`) rather than inferred from the shape of the constructor call, which cannot tell a `None`-returning worker from a cached `None`. `Broken.error` is typed `WorkerReturnedNothingError`, so a `Broken` carrying a worker's own exception is unrepresentable too.

2. **One ordering change in `store_results` (`bencher/result_collector.py:443-476`) is load-bearing, and the handler must be a NARROW subclass.** `require_worker_result` used to run *after* the `try/except catch`; now `result()` raises the violation from *inside* that `try`. The error subclasses `TypeError`, so `except catch` with `catch=Exception` would absorb it — the handler is therefore ordered **first**. Verified by swapping the two: `TestCatchDoesNotChangeContractHandling::test_catch_does_not_swallow_a_none_return` fails.

   Review caught the other half of this: catching the *public base class* `WorkerContractError` there silently tolerated a **worker-raised** one on the pooled path even with `catch=()` — aborting on SERIAL but completing with `n_failed=2` on MULTIPROCESSING, i.e. loud-or-silent chosen by the executor, the exact defect shape B3 exists to kill. Fixed by splitting the vocabulary: `WorkerReturnedNothingError` (`bencher/job.py:139`) is the harness's own diagnosis and the only thing exempt from `catch=`; a worker-raised `WorkerContractError` falls through to `except catch` as it did before P5. `TestAWorkerRaisedContractErrorIsStillASampleFault` (`test/test_collection_contract.py:279`) pins all four cells and was verified to fail on precisely the `pool` + `catch=()` cell when widened back to the base class. **The lesson: the disposition split is a property of the exception vocabulary, not of handler placement.**

`assert_never` is licensed by plan 24 A1 — the subject is `JobFuture.state`, a field this module writes and annotates, not a `param` read. Measured, not assumed: deleting the `Broken` arm gives `error[type-assertion-failure] … Inferred type of argument is 'Broken & ~Ready & ~Pending'`. Conversely `bencher.py`'s dispatch deliberately **does not** end in `assert_never` — `job_future` arrives from an untyped `list[tuple]` (A1: exhaustiveness there would be an assertion, not a proof), and its default arm is real behaviour rather than a residual.

Caching semantics preserved exactly: the pre-P5 `if self.cache is not None and self.res is not None` guard becomes `_cache_and_return`, reachable only with a non-`None` dict — enforced by construction rather than by a guard.

## C8 — `WorkerJob` cannot exist with unset hashes

`bencher/worker_job.py` — `function_input`, `canonical_input`, `fn_inputs_sorted` and `function_input_signature_pure` defaulted to `None` and were filled by `setup_hashes()`, which every construction site had to remember to call; nothing prevented caching a sample under `job_key=None`. They are now `cached_property`s and `setup_hashes()` is gone (its one production caller was in `bencher.py`'s job-building loop).

`cached_property` rather than the factory classmethod the plan also offers: a factory leaves the plain constructor reachable, which *was* the defect, and `__post_init__` would recompute hashes on every unpickle.

**Cache safety: no `CACHE_VERSION` bump.** `function_input_signature_pure` is still `hash_sha1((sorted(function_input.items()), tag))` over the same `function_input`, and `canonical_input` is still computed from the swept dims *before* constants are merged — the ordering the old imperative method relied on, now two independent properties that each rebuild the pre-merge dict. Proven byte-identical against `origin/main` for all four derived values over 10 edge cases (including `None` values, a list value, a const shadowing a swept dim, and an all-const job), and independently re-proven by review with an end-to-end sweep written by `main`'s code and read by this branch's → 6/6 cache hits.

`found_in_cache` and `msgs` are **deleted**: nothing in `bencher/` reads or writes either, and the only references were `test_worker_job.py`'s own default-checking test.

## Strict `ty` list: succeeded, and for three files rather than two

`pyproject.toml:320-331` — `bencher/job.py`, `bencher/worker_job.py` **and** `bencher/result_collector.py`. `pixi run ty` is `All checks passed!` with all three listed, so the block's "added only once clean" rule is honoured, not loosened.

`result_collector.py` is the bonus: plan 23 P2 item 7 recorded 4 remaining diagnostics and predicted *"fixing [WorkerJob's two-phase init] in P5 should let both files onto the strict list in one step"*. **Confirmed** — both `function_input`-is-`None` diagnostics were the same defect C8 removed. Getting there also surfaced two live defects P2 had recorded as out of scope, and in both cases the fix goes **past** what the checker asked for, because the narrowest change would have hidden the defect it pointed at:

- `bencher/job.py:655` `FutureCache.clear_tag` called `self.cache.evict(tag)` unguarded on `Cache | None` — an `AttributeError` for anyone with `cache_samples=False` clearing a tag. Now guarded *and* logging a WARNING: on a public path (`Bench.clear_tag_from_sample_cache`) a silent no-op must not read as "the tag was cleared".
- `bencher/job.py:743` `JobFunctionCache.call` passed `self.call_count` (an `int`) as `Job.job_id`, declared `str`. But `call_count` was initialised to 0 and incremented **nowhere**, so every call produced the same job id — the string every log line and contract message identifies a sample by. Casting alone would have made the annotation true while preserving that; it is now incremented (`call 1`, `call 2`, …). Cache keys are unaffected: `Job.job_key` derives from `job_args`, never `job_id`.

## Falsified plan claims

1. **P5's "the worker-`None` check moves into the factory that constructs `Ready`" is wrong as written** — see above. The check's *location* moved as the plan intended; its *disposition* could not, and a literal reading reintroduces the bug #1029/#1032 fixed.
2. **P5's `Ready | Pending` is not sufficient** — the union needs a third arm for `result()` to be total without a sentinel.
3. **P5's DoD understates the strict-list win** — it names two files; three are clean, exactly as P2 item 7 predicted.
4. **The pre-P5 `dict | None` docstring on `result()` claimed only P5's split could remove the `| None`.** True, and now done — but the removal came with the `Broken` arm the docstring did not anticipate.
5. **P5's own first implementation claimed `WorkerJob` crosses a process boundary; it does not.** Only `Job` (function + `job_args`) is submitted to an executor — a `WorkerJob` is built and consumed in the parent. The `cached_property` choice stands on its other reasons; the claim is corrected in the docstring, the test comment, and plan §10.
6. **This plan cited a test class that does not exist** — `TestCatchDoesNotAbsorbContractErrors` at two places (one pre-existing, one added here). The class is `TestCatchDoesNotChangeContractHandling`. Per plans-README rule 7 the symbol is the durable reference, so a plan whose thesis is "claims are measured" should not cite one that isn't there.

## Tests

`test/test_sample_fault_tolerance.py`, `test/test_sample_cache.py` and `test/test_cache_management.py` are **unchanged** — they pin the #1032 disposition and were the acceptance criterion for `Broken`'s semantics.

`test/test_collection_contract.py` gains the review's matrix (`TestAWorkerRaisedContractErrorIsStillASampleFault` + a module-level `RaisesContractError` worker so it pickles for the pool). **One existing assertion in it changed**, flagged rather than buried: `test_catch_does_not_swallow_a_none_return` did a `repr()` substring check for `"WorkerContractError"`, and the recorded class is now the narrower `WorkerReturnedNothingError`. It asserts the narrower name — strictly stronger, and it keeps the property the test exists for. Its wrong-length-vec sibling still checks the base class and still passes, since `_store_result_vars` raises that.

Otherwise changed only where the removed API was referenced:
- `test/test_worker_job.py` — `make_job` drops its `setup_hashes()` call; `test_defaults_before_setup` (asserting the four fields are `None`) is replaced by `test_hashes_exist_from_construction`; `test_msgs_lists_are_independent` (a `default_factory` regression test for a field that no longer exists) is dropped with `msgs`.
- `test/test_multiprocessing_executor.py` — `setup_hashes()` call replaced by touching `function_input_signature_pure`, so the pickle round-trip covers *populated* cached values rather than only lazy recomputation. Kept as a property test, with its "sent alongside the Job" comment corrected.

New in `test/test_job.py`: `TestJobFutureState` (variant parsing; every conflicting pair rejected; `res={}` still counts as given; the variant does not change on resolve — the property `bencher.py`'s old read lacked; caching on both paths), `TestJobFutureNoneReturn` (`Broken` stays quiet at construction and raises at the consume point; the generic diagnosis does not blame the benchmark function; an explicit error is kept verbatim; never cached; a worker-raised `WorkerContractError` is *not* the harness diagnosis), `TestJobFunctionCacheJobIds` and `TestClearTagWithoutACache`.

Verified with a private temp root (`TMPDIR=$(mktemp -d) PYTEST_DEBUG_TEMPROOT=$TMPDIR`): `pixi run ci` **2616 passed, 3 skipped**, no collection errors; `pixi run test-split` 2616 passed; pylint 10.00/10; `ty` clean; `prek` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
