### PR TITLE
style: recover the JobFuture docstring commit orphaned by the P5 merge

### DIFF
--- a/bencher/job.py
+++ b/bencher/job.py
@@ -299,9 +299,10 @@ class JobFuture:
     ) -> None:
         """Initialize a JobFuture with a result, a pending future, or an error.
 
-        The keyword signature is kept from the two-optional era so the four
-        construction sites (and tests that build one directly) read unchanged;
-        the arguments are parsed into a single :data:`JobState` here, at the
+        The keyword signature is kept from the two-optional era so every
+        construction site in ``FutureCache.submit`` (and tests that build one
+        directly) reads unchanged; the arguments are parsed into a single
+        :data:`JobState` here, at the
         boundary. One argument at most may be given -- previously ``res`` and
         ``future`` together were representable and never meaningful. ``error=``
         exists so a caller that *knows* why a job produced nothing (the serial
@@ -334,8 +335,10 @@ class JobFuture:
             self.state: JobState = Ready(res)
         elif future is not None:
             self.state = Pending(future)
+        elif error is not None:
+            self.state = Broken(error)
         else:
-            self.state = Broken(error or _no_result_error(job.job_id))
+            self.state = Broken(_no_result_error(job.job_id))
         self.cache = cache
 
     def result(self) -> dict:


### PR DESCRIPTION
`72fd90dc` was pushed to `plan/constructive-p5-job-state` after CI had gone green on
`66999c1e`, and #1037 was merged at the earlier commit — so this change was left behind on
the branch. Cherry-picked verbatim onto current `main`.

Contents are cosmetic and behavior-identical:

- `JobFuture.__init__`'s docstring said "the four construction sites", which was inaccurate
  once the sites consolidated; now names `FutureCache.submit`.
- `Broken(error or _no_result_error(job.job_id))` split into explicit `elif error is not
  None:` / `else:` branches. Equivalent at runtime (exception instances are always truthy),
  but it stops the reader having to prove that, and it makes the "caller knows the cause"
  path distinct from the "harness diagnosed it" path — which is the distinction the P5
  review was about.

`pixi run ty` clean. No behavior change, so no CHANGELOG entry.

Process note for future waves: verify each author's final SHA is an ancestor of `main`
before merging (`git merge-base --is-ancestor <sha> origin/main`) rather than merging on a
green-CI signal alone, since an author may push after CI reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify JobFuture initialization semantics without changing runtime behavior.

Enhancements:
- Update JobFuture.__init__ docstring to reference FutureCache.submit instead of outdated construction-site wording.
- Simplify JobFuture state selection logic by separating explicit error handling from default no-result error creation.