### PR TITLE
refactor: WorkerState sum type replaces the not-set invariant (plan 23 P9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `n_failed > 0`, in the same way the regression report is auto-inserted.
 
 ### Changed
+- **`WorkerManager` holds one `WorkerState` instead of a not-set invariant** (plan 23 P9,
+  C7). `worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None` carried
+  three different situations in one field — an instance, a declaration-only class, or
+  nothing — with "declaration only" inferred from `worker is None`, and three
+  `RuntimeError("Worker class instance not set")` sites plus two `# noqa: TRY004`
+  suppressions standing in for the type the field did not have. The state is now a single
+  `Unbound | Declared(cls) | RunnableFunction(fn) | RunnableInstance(instance)` sum of
+  frozen dataclasses, parsed once in `set_worker` / `set_worker_class`; `worker` and
+  `worker_class_instance` remain as read-only views over it, so **the public
+  `set_worker` / `set_worker_class` API, the attributes `Bench` mirrors, and the
+  `RuntimeError` contract for a class-vs-instance mix-up are all unchanged**. The three
+  raise sites collapse into one total `_declaring()` accessor, and all three matches over
+  the union end in `assert_never` — verified by seeding a fifth variant and measuring
+  `error[type-assertion-failure]` at each site. The messages are now actionable: reading
+  variables with nothing attached names `set_worker()` and `set_worker_class()`, and doing
+  it with a plain-function worker says so and points at `input_vars`/`result_vars`/
+  `const_vars` rather than repeating "Worker class instance not set". These are all
+  setup-time errors, raised before any sample exists, so no in-progress sweep can lose
+  collected data to them. `bencher/worker_manager.py` joins the strict `ty` list.
+
+  Note the sum has **four** variants where the plan sketched three: callability and
+  "declares the sweep's variables" are independent axes, and folding them together would
+  have needed a nullable `instance` field inside `Runnable` — the same sentinel, one level
+  down. Also corrected while putting the module under strict typing:
+  `worker_input_cfg` is annotated `type[ParametrizedSweep]`, the class every caller has
+  always passed and the body has always instantiated (the annotation said instance while
+  the docstring said class). `bencher.py` and `sweep_executor.py` still carry the old
+  annotation on their pass-through parameters.
+
 - **`BenchRunCfg.executor` is normalized to an `Executors` member at the sweep boundary**
   (plan 23 P2, C13). Because `Executors` is a `StrEnum`,
   `param.Selector(objects=list(Executors))` accepts the bare string `"SERIAL"` and stores a

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -1,7 +1,8 @@
 """Worker management for benchmarking.
 
 This module provides the WorkerManager class for handling worker function
-configuration and validation in benchmark runs.
+configuration and validation in benchmark runs, and the :data:`WorkerState` sum
+type that models what a manager is holding at any moment (plan 23 P9, C7).
 """
 
 from __future__ import annotations
@@ -9,18 +10,29 @@ from __future__ import annotations
 import logging
 import warnings
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
+from typing import assert_never
 
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 logger = logging.getLogger(__name__)
 
 
-def kwargs_to_input_cfg(worker_input_cfg: ParametrizedSweep, **kwargs) -> ParametrizedSweep:
+def kwargs_to_input_cfg(worker_input_cfg: type[ParametrizedSweep], **kwargs) -> ParametrizedSweep:
     """Create a configured instance of a ParametrizedSweep with the provided keyword arguments.
 
+    ``worker_input_cfg`` is a *class*, and always was: every caller passes one (the
+    docstrings said "class" while the annotation said instance) and the body
+    instantiates it. Annotated honestly here as part of putting this module on the
+    strict `ty` list -- with the old annotation, ``worker_input_cfg()`` reads as
+    ``ParametrizedSweep.__call__``, i.e. a ``dict``, and the next line is an error.
+    ``bencher.py`` and ``sweep_executor.py`` still carry the instance annotation on
+    their pass-through parameters; correcting those is for whenever they join the
+    strict list.
+
     Args:
-        worker_input_cfg (ParametrizedSweep): The ParametrizedSweep class to instantiate
+        worker_input_cfg (type[ParametrizedSweep]): The ParametrizedSweep class to instantiate
         **kwargs: Keyword arguments to update the configuration with
 
     Returns:
@@ -31,7 +43,9 @@ def kwargs_to_input_cfg(worker_input_cfg: ParametrizedSweep, **kwargs) -> Parame
     return input_cfg
 
 
-def worker_cfg_wrapper(worker: Callable, worker_input_cfg: ParametrizedSweep, **kwargs) -> dict:
+def worker_cfg_wrapper(
+    worker: Callable, worker_input_cfg: type[ParametrizedSweep], **kwargs
+) -> dict:
     """Wrap a worker function to accept keyword arguments instead of a config object.
 
     This wrapper creates an instance of the worker_input_cfg class, updates it with the
@@ -39,7 +53,7 @@ def worker_cfg_wrapper(worker: Callable, worker_input_cfg: ParametrizedSweep, **
 
     Args:
         worker (Callable): The worker function that expects a config object
-        worker_input_cfg (ParametrizedSweep): The class defining the configuration
+        worker_input_cfg (type[ParametrizedSweep]): The class defining the configuration
         **kwargs: Keyword arguments to update the configuration with
 
     Returns:
@@ -49,29 +63,182 @@ def worker_cfg_wrapper(worker: Callable, worker_input_cfg: ParametrizedSweep, **
     return worker(input_cfg)
 
 
+@dataclass(frozen=True)
+class Unbound:
+    """Nothing attached yet -- what a fresh :class:`WorkerManager` holds.
+
+    Neither callable nor declaring: every read of the sweep's variables raises from
+    here, naming the method to call (this is setup time, before any sample has been
+    collected, so raising loses nothing).
+    """
+
+
+@dataclass(frozen=True)
+class Declared:
+    """A worker *class*, attached by :meth:`WorkerManager.set_worker_class`.
+
+    Declaring but not callable. Everything the declaration path needs is class-level
+    (``param.objects()`` plus the ``get_inputs_only`` / ``get_input_defaults`` /
+    ``get_results_only`` classmethods), so this state can describe and hash a sweep;
+    what it cannot do is run one, which is why ``worker`` reads back as ``None``.
+    """
+
+    worker_class: type[ParametrizedSweep]
+
+
+@dataclass(frozen=True)
+class RunnableFunction:
+    """A plain callable worker -- a function, a bound method, or a ``partial``.
+
+    Callable but not declaring: no ``ParametrizedSweep`` is attached, so the sweep's
+    variables have to come from the caller (``input_vars`` / ``result_vars`` /
+    ``const_vars`` on ``plot_sweep``). ``worker_input_cfg`` is folded into ``fn`` as a
+    ``partial`` at bind time and deliberately does *not* become a declaration source:
+    it never was one, and making it one would silently switch on ``plot_sweep``'s
+    auto-discovery for every function-plus-config caller.
+    """
+
+    fn: Callable
+
+
+@dataclass(frozen=True)
+class RunnableInstance:
+    """A ``ParametrizedSweep`` instance: callable *and* the declaration source.
+
+    The common case. ``worker`` is the instance's bound ``__call__``, and the same
+    instance answers what inputs, results and defaults the sweep is made of.
+    """
+
+    instance: ParametrizedSweep
+
+
+# The states a WorkerManager can be in (plan 23 P9, C7). Previously one
+# `worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None` field
+# carried all four, with "declaration only" inferred from `worker is None` and three
+# `RuntimeError("Worker class instance not set")` sites standing in for the missing
+# type. Note this is *four* variants, not the three plan 23 P9 sketched: callability
+# and declaring-ness are independent axes, and the plan's `Runnable(fn, instance)`
+# would have needed `instance: ParametrizedSweep | None` -- putting the sentinel back
+# inside a variant, so the three raise sites could not become exhaustive matches. A
+# comment rather than a docstring: check-docstring-first reads a bare string after a
+# module-level assignment as a misplaced module docstring.
+WorkerState = Unbound | Declared | RunnableFunction | RunnableInstance
+
+
 class WorkerManager:
     """Manages worker function configuration and validation for benchmarks.
 
     This class handles the setup and management of worker functions used in benchmarking,
     including support for both callable functions and ParametrizedSweep instances.
 
+    The state is held as a single :data:`WorkerState` (plan 23 P9); ``worker`` and
+    ``worker_class_instance`` are backward-compatible read-only views over it, so the
+    public ``set_worker`` / ``set_worker_class`` API is unchanged.
+
     Attributes:
-        worker (Callable): The configured worker function
-        worker_class_instance (ParametrizedSweep): The worker class instance if provided
-        worker_input_cfg (ParametrizedSweep): The input configuration class
+        state (WorkerState): ``Unbound()`` | ``Declared(cls)`` | ``RunnableFunction(fn)``
+            | ``RunnableInstance(instance)``
+        worker (Callable | None): The configured worker function, or None when nothing
+            callable is attached (``Unbound`` / ``Declared``)
+        worker_class_instance (ParametrizedSweep | type[ParametrizedSweep] | None): The
+            declaration source -- an instance, a class, or None when there is none
+        worker_input_cfg (type[ParametrizedSweep] | None): The input configuration class,
+            when the worker is a function that takes one
     """
 
     def __init__(self) -> None:
         """Initialize a new WorkerManager."""
-        self.worker: Callable | None = None
-        # A *class* when attached via set_worker_class for declaration only.
-        self.worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None = None
-        self.worker_input_cfg: ParametrizedSweep | None = None
+        self._state: WorkerState = Unbound()
+        self.worker_input_cfg: type[ParametrizedSweep] | None = None
+
+    @property
+    def state(self) -> WorkerState:
+        """The worker's lifecycle state; only ``set_worker*`` may change it."""
+        return self._state
+
+    @property
+    def worker(self) -> Callable | None:
+        """The callable worker, or None when nothing callable is attached.
+
+        A backward-compatible view over :attr:`state`. ``None`` here is not a
+        sentinel any longer -- it is what the two non-callable states project to --
+        so callers reading it still see the pre-P9 contract (``Unbound`` and
+        ``Declared`` both mean "cannot sample").
+        """
+        match self._state:
+            case Unbound() | Declared():
+                return None
+            case RunnableFunction(fn=fn):
+                return fn
+            case RunnableInstance(instance=instance):
+                return instance.__call__
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    @property
+    def worker_class_instance(self) -> ParametrizedSweep | type[ParametrizedSweep] | None:
+        """The declaration source: an instance, a class, or None.
+
+        A backward-compatible view over :attr:`state` (``Bench`` mirrors it onto
+        itself and ``plot_sweep`` gates auto-discovery on it being non-None).
+        """
+        match self._state:
+            case Unbound() | RunnableFunction():
+                return None
+            case Declared(worker_class=worker_class):
+                return worker_class
+            case RunnableInstance(instance=instance):
+                return instance
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def _declaring(self) -> ParametrizedSweep | type[ParametrizedSweep]:
+        """Return whatever declares this sweep's variables, or raise saying what to call.
+
+        Total over :data:`WorkerState`: the three pre-P9
+        ``RuntimeError("Worker class instance not set")`` sites in
+        :meth:`get_result_vars` / :meth:`get_inputs_only` / :meth:`get_input_defaults`
+        collapse into this one exhaustive match, so a new state cannot be added without
+        `ty` demanding an answer for it here.
+
+        Raising (rather than returning an empty list) is correct because every caller
+        is on the *declaration* path -- ``plot_sweep`` deciding what to sweep, before
+        any sample exists -- so nothing expensive is lost, and a silent empty answer
+        would produce a sweep with no variables instead of an error naming the fix.
+
+        Returns:
+            ParametrizedSweep | type[ParametrizedSweep]: The instance or class whose
+                ``get_*`` classmethods describe the sweep.
+
+        Raises:
+            RuntimeError: If no ParametrizedSweep is attached to read variables from.
+        """
+        match self._state:
+            case RunnableInstance(instance=instance):
+                return instance
+            case Declared(worker_class=worker_class):
+                return worker_class
+            case Unbound():
+                raise RuntimeError(
+                    "No worker is attached, so there are no benchmark variables to read. "
+                    "Call set_worker(<ParametrizedSweep instance>) to attach one, or "
+                    "set_worker_class(<ParametrizedSweep subclass>) to declare a sweep "
+                    "without running it."
+                )
+            case RunnableFunction():
+                raise RuntimeError(
+                    "The worker is a plain function, so no ParametrizedSweep declares this "
+                    "sweep's variables. Either call set_worker(<ParametrizedSweep "
+                    "instance>) instead, or pass input_vars/result_vars/const_vars to "
+                    "plot_sweep() explicitly."
+                )
+            case _ as unreachable:
+                assert_never(unreachable)
 
     def set_worker(
         self,
         worker: Callable | ParametrizedSweep,
-        worker_input_cfg: ParametrizedSweep | None = None,
+        worker_input_cfg: type[ParametrizedSweep] | None = None,
     ) -> None:
         """Set the benchmark worker function and its input configuration.
 
@@ -83,39 +250,43 @@ class WorkerManager:
             worker (Callable | ParametrizedSweep): Either a function that will be benchmarked or a
                 ParametrizedSweep instance with a __call__ method. When a ParametrizedSweep is
                 provided, its __call__ method becomes the worker function.
-            worker_input_cfg (ParametrizedSweep, optional): The class defining the input parameters
+            worker_input_cfg (type[ParametrizedSweep], optional): The class defining the inputs
                 for the worker function. Only needed if worker is a function rather than a
                 ParametrizedSweep instance. Defaults to None.
 
         Raises:
             RuntimeError: If worker is a class type instead of an instance.
         """
-        if isinstance(worker, ParametrizedSweep):
-            self.worker_class_instance = worker
-            self.worker = self.worker_class_instance.__call__
-            if (
-                type(worker).__call__ is not ParametrizedSweep.__call__
-                and type(worker).benchmark is ParametrizedSweep.benchmark
-            ):
-                warnings.warn(
-                    f"{type(worker).__name__} overrides __call__() which is deprecated. "
-                    "Override benchmark() instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            logger.info("setting worker from bench class.__call__")
-        else:
-            if isinstance(worker, type):
-                # RuntimeError, not TypeError: existing contract asserted by
-                # test_set_worker_class_type_error and catchable by callers.
-                raise RuntimeError(  # noqa: TRY004
-                    "This should be a class instance, not a class"
-                )
-            if worker_input_cfg is None:
-                self.worker = worker
-            else:
-                self.worker = partial(worker_cfg_wrapper, worker, worker_input_cfg)
-            logger.info(f"setting worker {worker}")
+        # Parsed into one WorkerState here, at the boundary (plan 23 P9). A `match` on
+        # the *argument* rather than an isinstance ladder, which is also what retires
+        # the two TRY004 noqa suppressions this method and set_worker_class carried: the
+        # rule fires on a non-TypeError raised under an isinstance guard, and
+        # RuntimeError is the contract these two methods have always had (asserted by
+        # test_set_worker_class_type_error and test_set_worker_class_rejects_an_instance,
+        # and catchable by callers).
+        match worker:
+            case ParametrizedSweep():
+                state: WorkerState = RunnableInstance(worker)
+                if (
+                    type(worker).__call__ is not ParametrizedSweep.__call__
+                    and type(worker).benchmark is ParametrizedSweep.benchmark
+                ):
+                    warnings.warn(
+                        f"{type(worker).__name__} overrides __call__() which is deprecated. "
+                        "Override benchmark() instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                logger.info("setting worker from bench class.__call__")
+            case type():
+                raise RuntimeError("This should be a class instance, not a class")
+            case _:
+                if worker_input_cfg is None:
+                    state = RunnableFunction(worker)
+                else:
+                    state = RunnableFunction(partial(worker_cfg_wrapper, worker, worker_input_cfg))
+                logger.info(f"setting worker {worker}")
+        self._state = state
         self.worker_input_cfg = worker_input_cfg
 
     def set_worker_class(self, worker_class: type[ParametrizedSweep]) -> None:
@@ -125,9 +296,10 @@ class WorkerManager:
         ``param.objects()`` plus the ``get_inputs_only`` / ``get_input_defaults`` /
         ``get_results_only`` classmethods -- so a class is enough to resolve variables
         by name, describe a sweep and hash it. What a class cannot do is be *called*,
-        which is why :meth:`set_worker` rejects one; ``worker`` is deliberately left
-        ``None`` here so any attempt to sample raises rather than silently calling a
-        class object.
+        which is why :meth:`set_worker` rejects one. Since P9 that distinction *is* the
+        state -- :class:`Declared` is declaring-but-not-callable, so ``worker`` reads
+        back ``None`` by construction rather than by being left unassigned, and any
+        attempt to sample raises rather than silently calling a class object.
 
         This exists for :func:`bencher.identity.sweep_identity`, which answers "what
         keys would this declaration produce" without running anything. Requiring an
@@ -145,11 +317,14 @@ class WorkerManager:
                 ``set_worker``'s complaint, so neither method silently accepts what
                 the other is for.
         """
-        if not isinstance(worker_class, type):
-            raise RuntimeError(  # noqa: TRY004
-                "This should be a class, not a class instance. Use set_worker() for an instance."
-            )
-        self.worker_class_instance = worker_class
+        match worker_class:
+            case type():
+                self._state = Declared(worker_class)
+            case _:
+                raise RuntimeError(
+                    "This should be a class, not a class instance. Use set_worker() for "
+                    "an instance."
+                )
         logger.info(f"setting worker class {worker_class} for declaration only")
 
     def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
@@ -165,13 +340,12 @@ class WorkerManager:
                 or in their original form.
 
         Raises:
-            RuntimeError: If the worker class instance is not set.
+            RuntimeError: If no ParametrizedSweep is attached (see :meth:`_declaring`).
         """
-        if self.worker_class_instance is not None:
-            if as_str:
-                return [i.name for i in self.worker_class_instance.get_results_only()]
-            return self.worker_class_instance.get_results_only()
-        raise RuntimeError("Worker class instance not set")
+        declaring = self._declaring()
+        if as_str:
+            return [i.name for i in declaring.get_results_only()]
+        return declaring.get_results_only()
 
     def get_inputs_only(self) -> list[ParametrizedSweep]:
         """Retrieve the input variables from the worker class instance.
@@ -180,11 +354,9 @@ class WorkerManager:
             list[ParametrizedSweep]: A list of input variables.
 
         Raises:
-            RuntimeError: If the worker class instance is not set.
+            RuntimeError: If no ParametrizedSweep is attached (see :meth:`_declaring`).
         """
-        if self.worker_class_instance is not None:
-            return self.worker_class_instance.get_inputs_only()
-        raise RuntimeError("Worker class instance not set")
+        return self._declaring().get_inputs_only()
 
     def get_input_defaults(self) -> list:
         """Retrieve the default input values from the worker class instance.
@@ -193,8 +365,6 @@ class WorkerManager:
             list: A list of default input values as (parameter, value) tuples.
 
         Raises:
-            RuntimeError: If the worker class instance is not set.
+            RuntimeError: If no ParametrizedSweep is attached (see :meth:`_declaring`).
         """
-        if self.worker_class_instance is not None:
-            return self.worker_class_instance.get_input_defaults()
-        raise RuntimeError("Worker class instance not set")
+        return self._declaring().get_input_defaults()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,7 @@ include = [
     "bencher/job.py",
     "bencher/worker_job.py",
     "bencher/result_collector.py",
+    "bencher/worker_manager.py",
 ]
 [tool.ty.overrides.rules]
 invalid-assignment = "error"

--- a/test/test_worker_manager.py
+++ b/test/test_worker_manager.py
@@ -199,7 +199,7 @@ class TestWorkerState(unittest.TestCase):
         self.assertEqual(self.manager.worker, instance.__call__)
 
     def test_runnable_instance_to_declared(self):
-        """Re-declaring drops the callable rather than leaving a stale one behind."""
+        """Redeclaring drops the callable rather than leaving a stale one behind."""
         self.manager.set_worker(ExampleBenchCfg())
         self.manager.set_worker_class(ExampleBenchCfg)
         self.assertEqual(self.manager.state, Declared(ExampleBenchCfg))

--- a/test/test_worker_manager.py
+++ b/test/test_worker_manager.py
@@ -1,12 +1,23 @@
 """Tests for WorkerManager extracted from Bench."""
 
+import dataclasses
 import unittest
+from typing import get_args
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from bencher.example.benchmark_data import ExampleBenchCfg
-from bencher.worker_manager import WorkerManager, kwargs_to_input_cfg, worker_cfg_wrapper
+from bencher.worker_manager import (
+    Declared,
+    RunnableFunction,
+    RunnableInstance,
+    Unbound,
+    WorkerManager,
+    WorkerState,
+    kwargs_to_input_cfg,
+    worker_cfg_wrapper,
+)
 
 
 class TestWorkerManager(unittest.TestCase):
@@ -117,6 +128,166 @@ class TestWorkerManager(unittest.TestCase):
             self.assertTrue(all(isinstance(v, str) for v in result_vars))
         else:
             self.assertTrue(all(hasattr(v, "name") for v in result_vars))
+
+
+class TestWorkerState(unittest.TestCase):
+    """The WorkerState sum type and every transition between its variants (plan 23 P9).
+
+    Before P9 the same information lived in one
+    ``worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None`` field
+    with "declaration only" inferred from ``worker is None``, so "callable" and "declares
+    the sweep's variables" could not be told apart by type. These tests pin each of the
+    four states, the ``worker`` / ``worker_class_instance`` views over them, and that a
+    rejected call leaves the previous state untouched.
+    """
+
+    def setUp(self):
+        self.manager = WorkerManager()
+
+    def test_a_fresh_manager_is_unbound(self):
+        """Nothing attached is its own state, not a pair of Nones."""
+        self.assertEqual(self.manager.state, Unbound())
+        self.assertIsNone(self.manager.worker)
+        self.assertIsNone(self.manager.worker_class_instance)
+
+    def test_unbound_to_runnable_instance(self):
+        """set_worker(instance): callable *and* the declaration source."""
+        instance = ExampleBenchCfg()
+        self.manager.set_worker(instance)
+        self.assertEqual(self.manager.state, RunnableInstance(instance))
+        self.assertEqual(self.manager.worker, instance.__call__)
+        self.assertIs(self.manager.worker_class_instance, instance)
+
+    def test_unbound_to_runnable_function(self):
+        """set_worker(fn): callable, but nothing declares the sweep's variables."""
+
+        def my_worker(**_kwargs):
+            return {"result": 1}
+
+        self.manager.set_worker(my_worker)
+        self.assertEqual(self.manager.state, RunnableFunction(my_worker))
+        self.assertIs(self.manager.worker, my_worker)
+        self.assertIsNone(self.manager.worker_class_instance)
+
+    def test_unbound_to_runnable_function_with_input_cfg(self):
+        """The config class is folded into the callable, not kept as a second mode."""
+
+        def my_worker(cfg):
+            return {"result": cfg.theta}
+
+        self.manager.set_worker(my_worker, ExampleBenchCfg)
+        self.assertIsInstance(self.manager.state, RunnableFunction)
+        self.assertIsNot(self.manager.worker, my_worker)  # wrapped in a partial
+        self.assertIs(self.manager.worker_input_cfg, ExampleBenchCfg)
+        # A config class is still not a declaration source: it never was one, and
+        # promoting it would switch on plot_sweep's auto-discovery for these callers.
+        self.assertIsNone(self.manager.worker_class_instance)
+
+    def test_unbound_to_declared(self):
+        """set_worker_class(cls): declares the sweep but cannot be sampled."""
+        self.manager.set_worker_class(ExampleBenchCfg)
+        self.assertEqual(self.manager.state, Declared(ExampleBenchCfg))
+        self.assertIsNone(self.manager.worker)
+        self.assertIs(self.manager.worker_class_instance, ExampleBenchCfg)
+
+    def test_declared_to_runnable_instance(self):
+        """Declaring first and binding later (sweep_identity then a real run)."""
+        self.manager.set_worker_class(ExampleBenchCfg)
+        instance = ExampleBenchCfg()
+        self.manager.set_worker(instance)
+        self.assertEqual(self.manager.state, RunnableInstance(instance))
+        self.assertEqual(self.manager.worker, instance.__call__)
+
+    def test_runnable_instance_to_declared(self):
+        """Re-declaring drops the callable rather than leaving a stale one behind."""
+        self.manager.set_worker(ExampleBenchCfg())
+        self.manager.set_worker_class(ExampleBenchCfg)
+        self.assertEqual(self.manager.state, Declared(ExampleBenchCfg))
+        self.assertIsNone(self.manager.worker)
+
+    def test_runnable_function_to_runnable_instance(self):
+        """Rebinding a function manager to an instance makes it declaring too."""
+
+        def my_worker(**_kwargs):
+            return {"result": 1}
+
+        self.manager.set_worker(my_worker)
+        instance = ExampleBenchCfg()
+        self.manager.set_worker(instance)
+        self.assertEqual(self.manager.state, RunnableInstance(instance))
+        self.assertIs(self.manager.worker_class_instance, instance)
+
+    def test_a_rejected_class_leaves_the_state_untouched(self):
+        """set_worker(cls) raises without half-binding anything."""
+        instance = ExampleBenchCfg()
+        self.manager.set_worker(instance)
+        with self.assertRaises(RuntimeError):
+            self.manager.set_worker(ExampleBenchCfg)
+        self.assertEqual(self.manager.state, RunnableInstance(instance))
+
+    def test_a_rejected_instance_leaves_the_state_untouched(self):
+        """set_worker_class(instance) raises without half-declaring anything."""
+        self.manager.set_worker_class(ExampleBenchCfg)
+        with self.assertRaises(RuntimeError):
+            self.manager.set_worker_class(ExampleBenchCfg())
+        self.assertEqual(self.manager.state, Declared(ExampleBenchCfg))
+
+    def test_states_are_frozen(self):
+        """A state is a value: it is replaced by set_worker*, never mutated in place."""
+        self.manager.set_worker_class(ExampleBenchCfg)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            self.manager.state.worker_class = ExampleBenchCfg  # type: ignore[misc]
+
+    def test_the_union_has_exactly_the_four_documented_variants(self):
+        """Guards the union against a variant added without updating the matches."""
+        self.assertEqual(
+            set(get_args(WorkerState)),
+            {Unbound, Declared, RunnableFunction, RunnableInstance},
+        )
+
+    def test_unbound_variable_reads_name_what_to_call(self):
+        """Setup-time failure, so raising is right -- but the message must be actionable."""
+        for read in (
+            self.manager.get_result_vars,
+            self.manager.get_inputs_only,
+            self.manager.get_input_defaults,
+        ):
+            with self.subTest(read=read.__name__), self.assertRaises(RuntimeError) as ctx:
+                read()
+            message = str(ctx.exception)
+            self.assertIn("set_worker(", message)
+            self.assertIn("set_worker_class(", message)
+
+    def test_plain_function_variable_reads_say_why_and_what_to_pass(self):
+        """A function worker has no declaration source; the message says so by name."""
+
+        def my_worker(**_kwargs):
+            return {"result": 1}
+
+        self.manager.set_worker(my_worker)
+        for read in (
+            self.manager.get_result_vars,
+            self.manager.get_inputs_only,
+            self.manager.get_input_defaults,
+        ):
+            with self.subTest(read=read.__name__), self.assertRaises(RuntimeError) as ctx:
+                read()
+            message = str(ctx.exception)
+            self.assertIn("plain function", message)
+            self.assertIn("set_worker(", message)
+            self.assertIn("result_vars", message)
+
+    def test_declared_answers_every_variable_read(self):
+        """A class is enough to describe a sweep -- the reason Declared exists."""
+        self.manager.set_worker_class(ExampleBenchCfg)
+        self.assertIn("out_sin", self.manager.get_result_vars(as_str=True))
+        self.assertTrue(self.manager.get_inputs_only())
+        self.assertIsInstance(self.manager.get_input_defaults(), list)
+
+    def test_state_is_read_only(self):
+        """Only set_worker* may change the state; nothing may poke it directly."""
+        with self.assertRaises(AttributeError):
+            self.manager.state = Unbound()
 
 
 class TestKwargsToInputCfg(unittest.TestCase):


### PR DESCRIPTION
Implements **plan 23 §5 P9** (C7, `plans/23-constructive-data-modeling.md:242` and `:565`).
Read alongside **plan 24 §2** (where `assert_never` is legitimate) and **plan 11**
(`plans/11-worker-lifecycle-and-resource-injection.md`), which plan 23 §8 pairs P9 with.

## What changed

`WorkerManager` held `worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None`
(`worker_manager.py:68` at `1642f154`) — an instance, a declaration-only class, or nothing — with
the mode inferred from `worker is None`. Three `RuntimeError("Worker class instance not set")`
sites (`:174`, `:187`, `:200`) and two `# noqa: TRY004` suppressions (`:111`, `:149`) carried the
invariant. All four citations were exact at `HEAD`.

The state is now a single field parsed once at the boundary:

```python
WorkerState = Unbound | Declared | RunnableFunction | RunnableInstance
```

- `Unbound` — neither callable nor declaring (a fresh manager).
- `Declared(worker_class)` — declaring but not callable (`set_worker_class`, used by
  `sweep_identity`).
- `RunnableFunction(fn)` — callable but not declaring (plain function, or the
  function-plus-`worker_input_cfg` partial).
- `RunnableInstance(instance)` — callable **and** declaring (the common case).

`worker` and `worker_class_instance` survive as **read-only views** over the state, so
`Bench._expose_worker_attrs`, `plot_sweep`'s `worker_class_instance is not None`
auto-discovery gate, `bencher/identity.py`, `example_video.py:118` and the existing tests
all read exactly as before. The three raise sites collapse into one total `_declaring()`
accessor.

### Public API: verified unchanged

Grepped every caller across `bencher/`, `test/`, `bencher/example/` and `docs/`:
`set_worker` / `set_worker_class` signatures, the `RuntimeError` (not `TypeError`) contract
for a class-vs-instance mix-up, both error strings for those two, and the
`worker` / `worker_class_instance` / `worker_input_cfg` attribute reads are all untouched.
Nothing in the tree ever *assigned* to `manager.worker*`, which is what makes the views safe.

### Error messages are now actionable

`RuntimeError("Worker class instance not set")` named a private field, not a fix. Now:

- `Unbound` → “No worker is attached … Call `set_worker(<ParametrizedSweep instance>)` …, or
  `set_worker_class(<ParametrizedSweep subclass>)` to declare a sweep without running it.”
- `RunnableFunction` → “The worker is a plain function, so no ParametrizedSweep declares this
  sweep's variables. Either call `set_worker(<ParametrizedSweep instance>)` instead, or pass
  `input_vars`/`result_vars`/`const_vars` to `plot_sweep()` explicitly.”

Both are **setup-time**, raised on the declaration path before any sample exists, so the
owner principle (a sweep in progress must never abort and lose expensive collected data)
is untouched — nothing here can fire mid-run.

## `assert_never` verified empirically

Per plan 24 A1 the subject is legitimate: `self._state` is this class's own field, declared
`WorkerState` and only ever assigned a variant — not a `param` descriptor read. Seeded a 5th
variant (`Seeded`), ran `pixi run ty`, got **3 diagnostics, one per match site**, then reverted:

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
   --> bencher/worker_manager.py:181:17   (WorkerManager.worker)
    | Inferred type of argument is `Seeded & ~Unbound & ~Declared & ~RunnableFunction & ~RunnableInstance`
   --> bencher/worker_manager.py:198:17   (WorkerManager.worker_class_instance)
    | Inferred type of argument is `Seeded & ~Unbound & ~RunnableFunction & ~Declared & ~RunnableInstance`
   --> bencher/worker_manager.py:241:17   (WorkerManager._declaring)
    | Inferred type of argument is `Seeded & ~RunnableInstance & ~Declared & ~Unbound & ~RunnableFunction`
Found 3 diagnostics
```

Note the `match` in `set_worker` deliberately does **not** end in `assert_never`: its subject
is the *argument* (`Callable | ParametrizedSweep` arriving from user code), i.e. exactly the
untyped ingress plan 24 §2 measured as unsound. That match is the parse — its `case _` arm
*constructs* `RunnableFunction`, and the `case type()` arm raises.

## `ty` strict list

`bencher/worker_manager.py` **is** added to the strict override block — `pixi run ty` is
`All checks passed!` with it listed, so the block's "a file joins only once clean" rule holds.
One honest-annotation fix was needed to get there (see falsified claims).

## Tests

`test/test_worker_manager.py` gains `TestWorkerState` (16 cases): every transition
(`Unbound→{Declared, RunnableFunction, RunnableInstance}`, `Declared→RunnableInstance`,
`RunnableInstance→Declared`, `RunnableFunction→RunnableInstance`), that a *rejected*
`set_worker(cls)` / `set_worker_class(instance)` leaves the previous state untouched (no
half-bind), that the variants are frozen and `state` is read-only, that the union has exactly
the four documented variants, and that each of the three variable reads raises a message
naming what to call from both `Unbound` and `RunnableFunction`.

`pixi run ci` green: **2680 passed, 3 skipped**, ruff + pylint 10.00/10 + `ty` clean,
`generate-examples` produced no diff. The example corpus (integration tests here) is
unaffected.

## Interaction with plan 11 (worker lifecycle & resource injection)

Plan 11 is **not implemented**, so per plan 23 §8 this lands first and plan 11 rebases. Read
plan 11 in full before shaping this; the design accommodates it as follows.

- **Phases 1–2 (result-var reset, per-sample hooks)** live in
  `parametrised_sweep.py` / `sweep_executor.py` — untouched by this PR, zero interaction.
- **§4.4 resource injection** is the one real contact point. `bn.run(MyClass)` today does
  `target = target()` in `run.py:157-158`; plan 11 wants `bn.run(MyClass, resources=...)` to
  construct with arguments. That step is now expressible *as a state transition*:
  `Declared(cls)` is precisely "a class we have not instantiated yet", so plan 11's
  instantiate-then-bind becomes `Declared → RunnableInstance` inside `WorkerManager`, rather
  than an ad-hoc `target = target()` at the entry point with the manager none the wiser.
- **§4.3 run hooks** need a worker that is both callable and a `ParametrizedSweep` —
  i.e. exactly `RunnableInstance`. Where plan 11 would otherwise have written
  `if worker is not None and isinstance(worker_class_instance, ParametrizedSweep)`, it can
  match one variant, and `ty` will point at the sites it forgot.
- **Constraints this imposes on plan 11** (stated rather than left to be discovered):
  (a) `worker` is now *derived*, so plan 11 cannot assign `manager.worker = wrapped` — it must
  add a state or a transition method, which is the better shape anyway; (b) any new variant
  (say a `Declared` carrying pending `resources`) must answer all three match sites, and `ty`
  enforces that; (c) plan 11 §1.6's "resources must stay out of every hash" is unaffected —
  no variant is hashed or persisted, `WorkerState` is process-local, and no cache key,
  sentinel or stored value changes in this PR (plan 23 §7's general rule).
- Plan 11's own citations into this file drift by a few lines
  (`:92-94` → `:94-95`, `:112` → `:117` at `1642f154`, and again here); its §1.1/§1.5
  *claims* all still hold.

## Falsified / amended plan claims (plans/README rule 7)

1. **P9's three-variant sketch is not sufficient — this ships four.** The plan specifies
   `Unbound | Declared(cls) | Runnable(fn, instance)`. "Is callable" and "declares the
   sweep's variables" are **independent** axes: a plain function is callable but declares
   nothing (and `worker_class_instance` was `None` for it, pre-existing behaviour). So
   `Runnable` would have needed `instance: ParametrizedSweep | None` — the same sentinel one
   level down — and the three raise sites could *not* have become exhaustive matches, which is
   the phase's entire point. Split into `RunnableFunction` / `RunnableInstance`.
2. **The two `TRY004` suppressions are retired by the ingress `match`, not by an
   `assert_never` match.** P9 phrases both as collapsing "into exhaustive matches with
   `assert_never`". The suppressions existed because ruff flags a non-`TypeError` raised under
   an `isinstance` guard; matching on the argument (`case ParametrizedSweep()` / `case type()`)
   is what removes them, and per plan 24 that match must *not* end in `assert_never`.
   `RuntimeError` is kept deliberately — it is the contract two existing tests assert.
3. **`worker_input_cfg` was annotated as an instance when it has always been a class.** Not
   noted in either plan; it is what blocked the strict-list addition (`worker_input_cfg()` read
   as `ParametrizedSweep.__call__ -> dict`, so `input_cfg.param` was an
   `unresolved-attribute` error). Every caller passes a class (`ExampleBenchCfg`, see
   `test_sweep_executor.py:38`) and the body instantiates it; the docstrings already said
   "class". Corrected to `type[ParametrizedSweep]` in this module only —
   `bencher.py:158,204,273` and `sweep_executor.py:246` still carry the old annotation on their
   pass-through parameters, for whenever they join the strict list.
4. **A config class is still not a declaration source.** Tempting to let
   `RunnableFunction` + `worker_input_cfg` answer variable reads, but it never did, and
   promoting it would silently switch on `plot_sweep`'s auto-discovery for every
   function-plus-config caller. Behaviour preserved and the reasoning recorded in the variant's
   docstring.
5. Plan 23 C7's four citations (`:68`, `:174`, `:187`, `:200`) were **exact** at `1642f154`;
   no drift to report there.

Not merging — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a `WorkerState` sum type in `WorkerManager` to model worker lifecycle explicitly while preserving the public API and error contracts.

Enhancements:
- Refactor `WorkerManager` to store a single `WorkerState` union instead of relying on `None`-based invariants and multiple `RuntimeError` sites.
- Expose `worker` and `worker_class_instance` as read-only views over `WorkerState` so existing callers and behavior remain unchanged.
- Improve variable-read error messages to clearly describe missing `ParametrizedSweep` declarations and suggest concrete remediation steps.
- Correct the type annotation of `worker_input_cfg` to use `type[ParametrizedSweep]`, aligning annotations with actual usage and documentation.

Build:
- Add `bencher/worker_manager.py` to the strict `ty` override list to enforce type-checking on the refactored module.

Documentation:
- Update `WorkerManager` and changelog documentation to describe the new `WorkerState` model and clarify the semantics of worker configuration and declaration.

Tests:
- Add `TestWorkerState` coverage verifying all state transitions, invariants, error messages, and that `WorkerState` has exactly the four expected variants.