### PR TITLE
release: v1.118.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.118.0] - 2026-08-04
+
 ### Fixed
 - **`pixi run ty` no longer gives different answers before and after a docs build**
   (plan 26 R10). ty type-checks `.ipynb`, `generate-docs` writes notebooks under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.117.0"
+version = "1.118.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
Cuts a new bencher release: **v1.117.0 → v1.118.0**.

Promotes the `[Unreleased]` CHANGELOG section to `## [1.118.0] - 2026-08-04` and bumps `version` in `pyproject.toml`. On merge to `main`, the `Auto-publish` workflow parses the changelog and publishes to PyPI once CI passes.

## Highlights
- **ty type gate is now real** — enforced by running it (not reading config), all five Tier-B rules on, pinned to a single ty version so CI and local runs agree (plans 23/26).
- **Constructive-modeling refactors** remove sentinel/optional pairs across `VarRange`, `WorkerState`, `JobFuture`, `WorkerJob`, and executor normalization.
- **Content-addressed blob store** (`bencher/blob_store.py`) with reachability-based GC (`bn.clean_orphaned_blobs()`); `ResultDataSet` renders full `over_time` history.
- **Visible failure marks** — failed samples and failed renders no longer vanish silently from the report.

## Breaking
- Dropped **Python 3.10** support (floor raised to 3.11).
- One `AggFn` vocabulary; an unknown `agg_fn` now raises.
- `ResultDataSet` cells hold blob path strings; `BenchResult.dataset_list` is always empty.
- `ResultHmap` deprecated; dead setuptools files removed.

See the [1.118.0] section of `CHANGELOG.md` for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cut v1.118.0 release by promoting the Unreleased changelog section to a dated 1.118.0 entry and bumping the project version.

Enhancements:
- Document v1.118.0 changes in CHANGELOG with a new dated release section.

Build:
- Update pyproject.toml project version from 1.117.0 to 1.118.0 for the new release.