### PR TITLE
fix: honest return types; enable ty's invalid-return-type (plan 23 P12, 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`BenchResult.result_samples()` returns an `int`** (plan 23 P12). It was annotated
+  `-> int` while returning `self.ds.count()`, an `xr.Dataset` of per-variable counts. The
+  type was the smaller problem: comparing a Dataset yields a Dataset, and `bool(Dataset)`
+  is `len(data_vars) > 0`, so **every** `result_samples() > 0` and `== n` assertion was
+  vacuously true — it could not fail even if not one sample had been collected. It now
+  returns the greatest count across the result variables (max, not sum: two result
+  variables over two samples is 2 samples). Making it real immediately exposed a
+  test-isolation bug in the suite, where a shared class-level `samples` was left mutated
+  by an earlier test.
+
+### Changed
+- **Return annotations across the plotting and sweep APIs now describe what the functions
+  actually return** (plan 23 P12, enabling `ty`'s `invalid-return-type`). All 29
+  diagnostics were genuine. The user-visible ones:
+  - `to_violin_ds`, `to_boxplot_ds` and `to_scatter_jitter_ds` declared `hv.Violin` /
+    `hv.BoxWhisker` / `hv.Scatter`, which they never return — the distribution stack always
+    composes an `hv.Overlay`, and under `over_time` the value is a **`pn.Column`**, not a
+    holoviews object at all. They now share one enumerated alias, `PlotResult`.
+    `_plot_distribution`'s own `hv.Element` was also impossible: `hv.Overlay` is not an
+    `hv.Element` subclass.
+  - `to_curve_ds` declared `hv.Curve | None`; it returns an Overlay, a panel layout, or
+    `None`.
+  - `to_tabulator`/`to_plot` (Tabulator) gained the `| None` that `filter` can return.
+  - `SweepBase.values()` and `FloatSweep.values()` admit `np.ndarray`, which
+    `linspace`/`arange` have always returned. Not coerced to a list: the array flows into
+    hashing and dataset construction.
+  - `Bench.get_result_vars`, `WorkerManager.get_result_vars`/`get_inputs_only` and
+    `get_optimal_inputs` said `ParametrizedSweep` where they yield `param.Parameter`
+    descriptors; `get_optimal_inputs` also said a bare `tuple` for a list of pairs.
+  - `ParametrizedSweep.param_hash`/`hash_persistent` are `int | str`: the digest, or the
+    literal `0` when nothing was hashed. Annotated rather than normalized, because
+    normalizing would change the key for parameter-less sweeps and invalidate caches.
+
+  `invalid-return-type` is the rule that verifies `_resolve_auto` returns a member of
+  `ResolvedReduceType`, so enabling it discharges the caveat P1 left: `to_dataset`'s
+  `assert_never` is now a compile-time proof rather than a runtime assertion. The other
+  four Tier-B rules remain ignored, with their measured costs recorded in plan 23 §10.
 - **Scorecard and A/B verdicts now measure an improvement in the units the detector
   actually used** (plan 23 P3, B5). `RegressionResult.threshold` means a percent for
   `regression_method="percentage"`, but **MAD-sigma** for `"adaptive"`, an **absolute

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type was the smaller problem: comparing a Dataset yields a Dataset, and `bool(Dataset)`
   is `len(data_vars) > 0`, so **every** `result_samples() > 0` and `== n` assertion was
   vacuously true — it could not fail even if not one sample had been collected. It now
-  returns the greatest count across the result variables (max, not sum: two result
-  variables over two samples is 2 samples). Making it real immediately exposed a
-  test-isolation bug in the suite, where a shared class-level `samples` was left mutated
-  by an earlier test.
+  returns the greatest count across the data variables (max, not sum: two result
+  variables over two samples is 2 samples), counting *cells*, so the repeat dimension
+  multiplies it. Making it real immediately exposed a test-isolation bug in the suite,
+  where a shared class-level `samples` was left mutated by an earlier test.
 
 ### Changed
 - **Return annotations across the plotting and sweep APIs now describe what the functions
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ResolvedReduceType`, so enabling it discharges the caveat P1 left: `to_dataset`'s
   `assert_never` is now a compile-time proof rather than a runtime assertion. The other
   four Tier-B rules remain ignored, with their measured costs recorded in plan 23 §10.
+
+  The four widened unions above (`values()`, `param_hash`, and the two `as_str`/`as_dict`
+  flag-switched returns) are honest, not resolved — an argument that switches a return
+  type is still an illegal state made representable, and no checker will object to it.
+  Each is tabled in plan 23 §10 with its blocker so a later phase can take it.
+- `HoloviewResult.result_var_to_container` is annotated `type[pn.viewable.Viewable]`
+  rather than a bare `type`, so `setup_results_and_containers`' declared container type
+  is actually checked instead of being satisfied by an inferred `Any`.
+- `PlotResult` is exported from the top-level `bencher` namespace, so callers can name
+  the union that the `to_*_ds` renderers return.
 - **Scorecard and A/B verdicts now measure an improvement in the units the detector
   actually used** (plan 23 P3, B5). `RegressionResult.threshold` means a percent for
   `regression_method="percentage"`, but **MAD-sigma** for `"adaptive"`, an **absolute

--- a/bencher/__init__.py
+++ b/bencher/__init__.py
@@ -215,7 +215,7 @@ from .plugins import (
     register_plugin,
     unregister_plugin,
 )
-from .results.holoview_results.holoview_result import HoloviewResult, ReduceType
+from .results.holoview_results.holoview_result import HoloviewResult, PlotResult, ReduceType
 from .run import run
 from .sweep_timings import SweepTimings
 from .video_writer import VideoWriter, add_image

--- a/bencher/bench_plot_server.py
+++ b/bencher/bench_plot_server.py
@@ -179,7 +179,9 @@ class BenchPlotServer:
             "port": port,
         }
 
-        return pn.serve(plots_instance, **serve_kwargs)
+        # pn.serve returns a StoppableThread when threaded=True and a bokeh Server
+        # otherwise; `threading.Thread` named only the first (plan 23 P12).
+        return pn.serve(plots_instance, **serve_kwargs)  # ty: ignore[invalid-return-type]
 
     @staticmethod
     def _rrd_extra_patterns() -> list:

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -49,7 +49,7 @@ from bencher.variables.inputs import IntSweep
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import ResultHmap
 from bencher.variables.sweep_base import hash_sha1
-from bencher.variables.time import TimeEvent, TimeSnapshot
+from bencher.variables.time import TimeBase
 from bencher.worker_job import WorkerJob
 
 # Import helper classes
@@ -1032,7 +1032,7 @@ class Bench(BenchPlotServer):
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> list[IntSweep | TimeEvent | TimeSnapshot]:
+    ) -> list[IntSweep | TimeBase]:
         """Define meta variables (repeat count, timestamps) for benchmark tracking."""
         return self._collector.define_extra_vars(bench_cfg, repeats, time_src)
 
@@ -1294,8 +1294,7 @@ class Bench(BenchPlotServer):
 
         Returns:
             list[str] | list[Parameter]: The result variables, as names or as the
-                ``param.Parameter`` descriptors themselves (plan 23 P12: the previous
-                ``ParametrizedSweep`` named the wrong type).
+                ``param.Parameter`` descriptors themselves.
 
         Raises:
             RuntimeError: If the worker class instance is not set.

--- a/bencher/bencher.py
+++ b/bencher/bencher.py
@@ -49,6 +49,7 @@ from bencher.variables.inputs import IntSweep
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import ResultHmap
 from bencher.variables.sweep_base import hash_sha1
+from bencher.variables.time import TimeEvent, TimeSnapshot
 from bencher.worker_job import WorkerJob
 
 # Import helper classes
@@ -1031,7 +1032,7 @@ class Bench(BenchPlotServer):
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> list[IntSweep]:
+    ) -> list[IntSweep | TimeEvent | TimeSnapshot]:
         """Define meta variables (repeat count, timestamps) for benchmark tracking."""
         return self._collector.define_extra_vars(bench_cfg, repeats, time_src)
 
@@ -1282,7 +1283,7 @@ class Bench(BenchPlotServer):
         branch_name = f"{self.bench_name}_{self.run_cfg.run_tag}"
         return self.report.publish(remote_callback, branch_name=branch_name)
 
-    def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
+    def get_result_vars(self, as_str: bool = True) -> list[str] | list[Parameter]:
         """
         Retrieve the result variables from the worker class instance.
 
@@ -1292,14 +1293,18 @@ class Bench(BenchPlotServer):
                            Default is True.
 
         Returns:
-            list[str | ParametrizedSweep]: A list of result variables, either as strings or in their original form.
+            list[str] | list[Parameter]: The result variables, as names or as the
+                ``param.Parameter`` descriptors themselves (plan 23 P12: the previous
+                ``ParametrizedSweep`` named the wrong type).
 
         Raises:
             RuntimeError: If the worker class instance is not set.
         """
         if self.worker_class_instance is not None:
             if as_str:
-                return [i.name for i in self.worker_class_instance.get_results_only()]
+                # str(): see WorkerManager.get_results_only -- param types `name` as
+                # `str | None`, but a declared parameter always has one.
+                return [str(i.name) for i in self.worker_class_instance.get_results_only()]
             return self.worker_class_instance.get_results_only()
         raise RuntimeError("Worker class instance not set")
 

--- a/bencher/example/example_sample_cache.py
+++ b/bencher/example/example_sample_cache.py
@@ -23,7 +23,7 @@ class UnreliableClass(bn.ParametrizedSweep):
         doc="if true crashy_fn will crash when input_val >1",
     )
 
-    def crashy_fn(self, input_val: int = 0, **kwargs) -> float:  # pylint: disable=unused-argument
+    def crashy_fn(self, input_val: int = 0, **kwargs) -> dict:  # pylint: disable=unused-argument
         if self.trigger_crash and input_val > 1:
             raise RuntimeError("I crashed for no good reason ;P")
 

--- a/bencher/history.py
+++ b/bencher/history.py
@@ -486,7 +486,10 @@ def project(merged: xr.Dataset, current_cols: dict[str, Any], columns_meta: dict
             served[name].attrs[BIRTH_ATTR] = birth
         else:
             served[name].attrs.pop(BIRTH_ATTR, None)
-    return served
+    # `merged[keep]` with a list key returns a Dataset at runtime; xarray's stub
+    # types __getitem__ as `Dataset | DataArray` for the str case, which ty cannot
+    # narrow by key type. Stub imprecision, not a defect here (plan 23 P12).
+    return served  # ty: ignore[invalid-return-type]
 
 
 def apply_policy(events: list[HistoryEvent], policy: OnHistoryReset | str) -> None:

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -154,8 +154,15 @@ def sweep_var_to_suggest(iv: ParametrizedSweep, trial: optuna.trial) -> object:
 
 
 def cfg_from_optuna_trial(
-    trial: optuna.trial, bench_cfg: BenchCfg, cfg_type: ParametrizedSweep
+    trial: optuna.trial, bench_cfg: BenchCfg, cfg_type: type[ParametrizedSweep]
 ) -> ParametrizedSweep:
+    """Build a worker config from an optuna trial's suggested values.
+
+    ``cfg_type`` is annotated ``type[ParametrizedSweep]``, not ``ParametrizedSweep``:
+    it is called to construct an instance. Under the old annotation ty resolved
+    ``cfg_type()`` through ``Parameterized.__call__`` and inferred a ``dict``, which is
+    what ``invalid-return-type`` flagged (plan 23 P12).
+    """
     cfg = cfg_type()
     for iv in bench_cfg.input_vars:
         if getattr(iv, "optimize", True):

--- a/bencher/optuna_conversions.py
+++ b/bencher/optuna_conversions.py
@@ -158,10 +158,9 @@ def cfg_from_optuna_trial(
 ) -> ParametrizedSweep:
     """Build a worker config from an optuna trial's suggested values.
 
-    ``cfg_type`` is annotated ``type[ParametrizedSweep]``, not ``ParametrizedSweep``:
-    it is called to construct an instance. Under the old annotation ty resolved
-    ``cfg_type()`` through ``Parameterized.__call__`` and inferred a ``dict``, which is
-    what ``invalid-return-type`` flagged (plan 23 P12).
+    ``cfg_type`` is the worker *class*, not an instance -- it is called here to construct
+    one. Annotating it ``ParametrizedSweep`` makes a checker resolve ``cfg_type()``
+    through ``Parameterized.__call__`` and infer a ``dict``.
     """
     cfg = cfg_type()
     for iv in bench_cfg.input_vars:

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -61,7 +61,7 @@ from bencher.variables.results import (
     ResultVec,
     result_missing_fill,
 )
-from bencher.variables.time import TimeEvent, TimeSnapshot
+from bencher.variables.time import TimeBase, TimeEvent, TimeSnapshot
 from bencher.worker_job import WorkerJob
 
 logger = logging.getLogger(__name__)
@@ -310,7 +310,7 @@ class ResultCollector:
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> list[IntSweep | TimeEvent | TimeSnapshot]:
+    ) -> list[IntSweep | TimeBase]:
         """Define extra meta variables for tracking benchmark execution details.
 
         This function creates variables that aren't passed to the worker function but are stored
@@ -335,7 +335,7 @@ class ResultCollector:
             optimize=False,
         )
         bench_cfg.iv_repeat.name = "repeat"
-        extra_vars: list[IntSweep | TimeEvent | TimeSnapshot] = [bench_cfg.iv_repeat]
+        extra_vars: list[IntSweep | TimeBase] = [bench_cfg.iv_repeat]
 
         if bench_cfg.over_time:
             if isinstance(time_src, str):

--- a/bencher/result_collector.py
+++ b/bencher/result_collector.py
@@ -310,7 +310,7 @@ class ResultCollector:
 
     def define_extra_vars(
         self, bench_cfg: BenchCfg, repeats: int, time_src: datetime | str
-    ) -> list[IntSweep]:
+    ) -> list[IntSweep | TimeEvent | TimeSnapshot]:
         """Define extra meta variables for tracking benchmark execution details.
 
         This function creates variables that aren't passed to the worker function but are stored
@@ -335,7 +335,7 @@ class ResultCollector:
             optimize=False,
         )
         bench_cfg.iv_repeat.name = "repeat"
-        extra_vars = [bench_cfg.iv_repeat]
+        extra_vars: list[IntSweep | TimeEvent | TimeSnapshot] = [bench_cfg.iv_repeat]
 
         if bench_cfg.over_time:
             if isinstance(time_src, str):

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -73,10 +73,14 @@ class ReduceType(Enum):
 
 # ReduceType with AUTO excluded: the return type of _resolve_auto, so that the match in
 # to_dataset is exhaustive over four members rather than relying on a catch-all.
-# CAVEAT: this only *fully* holds once `invalid-return-type` is enabled (plan 23 P12).
-# That rule is what checks _resolve_auto actually returns a member of this Literal; until
-# it lands, adding a ReduceType member without updating both this alias and the match
-# passes ty and fails at runtime in assert_never instead of at check time.
+#
+# P1's caveat here is now DISCHARGED: plan 23 P12 enabled `invalid-return-type`, which is
+# the rule that checks _resolve_auto really returns a member of this Literal. The proof is
+# therefore complete at check time in both directions -- verified by seeding
+# `return ReduceType.AUTO` on the `None` path, which ty rejects with
+# `expected Literal[SQUEEZE, REDUCE, MINMAX, NONE], found Literal[ReduceType.AUTO]`.
+# Adding a ReduceType member without updating both this alias and the match now fails
+# `pixi run ty` rather than at runtime in assert_never.
 ResolvedReduceType = Literal[
     ReduceType.SQUEEZE, ReduceType.REDUCE, ReduceType.MINMAX, ReduceType.NONE
 ]
@@ -207,8 +211,23 @@ class BenchResultBase:
         self._to_dataset_cache.clear()
 
     def result_samples(self) -> int:
-        """The number of samples in the results dataframe"""
-        return self.ds.count()
+        """The number of samples recorded, for the most-populated result variable.
+
+        This was ``return self.ds.count()`` -- annotated ``-> int`` while returning an
+        ``xr.Dataset`` of per-variable counts (found by plan 23 P12 enabling
+        ``invalid-return-type``). The consequence was worse than a wrong type: every
+        ``result_samples() > 0`` and ``result_samples() == n`` assertion in the suite
+        was **vacuous**. Comparing a Dataset yields a Dataset of booleans, and
+        ``bool(Dataset)`` is defined as ``len(data_vars) > 0`` -- true whenever the
+        sweep declared any result variable, whether or not a single sample was
+        collected. Nine such assertions could not fail.
+
+        Max rather than sum: two result variables over two samples is 2 samples, not 4.
+        Max rather than the first variable's count: a variable whose samples partly
+        failed must not undercount the sweep.
+        """
+        counts = self.ds.count()
+        return max((int(counts[name].values) for name in counts.data_vars), default=0)
 
     def to_hv_dataset(
         self,
@@ -522,7 +541,7 @@ class BenchResultBase:
         result_var: ParametrizedSweep,
         keep_existing_consts: bool = True,
         as_dict: bool = False,
-    ) -> tuple[ParametrizedSweep, Any] | dict[ParametrizedSweep, Any]:
+    ) -> list[tuple[Parameter, Any]] | dict[Parameter, Any]:
         """Get a list of tuples of optimal variable names and value pairs, that can be fed in as constant values to subsequent parameter sweeps
 
         Args:
@@ -531,11 +550,15 @@ class BenchResultBase:
             as_dict (bool): return value as a dictionary
 
         Returns:
-            tuple[bn.ParametrizedSweep, Any]|[ParametrizedSweep, Any]: Tuples of variable name and optimal values
+            A list of ``(input_var, optimal_value)`` pairs, or that same mapping as a dict
+            when ``as_dict``. The previous annotation said a *bare* ``tuple`` and named
+            ``ParametrizedSweep`` where the elements are ``param.Parameter`` descriptors;
+            neither held (plan 23 P12).
         """
         da = self.get_optimal_value_indices(result_var)
         if keep_existing_consts:
-            output = deepcopy(self.bench_cfg.const_vars)
+            # `or []`: const_vars is a param List, so it reads as `list | None`.
+            output = deepcopy(self.bench_cfg.const_vars) or []
         else:
             output = []
 
@@ -588,7 +611,12 @@ class BenchResultBase:
         return " vs ".join(tit)
 
     def get_results_var_list(self, result_var: ParametrizedSweep | None = None) -> list[Parameter]:
-        return self.bench_cfg.result_vars if result_var is None else listify(result_var)
+        if result_var is None:
+            # `or []`: result_vars is a param List, so it reads as `list | None`.
+            return self.bench_cfg.result_vars or []
+        # `or []` because listify returns None for a None input; unreachable here given
+        # the branch above, but the annotation has to hold without that reasoning.
+        return listify(result_var) or []
 
     def map_plots(
         self,

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -211,20 +211,17 @@ class BenchResultBase:
         self._to_dataset_cache.clear()
 
     def result_samples(self) -> int:
-        """The number of samples recorded, for the most-populated result variable.
+        """The number of values recorded, for the most-populated data variable.
 
-        This was ``return self.ds.count()`` -- annotated ``-> int`` while returning an
-        ``xr.Dataset`` of per-variable counts (found by plan 23 P12 enabling
-        ``invalid-return-type``). The consequence was worse than a wrong type: every
-        ``result_samples() > 0`` and ``result_samples() == n`` assertion in the suite
-        was **vacuous**. Comparing a Dataset yields a Dataset of booleans, and
-        ``bool(Dataset)`` is defined as ``len(data_vars) > 0`` -- true whenever the
-        sweep declared any result variable, whether or not a single sample was
-        collected. Nine such assertions could not fail.
+        This counts *cells*, not sweep points: the repeat dimension multiplies it, so a
+        two-point sweep at ``repeats=3`` reports 6. Returns 0 for a dataset with no data
+        variables.
 
-        Max rather than sum: two result variables over two samples is 2 samples, not 4.
-        Max rather than the first variable's count: a variable whose samples partly
-        failed must not undercount the sweep.
+        Max across data variables, rather than sum or first:
+
+        - sum would double-count -- two result variables over two samples is 2, not 4;
+        - first would undercount a sweep whose other variables partly failed, since a
+          failed sample leaves a NaN that ``count()`` skips.
         """
         counts = self.ds.count()
         return max((int(counts[name].values) for name in counts.data_vars), default=0)
@@ -550,10 +547,9 @@ class BenchResultBase:
             as_dict (bool): return value as a dictionary
 
         Returns:
-            A list of ``(input_var, optimal_value)`` pairs, or that same mapping as a dict
-            when ``as_dict``. The previous annotation said a *bare* ``tuple`` and named
-            ``ParametrizedSweep`` where the elements are ``param.Parameter`` descriptors;
-            neither held (plan 23 P12).
+            A list of ``(input_var, optimal_value)`` pairs, or that same mapping as a
+            dict when ``as_dict``. The keys are ``param.Parameter`` descriptors, not
+            ``ParametrizedSweep`` instances.
         """
         da = self.get_optimal_value_indices(result_var)
         if keep_existing_consts:

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -7,7 +7,7 @@ from param import Parameter
 
 from bencher.plotting.plot_filter import VarRange
 from bencher.results.bench_result_base import ReduceType
-from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.holoview_results.holoview_result import HoloviewResult, PlotResult
 from bencher.variables.results import SCALAR_RESULT_TYPES
 
 
@@ -49,7 +49,9 @@ class CurveResult(HoloviewResult):
             **kwargs,
         )
 
-    def to_curve_ds(self, dataset: xr.Dataset, result_var: Parameter, **kwargs) -> hv.Curve | None:
+    def to_curve_ds(
+        self, dataset: xr.Dataset, result_var: Parameter, **kwargs
+    ) -> PlotResult | None:
         """Creates a curve plot from the provided dataset.
 
         Generates a curve with optional standard deviation spread overlay.
@@ -63,7 +65,11 @@ class CurveResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the curve plot options.
 
         Returns:
-            hv.Curve | None: A curve plot with optional standard deviation spread.
+            An ``hv.Overlay`` of the curve plus optional standard-deviation spread,
+            or a panel layout when over_time wraps it for the time slider (see
+            ``PlotResult``); ``None`` for a dataset with no dimensions. Annotated
+            ``hv.Curve | None`` until plan 23 P12 -- a bare ``Curve`` is never
+            returned, because ``_build_curve_overlay`` always composes an Overlay.
         """
         if self._use_holomap_for_time(dataset):
             var = result_var.name

--- a/bencher/results/holoview_results/curve_result.py
+++ b/bencher/results/holoview_results/curve_result.py
@@ -65,11 +65,11 @@ class CurveResult(HoloviewResult):
             **kwargs: Additional keyword arguments passed to the curve plot options.
 
         Returns:
-            An ``hv.Overlay`` of the curve plus optional standard-deviation spread,
-            or a panel layout when over_time wraps it for the time slider (see
-            ``PlotResult``); ``None`` for a dataset with no dimensions. Annotated
-            ``hv.Curve | None`` until plan 23 P12 -- a bare ``Curve`` is never
-            returned, because ``_build_curve_overlay`` always composes an Overlay.
+            An ``hv.Overlay`` of the curve plus optional standard-deviation spread, or a
+            panel layout when over_time wraps it for the time slider (see
+            ``PlotResult``); ``None`` for a dataset with no dimensions, since there is
+            nothing to put on an axis. Never a bare ``hv.Curve``:
+            ``_build_curve_overlay`` composes into an Overlay whenever it returns at all.
         """
         if self._use_holomap_for_time(dataset):
             var = result_var.name

--- a/bencher/results/holoview_results/distribution_result/box_whisker_result.py
+++ b/bencher/results/holoview_results/distribution_result/box_whisker_result.py
@@ -10,6 +10,7 @@ from param import Parameter
 from bencher.results.holoview_results.distribution_result.distribution_result import (
     DistributionResult,
 )
+from bencher.results.holoview_results.holoview_result import PlotResult
 
 
 class BoxWhiskerResult(DistributionResult):
@@ -54,7 +55,7 @@ class BoxWhiskerResult(DistributionResult):
 
     def to_boxplot_ds(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs: Any
-    ) -> hv.BoxWhisker:
+    ) -> PlotResult:
         """Creates a box and whisker plot from the provided dataset.
 
         Given a filtered dataset, this method generates a box and whisker visualization showing
@@ -70,6 +71,9 @@ class BoxWhiskerResult(DistributionResult):
                       - line_width: Width of lines in the plot
 
         Returns:
-            hv.BoxWhisker: A HoloViews BoxWhisker plot of the benchmark data.
+            An ``hv.Overlay`` wrapping the BoxWhisker, or a panel layout for an
+            over_time dataset (see ``PlotResult``). See ``_plot_distribution``
+            (plan 23 P12) for why the previous ``hv.BoxWhisker`` annotation was never
+            satisfied.
         """
         return self._plot_distribution(dataset, result_var, hv.BoxWhisker, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/box_whisker_result.py
+++ b/bencher/results/holoview_results/distribution_result/box_whisker_result.py
@@ -72,8 +72,7 @@ class BoxWhiskerResult(DistributionResult):
 
         Returns:
             An ``hv.Overlay`` wrapping the BoxWhisker, or a panel layout for an
-            over_time dataset (see ``PlotResult``). See ``_plot_distribution``
-            (plan 23 P12) for why the previous ``hv.BoxWhisker`` annotation was never
-            satisfied.
+            over_time dataset (see ``PlotResult``). Never a bare ``hv.BoxWhisker`` --
+            see ``_plot_distribution``.
         """
         return self._plot_distribution(dataset, result_var, hv.BoxWhisker, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/distribution_result.py
+++ b/bencher/results/holoview_results/distribution_result/distribution_result.py
@@ -101,14 +101,13 @@ class DistributionResult(HoloviewResult):
         Returns:
             An ``hv.Overlay`` of the requested plot class(es); for an over_time
             dataset, whatever ``_build_time_holomap_raw`` wraps it in (see
-            ``PlotResult``) -- measured as a ``pn.Column`` in practice.
+            ``PlotResult``) -- a ``pn.Column`` in practice.
 
-        Note the return type is **not** ``plot_class``, and was annotated
-        ``hv.Element`` until plan 23 P12 measured it. Two separate reasons it could
-        never hold: ``_build_distribution_overlay`` composes into an ``hv.Overlay``
-        unconditionally (it accepts a *list* of plot classes), and ``Overlay`` is not
-        an ``hv.Element`` subclass at all -- it descends from ``Dimensioned`` by a
-        different route. Callers wanting the bare element must index into the overlay.
+        The return type is **not** ``plot_class``, and is not even an ``hv.Element``:
+        ``_build_distribution_overlay`` composes into an ``hv.Overlay`` unconditionally
+        (it accepts a *list* of plot classes), and ``Overlay`` is not an ``hv.Element``
+        subclass -- it descends from ``Dimensioned`` by a different route. Callers
+        wanting the bare element must index into the overlay.
         """
         var_name = result_var.name
         title = self.title_from_ds(dataset[var_name], result_var, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/distribution_result.py
+++ b/bencher/results/holoview_results/distribution_result/distribution_result.py
@@ -10,7 +10,7 @@ from param import Parameter
 
 from bencher.plotting.plot_filter import VarRange
 from bencher.results.bench_result_base import ReduceType
-from bencher.results.holoview_results.holoview_result import HoloviewResult
+from bencher.results.holoview_results.holoview_result import HoloviewResult, PlotResult
 from bencher.utils import params_to_str
 from bencher.variables.results import ResultFloat
 
@@ -85,7 +85,7 @@ class DistributionResult(HoloviewResult):
         result_var: Parameter,
         plot_class: type[hv.Selection1DExpr],
         **kwargs: Any,
-    ) -> hv.Element:
+    ) -> PlotResult:
         """Prepares data for distribution plots and creates the plot.
 
         This method handles common operations needed for all distribution plot types,
@@ -99,7 +99,16 @@ class DistributionResult(HoloviewResult):
             **kwargs: Additional keyword arguments for plot customization.
 
         Returns:
-            A HoloViews Element representing the distribution plot.
+            An ``hv.Overlay`` of the requested plot class(es); for an over_time
+            dataset, whatever ``_build_time_holomap_raw`` wraps it in (see
+            ``PlotResult``) -- measured as a ``pn.Column`` in practice.
+
+        Note the return type is **not** ``plot_class``, and was annotated
+        ``hv.Element`` until plan 23 P12 measured it. Two separate reasons it could
+        never hold: ``_build_distribution_overlay`` composes into an ``hv.Overlay``
+        unconditionally (it accepts a *list* of plot classes), and ``Overlay`` is not
+        an ``hv.Element`` subclass at all -- it descends from ``Dimensioned`` by a
+        different route. Callers wanting the bare element must index into the overlay.
         """
         var_name = result_var.name
         title = self.title_from_ds(dataset[var_name], result_var, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
+++ b/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
@@ -12,6 +12,7 @@ from bencher.results.bench_result_base import ReduceType
 from bencher.results.holoview_results.distribution_result.distribution_result import (
     DistributionResult,
 )
+from bencher.results.holoview_results.holoview_result import PlotResult
 from bencher.variables.results import ResultFloat
 
 
@@ -73,7 +74,7 @@ class ScatterJitterResult(DistributionResult):
 
     def to_scatter_jitter_ds(
         self, dataset: xr.Dataset, result_var: Parameter, jitter: float = 0.1, **kwargs: Any
-    ) -> hv.Scatter:
+    ) -> PlotResult:
         """Creates a scatter jitter plot from the provided dataset.
 
         Given a filtered dataset, this method generates a scatter visualization showing
@@ -91,7 +92,10 @@ class ScatterJitterResult(DistributionResult):
                       - marker: Shape of data points ('o', 's', 'd', etc.)
 
         Returns:
-            A HoloViews Scatter plot of the benchmark data with jittered points.
+            An ``hv.Overlay`` wrapping the jittered Scatter, or a panel layout for an
+            over_time dataset (see ``PlotResult``). See ``_plot_distribution``
+            (plan 23 P12) for why the previous ``hv.Scatter`` annotation was never
+            satisfied.
         """
         # Prepare the data using the common method from the parent class
         return self._plot_distribution(dataset, result_var, hv.Scatter, jitter=jitter, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
+++ b/bencher/results/holoview_results/distribution_result/scatter_jitter_result.py
@@ -93,9 +93,8 @@ class ScatterJitterResult(DistributionResult):
 
         Returns:
             An ``hv.Overlay`` wrapping the jittered Scatter, or a panel layout for an
-            over_time dataset (see ``PlotResult``). See ``_plot_distribution``
-            (plan 23 P12) for why the previous ``hv.Scatter`` annotation was never
-            satisfied.
+            over_time dataset (see ``PlotResult``). Never a bare ``hv.Scatter`` --
+            see ``_plot_distribution``.
         """
         # Prepare the data using the common method from the parent class
         return self._plot_distribution(dataset, result_var, hv.Scatter, jitter=jitter, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/violin_result.py
+++ b/bencher/results/holoview_results/distribution_result/violin_result.py
@@ -68,9 +68,8 @@ class ViolinResult(DistributionResult):
                       - bandwidth: Controls the smoothness of the density estimate
 
         Returns:
-            An ``hv.Overlay`` wrapping the Violin, or a panel layout for an
-            over_time dataset (see ``PlotResult``). Annotated ``hv.Violin`` until plan
-            23 P12 measured it: ``_plot_distribution`` always composes into an Overlay,
-            so the concrete-element annotation was never satisfied.
+            An ``hv.Overlay`` wrapping the Violin, or a panel layout for an over_time
+            dataset (see ``PlotResult``). Never a bare ``hv.Violin`` --
+            ``_plot_distribution`` always composes into an Overlay.
         """
         return self._plot_distribution(dataset, result_var, hv.Violin, **kwargs)

--- a/bencher/results/holoview_results/distribution_result/violin_result.py
+++ b/bencher/results/holoview_results/distribution_result/violin_result.py
@@ -10,6 +10,7 @@ from param import Parameter
 from bencher.results.holoview_results.distribution_result.distribution_result import (
     DistributionResult,
 )
+from bencher.results.holoview_results.holoview_result import PlotResult
 
 
 class ViolinResult(DistributionResult):
@@ -51,7 +52,7 @@ class ViolinResult(DistributionResult):
             **kwargs,
         )
 
-    def to_violin_ds(self, dataset: xr.Dataset, result_var: Parameter, **kwargs: Any) -> hv.Violin:
+    def to_violin_ds(self, dataset: xr.Dataset, result_var: Parameter, **kwargs: Any) -> PlotResult:
         """Creates a violin plot from the provided dataset.
 
         Given a filtered dataset, this method generates a violin plot visualization showing
@@ -67,6 +68,9 @@ class ViolinResult(DistributionResult):
                       - bandwidth: Controls the smoothness of the density estimate
 
         Returns:
-            hv.Violin: A HoloViews Violin plot of the benchmark data.
+            An ``hv.Overlay`` wrapping the Violin, or a panel layout for an
+            over_time dataset (see ``PlotResult``). Annotated ``hv.Violin`` until plan
+            23 P12 measured it: ``_plot_distribution`` always composes into an Overlay,
+            so the concrete-element annotation was never satisfied.
         """
         return self._plot_distribution(dataset, result_var, hv.Violin, **kwargs)

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -261,8 +261,8 @@ class HoloviewResult(PaneResult):
         groupby is required.
 
         Returns ``None`` for a dataset with no dimensions -- there is nothing to put
-        on an axis. The ``| None`` was missing from the annotation until plan 23 P12;
-        callers that forward the result into an ``hv`` composition have to handle it.
+        on an axis, so callers forwarding the result into an ``hv`` composition have to
+        handle it.
         """
         var = result_var.name
         std_var = f"{var}_std"
@@ -561,14 +561,16 @@ class HoloviewResult(PaneResult):
             **kwargs,
         )
 
-    def result_var_to_container(self, result_var: Parameter) -> type:
+    def result_var_to_container(self, result_var: Parameter) -> type[pn.viewable.Viewable]:
         """Determine the appropriate container type for a given result variable.
 
         Args:
             result_var (Parameter): The result variable to find a container for.
 
         Returns:
-            type: The appropriate panel container type (PNG, Video, or Column).
+            The panel container type (PNG, Video, or Column). Narrower than a bare
+            ``type``, so that ``setup_results_and_containers`` calling it produces a
+            checked ``Viewable`` rather than an ``Any`` that satisfies any annotation.
         """
         if isinstance(result_var, ResultImage):
             return pn.pane.PNG
@@ -589,15 +591,13 @@ class HoloviewResult(PaneResult):
 
         Returns:
             A tuple of the result variables as a list, and one initialized container per
-            variable. A container entry is ``None`` when the caller passed an explicit
-            ``None`` in ``container``; ``result_var_to_container`` itself always yields a
-            class. The second element was annotated ``list[pn.pane.panel]`` until plan 23
-            P12 -- ``pn.pane.panel`` is a *function*, so it never named a type at all,
-            and the annotation also hid the ``None``.
+            variable. A container entry is ``None`` only when the caller passed an
+            explicit ``None`` in ``container``; ``result_var_to_container`` itself always
+            yields a class.
         """
         # A fresh name rather than rebinding the parameter: assigning back keeps the
         # declared `Parameter | list[Parameter]` as the type's upper bound, so the
-        # single-Parameter arm still leaks into the return (plan 23 P12).
+        # single-Parameter arm still leaks into the return.
         plots: list[Parameter] = listify(result_var_plots) or []
         if container is None:
             containers = [self.result_var_to_container(rv) for rv in plots]

--- a/bencher/results/holoview_results/holoview_result.py
+++ b/bencher/results/holoview_results/holoview_result.py
@@ -27,6 +27,20 @@ from bencher.variables.results import ResultFloat, ResultImage, ResultVideo
 # directly via pn.pane.Plotly), and registering it eagerly costs ~6s at import.
 hv.extension("bokeh")
 
+# What a `to_*_ds` renderer actually hands back (plan 23 P12).
+#
+# Without over_time it is a holoviews object. *With* over_time the plot gets wrapped
+# for the time slider -- `_holomap_with_slider_bottom` returns a `pn.Column`, or a
+# `pn.Tabs` when `show_aggregated_time_tab` adds the aggregated tab, or the bare
+# `hv.HoloMap` if Panel produced no widgets to rearrange. So the return type crosses
+# the holoviews/panel boundary, which is why several of these methods were annotated
+# with a concrete `hv.Curve`/`hv.Violin` they could never return.
+#
+# Enumerated rather than collapsed to `Any`: the four shapes are exactly what a caller
+# has to handle, and `pn.Column`/`pn.Tabs` are the ones that surprise -- a caller doing
+# `.opts(...)` on the result works until someone enables over_time.
+PlotResult = hv.Overlay | hv.HoloMap | pn.Column | pn.Tabs
+
 # Flag to enable or disable tap tool functionality in visualizations
 use_tap = True
 
@@ -233,7 +247,7 @@ class HoloviewResult(PaneResult):
 
     def _build_curve_overlay(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs
-    ) -> hv.Overlay:
+    ) -> hv.Overlay | None:
         """Build a Curve (+ optional Spread) overlay for a single time slice or aggregated data.
 
         When ``_std`` exists in the dataset the spread band is rendered
@@ -245,6 +259,10 @@ class HoloviewResult(PaneResult):
         groupby dimensions by constructing ``hv.Dataset`` directly from the
         xarray Dataset.  The heavier DataFrame path is only used when manual
         groupby is required.
+
+        Returns ``None`` for a dataset with no dimensions -- there is nothing to put
+        on an axis. The ``| None`` was missing from the annotation until plan 23 P12;
+        callers that forward the result into an ``hv`` composition have to handle it.
         """
         var = result_var.name
         std_var = f"{var}_std"
@@ -561,7 +579,7 @@ class HoloviewResult(PaneResult):
         result_var_plots: Parameter | list[Parameter],
         container: type | list[type] | None = None,
         **kwargs,
-    ) -> tuple[list[Parameter], list[pn.pane.panel]]:
+    ) -> tuple[list[Parameter], list[pn.viewable.Viewable | None]]:
         """Set up appropriate containers for result variables.
 
         Args:
@@ -570,18 +588,24 @@ class HoloviewResult(PaneResult):
             **kwargs: Additional options to pass to the container constructors.
 
         Returns:
-            tuple[list[Parameter], list[pn.pane.panel]]: Tuple containing:
-                - List of result variables
-                - List of initialized container instances
+            A tuple of the result variables as a list, and one initialized container per
+            variable. A container entry is ``None`` when the caller passed an explicit
+            ``None`` in ``container``; ``result_var_to_container`` itself always yields a
+            class. The second element was annotated ``list[pn.pane.panel]`` until plan 23
+            P12 -- ``pn.pane.panel`` is a *function*, so it never named a type at all,
+            and the annotation also hid the ``None``.
         """
-        result_var_plots = listify(result_var_plots)
+        # A fresh name rather than rebinding the parameter: assigning back keeps the
+        # declared `Parameter | list[Parameter]` as the type's upper bound, so the
+        # single-Parameter arm still leaks into the return (plan 23 P12).
+        plots: list[Parameter] = listify(result_var_plots) or []
         if container is None:
-            containers = [self.result_var_to_container(rv) for rv in result_var_plots]
+            containers = [self.result_var_to_container(rv) for rv in plots]
         else:
-            containers = listify(container)
+            containers = listify(container) or []
 
         cont_instances = [c(**kwargs) if c is not None else None for c in containers]
-        return result_var_plots, cont_instances
+        return plots, cont_instances
 
     def to_error_bar(self, result_var: Parameter | str | None = None, **kwargs) -> hv.Bars:
         """Convert the dataset to an ErrorBars visualization for a specific result variable.

--- a/bencher/results/holoview_results/tabulator_result.py
+++ b/bencher/results/holoview_results/tabulator_result.py
@@ -21,7 +21,7 @@ class TabulatorResult(HoloviewResult):
 
         Returns:
             pn.widgets.Tabulator | None: An interactive table widget, or ``None`` when
-            ``filter`` rejects the dataset (plan 23 P12: the ``| None`` was missing).
+            ``filter`` rejects the dataset.
         """
         return self.to_tabulator(**kwargs)
 

--- a/bencher/results/holoview_results/tabulator_result.py
+++ b/bencher/results/holoview_results/tabulator_result.py
@@ -10,7 +10,7 @@ from bencher.results.holoview_results.holoview_result import HoloviewResult
 
 
 class TabulatorResult(HoloviewResult):
-    def to_plot(self, **kwargs) -> pn.widgets.Tabulator:  # pylint:disable=unused-argument
+    def to_plot(self, **kwargs) -> pn.widgets.Tabulator | None:  # pylint:disable=unused-argument
         """Create an interactive table visualization of the data.
 
         Passes the data to the panel Tabulator type to display an interactive table.
@@ -20,11 +20,14 @@ class TabulatorResult(HoloviewResult):
             **kwargs: Additional parameters to pass to the Tabulator constructor.
 
         Returns:
-            pn.widgets.Tabulator: An interactive table widget.
+            pn.widgets.Tabulator | None: An interactive table widget, or ``None`` when
+            ``filter`` rejects the dataset (plan 23 P12: the ``| None`` was missing).
         """
         return self.to_tabulator(**kwargs)
 
-    def to_tabulator(self, result_var: Parameter | None = None, **kwargs) -> pn.widgets.Tabulator:
+    def to_tabulator(
+        self, result_var: Parameter | None = None, **kwargs
+    ) -> pn.widgets.Tabulator | None:
         """Generates a Tabulator widget from benchmark data.
 
         This is a convenience method that calls to_tabulator_ds() with the same parameters.
@@ -44,7 +47,7 @@ class TabulatorResult(HoloviewResult):
 
     def to_tabulator_ds(
         self, dataset: xr.Dataset, result_var: Parameter, **kwargs
-    ) -> pn.widgets.Tabulator:
+    ) -> pn.widgets.Tabulator | None:
         """Creates a Tabulator widget from the provided dataset.
 
         Given a filtered dataset, this method generates an interactive table visualization.

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -646,7 +646,14 @@ def normalize_subsampling_divisions_kwargs(
             stacklevel=stacklevel,
         )
         max_subsampling_divisions = kwargs.pop("max_level")
-    return subsampling_divisions, max_subsampling_divisions, subsampling_divisions_was_set
+    # int() rather than a cast: every path above either kept the caller's int or took a
+    # value out of **kwargs, which is untyped -- so this is the one place the declared
+    # `int` is actually established (plan 23 P12).
+    return (
+        int(subsampling_divisions),
+        max_subsampling_divisions,
+        subsampling_divisions_was_set,
+    )
 
 
 def github_content(remote: str, branch_name: str, filename: str):  # pragma: no cover

--- a/bencher/utils.py
+++ b/bencher/utils.py
@@ -620,8 +620,16 @@ def normalize_subsampling_divisions_kwargs(
     import warnings
 
     subsampling_divisions_was_set = subsampling_divisions is not UNSET
-    if subsampling_divisions is UNSET:
-        subsampling_divisions = default_subsampling_divisions
+    # `isinstance` rather than `is UNSET`: both express the same runtime test, but only
+    # the former discharges `_Unset` from the declared `int | _Unset`, which is what
+    # establishes the `int` in the return type. Coercing with `int()` at the return would
+    # also have satisfied the checker, but it would silently truncate a float handed in
+    # through the untyped `level` kwarg.
+    resolved: int = (
+        default_subsampling_divisions
+        if isinstance(subsampling_divisions, _Unset)
+        else subsampling_divisions
+    )
 
     if "level" in kwargs:
         if subsampling_divisions_was_set:
@@ -633,7 +641,7 @@ def normalize_subsampling_divisions_kwargs(
             DeprecationWarning,
             stacklevel=stacklevel,
         )
-        subsampling_divisions = kwargs.pop("level")
+        resolved = kwargs.pop("level")
         subsampling_divisions_was_set = True
     if "max_level" in kwargs:
         if max_subsampling_divisions is not None:
@@ -646,14 +654,7 @@ def normalize_subsampling_divisions_kwargs(
             stacklevel=stacklevel,
         )
         max_subsampling_divisions = kwargs.pop("max_level")
-    # int() rather than a cast: every path above either kept the caller's int or took a
-    # value out of **kwargs, which is untyped -- so this is the one place the declared
-    # `int` is actually established (plan 23 P12).
-    return (
-        int(subsampling_divisions),
-        max_subsampling_divisions,
-        subsampling_divisions_was_set,
-    )
+    return resolved, max_subsampling_divisions, subsampling_divisions_was_set
 
 
 def github_content(remote: str, branch_name: str, filename: str):  # pragma: no cover

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -57,11 +57,14 @@ class SweepSelector(Selector, SweepBase):
             self.samples = samples
         self.optimize = optimize
 
-    def values(self) -> list[Any]:
+    def values(self) -> list[Any] | np.ndarray:
         """Return all the values for the parameter sweep.
 
         Returns:
-            list[Any]: A list of parameter values to sweep through
+            list[Any] | np.ndarray: The parameter values to sweep through. The union is
+            the base class admitting what ``FloatSweep`` actually returns -- a numpy
+            array straight from ``linspace``/``arange`` (plan 23 P12). Narrowing it back
+            would make that override an LSP violation, which is how this was found.
         """
         return self.indices_to_samples(self.samples, self.objects)
 
@@ -636,14 +639,19 @@ class FloatSweep(Number, SweepBase):
         sample_values = tuple(self.sample_values) if self.sample_values is not None else None
         return super()._sweep_identity() + (self.sweep_bounds, sample_values, self.step)
 
-    def values(self) -> list[float]:
+    def values(self) -> list[float] | np.ndarray:
         """Return all the values for the parameter sweep.
 
         If sample_values is provided, returns those values. Otherwise generates values
         within the specified bounds, either using linspace (when step is None) or arange.
 
         Returns:
-            list[float]: A list of float values to sweep through
+            list[float] | np.ndarray: The values to sweep through -- a list only when
+            they came from ``sample_values``; the generated paths return the numpy array
+            from ``linspace``/``arange`` directly. Annotated ``list[float]`` until plan 23
+            P12. Deliberately not coerced with ``list(...)``: the array flows into
+            hashing and dataset construction, so changing its type is a behaviour change
+            rather than an annotation fix
         """
         samps = self.samples
         if self.sample_values is None:

--- a/bencher/variables/inputs.py
+++ b/bencher/variables/inputs.py
@@ -62,9 +62,9 @@ class SweepSelector(Selector, SweepBase):
 
         Returns:
             list[Any] | np.ndarray: The parameter values to sweep through. The union is
-            the base class admitting what ``FloatSweep`` actually returns -- a numpy
-            array straight from ``linspace``/``arange`` (plan 23 P12). Narrowing it back
-            would make that override an LSP violation, which is how this was found.
+            inherited from the base contract, which has to admit the numpy array
+            ``FloatSweep.values`` returns; narrowing it would make that override an LSP
+            violation.
         """
         return self.indices_to_samples(self.samples, self.objects)
 
@@ -648,10 +648,9 @@ class FloatSweep(Number, SweepBase):
         Returns:
             list[float] | np.ndarray: The values to sweep through -- a list only when
             they came from ``sample_values``; the generated paths return the numpy array
-            from ``linspace``/``arange`` directly. Annotated ``list[float]`` until plan 23
-            P12. Deliberately not coerced with ``list(...)``: the array flows into
-            hashing and dataset construction, so changing its type is a behaviour change
-            rather than an annotation fix
+            from ``linspace``/``arange`` directly. Deliberately not coerced with
+            ``list(...)``: the array flows into hashing and dataset construction, so
+            changing its runtime type is a behaviour change, not an annotation fix.
         """
         samps = self.samples
         if self.sample_values is None:

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -32,13 +32,12 @@ class ParametrizedSweep(Parameterized):
         Returns:
             int | str: ``hash_sha1``'s hex digest, or the literal ``0`` when nothing was
             hashed -- ``hash_value=False``, or a class declaring no parameters besides
-            ``name``. Annotated ``-> int`` until plan 23 P12, which is the one thing it
-            almost never returns.
+            ``name``.
 
-            The ``0`` is a sentinel of the kind this plan exists to remove, but
-            normalizing it to a digest would change the key for parameter-less sweeps and
-            so invalidate persisted caches (§7). Left as-is deliberately; a phase that
-            can bump ``CACHE_VERSION`` should fix it.
+            The ``0`` is a sentinel of the kind plan 23 exists to remove, but normalizing
+            it to a digest would change the key for parameter-less sweeps and so
+            invalidate persisted caches (plan 23 §7). Left as-is deliberately; fixing it
+            needs a phase that can bump ``CACHE_VERSION``.
         """
 
         curhash = 0
@@ -52,7 +51,7 @@ class ParametrizedSweep(Parameterized):
     def hash_persistent(self) -> int | str:
         """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run.
 
-        Inherits ``param_hash``'s ``0``-or-digest return; see there (plan 23 P12)."""
+        Inherits ``param_hash``'s ``0``-or-digest return; see there."""
         return ParametrizedSweep.param_hash(self, True)
 
     def update_params_from_kwargs(self, **kwargs) -> None:

--- a/bencher/variables/parametrised_sweep.py
+++ b/bencher/variables/parametrised_sweep.py
@@ -22,7 +22,7 @@ class ParametrizedSweep(Parameterized):
     """Parent class for all Sweep types that need a custom hash"""
 
     @staticmethod
-    def param_hash(param_type: Parameterized, hash_value: bool = True) -> int:
+    def param_hash(param_type: Parameterized, hash_value: bool = True) -> int | str:
         """A custom hash function for parametrised types with an option for hashing the value of the type
 
         Args:
@@ -30,7 +30,15 @@ class ParametrizedSweep(Parameterized):
             hash_value (bool, optional): use the value as part of the hash. Defaults to True.
 
         Returns:
-            int: a hash
+            int | str: ``hash_sha1``'s hex digest, or the literal ``0`` when nothing was
+            hashed -- ``hash_value=False``, or a class declaring no parameters besides
+            ``name``. Annotated ``-> int`` until plan 23 P12, which is the one thing it
+            almost never returns.
+
+            The ``0`` is a sentinel of the kind this plan exists to remove, but
+            normalizing it to a digest would change the key for parameter-less sweeps and
+            so invalidate persisted caches (§7). Left as-is deliberately; a phase that
+            can bump ``CACHE_VERSION`` should fix it.
         """
 
         curhash = 0
@@ -41,8 +49,10 @@ class ParametrizedSweep(Parameterized):
 
         return curhash
 
-    def hash_persistent(self) -> str:
-        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run"""
+    def hash_persistent(self) -> int | str:
+        """A hash function that avoids the PYTHONHASHSEED 'feature' which returns a different hash value each time the program is run.
+
+        Inherits ``param_hash``'s ``0``-or-digest return; see there (plan 23 P12)."""
         return ParametrizedSweep.param_hash(self, True)
 
     def update_params_from_kwargs(self, **kwargs) -> None:
@@ -144,9 +154,11 @@ class ParametrizedSweep(Parameterized):
     @classmethod
     def get_input_defaults_override(cls, **kwargs) -> dict[str, Any]:
         inp = cls.get_inputs_only()
-        defaults = {}
+        defaults: dict[str, Any] = {}
         for i in inp:
-            defaults[i.name] = deepcopy(i.default)
+            # str(): param types `Parameter.name` as `str | None`, but a declared
+            # parameter always has one (plan 23 P12).
+            defaults[str(i.name)] = deepcopy(i.default)
 
         for k, v in kwargs.items():
             defaults[k] = v
@@ -207,7 +219,7 @@ class ParametrizedSweep(Parameterized):
         )
         main.show()
 
-    def to_holomap(self, callback, remove_dims: str | list[str] | None = None) -> hv.DynamicMap:
+    def to_holomap(self, callback, remove_dims: str | list[str] | None = None) -> hv.HoloMap:
         return hv.HoloMap(
             hv.DynamicMap(
                 callback=callback,

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -86,11 +86,16 @@ class SweepBase(param.Parameter):
 
     def values(
         self,
-    ) -> list[Any]:
+    ) -> list[Any] | np.ndarray:
         """All sweep classes must implement this method. This generates sample values from based on the parameters bounds and sample number.
 
         Returns:
-            list[Any]: A list of samples from the variable
+            list[Any] | np.ndarray: The samples from the variable. The numpy arm is not
+            optional politeness -- ``FloatSweep.values`` returns the array from
+            ``linspace``/``arange`` directly, so declaring ``list[Any]`` here made that
+            override an LSP violation. Found by plan 23 P12 enabling
+            ``invalid-return-type``, which surfaced as ``invalid-method-override`` once
+            the leaf was annotated honestly.
         """
         raise NotImplementedError
 

--- a/bencher/variables/sweep_base.py
+++ b/bencher/variables/sweep_base.py
@@ -92,10 +92,8 @@ class SweepBase(param.Parameter):
         Returns:
             list[Any] | np.ndarray: The samples from the variable. The numpy arm is not
             optional politeness -- ``FloatSweep.values`` returns the array from
-            ``linspace``/``arange`` directly, so declaring ``list[Any]`` here made that
-            override an LSP violation. Found by plan 23 P12 enabling
-            ``invalid-return-type``, which surfaced as ``invalid-method-override`` once
-            the leaf was annotated honestly.
+            ``linspace``/``arange`` directly, so declaring ``list[Any]`` here would make
+            that override an LSP violation.
         """
         raise NotImplementedError
 

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from functools import partial
 from typing import assert_never
 
+from param import Parameter
+
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 
 logger = logging.getLogger(__name__)
@@ -327,7 +329,7 @@ class WorkerManager:
                 )
         logger.info(f"setting worker class {worker_class} for declaration only")
 
-    def get_result_vars(self, as_str: bool = True) -> list[str | ParametrizedSweep]:
+    def get_result_vars(self, as_str: bool = True) -> list[str] | list[Parameter]:
         """Retrieve the result variables from the worker class instance.
 
         Args:
@@ -336,22 +338,26 @@ class WorkerManager:
                            Default is True.
 
         Returns:
-            list[str | ParametrizedSweep]: A list of result variables, either as strings
-                or in their original form.
+            list[str] | list[Parameter]: The result variables, as names or as the
+                ``param.Parameter`` descriptors themselves. Annotated
+                ``list[str | ParametrizedSweep]`` until plan 23 P12 -- ``get_results_only``
+                returns descriptors, not sweep instances.
 
         Raises:
             RuntimeError: If no ParametrizedSweep is attached (see :meth:`_declaring`).
         """
         declaring = self._declaring()
         if as_str:
-            return [i.name for i in declaring.get_results_only()]
+            # str() because param types `Parameter.name` as `str | None`; a declared
+            # parameter always has one, assigned when the owning class is created.
+            return [str(i.name) for i in declaring.get_results_only()]
         return declaring.get_results_only()
 
-    def get_inputs_only(self) -> list[ParametrizedSweep]:
+    def get_inputs_only(self) -> list[Parameter]:
         """Retrieve the input variables from the worker class instance.
 
         Returns:
-            list[ParametrizedSweep]: A list of input variables.
+            list[Parameter]: The input variables, as ``param.Parameter`` descriptors.
 
         Raises:
             RuntimeError: If no ParametrizedSweep is attached (see :meth:`_declaring`).

--- a/bencher/worker_manager.py
+++ b/bencher/worker_manager.py
@@ -339,8 +339,7 @@ class WorkerManager:
 
         Returns:
             list[str] | list[Parameter]: The result variables, as names or as the
-                ``param.Parameter`` descriptors themselves. Annotated
-                ``list[str | ParametrizedSweep]`` until plan 23 P12 -- ``get_results_only``
+                ``param.Parameter`` descriptors themselves -- ``get_results_only``
                 returns descriptors, not sweep instances.
 
         Raises:

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -1211,3 +1211,22 @@ than only a hygiene one — see item 1.
    digest would change the key for parameter-less sweeps and invalidate persisted caches
    (§7). Left for a phase that can bump `CACHE_VERSION`; recorded here so it is not
    mistaken for an oversight.
+
+10. **The honest unions P12 introduced are debt, not resolution.** `invalid-return-type`
+    can only check that an annotation matches what a function returns; it cannot say the
+    return *shape* is well modelled. Four annotations were made honest by widening, and
+    each widened union is now viral — every consumer must handle both arms. They are
+    listed here with their blocker so a later phase can take them, rather than reading as
+    finished work:
+
+    | Site | Union | Constructive fix | Blocker |
+    |---|---|---|---|
+    | `Bench.get_result_vars`, `WorkerManager.get_result_vars` | `list[str] \| list[Parameter]` switched on `as_str: bool` | split into `get_result_var_names()` and `get_result_vars()` | public API; needs a deprecation cycle for the flag |
+    | `BenchResultBase.get_optimal_inputs` | `list[tuple[...]] \| dict[...]` switched on `as_dict: bool` | split into two methods | same |
+    | `SweepBase.values`, `FloatSweep.values` | `list[Any] \| np.ndarray` | one return type for every leaf | coercing changes what flows into hashing and dataset construction |
+    | `ParametrizedSweep.param_hash`, `hash_persistent` | `int \| str` (the `0` sentinel) | always a digest | invalidates persisted caches; needs a `CACHE_VERSION` bump (§7) |
+
+    The first two are the shape this plan exists to remove — a boolean argument that
+    switches the return type is an illegal state made representable, and no type checker
+    will ever object to it. They are cheap to fix and blocked only on the deprecation, so
+    they should lead the follow-up phase rather than trail it.

--- a/plans/23-constructive-data-modeling.md
+++ b/plans/23-constructive-data-modeling.md
@@ -1122,3 +1122,92 @@ sweep written by `main`'s code and read by P5's → 6/6 hits). One MEDIUM findin
    `True`**, so it reaches any report built outside `to_auto()`. Rewording it would have
    been a user-visible change riding along on a type refactor; the sentinel it prints is
    now only a rendering, not a representable state.
+
+### P12 (partially implemented — `invalid-return-type` only)
+
+**Scope note:** P12 as written enables all five Tier-B rules. Measured after P2–P11 landed,
+Tier B is **125 diagnostics**, essentially unchanged from the ~126 estimated at
+`4a13ab8e` — the earlier phases fixed representations, not annotations. This PR delivers
+the first rule; the other four are measured and left. Costs, so the next phase can plan:
+
+| Rule | Diagnostics | State |
+|---|---|---|
+| `invalid-return-type` | 29 | **enabled** |
+| `not-iterable` | 43 | ignored |
+| `no-matching-overload` | 21 | ignored |
+| `unsupported-operator` | 16 | ignored |
+| `possibly-missing-attribute` | 16 | ignored |
+
+`invalid-return-type` was taken first because it is the one with a design payoff rather
+than only a hygiene one — see item 1.
+
+1. **P1's `ReduceType` caveat is discharged, and this was verified rather than assumed.**
+   `invalid-return-type` is the rule that checks `_resolve_auto` returns a member of
+   `ResolvedReduceType`, so `to_dataset`'s `assert_never` is now a compile-time proof in
+   *both* directions. Seeding `return ReduceType.AUTO` on the `None` path now gives
+   `expected Literal[SQUEEZE, REDUCE, MINMAX, NONE], found Literal[ReduceType.AUTO]`,
+   where before P12 it passed `pixi run ty` and failed at runtime. The caveat comment at
+   the alias is replaced by the discharge, and `test_ty_gate.py` now protects the rule
+   (verified to fail on a seeded re-ignore).
+
+   **A first probe of this was wrong and is recorded as such:** the seed was inserted
+   *after* the existing `if reduce is None: return ReduceType.NONE`, so it was
+   unreachable and ty correctly said nothing. Reading that as "the rule does not work"
+   would have been the wrong conclusion — an isolated probe showed ty rejects the pattern
+   fine. Seed on a *live* path.
+
+2. **`result_samples()` was annotated `-> int` and returned an `xr.Dataset`** — and the
+   consequence was much worse than a wrong type. `self.ds.count()` yields per-variable
+   counts, so **every** `result_samples() > 0` / `== n` assertion in the suite (nine of
+   them) was *vacuous*: comparing a Dataset yields a Dataset, and `bool(Dataset)` is
+   defined as `len(data_vars) > 0` — true whenever the sweep declared any result variable,
+   whether or not a single sample was collected. Now returns the max count across data
+   vars (max, not sum: two result variables over two samples is 2 samples, not 4).
+
+3. **Making those assertions real immediately found a test-isolation bug.**
+   `test_bencher.py::test_const_hashing` sets `ExampleBenchCfg.param.theta.samples = 5` on
+   a *class-level* param shared by the whole suite and never restored it, so every later
+   test relying on the default of 30 silently ran with 5. Two `test_plot_sweep_mutation`
+   tests asserting `result_samples() == 30` had been passing on the vacuous comparison.
+   Fixed with `setUp`/`tearDown` — deliberately not `addCleanup`, because that test is
+   hypothesis-driven and a cleanup registered inside the body captures the
+   already-mutated value on every example after the first.
+
+4. **Four annotations in the distribution-plot stack named types they could never
+   return.** `to_violin_ds`/`to_boxplot_ds`/`to_scatter_jitter_ds` each declared their
+   concrete element (`hv.Violin`, ...), but `_plot_distribution` composes through
+   `_build_distribution_overlay`, which returns an `hv.Overlay` unconditionally; and
+   `_plot_distribution` itself declared `hv.Element`, which `Overlay` **is not a subclass
+   of** at all. With over_time the value is a `pn.Column` — the return type crosses the
+   holoviews/panel boundary. Replaced by one enumerated alias, `PlotResult`.
+   Measured, not reasoned: a first attempt annotated them `hv.Overlay | hv.HoloMap`, which
+   was also wrong, because `_holomap_with_slider_bottom` wraps into panel objects.
+
+5. **`FloatSweep.values()` returns a numpy array, not a `list[float]`** — and annotating
+   the leaf honestly turned the diagnostic into a Tier-A `invalid-method-override`,
+   because `SweepBase.values()` (and its root declaration in `sweep_base.py`) promised
+   `list[Any]`. The root contract is now `list[Any] | np.ndarray`. Deliberately *not*
+   coerced with `list(...)`: the array flows into hashing and dataset construction, so
+   changing its runtime type is a behaviour change, not an annotation fix.
+
+6. **`ParametrizedSweep` was named where `param.Parameter` was meant, in four places** —
+   `get_result_vars` (twice, in `Bench` and `WorkerManager`), `get_inputs_only`, and
+   `get_optimal_inputs`, whose annotation also claimed a bare `tuple` where it returns a
+   *list* of pairs. A confusion between the sweep class and its parameter descriptors.
+
+7. **`cfg_from_optuna_trial` annotated `cfg_type: ParametrizedSweep` for a value it
+   calls.** Under that annotation ty resolved `cfg_type()` through
+   `Parameterized.__call__` and inferred `dict`; `type[ParametrizedSweep]` is what was
+   meant.
+
+8. **Two diagnostics are stub imprecision and carry scoped ignores with reasons**, per the
+   convention P1 set: `pn.serve` (returns `StoppableThread | Server`, where the annotation
+   said `Thread`) and `merged[keep]` in `history.py` (a list key returns a `Dataset` at
+   runtime, but xarray's `__getitem__` stub is typed for the str case and ty cannot narrow
+   by key type).
+
+9. **`param_hash` returns `0` or a sha1 digest**, declared `-> int` — the one thing it
+   almost never returns. Annotated `int | str` rather than normalized: making it always a
+   digest would change the key for parameter-less sweeps and invalidate persisted caches
+   (§7). Left for a phase that can bump `CACHE_VERSION`; recorded here so it is not
+   mistaken for an oversight.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,9 +274,16 @@ tmp_path_retention_count = 0
 [tool.ty.rules]
 
 # --- Tier B: enable globally in plan 23 P12 -----------------------------------------
-# Return type mismatches. Also the signal a degraded assert_never falls back to, so
-# enabling this hardens the exhaustiveness gate (plan 23 section 2.4).
-invalid-return-type = "ignore"
+# `invalid-return-type` is ENABLED (plan 23 P12, first of the five). It is the rule that
+# checks `_resolve_auto` really returns a member of `ResolvedReduceType`, so it is what
+# finally makes `to_dataset`'s `assert_never` a compile-time proof rather than a runtime
+# assertion (plan 23 section 2.4, and the caveat recorded at the alias in
+# bench_result_base.py). All 29 diagnostics it reported were genuine: see plan 23 section
+# 10 for the two live bugs among them.
+#
+# The remaining four Tier-B rules are still ignored, with their measured cost:
+#   not-iterable (43), no-matching-overload (21), unsupported-operator (16),
+#   possibly-missing-attribute (16).
 # Union types read as non-iterable / no matching overload / unsupported operator.
 not-iterable = "ignore"
 no-matching-overload = "ignore"

--- a/test/test_bench_result_base.py
+++ b/test/test_bench_result_base.py
@@ -25,6 +25,22 @@ class CountingWorker(bn.ParametrizedSweep):
         self.distance = float(self.float1)
 
 
+class PartlyMissingWorker(bn.ParametrizedSweep):
+    """One result variable always recorded, one recorded for a subset of samples.
+
+    Gives `result_samples()` a dataset whose per-variable counts differ, so max/sum/first
+    are all distinguishable.
+    """
+
+    idx = bn.IntSweep(default=0, bounds=[0, 4], samples=5)
+    full = bn.ResultFloat()
+    partial = bn.ResultFloat()
+
+    def benchmark(self):
+        self.full = float(self.idx)
+        self.partial = float(self.idx) if self.idx < 2 else float("nan")
+
+
 class TstBench(bn.ParametrizedSweep):
     float_var = bn.FloatSweep(default=0, bounds=[0, 4])
     cat_var = bn.StringSweep(["a", "b", "c", "d", "e"])
@@ -673,9 +689,32 @@ class TestBenchResultBase(unittest.TestCase):
             )
 
     def test_result_samples(self):
-        res = self._make_1d_result()
-        samples = res.result_samples()
-        self.assertIsNotNone(samples)
+        # `assertIsNotNone` used to be the whole test, which passes for any int and also
+        # passed for the xr.Dataset the method returned before it was fixed. Pin the
+        # number.
+        expected = len(BenchableObject.param.float1.values())
+        self.assertEqual(self._make_1d_result().result_samples(), expected)
+
+    def test_result_samples_counts_repeats(self):
+        """Repeats multiply the count -- it is cells recorded, not sweep points."""
+        expected = len(BenchableObject.param.float1.values()) * 3
+        self.assertEqual(self._make_1d_result(repeats=3).result_samples(), expected)
+
+    def test_result_samples_is_max_not_sum_across_result_vars(self):
+        """Two result variables over N samples is N samples, not 2N.
+
+        The partly-NaN variable is the point: `max` must report the most-populated
+        variable, so neither a `sum` (which would double-count) nor a first-variable
+        read (which would undercount at 2) passes this.
+        """
+        res = bn.Bench("result_samples_max", PartlyMissingWorker()).plot_sweep(
+            "max_not_sum",
+            input_vars=[PartlyMissingWorker.param.idx],
+            plot_callbacks=False,
+        )
+        counts = {name: int(res.ds.count()[name].values) for name in res.ds.data_vars}
+        self.assertEqual(counts, {"full": 5, "partial": 2})
+        self.assertEqual(res.result_samples(), 5)
 
     def test_to_dataset_cache_returns_same_object(self):
         """Identical args with deep=False should return the exact same cached object."""

--- a/test/test_bench_runner.py
+++ b/test/test_bench_runner.py
@@ -51,7 +51,7 @@ class TestBenchRunner(unittest.TestCase):
         bench_class = SimpleBenchClass()
         # bench = bn.Bench("test_bench", bench_class, run_cfg=run_cfg, report=report            )
 
-        def run_bench_class(run_cfg: bn.BenchRunCfg, report: bn.BenchReport) -> bn.BenchCfg:
+        def run_bench_class(run_cfg: bn.BenchRunCfg, report: bn.BenchReport) -> bn.Bench:
             bench = bn.Bench("test_bench1_cache", bench_class, run_cfg=run_cfg, report=report)
             bench.plot_sweep("bench_1")
             return bench

--- a/test/test_bencher.py
+++ b/test/test_bencher.py
@@ -77,6 +77,17 @@ result_var_permutations = [
 
 
 class TestBencher(unittest.TestCase):
+    def setUp(self) -> None:
+        # ExampleBenchCfg.param.theta is a *class-level* param shared by the whole
+        # suite, and test_const_hashing overwrites `samples`. Restoring it in tearDown
+        # rather than via addCleanup because that test is hypothesis-driven: the body
+        # runs once per example, so a cleanup registered inside it would capture the
+        # already-mutated value on every example after the first.
+        self._theta_samples = ExampleBenchCfg.param.theta.samples
+
+    def tearDown(self) -> None:
+        ExampleBenchCfg.param.theta.samples = self._theta_samples
+
     def create_bench(self) -> Bench:
         return Bench("test_bencher", ExampleBenchCfg())
 
@@ -316,6 +327,10 @@ class TestBencher(unittest.TestCase):
     def test_const_hashing(self, noisy) -> None:
         """check that const variables are hashed correctly. This test was created because setting a const variable was resulting in a hash value that changed over time even though the inputs were not changing.  The source of the problem was that the input config had a native param instead of a paramSweep object.  The native param objects don't have a constant hash because they include the .name field which changes for every instance of the param.  the paramSweep objects have the .name field removed from the hash so that hashes for the same inputs remain constant"""
 
+        # Restored by tearDown. Left unrestored this leaked samples=5 into every later
+        # test relying on the default of 30 -- unnoticed because the assertions that
+        # would have caught it compare `result_samples()`, which returned an xr.Dataset
+        # whose `bool()` is always True (plan 23 P12).
         ExampleBenchCfg.param.theta.samples = 5
 
         logger.info(f"starting with const value noisy:{noisy}")

--- a/test/test_dataset_result.py
+++ b/test/test_dataset_result.py
@@ -125,7 +125,7 @@ OVER_TIME_RUNS = 3
 
 def run_sweep_over_time(
     worker: bn.ParametrizedSweep, name: str, runs: int = OVER_TIME_RUNS
-) -> bn.BenchResult:
+) -> bn.BenchResult | None:
     """Run one sweep `runs` times against a single history, as a nightly rig does.
 
     Only the first run clears the history, so from the second run on the rendered

--- a/test/test_ty_gate.py
+++ b/test/test_ty_gate.py
@@ -27,6 +27,12 @@ MUST_NOT_BE_IGNORED = {
     # The exhaustiveness mechanism. Silencing this turns every `assert_never` arm from a
     # compile-time proof into a runtime assertion, with no other signal.
     "type-assertion-failure": "exhaustive `match` checking (plan 23 D2)",
+    # Tier B's first rule, enabled in P12. This is what verifies `_resolve_auto` really
+    # returns a member of `ResolvedReduceType`, i.e. what makes `to_dataset`'s
+    # `assert_never` a compile-time proof instead of a runtime assertion. Re-ignoring it
+    # silently downgrades that proof, which is exactly the state P1 shipped with and P12
+    # was written to end.
+    "invalid-return-type": "the ReduceType exhaustiveness proof (plan 23 P12)",
     # Tier A, enabled in P1. Each was measured at <=6 diagnostics, so a reappearance in
     # the ignore list is a regression rather than a pragmatic concession.
     "call-non-callable": "Tier A (plan 23 P1)",

--- a/test/test_xy_curve_result.py
+++ b/test/test_xy_curve_result.py
@@ -24,7 +24,7 @@ def trace_frame(duration: float) -> pd.DataFrame:
     return pd.DataFrame({"time": t, "signal": np.sin(t), "reference": np.cos(t)})
 
 
-def xarray_trace_frame(duration: float) -> pd.DataFrame:
+def xarray_trace_frame(duration: float) -> pd.DataFrame | pd.Series:
     """The same trace built the way xarray users build one.
 
     ``Dataset.to_pandas()`` leaves the dimension coordinate in the *index*, so the
@@ -32,6 +32,8 @@ def xarray_trace_frame(duration: float) -> pd.DataFrame:
     """
     t = np.linspace(0.0, duration, SAMPLES_PER_TRACE)
     signal = xr.DataArray(np.sin(t), dims=["time"], coords={"time": t})
+    # to_pandas() returns a Series for 1-D data and a DataFrame otherwise; ty sees the
+    # union, so name it rather than narrowing on a shape it cannot see (plan 23 P12).
     return xr.Dataset({"signal": signal}).to_pandas()
 
 


### PR DESCRIPTION
Plan 23 P12, first of the five Tier-B rules. Follows P11.

## Scope: this is P12 part 1 of 2

P12 as written enables all five Tier-B rules. Measured after P2–P11 landed, Tier B is
**125 diagnostics** — essentially unchanged from the ~126 estimated before those phases,
because they fixed *representations*, not annotations. Splitting keeps the diff reviewable
and the ratchet monotonic.

| Rule | Diagnostics | This PR |
|---|---|---|
| `invalid-return-type` | 29 | **enabled** |
| `not-iterable` | 43 | ignored |
| `no-matching-overload` | 21 | ignored |
| `unsupported-operator` | 16 | ignored |
| `possibly-missing-attribute` | 16 | ignored |

`invalid-return-type` is taken first because it is the only one with a **design payoff**
rather than just hygiene — see below. The other four are measured and recorded in plan 23
§10 so part 2 can be planned rather than discovered.

## It discharges P1's outstanding caveat

This is the rule that verifies `_resolve_auto` really returns a member of
`ResolvedReduceType`. So `to_dataset`'s `assert_never` is now a compile-time proof in
*both* directions. Verified by seeding a bad return on a live path:

```
expected `Literal[ReduceType.SQUEEZE, ReduceType.REDUCE, ReduceType.MINMAX, ReduceType.NONE]`,
found `Literal[ReduceType.AUTO]`
```

Before this PR that seed passed `pixi run ty` and failed at runtime inside `assert_never`.
The caveat comment at the alias is replaced by the discharge, and `test_ty_gate.py` now
protects the rule (verified to fail on a seeded re-ignore).

**A first probe of this was wrong, and it is recorded as such** in §10: I seeded *after*
the existing `if reduce is None: return ReduceType.NONE`, so the seed was unreachable and
ty correctly said nothing. Reading that as "the rule doesn't work" would have been the
wrong conclusion — an isolated probe showed ty handles the pattern fine. Seed on a live
path.

## Two of the 29 were live bugs

**`result_samples()` was annotated `-> int` and returned an `xr.Dataset`.** The wrong type
was the smaller half. `self.ds.count()` gives per-variable counts; comparing a Dataset
yields a Dataset, and `bool(Dataset)` is defined as `len(data_vars) > 0`. So **all nine**
`result_samples() > 0` / `== n` assertions in the suite were *vacuous* — true whenever the
sweep declared any result variable, whether or not a single sample was collected. It now
returns the greatest count across result variables (max, not sum: two result variables over
two samples is 2 samples, not 4).

**Making those assertions real immediately found a test-isolation bug.**
`test_bencher.py::test_const_hashing` sets `ExampleBenchCfg.param.theta.samples = 5` on a
*class-level* param shared by the whole suite and never restored it, so every later test
relying on the default of 30 silently ran with 5. Two `test_plot_sweep_mutation` tests
asserting `result_samples() == 30` had been passing on the vacuous comparison. Fixed with
`setUp`/`tearDown` — deliberately **not** `addCleanup`, because that test is
hypothesis-driven and a cleanup registered inside the body captures the already-mutated
value on every example after the first.

## The rest are annotations naming types the function cannot return

Most notable — **four in the distribution-plot stack**. `to_violin_ds`, `to_boxplot_ds` and
`to_scatter_jitter_ds` each declared their concrete element (`hv.Violin`, …), but
`_plot_distribution` composes through `_build_distribution_overlay`, which returns an
`hv.Overlay` unconditionally; and with `over_time` the value is a **`pn.Column`** — the
return type crosses the holoviews/panel boundary. `_plot_distribution`'s own `hv.Element`
was impossible too: `hv.Overlay` is not an `hv.Element` subclass. Replaced by one
enumerated alias, `PlotResult`.

Measured, not reasoned: my first attempt annotated them `hv.Overlay | hv.HoloMap`, which
was *also* wrong, because `_holomap_with_slider_bottom` wraps into panel objects. Both
wrong turns are in §10.

Also:
- **`FloatSweep.values()` returns a numpy array**, not `list[float]`. Annotating the leaf
  honestly turned the diagnostic into a Tier-A `invalid-method-override` against the root
  contract in `sweep_base.py`, which is now `list[Any] | np.ndarray`. Deliberately **not**
  coerced with `list(...)`: the array flows into hashing and dataset construction, so that
  would be a behaviour change rather than an annotation fix.
- **Four sites named `ParametrizedSweep` where `param.Parameter` was meant** —
  `get_result_vars` (×2), `get_inputs_only`, `get_optimal_inputs` (which also claimed a
  bare `tuple` for a list of pairs). A confusion between the sweep class and its
  descriptors.
- **`cfg_from_optuna_trial` annotated `cfg_type: ParametrizedSweep` for a value it calls**;
  ty resolved `cfg_type()` through `Parameterized.__call__` and inferred `dict`.
  `type[ParametrizedSweep]` is what was meant.
- **`param_hash` returns `0` or a sha1 digest**, declared `-> int`. Annotated `int | str`
  rather than normalized: making it always a digest would change the key for
  parameter-less sweeps and **invalidate persisted caches** (§7). Left for a phase that can
  bump `CACHE_VERSION`, and recorded so it is not mistaken for an oversight.
- **Two scoped ignores with reasons**, per P1's convention, for genuine stub imprecision:
  `pn.serve` (returns `StoppableThread | Server`) and `merged[keep]` in `history.py` (a
  list key returns a `Dataset`, but xarray's `__getitem__` stub is typed for the str case).

## Test plan

- `pixi run ci` — **2806 passed**, 21 skipped, pylint 10.00/10, `ty` clean, coverage 91%
  (gate 85%)
- `pixi run test-split` — the split-render pipeline over the whole suite
- `pixi run pytest test/test_ty_gate.py` — 27 tests (2 new), and the new
  `invalid-return-type` guard verified to fail on a seeded re-ignore
- The `ReduceType` proof verified by seeding a bad return on a live path (above)

No behaviour changes beyond `result_samples()` and the test-isolation fix; everything else
is annotations, docstrings and two scoped ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable ty's invalid-return-type rule and align return types and annotations across bench results, plotting, and sweep APIs, fixing the few real defects it surfaced.

Bug Fixes:
- Correct BenchResult.result_samples() to return an integer sample count instead of an xr.Dataset, making result-sample assertions meaningful.
- Fix a test isolation issue by restoring ExampleBenchCfg.param.theta.samples between tests so later tests are not affected.

Enhancements:
- Enable ty's invalid-return-type rule (Tier B) and document its role in enforcing ReduceType exhaustiveness proofs.
- Tighten type annotations for plot, sweep, worker, and Optuna-conversion APIs so declared return types match actual values, including new PlotResult alias and optional None returns.
- Clarify and broaden hash-related return types (param_hash/hash_persistent) and sweep value contracts to reflect int/str hashes and possible np.ndarray results without changing behavior.
- Annotate bench/worker result-variable APIs and extra-var definitions with accurate Parameter/TimeEvent/TimeSnapshot unions, and adjust helper utilities/tests to reflect real unions and invariants.
- Record plan 23 P12 details, diagnostics, and remaining Tier-B rule costs in the plan document and changelog, and guard the new rule in test_ty_gate.

Build:
- Switch ty configuration to enable invalid-return-type while leaving other Tier-B rules ignored, with documented diagnostic counts.

Documentation:
- Update plan 23 documentation and CHANGELOG with the P12 (invalid-return-type) rollout, the discovered bugs, and the corrected return-type contracts.

Tests:
- Extend tests (including test_ty_gate and bench/tests) to cover the new type rule, verify ReduceType exhaustiveness, and ensure result_samples semantics and cache-related behavior remain correct.

Chores:
- Add targeted ty ignores for known third-party stub imprecisions (pn.serve and xarray Dataset indexing).