### PR TITLE
refactor: delete the two plot gates that could never fire (plan 23 P6, C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `str | None` inputs, which is what it has always accepted and returned.
 
 ### Removed
+- **Deleted the two plot-selection gates that could never fire: `vector_len` and
+  `result_vars`** (plan 23 P6, C4; owner decision §6.1 resolved as *delete*). Both were
+  declared on `PltCntCfg` *and* on `PlotFilter`, and both were read on every
+  plot-selection pass (`PlotMatchesResult`) — but nothing in the package ever assigned
+  the `PltCntCfg` side, so both always held their default `1` while every filter
+  defaulted to `VarRange(1, 1)`. The gates therefore always passed and could not filter
+  anything, including `surface_result`'s "exactly one scalar result" intent, which never
+  actually held. `result_vars` had carried a `# todo remove` for some time.
+
+  **What populating them instead would have done** (the analysis §6.1 required before
+  deleting): with every filter left at the `VarRange(1, 1)` default, a correctly
+  populated `vector_len` would have made *every* plot reject any sweep containing a
+  `ResultVec(size > 1)`, and a correctly populated `result_vars` would have made every
+  plot reject any sweep with more than one result variable — which describes most of the
+  example corpus. Populating was the breaking option; deleting is the inert one, and
+  `pixi run generate-examples` confirms the generated gallery is byte-identical.
+
+  `BenchResultBase.filter()`'s `vector_len=` and `result_vars=` keyword parameters are
+  removed with them. No caller in the tree passed either; a caller who did could only
+  ever have used them to unconditionally *disable* a plot, since the counts they were
+  compared against were frozen at `1`.
+
 - **Deleted the dead setuptools files `setup.py`, `setup.cfg`, and `MANIFEST.in`** (plan
   03). The build has been hatchling via `pyproject.toml` for a long time, and
   `[tool.hatch.build] include` never shipped these three in the wheel or the sdist, so

--- a/bencher/plotting/plot_filter.py
+++ b/bencher/plotting/plot_filter.py
@@ -74,8 +74,6 @@ class PlotFilter:
 
     float_range: VarRange = field(default_factory=VarRange)
     cat_range: VarRange = field(default_factory=VarRange)
-    vector_len: VarRange = field(default_factory=lambda: VarRange(1, 1))
-    result_vars: VarRange = field(default_factory=lambda: VarRange(1, 1))
     panel_range: VarRange = field(default_factory=lambda: VarRange(0, 0))
     repeats_range: VarRange = field(default_factory=lambda: VarRange(1, None))
     input_range: VarRange = field(default_factory=lambda: VarRange(1, None))
@@ -91,8 +89,6 @@ class PlotFilter:
         return cls(
             float_range=anything(),
             cat_range=anything(),
-            vector_len=anything(),
-            result_vars=anything(),
             panel_range=anything(),
             repeats_range=anything(),
             input_range=anything(),
@@ -138,8 +134,6 @@ class PlotMatchesResult:
         match_candidates: list[tuple[VarRange, int, str]] = [
             (plot_filter.float_range, plt_cnt_cfg.float_cnt, "float"),
             (plot_filter.cat_range, plt_cnt_cfg.cat_cnt, "cat"),
-            (plot_filter.vector_len, plt_cnt_cfg.vector_len, "vec"),
-            (plot_filter.result_vars, plt_cnt_cfg.result_vars, "results"),
             (plot_filter.panel_range, plt_cnt_cfg.panel_cnt, "panels"),
             (plot_filter.repeats_range, plt_cnt_cfg.repeats, "repeats"),
             (plot_filter.input_range, plt_cnt_cfg.inputs_cnt, "inputs"),

--- a/bencher/plotting/plt_cnt_cfg.py
+++ b/bencher/plotting/plt_cnt_cfg.py
@@ -35,8 +35,6 @@ class PltCntCfg(param.Parameterized):
     float_cnt = param.Integer(0, doc="The number of float variables to plot")
     cat_vars = param.List(doc="A list of categorical values to plot in order hue,row,col")
     cat_cnt = param.Integer(0, doc="The number of cat variables")
-    vector_len = param.Integer(1, doc="The vector length of the return variable , scalars = len 1")
-    result_vars = param.Integer(1, doc="The number result variables to plot")  # todo remove
     panel_vars = param.List(doc="A list of panel results")
     panel_cnt = param.Integer(0, doc="Number of results represent as panel panes")
     repeats = param.Integer(0, doc="The number of repeat samples")
@@ -132,7 +130,6 @@ class PltCntCfg(param.Parameterized):
             f"float_cnt: {self.float_cnt}\n"
             f"cat_cnt: {self.cat_cnt}\n"
             f"panel_cnt: {self.panel_cnt}\n"
-            f"vector_len: {self.vector_len}\n"
             f"has_time: {self.has_time}\n"
             f"time_steps: {self.time_steps}\n"
             f"result_kinds: {self.result_kinds}\n"

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -755,8 +755,6 @@ class BenchResultBase:
         plot_filter=None,
         float_range: VarRange | None = None,
         cat_range: VarRange | None = None,
-        vector_len: VarRange | None = None,
-        result_vars: VarRange | None = None,
         panel_range: VarRange | None = None,
         repeats_range: VarRange | None = None,
         input_range: VarRange | None = None,
@@ -777,10 +775,6 @@ class BenchResultBase:
             float_range = VarRange(0, None)
         if cat_range is None:
             cat_range = VarRange(0, None)
-        if vector_len is None:
-            vector_len = VarRange(1, 1)
-        if result_vars is None:
-            result_vars = VarRange(1, 1)
         if panel_range is None:
             panel_range = VarRange(0, None)
         if repeats_range is None:
@@ -790,8 +784,6 @@ class BenchResultBase:
         plot_filter = PlotFilter(
             float_range=float_range,
             cat_range=cat_range,
-            vector_len=vector_len,
-            result_vars=result_vars,
             panel_range=panel_range,
             repeats_range=repeats_range,
             input_range=input_range,
@@ -809,8 +801,6 @@ class BenchResultBase:
                 float_cnt=len(adj_float),
                 cat_vars=adj_cat,
                 cat_cnt=len(adj_cat),
-                vector_len=self.plt_cnt_cfg.vector_len,
-                result_vars=self.plt_cnt_cfg.result_vars,
                 panel_vars=list(self.plt_cnt_cfg.panel_vars),
                 panel_cnt=self.plt_cnt_cfg.panel_cnt,
                 repeats=self.plt_cnt_cfg.repeats,

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -117,8 +117,6 @@ class SurfaceResult(HoloviewResult):
         matches_res = PlotFilter(
             float_range=VarRange(2, 2),
             cat_range=VarRange(0, None),
-            vector_len=VarRange(1, 1),
-            result_vars=VarRange(1, 1),
         ).matches_result(self.plt_cnt_cfg, "to_surface_hv", override)
         if matches_res.overall:
             x = self.plt_cnt_cfg.float_vars[0]

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import unittest
 from unittest.mock import patch
 
@@ -493,7 +494,7 @@ class TestPlotFilterMatchAll(unittest.TestCase):
         for cfg in (
             PltCntCfg(),
             PltCntCfg(float_cnt=3, cat_cnt=2, repeats=5, inputs_cnt=5),
-            PltCntCfg(panel_cnt=2, vector_len=4, result_vars=3),
+            PltCntCfg(panel_cnt=2),
         ):
             self.assertTrue(f.matches_result(cfg, "match_all", override=False).overall)
 
@@ -594,6 +595,47 @@ class TestEntryPointDiscovery(unittest.TestCase):
             ep_mock.return_value = [FakeEP()]
             names = sorted(p.name for p in reg.all())
             self.assertEqual(names, ["ep.one", "ep.two"])
+
+
+class TestDeletedPlotGates(unittest.TestCase):
+    """Plan 23 P6 (C4): ``vector_len`` and ``result_vars`` are gone.
+
+    They were declared on both ``PltCntCfg`` and ``PlotFilter`` and read on
+    every plot-selection pass, but nothing in the package ever assigned the
+    ``PltCntCfg`` side -- so both always held their default ``1`` and both
+    gates (``VarRange(1, 1)``) always passed. They could not filter anything,
+    including ``surface_result``'s "exactly one scalar result" intent, which
+    is why deleting them leaves plot selection byte-identical.
+
+    Populating them instead would have been the breaking option: with every
+    filter defaulting to ``VarRange(1, 1)``, a real ``vector_len`` would have
+    made *every* plot reject any sweep containing a ``ResultVec(size > 1)``,
+    and a real ``result_vars`` would have made every plot reject any sweep
+    with more than one result variable -- which is most of them.
+    """
+
+    def test_plt_cnt_cfg_no_longer_declares_them(self):
+        params = PltCntCfg.param.objects()
+        self.assertNotIn("vector_len", params)
+        self.assertNotIn("result_vars", params)
+
+    def test_plot_filter_no_longer_declares_them(self):
+        fields = {f.name for f in dataclasses.fields(PlotFilter)}
+        self.assertNotIn("vector_len", fields)
+        self.assertNotIn("result_vars", fields)
+
+    def test_selection_ignores_them(self):
+        # A sweep shape that the deleted gates would have rejected had they
+        # ever been populated still matches a permissive filter.
+        cfg = PltCntCfg(float_cnt=1, cat_cnt=0, panel_cnt=0, repeats=1, inputs_cnt=1)
+        res = PlotFilter(
+            float_range=VarRange(1, 1),
+            cat_range=VarRange(0, None),
+            panel_range=VarRange(0, None),
+            repeats_range=VarRange(1, None),
+            input_range=VarRange(1, None),
+        ).matches_result(cfg, "probe", False)
+        self.assertTrue(res.overall)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements the **C4 half** of plan 23 P6, resolving OWNER DECISION §6.1 as **delete** —
with the analysis §6.1 required before deleting.

## The finding

`vector_len` and `result_vars` were declared on **both** `PltCntCfg` (`plt_cnt_cfg.py:38-39`)
and `PlotFilter` (`plot_filter.py:77-78`), and read on **every** plot-selection pass
(`PlotMatchesResult`'s `match_candidates`, `plot_filter.py:141-142`). But nothing in the
package ever assigned the `PltCntCfg` side — verified by grep across `bencher/`; the only
writer was one test. So both were frozen at their default `1` while every filter defaulted
to `VarRange(1, 1)`: the gates always passed and **could not filter anything**, including
`surface_result`'s "exactly one scalar result" intent (`surface_result.py:120-121`), which
therefore never held. `result_vars` had carried a `# todo remove`.

## What populating them would have done (the §6.1 analysis)

This is the part worth recording, because it inverts the intuition that populating is the
"correct" fix:

| Gate | If populated correctly | Consequence with the `VarRange(1, 1)` default every filter uses |
|---|---|---|
| `vector_len` | actual `ResultVec` size | **every** plot rejects any sweep containing a `ResultVec(size > 1)` |
| `result_vars` | count of result variables | **every** plot rejects any sweep with more than one result variable |

The second describes most of the example corpus. Populating was the breaking option;
deleting is the inert one.

## Evidence that it is inert

`pixi run generate-examples` leaves `bencher/example/generated/` and `docs/` **byte-identical** —
plot selection is provably unchanged, which is exactly what "the gates never fired" predicts.

## Public API note

`BenchResultBase.filter()`'s `vector_len=` and `result_vars=` keyword parameters are removed
with them. No caller in the tree passes either; a caller who did could only ever have used
them to unconditionally *disable* a plot, since the counts they were compared against were
frozen at `1`.

## Scope

This PR is **C4 only**. P6's other half — C3, the `VarRange` `-1`/`None` two-sentinel
redesign (named constructors, retiring `match_all()`/`anything`, and the
`plugins/plugin.py:72-73` "silently hiding the plugin forever" footgun) — touches 98
`VarRange(` call sites across 18 files and is left for a follow-up PR so this provably-inert
deletion is reviewable on its own.

## Tests

`TestDeletedPlotGates` in `test/test_plugins.py` pins that neither name is declared on
either class and that a sweep shape the gates would have rejected (had they been populated)
still matches. `pixi run ci` green: 91% coverage, pylint 10.00/10, `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove unused plot-selection gates and associated parameters to simplify configuration without changing plot behavior.

Enhancements:
- Drop `vector_len` and `result_vars` from plot filter and count configuration to eliminate inert gating logic.

Documentation:
- Document removal of the `vector_len` and `result_vars` plot-selection gates and related filter parameters in the changelog.

Tests:
- Add regression tests ensuring the deleted plot-selection gates are no longer declared and that plot matching behavior remains unchanged.