### PR TITLE
style: explicit error branch and accurate docstring in JobFuture (P5 follow-up)

### DIFF
--- a/bencher/job.py
+++ b/bencher/job.py
@@ -299,11 +299,12 @@ class JobFuture:
     ) -> None:
         """Initialize a JobFuture with a result, a pending future, or an error.
 
-        The keyword signature is kept from the two-optional era so the four
-        construction sites (and tests that build one directly) read unchanged;
-        the arguments are parsed into a single :data:`JobState` here, at the
-        boundary. One argument at most may be given -- previously ``res`` and
-        ``future`` together were representable and never meaningful. ``error=``
+        The keyword signature is kept from the two-optional era so every
+        construction site in ``FutureCache.submit`` (and tests that build one
+        directly) reads unchanged; the arguments are parsed into a single
+        :data:`JobState` here, at the boundary. One argument at most may be given
+        -- previously ``res`` and ``future`` together were representable and
+        never meaningful. ``error=``
         exists so a caller that *knows* why a job produced nothing (the serial
         site in ``FutureCache.submit``, which has just seen ``run_job`` return
         ``None``) can say so; with none of the three, the state is still
@@ -334,8 +335,10 @@ class JobFuture:
             self.state: JobState = Ready(res)
         elif future is not None:
             self.state = Pending(future)
+        elif error is not None:
+            self.state = Broken(error)
         else:
-            self.state = Broken(error or _no_result_error(job.job_id))
+            self.state = Broken(_no_result_error(job.job_id))
         self.cache = cache
 
     def result(self) -> dict:


### PR DESCRIPTION
Cosmetic follow-up to #1037 (plan 23 P5). **No behaviour change** — close this if you'd rather not carry the noise.

#1037 was merged at `66999c1e`; this one commit was pushed to that branch a few minutes after the merge and was therefore left out. Two items, both in `bencher/job.py`:

1. **The `JobFuture.__init__` docstring says "the four construction sites"**, which was true before the review round added `error=`. `FutureCache.submit` now has five `JobFuture(...)` calls, because the serial site branches on whether `run_job` returned `None`. Reworded to name the method rather than count its call sites, so it cannot drift again.

2. **`Broken(error or _no_result_error(job.job_id))` → an explicit `elif error is not None:` arm.** Semantically identical — `BaseException` defines no `__bool__`, so an exception is always truthy — but the `or` reads as a truthiness test on a value the surrounding code deliberately tests with `is not None` (three lines up, the arm-conflict check comments on exactly that point, because `res={}` is a valid falsy result). Making the arm explicit keeps one convention in one function.

Verified on current `main`: `pixi run ci` **2664 passed, 3 skipped** with a private temp root (`TMPDIR=$(mktemp -d) PYTEST_DEBUG_TEMPROOT=$TMPDIR`), pylint 10.00/10, `pixi run ty` clean with `job.py` on the strict block, `pixi run prek` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify JobFuture initialization semantics and keep FutureCache submit call sites consistent with the updated constructor.

Enhancements:
- Update JobFuture.__init__ docstring to describe construction via FutureCache.submit without relying on a fixed number of call sites.
- Make JobFuture state selection use an explicit error branch instead of a truthiness-based fallback for clearer intent and consistency.