### PR TITLE
chore: low-risk core cleanup (plan 07)

### DIFF
--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -1,5 +1,10 @@
 import warnings
 
+# matplotlib.projections warns at import time when it cannot import
+# mpl_toolkits.mplot3d, which disables *matplotlib's* 3D projection. Bencher only
+# reaches matplotlib through holoviews' matplotlib backend (regression PNG
+# export) and renders its 3D plots with plotly, so the warning says nothing about
+# this package -- it is import-order noise for anyone importing bencher.
 warnings.filterwarnings("ignore", message="Unable to import Axes3D", category=UserWarning)
 
 from bencher.results.dataset_result import DataSetResult

--- a/bencher/bench_cfg.py
+++ b/bencher/bench_cfg.py
@@ -726,6 +726,57 @@ class BenchCfg(BenchRunCfg):
         tag (str): Tags for grouping different benchmarks
         hash_value (str): Stored hash value of the config
         plot_callbacks (list): Callables that take a BenchResult and return panel representation
+
+    Parameter interactions:
+        The caching and history knobs below are declared on ``BenchRunCfg`` and
+        inherited here; the ``run_cfg`` passed to ``plot_sweep`` is merged onto
+        the ``BenchCfg`` before the run, so a run_cfg value wins over the one
+        stored on the config (except for parameters declared constant, which are
+        skipped with a warning).
+
+        Benchmark-level result cache (``cache_results``, ``clear_cache``):
+            * The *write* is unconditional. Whenever a sweep actually runs, the
+              finished ``BenchResult`` is stored under the config hash regardless
+              of ``cache_results`` — so a later run with ``cache_results=True``
+              can hit an entry left by a run that had it off.
+            * ``cache_results`` controls only the *read*: with it True, a stored
+              result under the same config hash is loaded and the entire sweep is
+              skipped.
+            * ``clear_cache=True`` takes precedence over ``cache_results``: the
+              entry is deleted and no read is attempted, so the sweep always
+              re-runs (and repopulates the entry at the end).
+            * ``only_plot=True`` forces ``cache_results=True``, and turns a cache
+              miss into ``FileNotFoundError`` instead of a re-run.
+
+        Per-sample cache (``cache_samples``, ``overwrite_sample_cache``,
+        ``clear_sample_cache``):
+            * Independent of the benchmark-level cache: this one caches individual
+              benchmark-function calls rather than the finished result.
+            * With ``cache_samples=False`` no sample cache is opened at all, so
+              nothing is read or written per sample and the other two flags have
+              nothing to act on — clearing a tag then logs a warning rather than
+              letting "nothing happened" look like "the tag was cleared".
+            * ``overwrite_sample_cache=True`` keeps writing but stops reading:
+              every sample is recomputed and its stored value replaced.
+            * ``clear_sample_cache=True`` evicts this benchmark's ``tag`` from the
+              sample cache before any sampling starts.
+
+        History and ``over_time`` (``clear_history``, ``max_time_events``):
+            * History is only loaded, merged and written back when
+              ``over_time=True``. With it False the run is a single snapshot and
+              neither ``clear_history`` nor ``max_time_events`` does anything.
+            * The history key deliberately excludes result variables, so adding or
+              removing a metric reconciles per column instead of orphaning the
+              whole series. The benchmark-level result cache above stays strict —
+              a hit there requires the exact result-var set.
+            * ``clear_history=True`` skips the load: a fresh series starts from
+              this run and is written back.
+            * ``max_time_events`` trims the merged dataset after reconciliation,
+              keeping the newest N events and dropping older ones; ``None`` means
+              unlimited. A result variable may additionally carry its own
+              ``max_time_events``, which nulls that variable's older cells (and
+              deletes any media files they owned) without shortening the shared
+              ``over_time`` axis.
     """
 
     input_vars = param.List(

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -623,7 +623,6 @@ class Bench(BenchPlotServer):
         with suppress(ValueError, AttributeError):
             for i in input_vars_in:
                 for c in const_vars_in:
-                    # print(i.hash_persistent())
                     if i.name == c[0].name:
                         const_vars_in.remove(c)
                         logger.info(f"removing {i.name} from constants")
@@ -986,30 +985,6 @@ class Bench(BenchPlotServer):
     def cache_results(self, bench_res: BenchResult, bench_cfg_hash: str) -> None:
         """Cache benchmark results to disk using the config hash as key."""
         self._collector.cache_results(bench_res, bench_cfg_hash, self.bench_cfg_hashes)
-
-    # def show(self, run_cfg: BenchRunCfg | None = None, pane: pn.panel = None) -> None:
-    #     """Launch a web server with plots of the benchmark results.
-    #
-    #     This method starts a Panel web server to display the benchmark results interactively.
-    #     It is a blocking call that runs until the server is terminated.
-    #
-    #     Args:
-    #         run_cfg (BenchRunCfg, optional): Configuration options for the web server,
-    #             such as the port number. If None, uses the instance's last_run_cfg
-    #             or creates a default one. Defaults to None.
-    #         pane (pn.panel, optional): A custom panel to display instead of the default
-    #             benchmark visualization. Defaults to None.
-    #
-    #     Returns:
-    #         None
-    #     """
-    #     if run_cfg is None:
-    #         if self.last_run_cfg is not None:
-    #             run_cfg = self.last_run_cfg
-    #         else:
-    #             run_cfg = BenchRunCfg()
-    #
-    #     return BenchPlotServer().plot_server(self.bench_name, run_cfg, pane)
 
     def load_history_cache(
         self,

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -166,13 +166,46 @@ def cfg_from_optuna_trial(
     return cfg
 
 
+# The failure modes optuna's plotting functions are known to raise: a bad or
+# empty study (ValueError), a plotly/optuna version mismatch (AttributeError,
+# TypeError), or a backend that refuses to render (RuntimeError). These get an
+# error pane and nothing more -- report_render_failure already logs at ERROR
+# and warns.
+_EXPECTED_PLOT_FAILURES = (RuntimeError, ValueError, TypeError, AttributeError)
+
+
+def _plot_failure_pane(plot_fn, exc: Exception, *, unexpected: bool = False):
+    """Build the error pane that replaces a plot that failed to render.
+
+    *unexpected* marks an exception outside ``_EXPECTED_PLOT_FAILURES``; it gets
+    an extra ERROR log naming the type, because an unanticipated type here is a
+    signal that the expected-failure tuple has fallen out of date.
+    """
+    fn_name = getattr(plot_fn, "__name__", str(plot_fn))
+    if unexpected:
+        logger.error(
+            "Unexpected %s while rendering optuna plot '%s'; rendering an error pane instead",
+            type(exc).__name__,
+            fn_name,
+            exc_info=exc,
+        )
+    return report_render_failure(f"Optuna plot '{fn_name}'", exc)
+
+
 def _append_safe(row, plot_fn, *args, **kwargs):
-    """Append a plot to *row*, surfacing any exception instead of propagating."""
+    """Append a plot to *row*, surfacing any exception instead of propagating.
+
+    Nothing is ever re-raised: this runs while the report is being built, after
+    the sweep has already paid for every sample, so a crash here would throw
+    away the whole run's results to report one missing plot. A visible error
+    pane costs nothing and keeps the rest of the report.
+    """
     try:
         row.append(plot_fn(*args, **kwargs))
+    except _EXPECTED_PLOT_FAILURES as exc:
+        row.append(_plot_failure_pane(plot_fn, exc))
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        fn_name = getattr(plot_fn, "__name__", str(plot_fn))
-        row.append(report_render_failure(f"Optuna plot '{fn_name}'", exc))
+        row.append(_plot_failure_pane(plot_fn, exc, unexpected=True))
 
 
 def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
@@ -182,6 +215,7 @@ def _append_safe_sized(row, plot_fn, width, *args, **kwargs):
         if hasattr(fig, "update_layout"):
             fig.update_layout(width=width)
         row.append(fig)
+    except _EXPECTED_PLOT_FAILURES as exc:
+        row.append(_plot_failure_pane(plot_fn, exc))
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        fn_name = getattr(plot_fn, "__name__", str(plot_fn))
-        row.append(report_render_failure(f"Optuna plot '{fn_name}'", exc))
+        row.append(_plot_failure_pane(plot_fn, exc, unexpected=True))

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -131,7 +131,6 @@ def _accepts_keyword(callback: Callable, name: str) -> bool:
 class BenchResultBase:
     def __init__(self, bench_cfg: BenchCfg) -> None:
         self.bench_cfg = bench_cfg
-        # self.wrap_long_time_labels(bench_cfg)  # todo remove
         self.ds = xr.Dataset()
         self.object_index = []
         self.hmaps = defaultdict(dict)
@@ -143,12 +142,6 @@ class BenchResultBase:
         self.regression_report = None
         self.perf_report = None
         self._to_dataset_cache: dict = {}
-
-        # self.width=600/
-        # self.height=600
-
-        #   bench_res.objects.append(rv)
-        # bench_res.reference_index = len(bench_res.objects)
 
     def to_xarray(self) -> xr.Dataset:
         return self.ds

--- a/bencher/results/composable_container/composable_container_base.py
+++ b/bencher/results/composable_container/composable_container_base.py
@@ -51,7 +51,6 @@ class Axis(StrEnum):
         return Axis.right if horizontal else Axis.down
 
 
-# TODO enable these options
 class ComposeType(StrEnum):
     right = auto()  # append the container to the right (creates a row)
     down = auto()  # append the container below (creates a column)

--- a/bencher/results/optuna_result.py
+++ b/bencher/results/optuna_result.py
@@ -366,21 +366,6 @@ class OptunaResult(BenchResultBase):
             return study_panes[0][1]
         return pn.Tabs(*study_panes)
 
-    # def extract_study_to_dataset(study: optuna.Study, bench_cfg: BenchCfg) -> BenchCfg:
-    #     """Extract an optuna study into an xarray dataset for easy plotting
-
-    #     Args:
-    #         study (optuna.Study): The result of a gridsearch
-    #         bench_cfg (BenchCfg): Options for the grid search
-
-    #     Returns:
-    #         BenchCfg: An updated config with the results included
-    #     """
-    #     for t in study.trials:
-    #         for it, rv in enumerate(bench_cfg.result_vars):
-    #             bench_cfg.ds[rv.name].loc[t.params] = t.values[it]
-    #     return bench_cfg
-
     def deep(self) -> OptunaResult:  # pragma: no cover
         """Return a deep copy of these results"""
         return deepcopy(self)

--- a/bencher/results/video_summary.py
+++ b/bencher/results/video_summary.py
@@ -201,8 +201,6 @@ class VideoSummaryResult(BenchResultBase):
                 dataset, compose_method, time_sequence_dimension=time_sequence_dimension
             )
 
-            # print(compose_method_list)
-
         compose_method_list_pop = deepcopy(compose_method_list)
         if len(compose_method_list_pop) > 1:
             compose_method = compose_method_list_pop.pop()

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -23,12 +23,11 @@ class ParametrizedSweep(Parameterized):
 
     @staticmethod
     def param_hash(param_type: Parameterized, hash_value: bool = True) -> int:
-        """A custom hash function for parametrised types with options for hashing the value of the type and hashing metadata
+        """A custom hash function for parametrised types with an option for hashing the value of the type
 
         Args:
             param_type (Parameterized): A parameter
             hash_value (bool, optional): use the value as part of the hash. Defaults to True.
-            # hash_meta (bool, optional): use metadata as part of the hash. Defaults to False.
 
         Returns:
             int: a hash
@@ -40,12 +39,6 @@ class ParametrizedSweep(Parameterized):
                 if k != "name":
                     curhash = hash_sha1((curhash, hash_sha1(v)))
 
-        # if hash_meta:
-        #     for k, v in param_type.param.objects().items():
-        #         if k != "name":
-        #             print(f"key:{k}, hash:{hash_sha1(k)}")
-        #             print(f"value:{v}, hash:{hash_sha1(v)}")
-        #             curhash = hash_sha1((curhash, hash_sha1(k), hash_sha1(v)))
         return curhash
 
     def hash_persistent(self) -> str:

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -53,7 +53,6 @@ def describe_variable(
     sampling_str = []
     sampling_str.append(f"{v.name}:")
     if include_samples:
-        # sampling_str.append(f"{indent}{v.sampling_str(debug)}")
         sampling_str.append(f"{indent}number of samples: {len(v.values())}")
         sampling_str.append(f"{indent}sample values: {[str(v) for v in v.values()]}")
 
@@ -69,12 +68,6 @@ def describe_variable(
 
 
 class SweepBase(param.Parameter):
-    # def __init__(self, **params):
-    # super().__init__(**params)
-    # self.units = ""
-    # slots = ["units", "samples"]
-    # __slots__ = shared_slots
-
     @property
     def sweep_bounds(self) -> tuple | None:
         """Return the sweep range (low, high).

--- a/bencher/variables/time.py
+++ b/bencher/variables/time.py
@@ -37,7 +37,6 @@ class TimeBase(SweepBase, Selector):
 
     def values(self) -> list[str]:
         """return all the values for a parameter sweep.  If debug is true return a reduced list"""
-        # print(self.sampling_str(debug))
         return self.objects
 
 

--- a/test/test_optuna_conversions.py
+++ b/test/test_optuna_conversions.py
@@ -1,6 +1,7 @@
 """Tests for bencher/optuna_conversions.py"""
 
 import unittest
+import warnings
 from enum import auto
 from unittest.mock import MagicMock
 
@@ -11,6 +12,8 @@ from strenum import StrEnum
 
 import bencher as bn
 from bencher.optuna_conversions import (
+    _append_safe,
+    _append_safe_sized,
     optuna_grid_search,
     param_importance,
     summarise_trial,
@@ -302,3 +305,67 @@ class TestOptunaGridSearch(unittest.TestCase):
         search_space = study.sampler._search_space  # pylint: disable=protected-access
         self.assertIn("repeat", search_space)
         self.assertIn("float_var", search_space)
+
+
+class _UnexpectedPlotError(Exception):
+    """An exception type outside _EXPECTED_PLOT_FAILURES."""
+
+
+def _boom_expected():
+    raise ValueError("expected boom")
+
+
+def _boom_unexpected():
+    raise _UnexpectedPlotError("unexpected boom")
+
+
+class TestAppendSafe(unittest.TestCase):
+    """A failed optuna plot must never abort report building.
+
+    By the time these run the sweep has already paid for every sample, so a
+    propagating exception would discard the whole run to report one missing
+    plot. Both handlers append a visible pane instead.
+    """
+
+    def _panes(self, append_fn, plot_fn):
+        row = pn.Row()
+        with (
+            self.assertLogs(level="ERROR") as captured,
+            warnings.catch_warnings(record=True),
+        ):
+            warnings.simplefilter("always")
+            append_fn(row, plot_fn)
+        return row, "\n".join(captured.output)
+
+    def test_expected_failure_appends_pane(self):
+        row, logs = self._panes(_append_safe, _boom_expected)
+        self.assertEqual(1, len(row))
+        self.assertIn("_boom_expected", row[0].object)
+        self.assertIn("expected boom", logs)
+        # The expected path adds no "Unexpected" log of its own.
+        self.assertNotIn("Unexpected", logs)
+
+    def test_unexpected_failure_also_appends_pane_and_logs(self):
+        row, logs = self._panes(_append_safe, _boom_unexpected)
+        self.assertEqual(1, len(row))
+        self.assertIn("_boom_unexpected", row[0].object)
+        self.assertIn("Unexpected _UnexpectedPlotError", logs)
+
+    def test_sized_variant_handles_both_paths(self):
+        for plot_fn in (_boom_expected, _boom_unexpected):
+            with self.subTest(plot_fn=plot_fn.__name__):
+                row = pn.Row()
+                with (
+                    self.assertLogs(level="ERROR"),
+                    warnings.catch_warnings(record=True),
+                ):
+                    warnings.simplefilter("always")
+                    _append_safe_sized(row, plot_fn, 400)
+                self.assertEqual(1, len(row))
+                self.assertIn(plot_fn.__name__, row[0].object)
+
+    def test_successful_plot_is_appended_unchanged(self):
+        row = pn.Row()
+        marker = pn.pane.Markdown("ok")
+        _append_safe(row, lambda: marker)
+        self.assertIs(marker, row[0])


### PR DESCRIPTION
Implements `plans/07-core-cleanup.md`. Mechanical, behaviour-preserving cleanup of
`bencher/`: dead code deleted, one broad exception handler narrowed, two
documentation gaps closed, and every TODO marker triaged. One commit per plan task.

**No public API changed.** Nothing was added to, removed from, or renamed in
`bencher/__init__.py`'s exports; no public class, method, parameter, or default value
changed. The only signature-level change is internal
(`bencher.optuna_conversions._plot_failure_pane`, a new private helper).

## Task 1 — dead code removed

Eight commented-out blocks, all disabled code rather than explanatory comments:

| File | Block |
|---|---|
| `bencher/bencher.py` | the fully commented-out `show()` method (24 lines, including its docstring and `BenchPlotServer().plot_server(...)` body) |
| `bencher/bencher.py` | `# print(i.hash_persistent())` inside the const-var filtering loop |
| `bencher/results/bench_result_base.py` | `# self.wrap_long_time_labels(bench_cfg)  # todo remove` in `BenchResultBase.__init__` |
| `bencher/results/bench_result_base.py` | the `# self.width=600/` / `# self.height=600` / `# bench_res.reference_index = ...` assignments at the end of `__init__` |
| `bencher/results/optuna_result.py` | the commented-out `extract_study_to_dataset` staticmethod (14 lines) |
| `bencher/results/video_summary.py` | `# print(compose_method_list)` |
| `bencher/variables/parametrised_sweep.py` | the commented `if hash_meta:` branch in `param_hash`, plus the docstring line advertising a `hash_meta` argument the signature never had |
| `bencher/variables/sweep_base.py` | the commented `__init__` / `slots` / `__slots__` block at the top of `SweepBase`, and a commented `sampling_str.append` in `describe_variable` |
| `bencher/variables/time.py` | `# print(self.sampling_str(debug))` in `TimeEvent.values` |

Left in place deliberately: `bencher/variables/sweep_base.py:181-183`, where the
commented `params["unit"] = ...` is the subject of a live TODO (see triage item 9).

## Task 2 — prints (no change)

Marked DONE/moot in the plan; re-verified. Every remaining `print()` under `bencher/`
outside `example/` is either an intentional CLI/user-facing message
(`render.py`, `file_server.py`, `cache_management.py`, `run.py`,
`test_timing_report.py`) or pre-dates the plan by years — `git log -L` dates the
`bench_result_base.py` ones to 2024-02/2024-06 and the `optuna_result.py` one to
2023-12, and they sit in `# pragma: no cover` debug helpers (`zip_results1D1`,
`zip_results1D2`). No new prints appeared, so nothing was changed.

## Task 3 — narrowed exception handler

`_append_safe` and `_append_safe_sized` in `bencher/optuna_conversions.py` now catch
`(RuntimeError, ValueError, TypeError, AttributeError)` — the documented failure modes
of optuna's plotting functions — in their own handler.

The final `except Exception` **stays, and still appends the error pane rather than
re-raising**. These run while the report is being built, after the sweep has already
paid for every sample; propagating would discard the whole run's results in order to
report one missing plot. It additionally logs at `logging.error` naming the unexpected
exception type, which is the signal that the expected-failure tuple has gone stale.
The existing broad-except pylint/ruff suppressions are kept on that handler.

Four new tests in `test/test_optuna_conversions.py` cover the expected path, the
unexpected path (asserting a pane is appended *and* the extra ERROR log is emitted),
the sized variant across both, and the success path.

## Task 4 — BenchCfg parameter interactions

Added a "Parameter interactions" section to the `BenchCfg` docstring covering three
groups whose combinations are not deducible from the individual parameter docs. Every
statement is derived from source, not from prior belief:

- **Benchmark-level result cache** — the write is unconditional
  (`bencher.py:909` is inside `if calculate_results:` and is not gated on
  `run_cfg.cache_results`; `result_collector.cache_results` writes unconditionally), so
  `cache_results` gates only the *read* (`bencher.py:846-854`). `clear_cache` wins via
  the `elif` at `bencher.py:843`. `only_plot` forces `cache_results=True`
  (`bencher.py:529`) and turns a miss into `FileNotFoundError` (`bencher.py:857`).
- **Per-sample cache** — `cache_samples=False` means `FutureCache` opens no cache at all
  (`job.py:544-548`), so `overwrite_sample_cache` and `clear_sample_cache` have nothing
  to act on and `clear_tag` logs a warning instead of appearing to succeed
  (`job.py:674-680`). `overwrite_sample_cache` maps to `FutureCache.overwrite`, which
  suppresses reads but not writes (`job.py:564`, `job.py:595`).
- **History / `over_time`** — history is only touched inside `if run_cfg.over_time:`
  (`bencher.py:872`); the key excludes result vars (`bencher.py:828`);
  `clear_history` skips the load (`result_collector.py:795`); `max_time_events` trims to
  the newest N after reconciliation (`result_collector.py:839-844`) while a
  per-variable `max_time_events` nulls that variable's older cells and deletes the media
  files they owned (`result_collector.py:846-854`).

`only_hash_tag` was deliberately **not** documented: it is written by `BenchRunner`
(`bench_runner.py:177`, `:424`) and printed in the sampling summary
(`bench_cfg.py:1067`), but no code reads it to change behaviour, so there is nothing
confirmable to say about it.

## Task 5 — TODO triage

Full triage of all 12 `TODO`/`FIXME`/`HACK` markers under `bencher/` excluding
`example/`. Nothing was implemented, per the plan.

Also done: added a comment above the `"Unable to import Axes3D"` warning filter in
`bencher/__init__.py`. The warning comes from `matplotlib/projections/__init__.py`,
which emits it when `mpl_toolkits.mplot3d` fails to import. Bencher renders its 3D
plots with plotly (`volume_result.py`, `surface_result.py`) and only reaches matplotlib
via holoviews' backend for regression PNG export, so the warning is irrelevant noise.

### (a) Deletable — verified done, comment removed

1. **`results/composable_container/composable_container_base.py:54`** —
   `# TODO enable these options` above `ComposeType`. All four members
   (`right`, `down`, `sequence`, `overlay`) are implemented and dispatched by
   exhaustive `match` statements in `composable_container_panel.py:41-57`,
   `composable_container_dataframe.py:25-35`, `composable_container_video.py:148-152`
   and `composable_container_rerun.py:167-169`, and `sequence`/`overlay` are covered by
   tests. Nothing is disabled. **Deleted.**

### (b) Real debt — comment left in place

2. **`bench_report.py:527`** — `# TODO DON'T OVERWRITE EVERYTHING`. `publish_report`
   still does `git init` in a fresh temp dir and `git push --set-upstream origin
   <branch> -f`, so publishing replaces the target branch's entire history.
3. **`variables/sweep_base.py:199`** and **`:258`** —
   `# TODO set up class properly. Slightly complicated due to slots`.
   `with_samples` / `with_sample_values` still assign attributes outside `__init__` on a
   `param.Parameter` with `__slots__`, each needing a pylint suppression.
4. **`variables/sweep_base.py:202`** — `# hack TODO fix this`, clearing `step` when
   `samples` is overridden. Same root cause as (3).
5. **`results/float_formatter.py:33`** — computing an exponent-width threshold up front
   instead of the descending `for n in range(...)` retry loop run per value.
   A perf micro-optimisation; unfixed.
6. **`results/explorer_result.py:23`** — hvplot's explorer needs a pandas conversion for
   datasets with no input vars; the underlying xarray indexing cause is still
   uninvestigated.
7. **`results/bench_result_base.py:1377`** — `# TODO make sure all vars have
   to_container method`. Only two classes define `to_container`
   (`variables/results.py:326`, `:458`), so the `except AttributeError: pass` fallback
   is still load-bearing for every other result type.

### (c) Needs a decision

8. **`bencher.py:973`** — `# TODO: Remove thin wrapper methods in major version bump`.
   The wrappers (`convert_vars_to_params`, `cache_results`, `load_history_cache`,
   `setup_dataset`, ...) are public `Bench` methods; removing them is a breaking change
   gated on a major version bump. **Decision needed:** when (or whether) to take it.
9. **`variables/sweep_base.py:181`** — `# TODO investigate why this stopped working
   after a holoviews update`, above a commented `params["unit"] = self.units` in
   `as_dim`. Checked against the pinned holoviews:
   `hv.Dimension(('x','x'), unit='m')` is accepted and pretty-prints as `x (m)`, so the
   TODO's premise is stale. But units already reach axis labels via
   `utils.label_with_units` (added in #960), so re-enabling `unit` here risks showing
   the unit twice. **Decision needed:** re-enable and drop one path, or delete the TODO
   as superseded. Not touched here since either choice changes rendered output.
10. **`variables/sweep_base.py:319`** — `# TODO work out if the order can be returned in
    subsampling_divisions order always`. Sample ordering feeds the sweep's identity
    tuple, so changing it moves benchmarks to different cache and history keys.
    **Decision needed:** is the reordering worth the history break?
11. **`results/bench_result_base.py:380`** — `ReduceType.MINMAX` "need to pass mean,
    center of minmax, and minmax". It currently emits mean plus a `<var>_range`.
    **Decision needed:** the intended reduce contract, since downstream plots consume
    the current shape.

## Verification

Both run at the branch tip:

- `pixi run ci` — **passed**, exit 0: `2799 passed, 21 skipped, 1508 warnings in 169.65s`
  (includes format, ruff-lint, pylint, ty, generate-examples, coverage).
- `pixi run test-split` — **passed**, exit 0: `2799 passed, 21 skipped, 1513 warnings in 106.67s`.

The split run emits one `RenderFailedWarning` (plot plugin 'panes',
`IndexError: list index out of range`) from
`test_generated_example[levels/example_levels_sample_density.py]`. It is
pre-existing: the same warning reproduces on `main` at 32655785 with
`BENCHER_FORCE_SPLIT_RENDER=1`, and the test passes either way. Not introduced
here and out of scope for this plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clean up internal bencher code and tighten optuna plot error handling without changing the public API.

Enhancements:
- Document BenchCfg caching and history parameter interactions in its docstring.
- Refine optuna plot error handling helpers to distinguish expected failures, append explicit error panes, and log unexpected exceptions.
- Remove obsolete commented-out and dead code across core modules, keeping behaviour unchanged.
- Clarify Axes3D warning filtering rationale to avoid irrelevant matplotlib warnings for bencher users.

Tests:
- Add tests for optuna plot helpers to verify panes are appended on both expected and unexpected failures, successful plots pass through unchanged, and unexpected failures emit an error log.