### PR TITLE
refactor: make partial ComposeType.flip unrepresentable; exhaustive composition matches (plan 23 P8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a public path (`Bench.clear_tag_from_sample_cache`) "nothing happened" must not read as
   "the tag was cleared".
 
+- **Flipping a composition direction lives on a two-member `Axis` type, so a partial flip
+  is unrepresentable** (plan 23 P8, C6). `ComposeType.flip()` raised
+  `RuntimeError("cannot flip this type")` on 2 of its 4 members, and that arm was reachable
+  from the public `compose_method_list_for_dims(first_compose_method=...)` /
+  `VideoSummaryResult.dataset_to_compose_list(first_compose_method=...)` — so a
+  `sequence`/`overlay` seed aborted a 2+-dimensional video or rerun composition part-way
+  through rendering, after the samples had already been collected. The new
+  `bencher.Axis` (`right | down`) owns `flip()`, which is total over its two members;
+  `ComposeType` keeps its four members and answers `as_axis() -> Axis | None`, so "has no
+  opposite" is a value rather than an exception. `compose_method_list_for_dims` accepts
+  either type and, for a seed with no axis, repeats it on every spatial level instead of
+  failing. Every input the old implementation answered returns a byte-identical list — the
+  test suite pins that against the pre-refactor algorithm.
+
+- **Composition `match` statements over `ComposeType` are exhaustively checked**
+  (plan 23 P8, C6). `ComposableContainerPanel.__post_init__` and
+  `ComposableContainerDataset.render` had no final arm, so a fifth `ComposeType` member
+  would have produced an `UnboundLocalError` three frames from the cause and a silent
+  `None` composition respectively. Both now end in `assert_never`; verified empirically by
+  seeding a fifth member and measuring `error[type-assertion-failure]` at all four match
+  sites. `ComposableContainerRerun`'s two tables that had to stay exactly complementary
+  (`_shares_one_view` and `_LAYOUT_CLASS_NAMES`) are merged into one exhaustive mapping
+  onto a `_SharedViewLayout | _StackedViewLayout` sum, which makes "shares one view" and
+  "has a stacking layout class" mutually exclusive by construction and retires the
+  `Unsupported Rerun compose type` raise as unreachable. The four
+  `bencher/results/composable_container/*` modules this touches join the strict `ty` list.
+
+- `ComposableContainerPanel._tabs` is declared on the class instead of being created only
+  by the `sequence` arm, and `append`/`render` read that one field rather than each
+  re-deriving "am I a tab strip?" from `compose_method`.
+  `ComposableContainerBase.label_formatter` is annotated `-> str | None` over
+  `str | None` inputs, which is what it has always accepted and returned.
+
 ### Removed
+- **`ComposableContainerPanel(horizontal=...)`**, which silently overwrote
+  `compose_method` — and did so *inverted* relative to the rest of the codebase
+  (`horizontal=True` meant a `pn.Column` here, while the same flag in
+  `BenchResultBase._to_panes_da` selects a row). Two spellings of one concept that
+  disagreed; only `compose_method` remains. No caller in the package used the kwarg
+  (plan 23 P8, C6).
+
+- **`ComposeType.flip()`** — superseded by `Axis.flip()`, see above. `ComposeType.as_axis()`
+  converts, and `Axis.to_compose_type()` converts back.
+
 - **BREAKING: dropped Python 3.10 support.** `requires-python` is now `>=3.11,<3.14`, and
   the CI matrix runs py311 + py313 (was py310 + py313). The `py310` pixi feature and
   environment are gone.

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -59,6 +59,7 @@ from .report_export import (
     series_for_var,
 )
 from .results.composable_container.composable_container_base import (
+    Axis,
     ComposableContainerBase,
     ComposeType,
     PaneLayout,

--- a/bencher/results/composable_container/__init__.py
+++ b/bencher/results/composable_container/__init__.py
@@ -1,4 +1,5 @@
 from bencher.results.composable_container.composable_container_base import (
+    Axis,
     ComposableContainerBase,
     ComposeType,
     PaneLayout,

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -2,11 +2,53 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import auto
-from typing import Any
+from typing import Any, assert_never
 
 from strenum import StrEnum
 
 from bencher.results.float_formatter import FormatFloat
+
+
+class Axis(StrEnum):
+    """A spatial composition direction -- the only thing that has an opposite.
+
+    ``ComposeType`` has two members that say *where* the next container goes
+    (``right``/``down``) and two that do not (``sequence``/``overlay``).  Only the
+    first pair can be flipped, so ``flip()`` lives here rather than on
+    ``ComposeType``: asking a non-spatial compose type for its opposite is now
+    unrepresentable instead of a ``RuntimeError`` raised mid-render
+    (plan 23 C6, phase P8).
+
+    The member values match the corresponding ``ComposeType`` values, so an ``Axis``
+    compares equal to the ``ComposeType`` it maps to.
+    """
+
+    right = auto()  # append the container to the right (creates a row)
+    down = auto()  # append the container below (creates a column)
+
+    def flip(self) -> Axis:
+        """Return the other axis.  Total by construction."""
+        match self:
+            case Axis.right:
+                return Axis.down
+            case Axis.down:
+                return Axis.right
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def to_compose_type(self) -> ComposeType:
+        """Return the ``ComposeType`` that composes along this axis."""
+        match self:
+            case Axis.right:
+                return ComposeType.right
+            case Axis.down:
+                return ComposeType.down
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    @staticmethod
+    def from_horizontal(horizontal: bool) -> Axis:
+        return Axis.right if horizontal else Axis.down
 
 
 # TODO enable these options
@@ -16,23 +58,30 @@ class ComposeType(StrEnum):
     sequence = auto()  # display the container after (in time)
     overlay = auto()  # overlay on top of the current container (alpha blending)
 
-    def flip(self):
+    def as_axis(self) -> Axis | None:
+        """The spatial axis this method composes along, or None if it has none.
+
+        ``sequence`` and ``overlay`` place nothing beside anything, so they have no
+        axis and nothing to flip -- hence ``None`` rather than a raise.
+        """
         match self:
             case ComposeType.right:
-                return ComposeType.down
+                return Axis.right
             case ComposeType.down:
-                return ComposeType.right
-            case _:
-                raise RuntimeError("cannot flip this type")
+                return Axis.down
+            case ComposeType.sequence | ComposeType.overlay:
+                return None
+            case _ as unreachable:
+                assert_never(unreachable)
 
     @staticmethod
-    def from_horizontal(horizontal: bool):
+    def from_horizontal(horizontal: bool) -> ComposeType:
         return ComposeType.right if horizontal else ComposeType.down
 
 
 def compose_method_list_for_dims(
     num_dims: int,
-    first_compose_method: ComposeType = ComposeType.down,
+    first_compose_method: ComposeType | Axis = ComposeType.down,
     time_sequence_dimension: int = 0,
 ) -> list[ComposeType]:
     """Choose a composition method per dimension for a *num_dims*-dimensional sweep.
@@ -43,8 +92,11 @@ def compose_method_list_for_dims(
 
     Args:
         num_dims (int): Number of dimensions being composed.
-        first_compose_method (ComposeType, optional): Direction of the first
-            composition. Defaults to ComposeType.down.
+        first_compose_method (ComposeType | Axis, optional): Direction of the first
+            composition. Defaults to ComposeType.down.  A method with no axis
+            (``sequence``/``overlay``) cannot alternate, so it is repeated on every
+            spatial level instead; before plan 23 P8 that combination raised
+            ``RuntimeError`` from ``ComposeType.flip`` partway through rendering.
         time_sequence_dimension (int, optional): Compose dimensions up to this
             index in time rather than in space. ``-1`` sequences everything.
             Defaults to 0.
@@ -55,10 +107,20 @@ def compose_method_list_for_dims(
     if time_sequence_dimension == -1:  # use time sequence for everything
         return [ComposeType.sequence] * (num_dims + 1)
 
-    compose_method_list = [first_compose_method]
-    compose_method_list.extend(
-        ComposeType.flip(compose_method_list[-1]) for _ in range(num_dims - 1)
-    )
+    if isinstance(first_compose_method, Axis):
+        first = first_compose_method.to_compose_type()
+        axis: Axis | None = first_compose_method
+    else:
+        first = first_compose_method
+        axis = first_compose_method.as_axis()
+
+    compose_method_list = [first]
+    for _ in range(num_dims - 1):
+        if axis is None:
+            compose_method_list.append(first)
+        else:
+            axis = axis.flip()
+            compose_method_list.append(axis.to_compose_type())
     compose_method_list.append(ComposeType.sequence)
 
     for i in range(min(len(compose_method_list), time_sequence_dimension + 1)):
@@ -94,15 +156,16 @@ class ComposableContainerBase:
     label_len: int = 0
 
     @staticmethod
-    def label_formatter(var_name: str, var_value: float | str) -> str:
+    def label_formatter(var_name: str | None, var_value: float | str | None) -> str | None:
         """Take a variable name and values and return a pretty version with approximate fixed width
 
         Args:
-            var_name (str): The name of the variable, usually a dimension
-            var_value (int | float | str): The value of the dimension
+            var_name (str | None): The name of the variable, usually a dimension
+            var_value (int | float | str | None): The value of the dimension
 
         Returns:
-            str: Pretty string representation with fixed width
+            str | None: Pretty string representation with fixed width, or None when
+                neither a name nor a value was given (every caller tests for None).
         """
 
         if isinstance(var_value, (int, float)):

--- a/bencher/results/composable_container/composable_container_dataframe.py
+++ b/bencher/results/composable_container/composable_container_dataframe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import assert_never
 
 import xarray as xr
 
@@ -30,3 +31,5 @@ class ComposableContainerDataset(ComposableContainerBase):
                 return xr.concat(self.container, dim="sequence")
             case ComposeType.overlay:
                 return xr.concat(self.container, dim="overlay").mean(dim="overlay")
+            case _ as unreachable:
+                assert_never(unreachable)

--- a/bencher/results/composable_container/composable_container_panel.py
+++ b/bencher/results/composable_container/composable_container_panel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any, assert_never
 
 import panel as pn
 
@@ -17,14 +18,18 @@ class ComposableContainerPanel(ComposableContainerBase):
     var_value: str | None = None
     width: int | None = None
     background_col: str | None = None
-    horizontal: bool | None = None
+    # This backend stores a live Panel layout rather than the base's plain list, so
+    # children can be appended straight into the rendered tree.  Declared here for the
+    # same reason ComposableContainerRerun narrows the field to its own element type.
+    container: pn.layout.ListLike | list[Any] = field(default_factory=list)
+    # Set only by the ComposeType.sequence arm below, None on every other method.  It is
+    # declared here (rather than assigned on one arm of the match) so that append() and
+    # render() read one field instead of each re-deriving "am I a tab strip?" from
+    # compose_method, and so a compose method that forgets to set it cannot produce an
+    # UnboundLocalError three frames from the cause (plan 23 C6, phase P8).
+    _tabs: pn.Tabs | None = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        # Backward compat: horizontal kwarg overrides compose_method
-        if self.horizontal is not None:
-            # Old behavior: horizontal=True -> pn.Column (down), horizontal=False -> pn.Row (right)
-            self.compose_method = ComposeType.down if self.horizontal else ComposeType.right
-
         styles = {}
         if self.width is not None:
             styles["border-bottom"] = f"{self.width}px solid grey"
@@ -48,25 +53,26 @@ class ComposableContainerPanel(ComposableContainerBase):
                 styles["position"] = "relative"
                 self.container = pn.Column(**container_args)
                 align = ("center", "center")
+            case _ as unreachable:
+                assert_never(unreachable)
 
         label = self.label_formatter(self.var_name, self.var_value)
         if label is not None:
             self.label_len = len(label)
             side = pn.pane.Markdown(label, align=align)
-            if self.compose_method == ComposeType.sequence:
+            if self._tabs is not None:
                 # For Tabs, label sits outside the tab bar in a wrapper Column
                 self.container.append(side)
             else:
                 self.append(side)
 
     def append(self, obj):
-        if self.compose_method == ComposeType.sequence:
+        if self._tabs is not None:
             self._tabs.append(obj)
         else:
             self.container.append(obj)
 
     def render(self):
-        if self.compose_method == ComposeType.sequence:
+        if self._tabs is not None:
             self.container.append(self._tabs)
-            return self.container
         return self.container

--- a/bencher/results/composable_container/composable_container_rerun.py
+++ b/bencher/results/composable_container/composable_container_rerun.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, assert_never
 
 from strenum import StrEnum
 
@@ -122,9 +122,60 @@ _VIEW_CLASS_NAMES = {
     RerunViewKind.state_timeline: "StateTimelineView",
 }
 
-_LAYOUT_CLASS_NAMES = {
-    ComposeType.right: "Horizontal",
-    ComposeType.down: "Vertical",
+
+@dataclass(frozen=True)
+class _SharedViewLayout:
+    """Every item is displayed in one shared view rooted at ``/``.
+
+    Args:
+        splice_in_time: whether the items are shifted so they play one after the
+            other (``sequence``) rather than all together (``overlay``).
+    """
+
+    splice_in_time: bool
+
+
+@dataclass(frozen=True)
+class _StackedViewLayout:
+    """Each item gets its own view, stacked by ``rrb.<layout_class_name>``.
+
+    ``rerun.blueprint`` is imported lazily, so the layout class is referenced by
+    attribute name rather than by value.
+    """
+
+    layout_class_name: str
+
+
+_RerunComposeSpec = _SharedViewLayout | _StackedViewLayout
+
+
+def _rerun_compose_spec(compose_method: ComposeType) -> _RerunComposeSpec:
+    """The one table mapping a compose method onto its Rerun presentation.
+
+    Before plan 23 P8 this was two tables -- a ``_shares_one_view`` predicate and a
+    ``_LAYOUT_CLASS_NAMES`` dict -- which had to stay exactly complementary with
+    nothing checking that they did.  The sum type makes "shares one view" and "has a
+    stacking layout class" mutually exclusive by construction, and the exhaustive
+    match makes a new ``ComposeType`` member a type error here rather than a
+    ``RuntimeError`` raised part-way through a render.
+    """
+    match compose_method:
+        case ComposeType.right:
+            return _StackedViewLayout(layout_class_name="Horizontal")
+        case ComposeType.down:
+            return _StackedViewLayout(layout_class_name="Vertical")
+        case ComposeType.overlay:
+            return _SharedViewLayout(splice_in_time=False)
+        case ComposeType.sequence:
+            return _SharedViewLayout(splice_in_time=True)
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+# Complete by construction: a ComposeType member that _rerun_compose_spec does not handle
+# is a `ty` error at the match above and an import-time failure here.
+_RERUN_COMPOSE_SPECS: dict[ComposeType, _RerunComposeSpec] = {
+    member: _rerun_compose_spec(member) for member in ComposeType
 }
 
 # Gap inserted between spliced recordings so consecutive items never share an index.
@@ -322,9 +373,13 @@ class ComposableContainerRerun(ComposableContainerBase):
         self.container.append(self._to_recording(obj, label=label, view_kinds=view_kinds))
 
     @property
-    def _shares_one_view(self) -> bool:
-        """Whether every item is displayed in the same view rooted at ``/``."""
-        return self.compose_method in (ComposeType.overlay, ComposeType.sequence)
+    def _spec(self) -> _RerunComposeSpec:
+        """How this compose method is presented in Rerun.
+
+        The value is normalized first, so an out-of-vocabulary one raises a ``ValueError``
+        naming it rather than a bare ``KeyError``.
+        """
+        return _RERUN_COMPOSE_SPECS[ComposeType(self.compose_method)]
 
     def _output_file(self) -> Path:
         if self.output_path is not None:
@@ -355,24 +410,24 @@ class ComposableContainerRerun(ComposableContainerBase):
 
     def _layout(self, rrb, items: list[_ComposedItem]):
         """Map the compose method onto a Blueprint layout of per-item views."""
-        if self._shares_one_view:
-            return self._views(
-                rrb,
-                set().union(*(item.view_kinds for item in items)),
-                origin="/",
-                label=self.name or self.compose_method.title(),
-            )
-
-        views = [
-            self._views(rrb, item.view_kinds, origin=item.prefix, label=item.label)
-            for item in items
-        ]
-        if len(views) == 1:
-            return views[0]
-        layout_class = _LAYOUT_CLASS_NAMES.get(self.compose_method)
-        if layout_class is None:
-            raise RuntimeError(f"Unsupported Rerun compose type: {self.compose_method}")
-        return getattr(rrb, layout_class)(*views, name=self.name)
+        match self._spec:
+            case _SharedViewLayout():
+                return self._views(
+                    rrb,
+                    set().union(*(item.view_kinds for item in items)),
+                    origin="/",
+                    label=self.name or self.compose_method.title(),
+                )
+            case _StackedViewLayout(layout_class_name=layout_class_name):
+                views = [
+                    self._views(rrb, item.view_kinds, origin=item.prefix, label=item.label)
+                    for item in items
+                ]
+                if len(views) == 1:
+                    return views[0]
+                return getattr(rrb, layout_class_name)(*views, name=self.name)
+            case _ as unreachable:
+                assert_never(unreachable)
 
     def _read_items(self) -> list[_ComposedItem]:
         items = []
@@ -430,7 +485,8 @@ class ComposableContainerRerun(ComposableContainerBase):
             make_thread_default=False,
         )
 
-        if self.compose_method == ComposeType.sequence:
+        spec = self._spec
+        if isinstance(spec, _SharedViewLayout) and spec.splice_in_time:
             self._send_spliced(recording, items)
         else:
             for item in items:

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -10,6 +10,7 @@ from param import Parameter
 from bencher.plotting.plot_filter import PlotFilter, VarRange
 from bencher.results.bench_result_base import BenchResultBase, ReduceType
 from bencher.results.composable_container.composable_container_base import (
+    Axis,
     compose_method_list_for_dims,
 )
 from bencher.results.composable_container.composable_container_video import (
@@ -153,14 +154,14 @@ class VideoSummaryResult(BenchResultBase):
     def dataset_to_compose_list(
         self,
         dataset: xr.Dataset,
-        first_compose_method: ComposeType = ComposeType.down,
+        first_compose_method: ComposeType | Axis = ComposeType.down,
         time_sequence_dimension: int = 0,
     ) -> list[ComposeType]:
         """ "Given a dataset, chose an order for composing the results.  By default will flip between right and down and the last dimension will be a time sequence.
 
         Args:
             dataset (xr.Dataset): the dataset to render
-            first_compose_method (ComposeType, optional): the direction of the first composition method. Defaults to ComposeType.right.
+            first_compose_method (ComposeType | Axis, optional): the direction of the first composition method. Defaults to ComposeType.down.  Only ``right`` and ``down`` alternate; ``sequence``/``overlay`` have no opposite and are repeated on every spatial level.
             time_sequence_dimension (int, optional): The dimension to start time sequencing instead of composing in space. Defaults to 0.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,10 @@ include = [
     "bencher/job.py",
     "bencher/worker_job.py",
     "bencher/result_collector.py",
+    "bencher/results/composable_container/composable_container_base.py",
+    "bencher/results/composable_container/composable_container_panel.py",
+    "bencher/results/composable_container/composable_container_dataframe.py",
+    "bencher/results/composable_container/composable_container_rerun.py",
 ]
 [tool.ty.overrides.rules]
 invalid-assignment = "error"

--- a/test/test_composable_container_base.py
+++ b/test/test_composable_container_base.py
@@ -2,38 +2,143 @@
 import pytest
 
 from bencher.results.composable_container.composable_container_base import (
+    Axis,
     ComposableContainerBase,
     ComposeType,
+    compose_method_list_for_dims,
 )
 
 
+def _legacy_compose_method_list(num_dims, first_compose_method, time_sequence_dimension):
+    """The pre-plan-23-P8 implementation, kept verbatim as this refactor's oracle.
+
+    ``ComposeType.flip`` raised on 2 of its 4 members, so the inputs this helper
+    raises on are exactly the ones that used to fail mid-render.
+    """
+
+    def legacy_flip(compose_method):
+        if compose_method == ComposeType.right:
+            return ComposeType.down
+        if compose_method == ComposeType.down:
+            return ComposeType.right
+        raise RuntimeError("cannot flip this type")
+
+    if time_sequence_dimension == -1:
+        return [ComposeType.sequence] * (num_dims + 1)
+    methods = [first_compose_method]
+    for _ in range(num_dims - 1):
+        methods.append(legacy_flip(methods[-1]))
+    methods.append(ComposeType.sequence)
+    for i in range(min(len(methods), time_sequence_dimension + 1)):
+        methods[i] = ComposeType.sequence
+    return methods
+
+
 class TestFlip:
-    # flipping ComposeType.right returns ComposeType.down
+    """Flipping belongs to Axis, the two-member type where it is total (plan 23 P8)."""
+
+    # flipping Axis.right returns Axis.down
     def test_flip_right_returns_down(self):
-        assert ComposeType.right.flip() == ComposeType.down
+        assert Axis.right.flip() == Axis.down
 
-    # flipping ComposeType.down returns ComposeType.right
+    # flipping Axis.down returns Axis.right
     def test_flip_down_returns_right(self):
-        assert ComposeType.down.flip() == ComposeType.right
+        assert Axis.down.flip() == Axis.right
 
-    # flipping an invalid ComposeType raises RuntimeError
-    def test_flip_invalid_raises_runtime_error(self):
-        with pytest.raises(RuntimeError):
-            invalid_type = ComposeType.sequence
-            invalid_type.flip()
+    # every member of Axis flips, so flip() has no failure mode to test
+    def test_flip_is_total_over_axis(self):
+        assert {axis.flip() for axis in Axis} == set(Axis)
+
+    # a non-spatial compose type can no longer be asked to flip at all
+    def test_compose_type_cannot_be_asked_to_flip(self):
+        assert not hasattr(ComposeType, "flip")
+        assert not hasattr(ComposeType.sequence, "flip")
+
+    # an Axis names the same composition as the ComposeType it maps to
+    def test_axis_maps_onto_compose_type(self):
+        assert Axis.right.to_compose_type() is ComposeType.right
+        assert Axis.down.to_compose_type() is ComposeType.down
+        assert Axis.right == ComposeType.right
+        assert Axis.down == ComposeType.down
 
     # method should handle large number of flip calls without performance degradation
     def test_flip_large_number_of_calls(self):
         for _ in range(1000000):
-            assert ComposeType.right.flip() == ComposeType.down
-            assert ComposeType.down.flip() == ComposeType.right
+            assert Axis.right.flip() == Axis.down
+            assert Axis.down.flip() == Axis.right
 
-    # method should maintain immutability of the original ComposeType instance
+    # method should maintain immutability of the original Axis instance
     def test_flip_maintains_immutability(self):
-        original = ComposeType.right
+        original = Axis.right
         flipped = original.flip()
-        assert original == ComposeType.right
-        assert flipped == ComposeType.down
+        assert original == Axis.right
+        assert flipped == Axis.down
+
+
+class TestComposeTypeAsAxis:
+    @pytest.mark.parametrize(
+        ("compose_method", "expected"),
+        [
+            (ComposeType.right, Axis.right),
+            (ComposeType.down, Axis.down),
+            (ComposeType.sequence, None),
+            (ComposeType.overlay, None),
+        ],
+    )
+    def test_as_axis(self, compose_method, expected):
+        assert compose_method.as_axis() is expected
+
+    def test_as_axis_is_total(self):
+        """Every member answers -- "has no axis" is None, not an exception."""
+        assert [member.as_axis() for member in ComposeType] == [
+            Axis.right,
+            Axis.down,
+            None,
+            None,
+        ]
+
+
+class TestComposeMethodListForDims:
+    @pytest.mark.parametrize("time_sequence_dimension", [-1, 0, 1, 2])
+    @pytest.mark.parametrize("num_dims", range(5))
+    @pytest.mark.parametrize("first_compose_method", list(ComposeType))
+    def test_matches_pre_refactor_implementation(
+        self, first_compose_method, num_dims, time_sequence_dimension
+    ):
+        """P8 is a refactor: every input the old code answered must be answered identically."""
+        try:
+            expected = _legacy_compose_method_list(
+                num_dims, first_compose_method, time_sequence_dimension
+            )
+        except RuntimeError:
+            pytest.skip("input reached the old ComposeType.flip RuntimeError")
+        assert (
+            compose_method_list_for_dims(num_dims, first_compose_method, time_sequence_dimension)
+            == expected
+        )
+
+    @pytest.mark.parametrize("num_dims", [2, 3, 4])
+    @pytest.mark.parametrize("first_compose_method", [ComposeType.sequence, ComposeType.overlay])
+    def test_non_spatial_first_method_no_longer_raises(self, first_compose_method, num_dims):
+        """The public path (video_summary.dataset_to_compose_list) that used to blow up."""
+        with pytest.raises(RuntimeError):
+            _legacy_compose_method_list(num_dims, first_compose_method, 0)
+
+        methods = compose_method_list_for_dims(num_dims, first_compose_method)
+        # A method with no axis cannot alternate, so it repeats on every spatial level.
+        assert methods[0] == ComposeType.sequence  # time_sequence_dimension=0 forces level 0
+        assert methods[1:-1] == [first_compose_method] * (num_dims - 1)
+        assert methods[-1] == ComposeType.sequence
+
+    @pytest.mark.parametrize("axis", list(Axis))
+    def test_axis_seed_equals_compose_type_seed(self, axis):
+        assert compose_method_list_for_dims(3, axis) == compose_method_list_for_dims(
+            3, axis.to_compose_type()
+        )
+
+    def test_returns_compose_type_members(self):
+        methods = compose_method_list_for_dims(3, Axis.right)
+        assert all(isinstance(method, ComposeType) for method in methods)
 
 
 # Generated by CodiumAI

--- a/test/test_composable_container_dataframe.py
+++ b/test/test_composable_container_dataframe.py
@@ -7,6 +7,7 @@ values, variable names, coordinates, and append order all stay intact.
 
 import numpy as np
 import pandas as pd
+import pytest
 import xarray as xr
 
 from bencher.results.composable_container.composable_container_base import ComposeType
@@ -84,6 +85,15 @@ class TestComposableContainerDataframe:
         c.append(_make_ds([3.0, 4.0, float("nan")]))
         result = c.render()
         np.testing.assert_allclose(result["metric"].values, [2.0, 4.0, 3.0])
+
+    def test_unknown_compose_method_is_loud(self):
+        """Before plan 23 P8 the match had no final arm, so render() silently
+        returned None and the caller composed nothing."""
+        c = ComposableContainerDataset(compose_method="not_a_compose_type")
+        c.append(_make_ds([1.0, 2.0, 3.0]))
+        c.append(_make_ds([4.0, 5.0, 6.0]))
+        with pytest.raises(AssertionError):
+            c.render()
 
     def test_var_name_and_value_fields_stored(self):
         c = ComposableContainerDataset(

--- a/test/test_composable_container_panel.py
+++ b/test/test_composable_container_panel.py
@@ -64,19 +64,37 @@ class TestComposableContainerPanel:
         assert "step" in str(result[0].object)
         assert isinstance(result[1], pn.Tabs)
 
-    def test_backward_compat_horizontal_true(self):
-        """horizontal=True was Column (down) in the old code."""
-        c = ComposableContainerPanel(horizontal=True)
-        c.append(pn.pane.Markdown("A"))
-        result = c.render()
-        assert isinstance(result, pn.Column)
+    @pytest.mark.parametrize("compose_method", list(ComposeType))
+    def test_compose_method_is_never_overwritten(self, compose_method):
+        """Plan 23 P8: `horizontal` silently overwrote compose_method, inverted at that.
 
-    def test_backward_compat_horizontal_false(self):
-        """horizontal=False was Row (right) in the old code."""
-        c = ComposableContainerPanel(horizontal=False)
-        c.append(pn.pane.Markdown("A"))
-        result = c.render()
-        assert isinstance(result, pn.Row)
+        `horizontal=True` mapped to `down` here while `_to_panes_da` maps the same flag
+        to `right`, so the two spellings of one concept disagreed.  Only compose_method
+        remains.
+        """
+        assert ComposableContainerPanel(compose_method=compose_method).compose_method is (
+            compose_method
+        )
+
+    def test_horizontal_kwarg_is_gone(self):
+        # The removed kwarg is the point of the test, so both checkers must tolerate it
+        # here -- and both flagging it is itself evidence that it is gone.
+        # pylint: disable=unexpected-keyword-arg
+        with pytest.raises(TypeError):
+            ComposableContainerPanel(horizontal=True)  # ty: ignore[unknown-argument]
+
+    @pytest.mark.parametrize("compose_method", list(ComposeType))
+    def test_tabs_declared_for_every_compose_method(self, compose_method):
+        """_tabs exists on every instance; only the sequence arm fills it in."""
+        c = ComposableContainerPanel(compose_method=compose_method)
+        tabs = c._tabs  # pylint: disable=protected-access
+        assert (tabs is not None) == (compose_method == ComposeType.sequence)
+
+    def test_unknown_compose_method_fails_at_construction(self):
+        """Before P8 the match had no final arm: `align` stayed unbound and the
+        failure surfaced as an UnboundLocalError three frames from the cause."""
+        with pytest.raises(AssertionError):
+            ComposableContainerPanel(compose_method="not_a_compose_type")
 
     @pytest.mark.parametrize("compose_type", list(ComposeType))
     def test_render_returns_panel_for_all_types(self, compose_type):

--- a/test/test_composable_container_rerun.py
+++ b/test/test_composable_container_rerun.py
@@ -9,10 +9,13 @@ import bencher as bn
 from bencher.result_collector import _materialize_result_value
 from bencher.results.composable_container.composable_container_base import ComposeType
 from bencher.results.composable_container.composable_container_rerun import (
+    _RERUN_COMPOSE_SPECS,
     ComposableContainerRerun,
     RerunRecording,
     RerunViewKind,
     _batch_time_bounds,
+    _SharedViewLayout,
+    _StackedViewLayout,
 )
 from bencher.variables.results import ResultRerun
 
@@ -253,6 +256,41 @@ def test_result_rerun_materializes_composable_container(tmp_path):
 
     assert result == str(output)
     assert output.is_file()
+
+
+def test_every_compose_type_has_a_rerun_spec():
+    """One table, checked (plan 23 P8).
+
+    This replaced a pair of tables -- a ``_shares_one_view`` predicate and a
+    ``_LAYOUT_CLASS_NAMES`` dict -- that had to stay exactly complementary with
+    nothing asserting that they did.
+    """
+    assert set(_RERUN_COMPOSE_SPECS) == set(ComposeType)
+    for member in ComposeType:
+        assert isinstance(_RERUN_COMPOSE_SPECS[member], (_SharedViewLayout, _StackedViewLayout))
+
+
+def test_rerun_specs_match_the_two_tables_they_replaced():
+    """Parity oracle: the pre-P8 ``_shares_one_view`` / ``_LAYOUT_CLASS_NAMES`` pair."""
+    legacy_shares_one_view = {ComposeType.overlay, ComposeType.sequence}
+    legacy_layout_class_names = {ComposeType.right: "Horizontal", ComposeType.down: "Vertical"}
+
+    for member in ComposeType:
+        spec = _RERUN_COMPOSE_SPECS[member]
+        if member in legacy_shares_one_view:
+            assert isinstance(spec, _SharedViewLayout)
+            # Only sequence spliced its items along the timeline.
+            assert spec.splice_in_time is (member == ComposeType.sequence)
+        else:
+            assert isinstance(spec, _StackedViewLayout)
+            assert spec.layout_class_name == legacy_layout_class_names[member]
+
+
+def test_unknown_compose_method_is_rejected_by_name():
+    """An out-of-vocabulary compose method names itself instead of raising KeyError."""
+    container = ComposableContainerRerun(compose_method="not_a_compose_type")
+    with pytest.raises(ValueError, match="not_a_compose_type"):
+        _ = container._spec  # pylint: disable=protected-access
 
 
 def test_public_api_exports_rerun_composition_types():


### PR DESCRIPTION
Implements **plan 23 §5 P8** (composition types, C6) — `plans/23-constructive-data-modeling.md`.
Pure refactor: no rendered output changes (see *Output parity* below).

## 1. Partial `flip` is now unrepresentable (`composable_container_base.py`)

`ComposeType.flip()` raised `RuntimeError("cannot flip this type")` on 2 of its 4 members, and that
arm was **reachable from the public API** — `compose_method_list_for_dims(first_compose_method=…)`
and `VideoSummaryResult.dataset_to_compose_list(first_compose_method=…)` — so a `sequence`/`overlay`
seed aborted a 2+-dimensional video or rerun composition *after* the expensive samples had been
collected.

- New `Axis(StrEnum)` = `right | down` owns `flip()`, total over its two members.
- `ComposeType` keeps its four members and answers `as_axis() -> Axis | None`: "has no opposite" is
  a value, not an exception. `Axis.to_compose_type()` converts back, and `Axis` member values match
  the corresponding `ComposeType` values so the two compare equal.
- `ComposeType.flip()` is **removed** — there is no longer any way to ask a non-spatial compose type
  to flip, which is what "unrepresentable" has to mean here.
- `compose_method_list_for_dims` accepts `ComposeType | Axis`. For a seed with no axis it repeats
  that method on every spatial level instead of failing, so the **only** inputs whose behaviour
  changes are the ones that used to raise. Verified the public call path can no longer reach a flip
  error: `Axis.flip` is the only `flip` left in the tree and both of its arms return.

## 2. Exhaustive matches with `assert_never`

- `composable_container_panel.py`: the `match` had no final arm, so a 5th member left `align`
  unbound → `UnboundLocalError` three frames from the cause. Now `assert_never`.
- `composable_container_dataframe.py`: same shape, but its fall-through **silently returned `None`**
  — an unhandled compose method composed nothing at all. Now `assert_never`.
- `_tabs` is declared on the class instead of being created only on the `sequence` arm, and
  `append()` / `render()` read that one field rather than each re-deriving "am I a tab strip?" from
  `compose_method`.
- `horizontal: bool | None` — which silently overwrote `compose_method`, and did so **inverted**
  relative to the rest of the codebase (`horizontal=True` meant a `pn.Column` here, while the same
  flag in `BenchResultBase._to_panes_da` selects a row) — is **removed**. Every constructor call site
  was checked first: `bench_result_base.py:917/926/933` pass `compose_method=` only, and the only two
  `horizontal=` uses in the tree were the two "backward compat" tests. Per the plan I removed the
  overwrite rather than documenting a precedence: two spellings of one concept that disagree is the
  defect, not the silence.

## 3. One rerun table instead of two that had to stay complementary

`_shares_one_view` (a predicate over two members) and `_LAYOUT_CLASS_NAMES` (a dict over the other
two) had to stay exactly complementary with nothing checking it. They are now one mapping onto a
`_SharedViewLayout | _StackedViewLayout` sum, so "shares one view" and "has a stacking layout class"
are mutually exclusive **by construction**:

```python
_RERUN_COMPOSE_SPECS: dict[ComposeType, _RerunComposeSpec] = {
    member: _rerun_compose_spec(member) for member in ComposeType   # complete by construction
}
```

The dict is derived from an exhaustive `match`, so a new member is a `ty` error (and an import-time
failure if the checker were bypassed) rather than a silently missing entry. `render()`'s splice
branch reads the spec instead of re-comparing `compose_method`, and the
`RuntimeError("Unsupported Rerun compose type")` arm is gone as unreachable. `_spec` normalizes via
`ComposeType(...)` so an out-of-vocabulary value raises a `ValueError` naming it, not a bare
`KeyError`.

## DoD: a 5th `ComposeType` member fails `ty` at every match site (measured)

Seeded `diagonal = auto()` into the real enum, ran `pixi run ty`, then reverted.
**4 diagnostics, all `type-assertion-failure`, one per match site:**

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
  --> composable_container_base.py:76:17        (ComposeType.as_axis)
      Inferred type of argument is `Self@as_axis & ~Literal[ComposeType.right]
        & ~Literal[ComposeType.down] & ~Literal[ComposeType.sequence] & ~Literal[ComposeType.overlay]`
  --> composable_container_dataframe.py:35:17   Inferred type is `Literal[ComposeType.diagonal]`
  --> composable_container_panel.py:57:17       Inferred type is `Literal[ComposeType.diagonal]`
  --> composable_container_rerun.py:171:13      Inferred type is `Literal[ComposeType.diagonal]`
      (_rerun_compose_spec)
```

Three of the four name the forgotten member outright; `as_axis`'s subtracts the four handled members
from `Self`, which is equally readable. Reverted, `ty` clean again.

`composable_container_video.py:158`'s `case _: raise` is **deliberately not converted** — plan 23 D2
names it the correct trust-boundary raise, and it is one: `render(**kwargs)` builds
`RenderCfg(**kwargs)` from caller kwargs, so its subject is genuinely untrusted. That site therefore
produces no ty diagnostic and fails loudly at runtime instead, by design.

## Strict `ty` list: added, and clean

All four touched `bencher/results/composable_container/*` modules are on the strict override block in
`pyproject.toml`, and `pixi run ty` passes with them listed. Two annotation truths were needed to get
there, both zero-runtime-change:

- `ComposableContainerPanel.container` is declared `pn.layout.ListLike | list[Any]` — this backend
  stores a live Panel layout, not the base's list (the same narrowing `ComposableContainerRerun`
  already does for its element type).
- `ComposableContainerBase.label_formatter` is annotated
  `(str | None, float | str | None) -> str | None`, which is what it has always accepted and returned
  (four `is not None` branches and a `return None` in its body).

## Output parity (this is a refactor)

- `test_matches_pre_refactor_implementation` pins `compose_method_list_for_dims` against a verbatim
  copy of the pre-P8 algorithm over `ComposeType` × `num_dims` 0–4 × `time_sequence_dimension` −1–2:
  identical for every input the old code answered. The 18 combinations it raised on are skipped there
  and covered by `test_non_spatial_first_method_no_longer_raises` instead.
- `test_rerun_specs_match_the_two_tables_they_replaced` pins the merged mapping against both tables.
- `generate-examples` (inside `pixi run ci`) leaves `bencher/example/generated/` and `docs/`
  diff-clean.
- **No rendered output changed.**

Other tests added: `Axis.flip` totality, `ComposeType` no longer has `flip`, `as_axis` per member,
`_tabs` present-and-`None` for every compose method, the removed `horizontal` kwarg raising
`TypeError`, every `ComposeType` member having a rerun spec, and the two previously-silent failure
modes (panel `UnboundLocalError`, dataframe `None`) now being loud.

## Falsified plan claim (plans/README rule 7)

**Plan 24 §3 A3 states: "23-P8's `compose_method` — not a `param` field anywhere in the tree." That
is false.** `bencher/example/generated/composable_containers/example_composable_all_compose_types.py:51`
declares `compose_method = bn.EnumSweep(bn.ComposeType, default=bn.ComposeType.right)` — an
`EnumSweep`, i.e. a `param.Selector` subclass — and feeds the descriptor read `self.compose_method`
into `RenderCfg` at `:69` (generated from `generate_meta_composable.py:239-259`).

Why it does not invalidate this phase, stated rather than worked around:

1. The only `match` that param-sourced value reaches is `composable_container_video.py`'s, which D2
   keeps as a runtime `raise` — exactly the disposition plan 24 A1 prescribes for an un-established
   subject. **None of the four new `assert_never` arms is fed from a `param` read**; their subjects
   are `ComposeType`-annotated dataclass fields (plus, for rerun, a normalizing `ComposeType(...)`
   parse).
2. `EnumSweep` is a `param.Selector` over `list(ComposeType)`, so membership is validated **at set
   time** and only real members can be read back — the boundary normalization A1 asks for is already
   in place here.

Residual exposure, recorded rather than expanding P8's scope: were a 5th member added, ty would flag
all four sites above, but the *video* site would still be discovered at runtime.

## Owner principles

Nothing in this diff turns a tolerated render path into an abort. The one behaviour change on a
previously-working input is the opposite direction: `first_compose_method=sequence|overlay` used to
raise `RuntimeError` mid-composition and now renders. The two new raises replace *silent* failures
(`None` composition, `UnboundLocalError`) and are reachable only by passing a value that is not a
`ComposeType` at all — a construction-time programming error, never a `param` field, deserialized
cache, or worker output.

- `CHANGELOG.md` entry added under `[Unreleased]` (Changed + Removed), per the sibling plan-23 phases.
- `bencher.Axis` is exported alongside `ComposeType`.
- `pixi run ci` green: format, ruff, pylint 10.00/10, ty, generate-examples, full pytest + coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor composition handling to make flip operations total and unreachable states impossible, while tightening type-checking and error paths around compose methods.

New Features:
- Introduce an Axis type to represent spatial composition directions and own flip behaviour, decoupled from ComposeType.
- Allow compose_method_list_for_dims and video composition APIs to accept Axis as a seed alongside ComposeType.

Bug Fixes:
- Prevent non-spatial compose methods from triggering runtime flip errors by treating lack of an axis as a repeat behaviour rather than a failure.
- Replace silent failure modes in panel and dataframe composable containers with explicit assertion-based errors when given invalid compose methods.
- Ensure Rerun compose methods are normalized and report invalid values with clear ValueError messages instead of bare KeyErrors or runtime errors.

Enhancements:
- Make ComposeType pattern matches exhaustive using assert_never, so adding new members fails at type-check time instead of at runtime.
- Unify Rerun composition configuration into a single exhaustive mapping from ComposeType to shared or stacked view layouts, removing complementary tables and unreachable runtime guards.
- Declare panel container and tabs fields on the class to avoid re-deriving layout state and eliminate potential UnboundLocalError paths.
- Tighten type annotations for label formatting and compose-related modules and add them to the strict type-checking configuration.

Documentation:
- Update CHANGELOG with details of the Axis introduction, ComposeType.flip removal, exhaustive composition matches, and the removal of the horizontal compatibility flag.

Tests:
- Add parity and regression tests for compose_method_list_for_dims to guarantee output-equivalent behaviour to the legacy implementation and verify non-spatial seeds no longer raise.
- Add tests confirming Axis flip totality, ComposeType.as_axis behaviour, the absence of ComposeType.flip, and that only valid ComposeType members are produced and mapped.
- Add tests ensuring all ComposeType members have Rerun specs matching the legacy tables and that invalid compose methods are rejected loudly in panel, dataframe, and Rerun containers.
- Add tests validating tabs existence across compose methods and that the removed horizontal kwarg on ComposableContainerPanel now raises a TypeError.

Chores:
- Export the new Axis type from the public bencher API and composable_container package.
- Include composable_container modules in the strict ty override list in pyproject.toml.