### PR TITLE
refactor: history event kinds and reset policy as enums (plan 23 P7)

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -170,7 +170,7 @@ from .cache_management import (
     print_orphaned_blobs,
 )
 from .git_info import git_time_event
-from .history import HistoryEvent, HistoryResetError
+from .history import HistoryEvent, HistoryEventKind, HistoryResetError, OnHistoryReset
 from .perf_tracker import PerfReport, PerfTracker
 from .plotting.plot_filter import PlotFilter, VarRange
 from .regression import (

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -13,6 +13,7 @@ import param
 from strenum import LowercaseStrEnum
 
 from bencher.cache_management import CACHE_VERSION
+from bencher.history import OnHistoryReset
 from bencher.job import Executors
 from bencher.results.composable_container.composable_container_base import PaneLayout
 from bencher.results.laxtex_result import to_latex
@@ -388,8 +389,8 @@ class BenchRunCfg(BenchPlotSrvCfg):
     clear_history: bool = param.Boolean(False, doc="Clear historical results")
 
     on_history_reset: str = param.Selector(
-        default="warn",
-        objects=["warn", "error", "ignore"],
+        default=OnHistoryReset.WARN,
+        objects=list(OnHistoryReset),
         doc="Policy for history-affecting schema changes detected at history-load "
         "time (a result column removed or redefined, or the whole history "
         "orphaned by an input/const change). 'warn' (default): log a WARNING "

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -25,6 +25,7 @@ from bencher.bench_cfg import BenchCfg, BenchRunCfg
 from bencher.bench_plot_server import BenchPlotServer
 from bencher.bench_report import BenchReport
 from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES, ensure_cache_version
+from bencher.history import OnHistoryReset
 from bencher.history import config_summary as history_config_summary
 from bencher.job import (
     Executors,
@@ -516,6 +517,14 @@ class Bench(BenchPlotServer):
         # compared with both `==` and `is` further down. Assigning the member back
         # makes the field's type true for every reader.
         run_cfg.executor = normalize_executor(run_cfg.executor)
+        # Same reasoning again for `on_history_reset` (plan 23 P7): the policy is
+        # only consumed by load_history_cache, which runs *after*
+        # calculate_benchmark_results and before cache_results -- so parsing it
+        # there would raise on a bad value only once every sample had already been
+        # collected and (with cache_samples off by default) thrown away. Parsing
+        # here moves that config error ahead of all sampling. Assigning the member
+        # back also makes the field's type true for every downstream reader.
+        run_cfg.on_history_reset = OnHistoryReset(run_cfg.on_history_reset)
 
         if run_cfg.only_plot:
             run_cfg.cache_results = True
@@ -1010,13 +1019,18 @@ class Bench(BenchPlotServer):
         max_time_events: int | None = None,
         result_vars: list | None = None,
         *,
-        on_history_reset: str = "warn",
+        on_history_reset: OnHistoryReset | str = OnHistoryReset.WARN,
         bench_name: str | None = None,
         tag: str | None = None,
         series_id: str | None = None,
         config_summary: dict | None = None,
     ) -> xr.Dataset:
-        """Load, reconcile, and persist historical benchmark data from cache."""
+        """Load, reconcile, and persist historical benchmark data from cache.
+
+        Raises:
+            ValueError: If ``on_history_reset`` is not an ``OnHistoryReset``
+                member or one of its values.
+        """
         return self._collector.load_history_cache(
             dataset,
             bench_cfg_hash,

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -104,6 +104,21 @@ class HistoryEvent:
     detail: str
     column: str | None = None
 
+    def __post_init__(self) -> None:
+        """Coerce ``kind`` to a ``HistoryEventKind``, raising on an unknown value.
+
+        ``HistoryEvent`` is exported public API, so ``kind`` can arrive as a raw
+        string from outside this module. Parsing here is what makes ``lossy``'s
+        ``assert_never`` arm *provably* dead rather than merely unreached: a bad
+        kind raises a ``ValueError`` naming it, instead of the misdirecting
+        "Expected code to be unreachable" that plan 24 A1 warns about. Valid
+        raw strings (``"full_reset"``) keep working and become members.
+
+        Raises:
+            ValueError: If ``kind`` is not a ``HistoryEventKind`` member or value.
+        """
+        self.kind = HistoryEventKind(self.kind)
+
     @property
     def lossy(self) -> bool:
         """True when the event removes data from what consumers will see.
@@ -111,7 +126,8 @@ class HistoryEvent:
         Exhaustive over ``HistoryEventKind``: a new kind must be classified
         here before it can exist, where the old ``_LOSSY_KINDS`` set silently
         treated an unlisted (or typo'd) kind as non-lossy, defeating the
-        ``on_history_reset='error'`` CI gate.
+        ``on_history_reset='error'`` CI gate. ``__post_init__`` guarantees the
+        subject is a member, so the final arm is dead by construction.
         """
         match self.kind:
             case (

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -40,10 +40,11 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, assert_never
 
 import numpy as np
 import xarray as xr
+from strenum import StrEnum
 
 from bencher.utils import hash_sha1
 from bencher.variables.results import (
@@ -63,7 +64,32 @@ HISTORY_FORMAT = 1
 # Absent for columns as old as the history itself.
 BIRTH_ATTR = "history_birth"
 
-_LOSSY_KINDS = frozenset({"full_reset", "column_dormant", "column_retired", "history_discarded"})
+
+class HistoryEventKind(StrEnum):
+    """Kind of schema-affecting event detected while loading over_time history.
+
+    Runtime-only: kinds are produced inside :mod:`bencher.history` and
+    ``ResultCollector`` and consumed by ``apply_policy`` in the same run; no
+    kind string is ever persisted into a history record. Explicit lowercase
+    values rather than ``auto()``: ``strenum``'s ``auto()`` yields the member
+    *name* verbatim, which would change these to uppercase (plan 23 D4).
+    """
+
+    FULL_RESET = "full_reset"
+    HISTORY_RENAMED = "history_renamed"
+    COLUMN_BORN = "column_born"
+    COLUMN_DORMANT = "column_dormant"
+    COLUMN_RETIRED = "column_retired"
+    COLUMN_RESUMED = "column_resumed"
+    HISTORY_DISCARDED = "history_discarded"
+
+
+class OnHistoryReset(StrEnum):
+    """Policy for surfacing lossy history events (``BenchRunCfg.on_history_reset``)."""
+
+    WARN = "warn"
+    ERROR = "error"
+    IGNORE = "ignore"
 
 
 class HistoryResetError(Exception):
@@ -74,15 +100,35 @@ class HistoryResetError(Exception):
 class HistoryEvent:
     """One schema-affecting event detected while loading over_time history."""
 
-    kind: str  # full_reset | history_renamed | column_born | column_dormant |
-    #            column_retired | column_resumed | history_discarded
+    kind: HistoryEventKind
     detail: str
     column: str | None = None
 
     @property
     def lossy(self) -> bool:
-        """True when the event removes data from what consumers will see."""
-        return self.kind in _LOSSY_KINDS
+        """True when the event removes data from what consumers will see.
+
+        Exhaustive over ``HistoryEventKind``: a new kind must be classified
+        here before it can exist, where the old ``_LOSSY_KINDS`` set silently
+        treated an unlisted (or typo'd) kind as non-lossy, defeating the
+        ``on_history_reset='error'`` CI gate.
+        """
+        match self.kind:
+            case (
+                HistoryEventKind.FULL_RESET
+                | HistoryEventKind.COLUMN_DORMANT
+                | HistoryEventKind.COLUMN_RETIRED
+                | HistoryEventKind.HISTORY_DISCARDED
+            ):
+                return True
+            case (
+                HistoryEventKind.HISTORY_RENAMED
+                | HistoryEventKind.COLUMN_BORN
+                | HistoryEventKind.COLUMN_RESUMED
+            ):
+                return False
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 def data_var_columns(result_vars: list | None) -> dict[str, Any]:
@@ -285,7 +331,7 @@ def reconcile(
             else:
                 events.append(
                     HistoryEvent(
-                        "column_born",
+                        HistoryEventKind.COLUMN_BORN,
                         f"result column '{name}' added; earlier history is backfilled "
                         f"as missing and its regression baseline starts now",
                         column=name,
@@ -301,7 +347,7 @@ def reconcile(
             if was_dormant:
                 events.append(
                     HistoryEvent(
-                        "column_resumed",
+                        HistoryEventKind.COLUMN_RESUMED,
                         f"result column '{name}' returned with the same identity; "
                         f"its earlier history resumes",
                         column=name,
@@ -316,7 +362,7 @@ def reconcile(
             columns[name] = column_meta(rv, name, birth_val)
             events.append(
                 HistoryEvent(
-                    "column_retired",
+                    HistoryEventKind.COLUMN_RETIRED,
                     f"result column '{name}' changed identity "
                     f"(class/units/meaning_version); {n_history} historical events "
                     f"retired to '{mangled}' and the column restarts",
@@ -327,7 +373,7 @@ def reconcile(
             meta["dormant"] = False
             events.append(
                 HistoryEvent(
-                    "column_resumed",
+                    HistoryEventKind.COLUMN_RESUMED,
                     f"result column '{name}' returned with the same identity; "
                     f"its earlier history resumes",
                     column=name,
@@ -352,7 +398,7 @@ def reconcile(
         }
         events.append(
             HistoryEvent(
-                "column_dormant",
+                HistoryEventKind.COLUMN_DORMANT,
                 f"result column '{name}' from a record predating column tracking is "
                 f"absent from the config; {n_history} historical events retained "
                 f"(dormant) and will resume if it returns",
@@ -365,7 +411,7 @@ def reconcile(
             meta["dormant"] = True
             events.append(
                 HistoryEvent(
-                    "column_dormant",
+                    HistoryEventKind.COLUMN_DORMANT,
                     f"result column '{name}' removed from the config; {n_history} "
                     f"historical events retained (dormant) and will resume if it "
                     f"returns with the same identity",
@@ -427,7 +473,7 @@ def project(merged: xr.Dataset, current_cols: dict[str, Any], columns_meta: dict
     return served
 
 
-def apply_policy(events: list[HistoryEvent], policy: str) -> None:
+def apply_policy(events: list[HistoryEvent], policy: OnHistoryReset | str) -> None:
     """Surface history events according to on_history_reset.
 
     Informational events (born, resumed) always log at INFO. Lossy events
@@ -435,15 +481,30 @@ def apply_policy(events: list[HistoryEvent], policy: str) -> None:
     policy='error' they raise HistoryResetError — callers must apply the
     policy *before* persisting the merged record so an erroring CI run does
     not advance history state; policy='ignore' logs at DEBUG.
+
+    Raises:
+        ValueError: If ``policy`` is not an ``OnHistoryReset`` member or one of
+            its values. The policy string is a trust boundary (it arrives from
+            user config), so an unknown value must raise rather than silently
+            meaning "ignore" as it used to (plan 24 §3).
     """
+    # Parse first, so the match below is over a value whose type is established
+    # rather than over a raw string (plan 24 A1/A2).
+    normalized = OnHistoryReset(policy)
     for event in events:
         if not event.lossy:
             logger.info("history: %s", event.detail)
     lossy = [e for e in events if e.lossy]
     if not lossy:
         return
-    if policy == "error":
-        raise HistoryResetError("; ".join(e.detail for e in lossy))
-    log = logger.warning if policy == "warn" else logger.debug
+    match normalized:
+        case OnHistoryReset.ERROR:
+            raise HistoryResetError("; ".join(e.detail for e in lossy))
+        case OnHistoryReset.WARN:
+            log = logger.warning
+        case OnHistoryReset.IGNORE:
+            log = logger.debug
+        case _ as unreachable:
+            assert_never(unreachable)
     for event in lossy:
         log("history: %s", event.detail)

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -26,6 +26,8 @@ from bencher.cache_management import DEFAULT_CACHE_SIZE_BYTES
 from bencher.history import (
     HISTORY_FORMAT,
     HistoryEvent,
+    HistoryEventKind,
+    OnHistoryReset,
     apply_policy,
     column_meta,
     current_time_value,
@@ -653,7 +655,7 @@ class ResultCollector:
             if adopted is not None:
                 events.append(
                     HistoryEvent(
-                        "history_renamed",
+                        HistoryEventKind.HISTORY_RENAMED,
                         f"over_time history adopted for series '{series_id}': the "
                         f"history key moved from {old_key} to {bench_cfg_hash} with an "
                         f"unchanged declaration (benchmark '{bench_name}', tag "
@@ -672,7 +674,7 @@ class ResultCollector:
             + f"; {last.get('events', '?')} historical events are "
             f"orphaned under the old key"
         )
-        events.append(HistoryEvent("full_reset", detail))
+        events.append(HistoryEvent(HistoryEventKind.FULL_RESET, detail))
         return None
 
     def _load_history_record(self, cache: Cache, bench_cfg_hash: str) -> dict | None:
@@ -717,7 +719,7 @@ class ResultCollector:
         max_time_events: int | None = None,
         result_vars: list | None = None,
         *,
-        on_history_reset: str = "warn",
+        on_history_reset: OnHistoryReset | str = OnHistoryReset.WARN,
         bench_name: str | None = None,
         tag: str | None = None,
         series_id: str | None = None,
@@ -743,8 +745,10 @@ class ResultCollector:
             result_vars (list | None): Result variable instances defining the served
                 columns. Also used for per-variable ``max_time_events`` aging. When
                 None, column reconciliation and projection are skipped entirely.
-            on_history_reset (str): Policy for loss-y schema events — "warn",
-                "error" (raise HistoryResetError before persisting), or "ignore".
+            on_history_reset (OnHistoryReset | str): Policy for loss-y schema
+                events — "warn", "error" (raise HistoryResetError before
+                persisting), or "ignore". Any other value raises ValueError
+                at the parse, before the cache is touched.
             bench_name (str | None): Benchmark name, used in event messages and as
                 half of the legacy index key read during the one-release upgrade.
             tag (str | None): Benchmark tag, same two uses as bench_name.
@@ -761,6 +765,10 @@ class ResultCollector:
             xr.Dataset: The current config's view of the accumulated history —
                 historical plus current data, projected onto the current columns.
         """
+        # Parse the policy up front: it arrives as user config (a trust
+        # boundary), so an unknown value must raise here — before any cache
+        # read or write — instead of silently meaning "ignore" as it used to.
+        policy = OnHistoryReset(on_history_reset)
         c = self.get_history_cache()
         # An explicit series_id wins; otherwise the series is bench_name:tag, which
         # is what the index was keyed on before series_id existed. Deriving it here
@@ -799,7 +807,7 @@ class ResultCollector:
                 if incompatible:
                     events.append(
                         HistoryEvent(
-                            "history_discarded",
+                            HistoryEventKind.HISTORY_DISCARDED,
                             f"Discarding incompatible historical data ({incompatible})",
                         )
                     )
@@ -817,7 +825,7 @@ class ResultCollector:
 
         # Policy runs before anything is persisted so on_history_reset="error"
         # leaves the stored history untouched for the next (acknowledged) run.
-        apply_policy(events, on_history_reset)
+        apply_policy(events, policy)
 
         if (
             max_time_events is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ include = [
     "bencher/sweep_timings.py",
     "bencher/blob_store.py",
     "bencher/variables/results.py",
+    "bencher/history.py",
 ]
 [tool.ty.overrides.rules]
 invalid-assignment = "error"

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -11,6 +11,7 @@ import shutil
 import tempfile
 import unittest
 import uuid
+from typing import ClassVar
 
 import numpy as np
 import xarray as xr
@@ -454,9 +455,16 @@ class TestResetPolicy(ReconcilerBase):
 
     def test_unknown_policy_raises_before_touching_the_cache(self):
         """An unknown policy string used to silently mean 'ignore'; now it is a
-        config error raised at the parse, before any cache read or write."""
+        config error raised at the parse, before any history-cache read or write.
+
+        Keep the invalid value out of codespell's dictionary. A plausible
+        misspelling of a policy name is usually a dictionary entry, and the
+        repo's hook runs with --write-changes: it would rewrite the value here
+        into the correctly-spelled *valid* policy, silently turning this
+        assertion into one that can never fail.
+        """
         with self.assertRaises(ValueError):
-            self.load(["a"], 1, [_result_float("a")], on_history_reset="ignroe")
+            self.load(["a"], 1, [_result_float("a")], on_history_reset="silently-ignore")
         # nothing was persisted: the bad-config run advanced no history state
         cache = self.collector.get_history_cache()
         self.assertNotIn(self.key, cache)
@@ -515,6 +523,102 @@ class TestEventKindLossiness(unittest.TestCase):
     def test_apply_policy_rejects_unknown_policy_even_with_no_events(self):
         with self.assertRaises(ValueError):
             apply_policy([], "silently-ignore")
+
+    def test_raw_string_kinds_are_parsed_to_members(self):
+        """HistoryEvent is public API; a valid raw-string kind still classifies."""
+        for kind in HistoryEventKind:
+            with self.subTest(kind=kind):
+                event = HistoryEvent(str(kind), "from a raw string")
+                self.assertIs(event.kind, kind)
+                self.assertEqual(event.lossy, HistoryEvent(kind, "x").lossy)
+
+    def test_unknown_kind_raises_naming_the_value(self):
+        """A bad kind is a ValueError naming it, not the misdirecting
+        "Expected code to be unreachable" of a reached assert_never arm."""
+        with self.assertRaises(ValueError) as ctx:
+            HistoryEvent("not_a_real_kind", "detail")
+        self.assertIn("not_a_real_kind", str(ctx.exception))
+
+
+class _CountingSweep(bn.ParametrizedSweep):
+    """Module-level (so results stay pickleable) sweep that records each sample."""
+
+    calls: ClassVar[list] = []
+
+    x = bn.FloatSweep(default=0.0, bounds=[0.0, 1.0])
+    out = bn.ResultFloat()
+
+    def benchmark(self):
+        _CountingSweep.calls.append(self.x)
+        return {"out": self.x}
+
+
+class TestPolicyVocabularySingleSource(unittest.TestCase):
+    """The policy vocabulary is defined once, by OnHistoryReset (plan 23 §9)."""
+
+    def setUp(self):
+        self._old_cwd = os.getcwd()
+        self._tmp = tempfile.mkdtemp()
+        os.chdir(self._tmp)
+        _CountingSweep.calls = []
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_run_cfg_selector_objects_come_from_the_enum(self):
+        """The Selector's objects must be the enum *members*, not equal strings.
+
+        Asserting equality alone would not gate this: OnHistoryReset is a
+        StrEnum, so a hardcoded ["warn", "error", "ignore"] compares equal to
+        list(OnHistoryReset). Only an identity/type check catches a second,
+        drifting definition of the vocabulary.
+        """
+        objects = list(BenchRunCfg.param.on_history_reset.objects)
+        self.assertEqual(objects, list(OnHistoryReset))
+        for obj in objects:
+            self.assertIsInstance(obj, OnHistoryReset)
+
+    def test_run_cfg_default_is_an_enum_member(self):
+        self.assertIs(BenchRunCfg().on_history_reset, OnHistoryReset.WARN)
+
+    def test_plot_sweep_normalizes_a_string_policy_to_a_member(self):
+        """plot_sweep assigns the member back, so downstream readers see the enum.
+
+        This is the half of the fix that param cannot provide: a raw string
+        passes the Selector (StrEnum members compare equal to their values), so
+        without the normalization the field stays a ``str`` all the way into
+        ``load_history_cache``.
+        """
+        bench = bn.Bench("policy-normalize", _CountingSweep())
+        run_cfg = BenchRunCfg(over_time=True, repeats=1, on_history_reset="ignore")
+        bench.plot_sweep(input_vars=[_CountingSweep.param.x], run_cfg=run_cfg)
+        self.assertIs(run_cfg.on_history_reset, OnHistoryReset.IGNORE)
+        self.assertTrue(_CountingSweep.calls, "the sweep should have run")
+
+    def test_bad_policy_raises_before_any_sample_is_collected(self):
+        """A bad policy must never cost a fully-collected run.
+
+        ``load_history_cache`` runs *after* ``calculate_benchmark_results`` and
+        before ``cache_results``, and ``cache_samples`` defaults False — so a
+        parse that only happened there would discard every sample it just paid
+        for. Two independent guards now sit ahead of sampling: param's own
+        Selector check (whose vocabulary is the enum, per the test above) and
+        ``plot_sweep``'s normalization. This disables the former on both config
+        classes to prove the latter alone is early enough.
+        """
+        bench = bn.Bench("policy-presample", _CountingSweep())
+        run_cfg = BenchRunCfg(over_time=True, repeats=1)
+        run_params = (run_cfg.param.on_history_reset, BenchCfg.param.on_history_reset)
+        for p in run_params:
+            p.check_on_set = False
+        self.addCleanup(lambda: [setattr(p, "check_on_set", True) for p in run_params])
+        run_cfg.on_history_reset = "silently-ignore"
+        with self.assertRaises(ValueError):
+            bench.plot_sweep(input_vars=[_CountingSweep.param.x], run_cfg=run_cfg)
+        self.assertEqual(
+            _CountingSweep.calls, [], "samples were collected before the policy was parsed"
+        )
 
 
 class TestYoungBaselineGating(unittest.TestCase):

--- a/test/test_history_reconciliation.py
+++ b/test/test_history_reconciliation.py
@@ -19,7 +19,11 @@ import bencher as bn
 from bencher.bench_cfg import BenchCfg, BenchRunCfg
 from bencher.history import (
     BIRTH_ATTR,
+    HistoryEvent,
+    HistoryEventKind,
     HistoryResetError,
+    OnHistoryReset,
+    apply_policy,
     column_identity,
     data_var_columns,
     legacy_last_seen_key,
@@ -447,6 +451,70 @@ class TestResetPolicy(ReconcilerBase):
             self.load(
                 ["a", "c"], 2, [_result_float("a"), _result_float("c")], on_history_reset="error"
             )
+
+    def test_unknown_policy_raises_before_touching_the_cache(self):
+        """An unknown policy string used to silently mean 'ignore'; now it is a
+        config error raised at the parse, before any cache read or write."""
+        with self.assertRaises(ValueError):
+            self.load(["a"], 1, [_result_float("a")], on_history_reset="ignroe")
+        # nothing was persisted: the bad-config run advanced no history state
+        cache = self.collector.get_history_cache()
+        self.assertNotIn(self.key, cache)
+        ls_key = legacy_last_seen_key(self.kwargs["bench_name"], self.kwargs["tag"])
+        self.assertIsNone(cache.get(ls_key))
+
+    def test_enum_policy_value_accepted(self):
+        served = self.load(["a"], 1, [_result_float("a")], on_history_reset=OnHistoryReset.ERROR)
+        self.assertEqual(set(served.data_vars), {"a"})
+
+
+class TestEventKindLossiness(unittest.TestCase):
+    """Every HistoryEventKind is classified through apply_policy under 'error'.
+
+    Exhaustive over the enum: adding a kind without classifying it in
+    ``HistoryEvent.lossy`` fails here (and in ty's exhaustiveness check)
+    instead of silently defeating the on_history_reset='error' CI gate the
+    way the old ``_LOSSY_KINDS`` set did for a typo'd kind.
+    """
+
+    LOSSY = frozenset(
+        {
+            HistoryEventKind.FULL_RESET,
+            HistoryEventKind.COLUMN_DORMANT,
+            HistoryEventKind.COLUMN_RETIRED,
+            HistoryEventKind.HISTORY_DISCARDED,
+        }
+    )
+    NON_LOSSY = frozenset(
+        {
+            HistoryEventKind.HISTORY_RENAMED,
+            HistoryEventKind.COLUMN_BORN,
+            HistoryEventKind.COLUMN_RESUMED,
+        }
+    )
+
+    def test_partition_covers_every_kind(self):
+        self.assertEqual(self.LOSSY | self.NON_LOSSY, set(HistoryEventKind))
+        self.assertEqual(self.LOSSY & self.NON_LOSSY, set())
+
+    def test_lossy_kinds_raise_under_error_policy(self):
+        for kind in self.LOSSY:
+            with self.subTest(kind=kind):
+                event = HistoryEvent(kind, f"synthetic {kind} event")
+                self.assertTrue(event.lossy)
+                with self.assertRaises(HistoryResetError):
+                    apply_policy([event], "error")
+
+    def test_non_lossy_kinds_pass_under_error_policy(self):
+        for kind in self.NON_LOSSY:
+            with self.subTest(kind=kind):
+                event = HistoryEvent(kind, f"synthetic {kind} event")
+                self.assertFalse(event.lossy)
+                apply_policy([event], "error")  # must not raise
+
+    def test_apply_policy_rejects_unknown_policy_even_with_no_events(self):
+        with self.assertRaises(ValueError):
+            apply_policy([], "silently-ignore")
 
 
 class TestYoungBaselineGating(unittest.TestCase):


### PR DESCRIPTION
Implements **plan 23 P7 (C5)** — `plans/23-constructive-data-modeling.md` §3 C5, §5 P7.

## The defect

`HistoryEvent.kind` was a bare `str` whose 7 legal values existed only in a
trailing comment (`bencher/history.py:77-78`), and `lossy` was set membership in
`_LOSSY_KINDS` (`:66`) which listed only 4 of the 7. A typo'd kind — or a newly
added one whose author forgot the set — was therefore **silently non-lossy**,
defeating the `on_history_reset="error"` CI gate that exists to stop a run from
quietly losing a regression baseline. Separately, `load_history_cache` accepted
any policy string, and every unrecognised value silently behaved as `"ignore"`
(`history.py:447`, old `log = logger.warning if policy == "warn" else logger.debug`)
— so `on_history_reset="eror"` disabled the gate instead of reporting a typo.

## Changes

- **`HistoryEventKind(StrEnum)`** — `bencher/history.py:69` — all 7 members
  (`FULL_RESET`, `HISTORY_RENAMED`, `COLUMN_BORN`, `COLUMN_DORMANT`,
  `COLUMN_RETIRED`, `COLUMN_RESUMED`, `HISTORY_DISCARDED`). `strenum.StrEnum`
  with explicit lowercase values, matching `ResultKind` and the rest of the tree
  (plan 23 D4 — `strenum`'s `auto()` would yield uppercase member names).
  `HistoryEvent.kind` (`:104`) is now this enum.
- **`HistoryEvent.lossy`** — `bencher/history.py:107` — exhaustive `match` +
  `assert_never` over `HistoryEventKind`, replacing `_LOSSY_KINDS`. A kind cannot
  exist without being classified on one side or the other. Licensed by plan 24
  A3: `kind` is internally produced (never deserialized, never read from config),
  so `assert_never` is sound here.
- **`OnHistoryReset(StrEnum)`** — `bencher/history.py:88` — `WARN` / `ERROR` /
  `IGNORE`.
- **Unknown policy now raises.** `load_history_cache`
  (`bencher/result_collector.py:768`) parses `OnHistoryReset(on_history_reset)` as
  its **first statement**, before `get_history_cache()` and therefore before any
  cache read or write. `apply_policy` (`bencher/history.py:476`) parses defensively
  too and then matches over the parsed value with `assert_never` — the
  parse-then-match shape plan 24 A1/A2 requires, since the value originates from a
  `param.Selector` read (`bench_cfg.py:390`) which `ty` resolves as `Unknown`.
- All 6 event construction sites updated to enum members
  (`history.py:332,348,363,374`; `result_collector.py:658,677,810`).
- `HistoryEventKind` and `OnHistoryReset` exported from `bencher/__init__.py:173`.

## Cache-safety finding (mandatory check)

**`HistoryEvent` is runtime-only — no `kind` string is persisted anywhere.**
Verified before enum-ifying:

- The stored history record is `{"format", "dataset", "columns", "retired"}`
  (`result_collector.py:848-853`); the last-seen index entry is
  `{"key", "summary", "events"}` (`:855-859`, where `events` is an **int count**,
  not event objects). Neither carries a kind.
- Per-column metadata (`history.column_meta`) is
  `{identity, class, units, meaning_version, birth, dormant}` — no kind.
- `HistoryEvent` values are constructed in `reconcile()` and
  `_adopt_or_report_reset()`, accumulated in a local `events` list, and consumed
  by `apply_policy` in the same call. The only cross-module reads are
  `result_collector.py` (construction) and `bencher/__init__.py` (export).
- Grep for the 7 kind literals across `bencher/` and `test/` found no producer or
  consumer outside these two modules; the three test hits are method *names*
  (`test_full_reset_reported_via_last_seen_index` etc.), not stored strings.

So **no stored cell value changes** — plan 23 §7's general rule holds, and no
cache invalidation or format bump is needed. `HISTORY_FORMAT` stays at 1.

## Owner-principle categories

- **Config-time raise (permitted, and the point of the change):** the new
  `ValueError` on an unknown `on_history_reset`. It fires at the parse in
  `load_history_cache`, at setup before any sampling and before the cache is
  touched, so no collected data can be lost by it. A bad config value should
  raise; this is exactly that category.
- **No mid-run behavior change:** `lossy` only reclassifies which events are
  loss-y (three previously-unlisted kinds are now explicitly non-lossy, which is
  what the old set already produced for them — the change is that the
  classification is now total). No data is deleted or rewritten; dormant and
  retired columns still stay in the stored record.
- `HistoryResetError` under `"error"` is pre-existing behavior and still raises
  *before* anything is persisted (`result_collector.py:826-828`), so an erroring
  run advances no history state — the existing tests for that still pass.

## Verification

- **Grep check (plan 23 §9): no `_LOSSY_KINDS` remains** — the only two hits are
  prose in a docstring and a test docstring explaining what was replaced.
- `bencher/history.py` **added to the strict ty block** (`pyproject.toml:326`) —
  it was clean, `pixi run ty` reports `All checks passed!`.
- `pixi run format` (520 files unchanged), `pixi run lint` (ruff clean, pylint
  10.00/10), and `pytest test/test_history_reconciliation.py
  test/test_series_identity.py test/test_regression.py test/test_result_collector.py`
  → **236 passed**.
- Tests **extended in place** in `test/test_history_reconciliation.py` (not
  duplicated):
  - `TestResetPolicy.test_unknown_policy_raises_before_touching_the_cache` —
    asserts `ValueError` *and* that neither the history key nor the last-seen
    index entry was written.
  - `TestResetPolicy.test_enum_policy_value_accepted` — an `OnHistoryReset`
    member works, not just its string value.
  - `TestEventKindLossiness` — asserts its lossy/non-lossy partition covers
    `set(HistoryEventKind)` **exactly** (so a new member fails the test until
    classified), drives **every** kind through `apply_policy` under
    `on_history_reset="error"` asserting raise/no-raise per side, and asserts
    `apply_policy([], "silently-ignore")` raises even with no events.

## Falsified plan claims

None. C5's description was accurate in every particular: the comment at
`:77-78` listed 7 kinds, `_LOSSY_KINDS` at `:66` listed 4, and the unknown-policy
path did silently mean "ignore".

## Deviations

- **`apply_policy` accepts `OnHistoryReset | str` rather than only the enum.** It
  is exported public API and is called with a raw string by tests and
  potentially by users; parsing inside it (rather than demanding a pre-parsed
  enum) keeps the boundary closed at both entry points instead of trusting the
  caller. The `match` still runs over the parsed value, so `assert_never` stays
  sound.
- **A local full `pixi run ci` did not complete** — two runs were killed by
  environment contention (a concurrent CI run in a sibling worktree, plus
  `/tmp/pytest-of-*` collisions between them, exit 143). Every CI *stage* was run
  individually and passes: `format`, `ruff-lint`, `pylint`, `ty`, and pytest over
  the affected test files. GitHub CI (`ci` py311 + py313, `ci-split`) is the
  authoritative full-suite gate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce enums for history event kinds and reset policy to make lossiness classification exhaustive and configuration policies validated eagerly.

New Features:
- Add HistoryEventKind StrEnum for all schema-affecting history event types used during reconciliation.
- Add OnHistoryReset StrEnum to represent history reset policies and export both enums from the public API.

Bug Fixes:
- Make on_history_reset configuration reject unknown values with a ValueError instead of silently behaving as "ignore".
- Ensure every history event kind is explicitly classified as lossy or non-lossy so typoed or new kinds cannot silently bypass the reset-error gate.

Enhancements:
- Refine HistoryEvent.lossy and apply_policy to use exhaustive matching over enums with type-checked trust boundaries.
- Update history reconciliation and result collection code to construct HistoryEvent instances with enum kinds and to parse reset policy before any cache read or write.

Tests:
- Extend history reconciliation tests to cover enum-based policies, verify lossiness partition across all HistoryEventKind members, and assert unknown policies raise before touching the cache.