### PR TITLE
build: move libc system requirement onto the platforms entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,7 @@ bencher = "bencher.render:main"
 
 [tool.pixi.workspace]
 channels = ["conda-forge", "https://prefix.dev/blooop"]
-platforms = ["linux-64"]
-
-[tool.pixi.system-requirements]
-libc = "2.31"
+platforms = [{ platform = "linux-64", glibc = "2.31" }]
 
 [tool.pixi.dependencies]
 python = ">=3.11"


### PR DESCRIPTION
## Summary
pixi 0.75 deprecated `[tool.pixi.system-requirements]` in favour of virtual packages declared on each `platforms` entry, so every `pixi install` / `pixi run` printed a multi-line warning about `pyproject.toml:42`.

Moved `libc = "2.31"` onto the platform entry. Note the key is spelled `glibc` in the new form — `libc` is rejected outright.

```toml
platforms = [{ platform = "linux-64", glibc = "2.31" }]
```

## Testing
`pixi install` now completes with no warnings, and `pixi.lock` is unchanged (same resolved environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)