### PR TITLE
refactor: VarRange named constructors, no sentinel bounds (plan 23 P6, C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match-nothing `float_range`/`cat_range` default. `volume_result`'s `cat_range` was
   written `VarRange(-1, 0)`, whose negative lower bound was inert because `matches()`
   rejects negative counts — it is now the `VarRange.exactly(0)` it always meant.
-  `pixi run generate-docs` produces a byte-identical output tree.
+  Verified two ways: every removed `VarRange(lo, hi)` literal was paired with the
+  constructor that replaced it and their truth tables compared over counts 0..40 against
+  the pre-change implementation (29/29 identical); and `pixi run generate-docs` was run on
+  `main`, on this branch, and a second time on this branch as a noise floor. The reports
+  are *not* byte-comparable — they embed random UUIDs, wall-clock times and randomly
+  generated benchmark values, so two runs of identical code differ — but the plot skeleton
+  (the ordered sequence of Bokeh/Panel model types per report) is identical for 294 of 295
+  reports, the exception being `example_advanced_git_time_event`, which is keyed by the
+  current commit and also differs in the noise floor. All 231 plain-text gallery outputs
+  are byte-identical.
 
 - **`WorkerManager` holds one `WorkerState` instead of a not-set invariant** (plan 23 P9,
   C7). `worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None` carried

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `n_failed > 0`, in the same way the regression report is auto-inserted.
 
 ### Changed
+- **`VarRange` is built with named constructors; the `-1`/`None` sentinel pair is gone**
+  (plan 23 P6, C3). `VarRange.upper_bound` carried three meanings on one field — `-1`
+  meant "match nothing" (and was the default), `None` meant "no upper bound", and any
+  other value was a real bound — while `lower_bound` accepted `None` as a fourth
+  spelling of `0`. The class docstring had already drifted away from the code (it claimed
+  both bounds defaulted to `-1`; `lower_bound` defaulted to `0`). A `VarRange` is now a
+  frozen wrapper over a three-variant sum — no counts, a closed `low..high` interval, or
+  an open `low..` interval — built through `VarRange.none()`, `.exactly(n)`,
+  `.between(lo, hi)`, `.at_most(n)`, `.at_least(n)` and `.unbounded()`. Nonsense that the
+  old constructor accepted silently (`VarRange(2, 1)`, a negative bound) now raises at
+  construction, and `matches()` dispatches over the variants with `assert_never`.
+
+  **`PlotFilter()` no longer matches nothing.** Every field now defaults to
+  `VarRange.unbounded()`, so an omitted range never narrows a filter and a plugin
+  declared with the obvious `match=PlotFilter()` — or with no match rule at all — is
+  eligible for every sweep shape instead of being hidden forever. `PlotFilter.match_all()`
+  existed only to work around the old default and has been **removed**; use `PlotFilter()`.
+  `BenchResultBase.filter()`'s five `*_range` parameters lose their `None` defaults for
+  the real ranges they always stood in for, and its long-dead `plot_filter=` parameter
+  (unconditionally overwritten two lines later) is gone.
+
+  **Plot selection is unchanged.** Every production filter now states all five ranges
+  explicitly, so the new permissive default cannot widen anything: the three direct
+  `PlotFilter(...)` sites that previously inherited a restrictive default
+  (`surface_result`'s `panel_range`, plus `repeats_range` in `video_summary` and
+  `rerun_summary`) spell those values out. No production filter had ever inherited the
+  match-nothing `float_range`/`cat_range` default. `volume_result`'s `cat_range` was
+  written `VarRange(-1, 0)`, whose negative lower bound was inert because `matches()`
+  rejects negative counts — it is now the `VarRange.exactly(0)` it always meant.
+  `pixi run generate-docs` produces a byte-identical output tree.
+
 - **`WorkerManager` holds one `WorkerState` instead of a not-set invariant** (plan 23 P9,
   C7). `worker_class_instance: ParametrizedSweep | type[ParametrizedSweep] | None` carried
   three different situations in one field — an instance, a declaration-only class, or

--- a/bencher/plotting/plot_filter.py
+++ b/bencher/plotting/plot_filter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import assert_never
 
 import panel as pn
 
@@ -10,49 +11,117 @@ from bencher.plotting.plt_cnt_cfg import PltCntCfg
 logger = logging.getLogger(__name__)
 
 
-class VarRange:
-    """A VarRange represents the bounded and unbounded ranges of integers.  This class is used to define filters for various variable types.  For example by defining cat_var = VarRange(0,0), calling matches(0) will return true, but any other integer will not match.  You can also have unbounded ranges for example VarRange(2,None) will match to 2,3,4... up to infinity. for By default the lower and upper bounds are set to -1 so so that no matter what value is passed to matches() will return false.  Matches only takes 0 and positive integers."""
+@dataclass(frozen=True)
+class _Nothing:
+    """No count matches at all."""
 
-    def __init__(self, lower_bound: int = 0, upper_bound: int = -1) -> None:
-        """
-        Args:
-            lower_bound (int, optional): The smallest acceptable value to matches(). Passing None will result in a lower bound of 0 (as matches only accepts positive integers). Defaults to 0.
-            upper_bound (int, optional): The largest acceptable value to matches().  Passing None will result in no upper bound. Defaults to -1 which results in a range with no matches.
-        """
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+
+@dataclass(frozen=True)
+class _Between:
+    """Every count from ``low`` to ``high`` inclusive matches."""
+
+    low: int
+    high: int
+
+    def __post_init__(self) -> None:
+        if self.low < 0:
+            raise ValueError(f"low must be >= 0, got {self.low}")
+        if self.high < self.low:
+            raise ValueError(f"high must be >= low, got low={self.low} high={self.high}")
+
+
+@dataclass(frozen=True)
+class _AtLeast:
+    """Every count from ``low`` upwards matches; there is no upper bound."""
+
+    low: int
+
+    def __post_init__(self) -> None:
+        if self.low < 0:
+            raise ValueError(f"low must be >= 0, got {self.low}")
+
+
+_Bounds = _Nothing | _Between | _AtLeast
+
+
+@dataclass(frozen=True)
+class VarRange:
+    """A set of acceptable counts, used to declare which sweep shapes a plot handles.
+
+    ``matches()`` only accepts counts of 0 or more (a count of variables can never be
+    negative). Build a range with one of the named constructors -- there is no
+    meaningful "raw" pair of bounds, and no sentinel value standing in for
+    "unbounded" or "nothing":
+
+    * :meth:`none` -- matches no count at all.
+    * :meth:`exactly` -- ``exactly(2)`` matches only 2.
+    * :meth:`between` -- ``between(0, 1)`` matches 0 and 1.
+    * :meth:`at_most` -- ``at_most(2)`` matches 0, 1 and 2.
+    * :meth:`at_least` -- ``at_least(2)`` matches 2, 3, 4, ... with no upper limit.
+    * :meth:`unbounded` -- matches every count.
+    """
+
+    bounds: _Bounds
+
+    @classmethod
+    def none(cls) -> VarRange:
+        """A range that no count matches."""
+        return cls(_Nothing())
+
+    @classmethod
+    def exactly(cls, count: int) -> VarRange:
+        """A range matching ``count`` and nothing else."""
+        return cls(_Between(count, count))
+
+    @classmethod
+    def between(cls, low: int, high: int) -> VarRange:
+        """A range matching every count from ``low`` to ``high`` inclusive."""
+        return cls(_Between(low, high))
+
+    @classmethod
+    def at_most(cls, high: int) -> VarRange:
+        """A range matching every count from 0 to ``high`` inclusive."""
+        return cls(_Between(0, high))
+
+    @classmethod
+    def at_least(cls, low: int) -> VarRange:
+        """A range matching ``low`` and every larger count."""
+        return cls(_AtLeast(low))
+
+    @classmethod
+    def unbounded(cls) -> VarRange:
+        """A range matching every count."""
+        return cls(_AtLeast(0))
 
     def matches(self, val: int) -> bool:
-        """Checks that a value is within the variable range.  lower_bound and upper_bound are inclusive (lower_bound<=val<=upper_bound )
+        """Check whether a count falls in this range.
 
         Args:
-            val (int): A positive integer representing a number of items
+            val (int): A count of items; must be 0 or more.
 
         Returns:
-            bool: True if the items is within the range, False otherwise.
+            bool: True if the count is in the range, False otherwise.
 
         Raises:
             ValueError: If val < 0
         """
         if val < 0:
             raise ValueError("val must be >= 0")
-        if self.lower_bound is not None:
-            lower_match = val >= self.lower_bound
-        else:
-            lower_match = True
-
-        if self.upper_bound is not None:
-            upper_match = val <= self.upper_bound
-        else:
-            upper_match = True
-
-        return lower_match and upper_match
+        match self.bounds:
+            case _Nothing():
+                return False
+            case _Between(low=low, high=high):
+                return low <= val <= high
+            case _AtLeast(low=low):
+                return low <= val
+            case _ as unreachable:
+                assert_never(unreachable)
 
     def matches_info(self, val: int, name: str) -> tuple[bool, str]:
         """Get matching info for a value with a descriptive name.
 
         Args:
-            val (int): A positive integer to check against the range
+            val (int): A count of items to check against the range
             name (str): A descriptive name for the value being checked, used in the output string
 
         Returns:
@@ -61,38 +130,61 @@ class VarRange:
                 - str: A formatted string describing the match result
         """
         match = self.matches(val)
-        info = f"{name}\t{self.lower_bound}>= {val} <={self.upper_bound} is {match}"
+        info = f"{name}\t{self._describe(val)} is {match}"
         return match, info
 
+    def _describe(self, val: int) -> str:
+        """Render this range around ``val`` for the human-readable match report.
+
+        The ``lo>= val <=hi`` spelling (with ``None`` for "no upper bound") is kept
+        verbatim from the pre-sum-type implementation so that debug panes and
+        ``explain_selection()`` reasons read exactly as before.
+        """
+        match self.bounds:
+            case _Nothing():
+                return f"no count matches {val}"
+            case _Between(low=low, high=high):
+                return f"{low}>= {val} <={high}"
+            case _AtLeast(low=low):
+                return f"{low}>= {val} <=None"
+            case _ as unreachable:
+                assert_never(unreachable)
+
     def __str__(self) -> str:
-        return f"VarRange(lower_bound={self.lower_bound}, upper_bound={self.upper_bound})"
+        match self.bounds:
+            case _Nothing():
+                return "VarRange.none()"
+            case _Between(low=low, high=high):
+                if low == high:
+                    return f"VarRange.exactly({low})"
+                if low == 0:
+                    return f"VarRange.at_most({high})"
+                return f"VarRange.between({low}, {high})"
+            case _AtLeast(low=low):
+                if low == 0:
+                    return "VarRange.unbounded()"
+                return f"VarRange.at_least({low})"
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def __repr__(self) -> str:
+        return str(self)
 
 
 @dataclass
 class PlotFilter:
-    """A class for representing the types of results a plot is able to represent."""
+    """The sweep shapes a plot is able to represent.
 
-    float_range: VarRange = field(default_factory=VarRange)
-    cat_range: VarRange = field(default_factory=VarRange)
-    panel_range: VarRange = field(default_factory=lambda: VarRange(0, 0))
-    repeats_range: VarRange = field(default_factory=lambda: VarRange(1, None))
-    input_range: VarRange = field(default_factory=lambda: VarRange(1, None))
+    Every field defaults to :meth:`VarRange.unbounded`, so a default-constructed
+    ``PlotFilter()`` matches every shape. Narrow only the dimensions a plot actually
+    constrains; an omitted field never silently hides the plot.
+    """
 
-    @classmethod
-    def match_all(cls) -> PlotFilter:
-        """A filter that matches every sweep shape.
-
-        The default ``PlotFilter()`` ranges are restrictive (``VarRange()`` matches
-        nothing), which suits plots that opt in to specific shapes. Plugins that do
-        their own internal shape handling should use this instead."""
-        anything = lambda: VarRange(0, None)
-        return cls(
-            float_range=anything(),
-            cat_range=anything(),
-            panel_range=anything(),
-            repeats_range=anything(),
-            input_range=anything(),
-        )
+    float_range: VarRange = field(default_factory=VarRange.unbounded)
+    cat_range: VarRange = field(default_factory=VarRange.unbounded)
+    panel_range: VarRange = field(default_factory=VarRange.unbounded)
+    repeats_range: VarRange = field(default_factory=VarRange.unbounded)
+    input_range: VarRange = field(default_factory=VarRange.unbounded)
 
     def matches_result(
         self, plt_cnt_cfg: PltCntCfg, plot_name: str, override: bool

--- a/bencher/plugins/builtins.py
+++ b/bencher/plugins/builtins.py
@@ -3,9 +3,9 @@
 Each wrapper delegates to the existing renderer method on the live BenchResult
 (carried in ``BenchData.legacy_result``), so renderer logic is unchanged — this
 phase only moves *dispatch* onto the plugin registry. The registry-level match
-rule is permissive (``PlotFilter.match_all()``) because today's renderers build
-their shape filters dynamically inside ``to_plot`` (scenario lists, over_time
-special cases) and return ``None`` on mismatch; centralizing those filters into
+rule is permissive (a default ``PlotFilter()``, which matches every shape) because
+today's renderers build their shape filters dynamically inside ``to_plot`` (scenario
+lists, over_time special cases) and return ``None`` on mismatch; centralizing those into
 declarative signatures is the plot-selection redesign (A2), not this phase.
 
 Priorities encode the legacy ``default_plot_callbacks()`` ordering so reports
@@ -156,7 +156,7 @@ def register_builtin_plugins() -> None:
             LegacyResultPlugin(
                 name=name,
                 backend=backend,
-                match=PlotFilter.match_all(),
+                match=PlotFilter(),
                 priority=priority,
                 requires=frozenset({"legacy_result"}),
                 callback=callback,
@@ -169,7 +169,7 @@ def register_builtin_plugins() -> None:
             LegacyResultPlugin(
                 name=name,
                 backend=backend,
-                match=PlotFilter.match_all(),
+                match=PlotFilter(),
                 priority=priority,
                 requires=frozenset({"legacy_result"}),
                 callback=callback,

--- a/bencher/plugins/plugin.py
+++ b/bencher/plugins/plugin.py
@@ -69,12 +69,12 @@ def plot_plugin(
     ``plot_list``/``include``/``only``."""
 
     def decorator(fn: Callable[[BenchData], pn.viewable.Viewable]) -> _FunctionPlugin:
-        # No match rule means "always eligible": PlotFilter() would match nothing
-        # (its default VarRanges are empty), silently hiding the plugin forever.
+        # No match rule means "always eligible": every PlotFilter field defaults to
+        # VarRange.unbounded(), so a default-constructed filter matches every shape.
         plugin = _FunctionPlugin(
             name=name,
             backend=backend,
-            match=match if match is not None else PlotFilter.match_all(),
+            match=match if match is not None else PlotFilter(),
             priority=priority,
             requires=frozenset(requires) if requires else frozenset(),
             _fn=fn,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -53,6 +53,11 @@ from bencher.variables.results import (
 
 logger = logging.getLogger(__name__)
 
+# Shared defaults for BenchResultBase.filter(). VarRange is frozen, so a single
+# instance can back every call; module-level names also keep ruff's B008 happy.
+_ANY_COUNT = VarRange.unbounded()
+_AT_LEAST_ONE = VarRange.at_least(1)
+
 # todo add plugins
 # https://gist.github.com/dorneanu/cce1cd6711969d581873a88e0257e312
 # https://kaleidoescape.github.io/decorated-plugins/
@@ -752,12 +757,11 @@ class BenchResultBase:
     def filter(
         self,
         plot_callback: Callable,
-        plot_filter=None,
-        float_range: VarRange | None = None,
-        cat_range: VarRange | None = None,
-        panel_range: VarRange | None = None,
-        repeats_range: VarRange | None = None,
-        input_range: VarRange | None = None,
+        float_range: VarRange = _ANY_COUNT,
+        cat_range: VarRange = _ANY_COUNT,
+        panel_range: VarRange = _ANY_COUNT,
+        repeats_range: VarRange = _AT_LEAST_ONE,
+        input_range: VarRange = _AT_LEAST_ONE,
         reduce: ReduceType = ReduceType.AUTO,
         target_dimension: int = 2,
         result_var: ResultFloat | None = None,
@@ -770,17 +774,7 @@ class BenchResultBase:
         pane_layout: PaneLayout = PaneLayout.grid,
         **kwargs,
     ) -> pn.panel | None:
-        # Initialize default filters if not provided to avoid shared mutable defaults
-        if float_range is None:
-            float_range = VarRange(0, None)
-        if cat_range is None:
-            cat_range = VarRange(0, None)
-        if panel_range is None:
-            panel_range = VarRange(0, None)
-        if repeats_range is None:
-            repeats_range = VarRange(1, None)
-        if input_range is None:
-            input_range = VarRange(1, None)
+        # VarRange is frozen, so these defaults are safe to share between calls.
         plot_filter = PlotFilter(
             float_range=float_range,
             cat_range=cat_range,

--- a/bencher/results/histogram_result.py
+++ b/bencher/results/histogram_result.py
@@ -40,9 +40,9 @@ class HistogramResult(HoloviewResult):
         self_snapshot.ds = ds
         return self_snapshot.filter(
             self.to_histogram_ds,
-            float_range=VarRange(0, 0),
-            cat_range=VarRange(0, None),
-            input_range=VarRange(0, 0),
+            float_range=VarRange.exactly(0),
+            cat_range=VarRange.unbounded(),
+            input_range=VarRange.exactly(0),
             reduce=ReduceType.NONE,
             target_dimension=target_dimension,
             result_var=result_var,

--- a/bencher/results/holoview_results/band_result.py
+++ b/bencher/results/holoview_results/band_result.py
@@ -38,10 +38,10 @@ class BandResult(HoloviewResult):
         kwargs.pop("agg_fn", None)
         return self.filter(
             self.to_band_ds,
-            float_range=VarRange(0, None),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(1, None),
-            input_range=VarRange(0, None),
+            float_range=VarRange.unbounded(),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.at_least(1),
+            input_range=VarRange.unbounded(),
             reduce=ReduceType.NONE,
             target_dimension=None,
             result_var=result_var,

--- a/bencher/results/holoview_results/bar_result.py
+++ b/bencher/results/holoview_results/bar_result.py
@@ -49,11 +49,11 @@ class BarResult(HoloviewResult):
         """
         # When over_time is active, allow 0 inputs so 0D+0cat+over_time can produce
         # a line chart.  Without over_time, require at least 1 input (the default).
-        input_range = VarRange(0, None) if self.bench_cfg.over_time else None
+        input_range = VarRange.unbounded() if self.bench_cfg.over_time else VarRange.at_least(1)
         common = {
-            "float_range": VarRange(0, 0),
-            "cat_range": VarRange(0, None),
-            "panel_range": VarRange(0, None),
+            "float_range": VarRange.exactly(0),
+            "cat_range": VarRange.unbounded(),
+            "panel_range": VarRange.unbounded(),
             "input_range": input_range,
             "target_dimension": target_dimension,
             "result_var": result_var,
@@ -63,12 +63,12 @@ class BarResult(HoloviewResult):
 
         scenarios = [
             {
-                "repeats_range": VarRange(1, 1),
+                "repeats_range": VarRange.exactly(1),
                 "reduce": ReduceType.SQUEEZE,
                 "result_types": (ResultFloat,),
             },
             {
-                "repeats_range": VarRange(2, None),
+                "repeats_range": VarRange.at_least(2),
                 "reduce": ReduceType.REDUCE,
                 "result_types": (ResultBool,),
             },

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -38,9 +38,9 @@ class CurveResult(HoloviewResult):
         """
         return self.filter(
             self.to_curve_ds,
-            float_range=VarRange(1, 1),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(2, None),
+            float_range=VarRange.exactly(1),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.at_least(2),
             reduce=ReduceType.REDUCE,
             target_dimension=2,
             result_var=result_var,

--- a/bencher/results/holoview_results/distribution_result/distribution_result.py
+++ b/bencher/results/holoview_results/distribution_result/distribution_result.py
@@ -51,9 +51,9 @@ class DistributionResult(HoloviewResult):
         """
         return self.filter(
             plot_method,
-            float_range=VarRange(0, 0),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(2, None),
+            float_range=VarRange.exactly(0),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.at_least(2),
             reduce=ReduceType.NONE,
             target_dimension=self.plt_cnt_cfg.cat_cnt + 1,  # +1 cos we have a repeats dimension
             result_var=result_var,

--- a/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
+++ b/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
@@ -59,9 +59,9 @@ class ScatterJitterResult(DistributionResult):
             target_dimension = self.plt_cnt_cfg.cat_cnt + 1
         return self.filter(
             self.to_scatter_jitter_ds,
-            float_range=VarRange(0, 0),
-            cat_range=VarRange(0, 1),
-            repeats_range=VarRange(2, None),
+            float_range=VarRange.exactly(0),
+            cat_range=VarRange.at_most(1),
+            repeats_range=VarRange.at_least(2),
             reduce=ReduceType.NONE,
             target_dimension=target_dimension,
             result_var=result_var,

--- a/bencher/results/holoview_results/heatmap_result.py
+++ b/bencher/results/holoview_results/heatmap_result.py
@@ -72,10 +72,10 @@ class HeatmapResult(HoloviewResult):
 
         return self.filter(
             heatmap_cb,
-            float_range=VarRange(2, None),
-            cat_range=VarRange(0, None),
-            input_range=VarRange(2, None),
-            panel_range=VarRange(0, None),
+            float_range=VarRange.at_least(2),
+            cat_range=VarRange.unbounded(),
+            input_range=VarRange.at_least(2),
+            panel_range=VarRange.unbounded(),
             target_dimension=target_dimension,
             result_var=result_var,
             result_types=(ResultFloat,),

--- a/bencher/results/holoview_results/line_result.py
+++ b/bencher/results/holoview_results/line_result.py
@@ -72,17 +72,17 @@ class LineResult(HoloviewResult):
         # When over_time is active, also accept 0 float vars so a 0D benchmark
         # gets a time-series line (x=over_time, y=value).
         if self.bench_cfg.over_time:
-            float_range = VarRange(0, 1)
-            input_range = VarRange(0, None)
+            float_range = VarRange.at_most(1)
+            input_range = VarRange.unbounded()
         else:
-            float_range = VarRange(1, 1)
-            input_range = None
+            float_range = VarRange.exactly(1)
+            input_range = VarRange.at_least(1)
         return self.filter(
             line_cb,
             float_range=float_range,
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(1, 1),
-            panel_range=VarRange(0, None),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.exactly(1),
+            panel_range=VarRange.unbounded(),
             input_range=input_range,
             reduce=ReduceType.SQUEEZE,
             target_dimension=target_dimension,

--- a/bencher/results/holoview_results/scatter_result.py
+++ b/bencher/results/holoview_results/scatter_result.py
@@ -40,9 +40,9 @@ class ScatterResult(HoloviewResult):
         """
         return self.filter(
             self._to_scatter_ds,
-            float_range=VarRange(0, 0),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(1, 1),
+            float_range=VarRange.exactly(0),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.exactly(1),
             reduce=ReduceType.SQUEEZE,
             result_var=result_var,
             result_types=(ResultVar,),

--- a/bencher/results/holoview_results/surface_result.py
+++ b/bencher/results/holoview_results/surface_result.py
@@ -76,9 +76,9 @@ class SurfaceResult(HoloviewResult):
         """
         return self.filter(
             self.to_surface_ds,
-            float_range=VarRange(2, None),
-            cat_range=VarRange(0, None),
-            input_range=VarRange(1, None),
+            float_range=VarRange.at_least(2),
+            cat_range=VarRange.unbounded(),
+            input_range=VarRange.at_least(1),
             reduce=ReduceType.REDUCE,
             target_dimension=target_dimension,
             result_var=result_var,
@@ -115,8 +115,11 @@ class SurfaceResult(HoloviewResult):
                                otherwise returns filter match results.
         """
         matches_res = PlotFilter(
-            float_range=VarRange(2, 2),
-            cat_range=VarRange(0, None),
+            float_range=VarRange.exactly(2),
+            cat_range=VarRange.unbounded(),
+            panel_range=VarRange.exactly(0),
+            repeats_range=VarRange.at_least(1),
+            input_range=VarRange.at_least(1),
         ).matches_result(self.plt_cnt_cfg, "to_surface_hv", override)
         if matches_res.overall:
             x = self.plt_cnt_cfg.float_vars[0]

--- a/bencher/results/rerun_summary.py
+++ b/bencher/results/rerun_summary.py
@@ -104,10 +104,11 @@ class RerunSummaryResult(BenchResultBase):
             pn.panel | None: a panel pane holding one rerun viewer per result var.
         """
         plot_filter = PlotFilter(
-            float_range=VarRange(0, None),
-            cat_range=VarRange(0, None),
-            panel_range=VarRange(1, None),
-            input_range=VarRange(1, None),
+            float_range=VarRange.unbounded(),
+            cat_range=VarRange.unbounded(),
+            panel_range=VarRange.at_least(1),
+            repeats_range=VarRange.at_least(1),
+            input_range=VarRange.at_least(1),
         )
         matches_res = plot_filter.matches_result(
             self.plt_cnt_cfg, callable_name(self.to_rerun_grid), override=False

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -62,10 +62,11 @@ class VideoSummaryResult(BenchResultBase):
             pn.panel | None: a panel pane with a video of all results concatenated together
         """
         plot_filter = PlotFilter(
-            float_range=VarRange(0, None),
-            cat_range=VarRange(0, None),
-            panel_range=VarRange(1, None),
-            input_range=VarRange(1, None),
+            float_range=VarRange.unbounded(),
+            cat_range=VarRange.unbounded(),
+            panel_range=VarRange.at_least(1),
+            repeats_range=VarRange.at_least(1),
+            input_range=VarRange.at_least(1),
         )
         matches_res = plot_filter.matches_result(
             self.plt_cnt_cfg, callable_name(self.to_video_grid_ds), override=False

--- a/bencher/results/volume_result.py
+++ b/bencher/results/volume_result.py
@@ -63,8 +63,8 @@ class VolumeResult(BenchResultBase):
             return None
         return self.filter(
             self.to_volume_ds,
-            float_range=VarRange(3, 3),
-            cat_range=VarRange(-1, 0),
+            float_range=VarRange.exactly(3),
+            cat_range=VarRange.exactly(0),
             reduce=ReduceType.REDUCE,
             target_dimension=target_dimension,
             result_var=result_var,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -334,10 +334,12 @@ A `PlotFilter` specifies acceptable ranges for:
 - `cat_range` — how many categorical inputs
 - `repeats_range` — how many repeats
 - `panel_range` — how many panel-type results (images, videos)
-- `result_vars` — how many numeric result variables
 - `input_range` — total input count
 
-Each range is a `VarRange(lower, upper)` where `None` for upper means unbounded. A plot type
+Each range is built with a named constructor — `VarRange.exactly(1)`,
+`VarRange.between(0, 2)`, `VarRange.at_most(2)`, `VarRange.at_least(2)`,
+`VarRange.unbounded()` or `VarRange.none()`. Any range left unstated defaults to
+`VarRange.unbounded()`, so omitting a dimension never narrows the filter. A plot type
 matches only when *all* ranges are satisfied. When multiple plot types match, Bencher renders
 all of them, giving a multi-perspective view of the data.
 

--- a/docs/plot_plugin_design.md
+++ b/docs/plot_plugin_design.md
@@ -455,7 +455,7 @@ internally):
 
 ```python
 @bencher.plot_plugin(name="my.line", backend="user",
-                     match=PlotFilter(float_range=VarRange(1, 1)),
+                     match=PlotFilter(float_range=VarRange.exactly(1)),
                      priority=10,
                      requires={"optimizer_study"},  # optional
                      auto=True)                     # False = named-only
@@ -684,7 +684,7 @@ To start tier 1:
    from bencher.plugins import BenchData, PlotFilter, VarRange, plot_plugin
 
    @plot_plugin(name="holoviews.line", backend="holoviews",
-                match=PlotFilter(float_range=VarRange(1, 1), ...))
+                match=PlotFilter(float_range=VarRange.exactly(1), ...))
    def render_line(data: BenchData) -> pn.viewable.Viewable:
        # Move the rendering logic out of LineResult.to_line() into here.
        ...

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -535,8 +535,11 @@ and may be reordered or dropped individually.
   `results/holoview_results/*`, `bench_result_base.py`, `plugins/`,
   `surface_result.py`, `test/test_plugins.py` (~18 files, mechanical).
 - **DoD:** plot-selection output unchanged on the gallery-driving tests
-  (`pixi run generate-docs` diff-clean); a default-constructed filter can no longer
-  hide a plugin.
+  (~~`pixi run generate-docs` diff-clean~~ — **not achievable, see §10 P6 item 1**: the
+  reports embed random UUIDs, wall-clock times and randomly generated benchmark values,
+  so two runs of *identical* code differ in bytes. The substitute measurement is the
+  id-independent plot skeleton of every report, against a same-code noise floor);
+  a default-constructed filter can no longer hide a plugin.
 
 ### P7 — History enums (C5)
 
@@ -1057,3 +1060,65 @@ sweep written by `main`'s code and read by P5's → 6/6 hits). One MEDIUM findin
    §10 P2 item 1, one added by P5); the class is `TestCatchDoesNotChangeContractHandling`.
    Per plans-README rule 7 the symbol is the durable reference, so a plan whose thesis is
    "claims are measured" should not cite one that does not exist.
+
+### P6 (implemented, C3 half)
+
+1. **The DoD's "`pixi run generate-docs` diff-clean" is not achievable, by this or any
+   other change — including a no-op.** The generated reports embed a fresh UUID per Bokeh
+   document, a wall-clock `run date`, gzip-encoded arrays of *randomly generated*
+   benchmark values, and CPython `id()` addresses in `CustomJS` tags. Measured rather
+   than assumed: `generate-docs` was run three times — once on clean `origin/main`, once
+   on the branch, and a second time on the branch to establish a noise floor. Every pair
+   differs in raw bytes, including the two runs of identical code.
+   **The substitute measurement, which is what the DoD was reaching for:** compare the
+   id-independent *plot skeleton* of each report — the ordered sequence of Bokeh/Panel
+   model types plus the pane-title sequence — which is exactly what plot selection
+   determines and is unaffected by data values. Noise floor (branch vs branch): 0 of 295
+   reports differ in model-type sequence. Main vs branch: 1 of 295, and it is
+   `advanced/example_advanced_git_time_event`, whose sweep is keyed by
+   `time_src=bn.git_time_event()` — a different commit gives its over_time axis a second
+   tick and a regression-comparison plot. That report also differs in the noise floor.
+   All 231 plain-text outputs (gallery `.rst`/`.md`/`.json`) *are* byte-identical, and so
+   is `bencher/example/generated/**.py`. A future phase quoting "diff-clean" for a
+   rendering change should state this measurement instead.
+   The Bokeh model-id counter also drifts run-to-run at the same file boundaries in the
+   noise floor as it does between main and branch, so counter deltas are not evidence.
+
+2. **A second, stronger check that does not depend on the doc build:** each removed
+   `VarRange(lo, hi)` literal was paired with the constructor that replaced it and their
+   truth tables compared over counts 0..40, evaluating the old literal with the *pre-P6*
+   `matches()` implementation. 29 of 29 automatically pairable sites are identical; the
+   9 files whose literal count changed are the hand-edits in items 3–5.
+
+3. **Nothing in `bencher/` ever inherited the match-nothing default, so flipping it was
+   safe.** There are only four `PlotFilter(...)` constructions in the package — everything
+   else routes through `BenchResultBase.filter()`, whose own `None`-defaults were already
+   permissive. Of the four, `bench_result_base.py` states all five ranges;
+   `surface_result.py` omitted `panel_range`/`repeats_range`/`input_range` and
+   `video_summary.py`/`rerun_summary.py` omitted `repeats_range` — all *restrictive*
+   inherited values, none of them `float_range`/`cat_range`. Those three now state every
+   range explicitly at its previous value, so the default's value no longer reaches any
+   production filter. The old default could therefore only ever have harmed plugin
+   authors, which is exactly what `plugin.py:72-73` had written down.
+
+4. **`VarRange(-1, 0)`** (`volume_result.py`, `cat_range`) was not a fourth sentinel: a
+   negative lower bound is inert because `matches()` rejects negative counts, so the range
+   matched exactly `0`. It is now `VarRange.exactly(0)`. **`VarRange(None, None)`** (7
+   sites, all in `test/test_plot_filter.py`) meant "no lower bound, no upper bound" =
+   every count = `VarRange.unbounded()`; two of those tests had become the same test and
+   are replaced by an `unbounded` test plus a real `at_least` test.
+
+5. **Two adjacent removals the phase spec did not name.** `BenchResultBase.filter()`'s
+   `plot_filter=` parameter was dead — unconditionally overwritten two lines below its own
+   declaration — and its five `*_range: VarRange | None = None` parameters plus the
+   five-branch "avoid shared mutable defaults" fixup collapse into real defaults now that
+   `VarRange` is frozen (module-level singletons, because ruff B008 forbids the call in
+   the signature).
+
+6. **The human-readable match report keeps its exact pre-P6 wording**
+   (`float\t1>= 2 <=None is False`, with `None` still standing for "no upper bound").
+   That string is surfaced by `explain_selection()` rejection reasons and by the debug
+   pane `filter()` returns when `PltCntCfg.print_debug` is set — which **defaults to
+   `True`**, so it reaches any report built outside `to_auto()`. Rewording it would have
+   been a user-visible change riding along on a type refactor; the sentinel it prints is
+   now only a rendering, not a representable state.

--- a/test/test_explain_selection.py
+++ b/test/test_explain_selection.py
@@ -95,17 +95,18 @@ class TestExplainMatchesSelect(unittest.TestCase):
         self.assertTrue(line.chosen)
 
     def test_shape_filter_rejection_reason(self):
-        """Built-ins register match_all (shape gating still lives inside to_plot),
+        """Built-ins register a permissive default filter (shape gating still lives
+        inside to_plot),
         so use a plugin with an honest filter to exercise the mismatch reason."""
 
         @plot_plugin(
             name="needs_two_floats",
             backend="test",
             match=PlotFilter(
-                float_range=VarRange(2, 2),
-                cat_range=VarRange(0, None),
-                repeats_range=VarRange(1, None),
-                input_range=VarRange(1, None),
+                float_range=VarRange.exactly(2),
+                cat_range=VarRange.unbounded(),
+                repeats_range=VarRange.at_least(1),
+                input_range=VarRange.at_least(1),
             ),
         )
         def _two_floats(_: object):

--- a/test/test_plot_filter.py
+++ b/test/test_plot_filter.py
@@ -8,21 +8,21 @@ from bencher.plotting.plot_filter import PlotFilter, PltCntCfg, VarRange
 
 class TestVarRange(unittest.TestCase):
     def test_matches_zero(self) -> None:
-        zero_case = VarRange(0, 0)
+        zero_case = VarRange.exactly(0)
         self.assertTrue(zero_case.matches(0))
         self.assertFalse(zero_case.matches(1))
 
     def test_matches_upto(self) -> None:
-        var_range = VarRange(0, 1)
+        var_range = VarRange.at_most(1)
         # self.assertFalse(zero_case.matches(-1))
         self.assertTrue(var_range.matches(0))
         self.assertTrue(var_range.matches(1))
         self.assertFalse(var_range.matches(2))
 
     @given(st.integers())
-    def test_default_matches_nothing(self, val) -> None:
-        """Check that the default constructor produces a range that always returns false (so that any matches must be defined explicitly by the developer)"""
-        var_range = VarRange()
+    def test_none_matches_nothing(self, val) -> None:
+        """VarRange.none() must reject every count (and still reject negatives)."""
+        var_range = VarRange.none()
         if val >= 0:
             self.assertFalse(var_range.matches(val))
         else:
@@ -30,37 +30,86 @@ class TestVarRange(unittest.TestCase):
                 var_range.matches(val)
 
     @given(st.integers(min_value=0))
-    def test_matches_none_upper(self, val) -> None:
-        """Check that no upper bound matches all positive integers"""
-        var_range = VarRange(0, None)
-        self.assertTrue(var_range.matches(val))
+    def test_unbounded_matches_everything(self, val) -> None:
+        """VarRange.unbounded() must accept every count."""
+        self.assertTrue(VarRange.unbounded().matches(val))
 
     @given(st.integers(min_value=0))
-    def test_matches_none_none(self, val) -> None:
-        """No lower and no upper bounds should always match regardless of input"""
-        var_range = VarRange(None, None)
-        self.assertTrue(var_range.matches(val))
+    def test_at_least_has_no_upper_bound(self, val) -> None:
+        """at_least(2) accepts 2 and every larger count, and nothing below it."""
+        var_range = VarRange.at_least(2)
+        self.assertEqual(var_range.matches(val), val >= 2)
+
+    def test_exactly(self) -> None:
+        var_range = VarRange.exactly(2)
+        self.assertFalse(var_range.matches(1))
+        self.assertTrue(var_range.matches(2))
+        self.assertFalse(var_range.matches(3))
+
+    def test_between(self) -> None:
+        var_range = VarRange.between(1, 3)
+        self.assertFalse(var_range.matches(0))
+        for val in (1, 2, 3):
+            self.assertTrue(var_range.matches(val))
+        self.assertFalse(var_range.matches(4))
+
+    def test_ranges_are_frozen_and_comparable(self) -> None:
+        """Frozen + value equality is what lets the ranges be shared as defaults."""
+        self.assertEqual(VarRange.unbounded(), VarRange.at_least(0))
+        self.assertEqual(VarRange.exactly(2), VarRange.between(2, 2))
+        self.assertNotEqual(VarRange.none(), VarRange.exactly(0))
+        self.assertEqual(hash(VarRange.exactly(1)), hash(VarRange.exactly(1)))
+
+    def test_nonsense_bounds_are_rejected(self) -> None:
+        """The old two-sentinel constructor could express these; the new one cannot."""
+        with self.assertRaises(ValueError):
+            VarRange.between(2, 1)
+        with self.assertRaises(ValueError):
+            VarRange.at_least(-1)
+        with self.assertRaises(ValueError):
+            VarRange.exactly(-1)
+
+    def test_str_round_trips_to_its_constructor(self) -> None:
+        for var_range, text in (
+            (VarRange.none(), "VarRange.none()"),
+            (VarRange.exactly(2), "VarRange.exactly(2)"),
+            (VarRange.at_most(2), "VarRange.at_most(2)"),
+            (VarRange.between(1, 3), "VarRange.between(1, 3)"),
+            (VarRange.at_least(2), "VarRange.at_least(2)"),
+            (VarRange.unbounded(), "VarRange.unbounded()"),
+        ):
+            self.assertEqual(str(var_range), text)
 
 
 class TestPlotFilter(unittest.TestCase):
     @given(st.integers(min_value=0), st.integers(min_value=0))
-    def test_matches_none(self, float_cnt, cat_cnt) -> None:
-        """The default plot filter should not match any inputs"""
+    def test_default_filter_matches_everything(self, float_cnt, cat_cnt) -> None:
+        """Every PlotFilter field defaults to VarRange.unbounded(), so an omitted
+        field never narrows the filter. A default PlotFilter() matches any shape."""
 
-        null_case = PlotFilter()
-        self.assertFalse(
-            null_case.matches_result(
-                PltCntCfg(float_cnt=float_cnt, cat_cnt=cat_cnt), "test_matches_none", False
-            ).overall
+        self.assertTrue(
+            PlotFilter()
+            .matches_result(
+                PltCntCfg(float_cnt=float_cnt, cat_cnt=cat_cnt),
+                "test_default_filter_matches_everything",
+                False,
+            )
+            .overall
         )
+
+    def test_omitted_fields_do_not_narrow(self) -> None:
+        """Stating one dimension must not silently constrain the other four."""
+        cfg = PltCntCfg(float_cnt=1, cat_cnt=3, panel_cnt=2, repeats=4, inputs_cnt=4)
+        pf = PlotFilter(float_range=VarRange.exactly(1))
+        self.assertTrue(pf.matches_result(cfg, "one_float_only", False).overall)
 
     def test_matches_float(self) -> None:
         # match only float from 0 to 1
         pf = PlotFilter(
-            float_range=VarRange(0, 1),
-            cat_range=VarRange(None, None),
-            repeats_range=VarRange(None, None),
-            input_range=VarRange(None, None),
+            float_range=VarRange.at_most(1),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.unbounded(),
+            input_range=VarRange.unbounded(),
         )
 
         self.assertTrue(
@@ -77,10 +126,10 @@ class TestPlotFilter(unittest.TestCase):
     def test_matches_float_cat(self, cat_cnt) -> None:
         # match any cat count but only float from 0 to 1
         pf = PlotFilter(
-            float_range=VarRange(0, 1),
-            cat_range=VarRange(None, None),
-            repeats_range=VarRange(None, None),
-            input_range=VarRange(None, None),
+            float_range=VarRange.at_most(1),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.unbounded(),
+            input_range=VarRange.unbounded(),
         )
 
         self.assertTrue(

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -130,10 +130,10 @@ class TestRegistry(unittest.TestCase):
             name="mutated",
             backend="t",
             match=PlotFilter(
-                float_range=VarRange(0, None),
-                cat_range=VarRange(0, None),
-                repeats_range=VarRange(0, None),
-                input_range=VarRange(0, None),
+                float_range=VarRange.unbounded(),
+                cat_range=VarRange.unbounded(),
+                repeats_range=VarRange.unbounded(),
+                input_range=VarRange.unbounded(),
             ),
             register=False,
         )
@@ -230,10 +230,10 @@ class TestSelection(unittest.TestCase):
         self.reg.mark_entry_points_loaded()
 
         self.permissive_filter = PlotFilter(
-            float_range=VarRange(0, None),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(0, None),
-            input_range=VarRange(0, None),
+            float_range=VarRange.unbounded(),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.unbounded(),
+            input_range=VarRange.unbounded(),
         )
 
         @plot_plugin(
@@ -256,9 +256,15 @@ class TestSelection(unittest.TestCase):
         def _beta(_: BenchData) -> pn.viewable.Viewable:
             return _make_pane("beta")
 
-        @plot_plugin(name="gamma", backend="hv", match=PlotFilter(), register=False)
+        # gamma opts out of every shape explicitly; selection must skip it.
+        @plot_plugin(
+            name="gamma",
+            backend="hv",
+            match=PlotFilter(float_range=VarRange.none()),
+            register=False,
+        )
         def _gamma(_: BenchData) -> pn.viewable.Viewable:
-            return _make_pane("gamma")  # default PlotFilter never matches
+            return _make_pane("gamma")
 
         self.alpha, self.beta, self.gamma = _alpha, _beta, _gamma
         for p in (_alpha, _beta, _gamma):
@@ -394,10 +400,10 @@ class TestRender(unittest.TestCase):
         self.reg = PluginRegistry()
         self.reg.mark_entry_points_loaded()
         self.permissive = PlotFilter(
-            float_range=VarRange(0, None),
-            cat_range=VarRange(0, None),
-            repeats_range=VarRange(0, None),
-            input_range=VarRange(0, None),
+            float_range=VarRange.unbounded(),
+            cat_range=VarRange.unbounded(),
+            repeats_range=VarRange.unbounded(),
+            input_range=VarRange.unbounded(),
         )
 
     def test_render_happy_path(self) -> None:
@@ -474,7 +480,8 @@ class TestGlobalRegistration(unittest.TestCase):
 
     def test_default_match_is_always_eligible(self) -> None:
         """A plugin declared without a match rule must be selectable for any sweep
-        shape — PlotFilter()'s empty default ranges would silently hide it forever."""
+        shape. Before plan 23 P6 the default ranges were empty, so a plugin author
+        who wrote the obvious ``match=PlotFilter()`` hid it forever."""
         reg = PluginRegistry()
         reg.mark_entry_points_loaded()
 
@@ -488,19 +495,47 @@ class TestGlobalRegistration(unittest.TestCase):
             self.assertEqual([p.name for p in selected], ["global.smoke"])
 
 
-class TestPlotFilterMatchAll(unittest.TestCase):
-    def test_match_all_matches_various_shapes(self) -> None:
-        f = PlotFilter.match_all()
-        for cfg in (
-            PltCntCfg(),
-            PltCntCfg(float_cnt=3, cat_cnt=2, repeats=5, inputs_cnt=5),
-            PltCntCfg(panel_cnt=2),
-        ):
-            self.assertTrue(f.matches_result(cfg, "match_all", override=False).overall)
+class TestDefaultPlotFilterIsPermissive(unittest.TestCase):
+    """Plan 23 P6 (C3): a default-constructed filter can no longer hide a plugin.
 
-    def test_default_plot_filter_matches_nothing(self) -> None:
-        # Documents the existing default: PlotFilter() is restrictive by design.
-        self.assertFalse(PlotFilter().matches_result(PltCntCfg(), "default", False).overall)
+    ``PlotFilter.match_all()`` used to exist only because ``PlotFilter()`` matched
+    nothing; every field now defaults to ``VarRange.unbounded()`` and the classmethod
+    is gone."""
+
+    SHAPES = (
+        PltCntCfg(),
+        PltCntCfg(float_cnt=3, cat_cnt=2, repeats=5, inputs_cnt=5),
+        PltCntCfg(panel_cnt=2),
+    )
+
+    def test_default_filter_matches_various_shapes(self) -> None:
+        f = PlotFilter()
+        for cfg in self.SHAPES:
+            self.assertTrue(f.matches_result(cfg, "default", override=False).overall)
+
+    def test_match_all_is_gone(self) -> None:
+        self.assertFalse(hasattr(PlotFilter, "match_all"))
+
+    def test_plugin_without_a_match_rule_is_never_hidden(self) -> None:
+        """The plugin.py footgun: declaring a plugin with no match rule, or with the
+        obvious ``match=PlotFilter()``, must leave it eligible for every shape."""
+        reg = PluginRegistry()
+        reg.mark_entry_points_loaded()
+
+        @plot_plugin(name="p6.implicit", register=False)
+        def _implicit(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("implicit")
+
+        @plot_plugin(name="p6.explicit", match=PlotFilter(), register=False)
+        def _explicit(_: BenchData) -> pn.viewable.Viewable:
+            return _make_pane("explicit")
+
+        reg.register(_implicit)
+        reg.register(_explicit)
+        for cfg in self.SHAPES:
+            data = BenchData.fake(plt_cnt_cfg=cfg)
+            names = sorted(p.name for p in reg.select(data))
+            self.assertEqual(names, ["p6.explicit", "p6.implicit"], msg=str(cfg))
 
 
 class TestEntryPointDiscovery(unittest.TestCase):
@@ -603,12 +638,12 @@ class TestDeletedPlotGates(unittest.TestCase):
     They were declared on both ``PltCntCfg`` and ``PlotFilter`` and read on
     every plot-selection pass, but nothing in the package ever assigned the
     ``PltCntCfg`` side -- so both always held their default ``1`` and both
-    gates (``VarRange(1, 1)``) always passed. They could not filter anything,
+    gates (``VarRange.exactly(1)``) always passed. They could not filter anything,
     including ``surface_result``'s "exactly one scalar result" intent, which
     is why deleting them leaves plot selection byte-identical.
 
     Populating them instead would have been the breaking option: with every
-    filter defaulting to ``VarRange(1, 1)``, a real ``vector_len`` would have
+    filter defaulting to ``VarRange.exactly(1)``, a real ``vector_len`` would have
     made *every* plot reject any sweep containing a ``ResultVec(size > 1)``,
     and a real ``result_vars`` would have made every plot reject any sweep
     with more than one result variable -- which is most of them.
@@ -629,11 +664,11 @@ class TestDeletedPlotGates(unittest.TestCase):
         # ever been populated still matches a permissive filter.
         cfg = PltCntCfg(float_cnt=1, cat_cnt=0, panel_cnt=0, repeats=1, inputs_cnt=1)
         res = PlotFilter(
-            float_range=VarRange(1, 1),
-            cat_range=VarRange(0, None),
-            panel_range=VarRange(0, None),
-            repeats_range=VarRange(1, None),
-            input_range=VarRange(1, None),
+            float_range=VarRange.exactly(1),
+            cat_range=VarRange.unbounded(),
+            panel_range=VarRange.unbounded(),
+            repeats_range=VarRange.at_least(1),
+            input_range=VarRange.at_least(1),
         ).matches_result(cfg, "probe", False)
         self.assertTrue(res.overall)
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -498,7 +498,7 @@ class TestGlobalRegistration(unittest.TestCase):
 class TestDefaultPlotFilterIsPermissive(unittest.TestCase):
     """Plan 23 P6 (C3): a default-constructed filter can no longer hide a plugin.
 
-    ``PlotFilter.match_all()`` used to exist only because ``PlotFilter()`` matched
+    The ``match_all`` classmethod used to exist only because ``PlotFilter()`` matched
     nothing; every field now defaults to ``VarRange.unbounded()`` and the classmethod
     is gone."""
 

--- a/test/test_plugins_builtins.py
+++ b/test/test_plugins_builtins.py
@@ -362,7 +362,7 @@ class TestNamedOnlyPlugins(unittest.TestCase):
         plugin = LegacyResultPlugin(
             name="fixed",
             backend="test",
-            match=PlotFilter.match_all(),
+            match=PlotFilter(),
             priority=0,
             requires=frozenset({"legacy_result"}),
             callback=fixed_callback,
@@ -388,7 +388,7 @@ class TestNamedOnlyPlugins(unittest.TestCase):
         plugin = LegacyResultPlugin(
             name="kwargs",
             backend="test",
-            match=PlotFilter.match_all(),
+            match=PlotFilter(),
             priority=0,
             requires=frozenset({"legacy_result"}),
             callback=kwargs_callback,
@@ -415,7 +415,7 @@ class TestNamedOnlyPlugins(unittest.TestCase):
         plugin = LegacyResultPlugin(
             name="unhashable",
             backend="test",
-            match=PlotFilter.match_all(),
+            match=PlotFilter(),
             priority=0,
             requires=frozenset({"legacy_result"}),
             callback=UnhashableCallable(),
@@ -455,7 +455,7 @@ class TestLegacyResultPlugin(unittest.TestCase):
         plugin = LegacyResultPlugin(
             name="fake",
             backend="test",
-            match=PlotFilter.match_all(),
+            match=PlotFilter(),
             priority=0,
             requires=frozenset({"legacy_result"}),
             callback=fake_callback,


### PR DESCRIPTION
Plan 23 phase P6, defect **C3** (C4 already landed in #1046).

## The defect

`VarRange.upper_bound` carried three meanings on one field: `-1` = match nothing
(the default), `None` = unbounded, `>= 0` = a real bound — and `lower_bound` accepted
`None` as a fourth spelling of `0`. Two sentinels on one field, the audit's
highest-severity smell. The costs were already visible in the code:

- the class docstring had drifted (it claimed both bounds defaulted to `-1`;
  `lower_bound` defaulted to `0`);
- `PlotFilter.match_all()` and its inner `anything = lambda: VarRange(0, None)` existed
  only because a default-constructed `PlotFilter()` matched nothing;
- `plugins/plugin.py` documented that same default as *"silently hiding the plugin
  forever"* — a footgun a plugin author hits by writing the obvious thing.

## What changed

`VarRange` is now a frozen wrapper over a three-variant sum — `_Nothing`,
`_Between(low, high)`, `_AtLeast(low)` — built through named constructors:

```python
VarRange.none()          # no count matches
VarRange.exactly(2)      # only 2
VarRange.between(1, 3)   # 1, 2, 3
VarRange.at_most(2)      # 0, 1, 2
VarRange.at_least(2)     # 2, 3, 4, ...
VarRange.unbounded()     # every count
```

`matches()` dispatches over the variants and ends in `assert_never`. Bounds the old
constructor accepted silently — `VarRange(2, 1)`, a negative bound — now raise at
construction. There is no longer any value of any field that means "nothing" or
"unbounded" by convention.

**`PlotFilter()` no longer matches nothing.** Every field defaults to
`VarRange.unbounded()`, so an omitted range never narrows a filter and a plugin declared
with `match=PlotFilter()` — or with no match rule at all — is eligible for every shape.
`PlotFilter.match_all()` is **removed** (it was exactly `PlotFilter()` under the new
default), and the `plugin.py` warning comment is gone with it.

`BenchResultBase.filter()` takes real `VarRange` defaults instead of five `None`s plus a
five-branch fixup block, and its dead `plot_filter=` parameter — unconditionally
overwritten two lines later — is deleted.

96 call sites across 18 files were converted; the debug string
(`float\t1>= 2 <=None is False`) is deliberately kept verbatim so `explain_selection()`
reasons and debug panes read exactly as before.

## PlotFilter default-inheritance audit (asked for before flipping the default)

Every `PlotFilter(...)` construction in `bencher/` — there are only four, everything else
routes through `BenchResultBase.filter()`:

| site | omitted (inherited) | old inherited value |
|---|---|---|
| `bench_result_base.py:784` | none | — |
| `surface_result.py:117` | `panel_range`, `repeats_range`, `input_range` | `(0,0)`, `(1,None)`, `(1,None)` |
| `rerun_summary.py:106` | `repeats_range` | `(1,None)` |
| `video_summary.py:64` | `repeats_range` | `(1,None)` |

**No production filter ever inherited the match-nothing `float_range`/`cat_range`
default** — which is why the old default could only ever hurt plugin authors, never
bencher's own plots. The three sites above did inherit *restrictive* `panel_range` /
`repeats_range` defaults, so each now states all five ranges explicitly at exactly its
previous values. The default's value therefore no longer affects any production filter.

`filter()`'s own `None`-defaults were already permissive (`(0,None)` for
float/cat/panel, `(1,None)` for repeats/input) and are preserved as
`VarRange.unbounded()` / `VarRange.at_least(1)`.

## The two odd call sites

- **`VarRange(-1, 0)`** (`volume_result.py`, cat_range): the negative lower bound was
  inert, because `matches()` rejects negative counts and every count is `>= 0` — the
  range matched exactly `0`. Converted to `VarRange.exactly(0)`, which is what it always
  meant. Truth table verified identical for every count 0..40.
- **`VarRange(None, None)`** (7 sites, all in `test/test_plot_filter.py`): `None` lower
  meant "no lower bound", which for non-negative counts is `0`; `None` upper meant
  unbounded. So it matched everything — `VarRange.unbounded()`. The two tests that
  asserted this (`test_matches_none_upper`, `test_matches_none_none`) had become
  literally the same test, so they are replaced by `test_unbounded_matches_everything`
  plus a real `at_least` test.

## Verification that plot selection is unchanged

**1. Truth-table equivalence of every converted site.** A script pairs each removed
`VarRange(lo, hi)` literal against the constructor that replaced it and compares
`matches(v)` for `v` in 0..40, using the *pre-P6* implementation for the old literal:
**29/29 automatically paired sites match exactly, 0 mismatches.** The 9 files where the
literal count changed are the ones hand-edited above (defaults made explicit, tests
rewritten) and are itemised in this description.

**2. `generate-docs` diff.** Stated plainly: **the output is not byte-identical, and it
cannot be** — not for this change and not for a no-op. The reports embed a fresh UUID per
Bokeh document, a wall-clock `run date`, gzip-encoded arrays of *randomly generated*
benchmark values, and CPython `id()` addresses. To measure that properly I ran
`generate-docs` three times: once on clean `origin/main`, once on this branch, and a
second time on this branch to establish the run-to-run noise floor.

Comparing the id-independent plot skeleton — the ordered sequence of Bokeh/Panel model
types in every report, which is precisely what plot selection determines:

| comparison | reports | model-type sequence differs | pane-title sequence differs |
|---|---|---|---|
| branch run 1 vs branch run 2 (noise floor) | 295 | 0 | 1 |
| **main vs branch** | **295** | **1** | **1** |

The one report that differs in both comparisons is
`advanced/example_advanced_git_time_event`, whose sweep is keyed by
`time_src=bn.git_time_event()` — the current commit. The baseline ran at `32655785`,
the branch at a new commit, so its over_time axis gained a second tick and with it a
regression-comparison plot (70 → 167 models). It is a commit-identity artifact, present
in the noise floor too, not a selection change. **All 294 other reports have identical
model-type sequences and identical pane titles.**

Additionally, all **231** plain-text outputs (gallery `.rst`, `.md`, `.json`) are
byte-for-byte identical, `bencher/example/generated/**.py` is unchanged, and the bokeh
model-id counter drift seen between main and branch reproduces at the same file
boundaries between two runs of *identical* code.

## Tests

- `test_plot_filter.py`: named-constructor semantics, frozen/value-equality, and
  `between(2, 1)` / negative bounds now raising — states the old constructor could
  represent and the new one cannot.
- `test_plugins.py::TestDefaultPlotFilterIsPermissive` — the DoD regression test: a
  plugin declared with no match rule *and* one declared with `match=PlotFilter()` are
  both selected for every sweep shape, and `PlotFilter.match_all` no longer exists.
- `PlotFilter()`'s old "matches nothing" tests are inverted; the `gamma` fixture that
  relied on that default to be excluded now says so explicitly with
  `VarRange.none()`.

`pixi run ci` and `pixi run test-split` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine the VarRange and PlotFilter APIs to use explicit, named range constructors, remove sentinel-bound semantics, and make the default PlotFilter permissive while keeping plot selection behavior unchanged.

New Features:
- Introduce named VarRange constructors (none, exactly, between, at_most, at_least, unbounded) to express count ranges explicitly.
- Make PlotFilter fields default to an unbounded VarRange so a default PlotFilter matches all sweep shapes.

Enhancements:
- Refactor VarRange into an immutable sum-type-backed range with validation and clearer string/debug representations.
- Simplify BenchResultBase.filter by using shared VarRange defaults instead of None-based sentinel handling and removing the unused plot_filter parameter.
- Update plot plugins and built-in plugin registration to rely on the permissive default PlotFilter instead of a separate match_all helper.
- Clarify PlotFilter and VarRange usage in concepts and plot plugin design documentation to reflect the new constructors and defaults.

Tests:
- Extend VarRange and PlotFilter tests to cover the new constructors, immutability, validation behavior, and the guarantee that default plot filters and plugins without match rules are always eligible.