### PR TITLE
docs: supersede plan 26 R9 §3 — its assert_never premise was wrong

### DIFF
--- a/plans/26-post-merge-audit-remediation.md
+++ b/plans/26-post-merge-audit-remediation.md
@@ -322,11 +322,30 @@ this list, and fold the small fixes in where the files are already being touched
    raising a `TypeError` that names the six named constructors.
 2. **P8's DoD is unmet at the fifth match site:**
    `composable_container_video.py:158-161` still ends `match render_cfg.compose_method` with
-   `case _: raise RuntimeError`, and the file isn't strict-listed. `assert_never` arm +
-   strict-list.
-3. **Strict-list additions** so the new `assert_never`s stop being decorative: `plot_filter.py`,
-   `utils.py`, `plugins/bench_data.py`, `results/bench_result_base.py` (the statement-form AggFn
-   ladder is not caught by P12's global `invalid-return-type`).
+   `case _: raise RuntimeError`. Replace it with an `assert_never` arm. **Do the arm only — the
+   "+ strict-list" half of this item is unnecessary**, for the reason recorded under item 3: the
+   arm takes effect the moment it is written, with no override entry.
+3. ~~**Strict-list additions** so the new `assert_never`s stop being decorative: `plot_filter.py`,
+   `utils.py`, `plugins/bench_data.py`, `results/bench_result_base.py`.~~ **SUPERSEDED by plan 28**
+   (the Tier-C global ratchet), which covers all four files by rule rather than by file.
+
+   **The premise above was wrong, and is recorded here so it is not re-derived.** Those
+   `assert_never`s were never decorative. A non-exhaustive `assert_never` is caught by
+   `type-assertion-failure`, which is **not** one of the five Tier-C rules and is not ignored
+   anywhere (plan 23 §9 requires exactly that) — so it fires on every file under `bencher/`,
+   strict-listed or not. Verified by seeding an incomplete `match` at a non-listed path under
+   `bencher/` and running the repo's own unmodified pixi task argv from the repo root; it
+   reported `error[type-assertion-failure]`. Strict-listing changed nothing about it.
+
+   What the additions would actually have bought is interim Tier-C regression protection for
+   those files. Measured on `5da6f213` (ty 0.0.66): `plot_filter.py` and `plugins/bench_data.py`
+   are already at **0** Tier-C diagnostics, `utils.py` has 3 and `results/bench_result_base.py`
+   has 15 — and **315 of 387** files under `bencher/` are already clean, against 17 strict-listed.
+   Protecting two more of 315 encodes nothing but which files this item happened to name.
+
+   Decided in
+   [Does plan 26 R9 section 3's strict-list work still happen?](https://github.com/blooop/bencher/issues/1062),
+   a ticket on the [ty adoption map](https://github.com/blooop/bencher/issues/1056).
 4. `HistoryEvent` is not frozen (`bencher/history.py:99-100`) — `event.kind = "typo"` bypasses
    the `__post_init__` parse; freeze it.
 5. **`IntSweep.with_bounds` coercion bypasses both plan-17 guards** (verified):


### PR DESCRIPTION
## Summary

- **Supersedes plan 26 R9 §3** (strict-list additions) in favour of plan 28, the Tier-C global
  ratchet, which covers all four of its files by rule rather than by file.
- **Records why §3's premise was wrong**, not just that it is superseded. §3 justifies the
  additions as *"so the new `assert_never`s stop being decorative"*. They were never decorative:
  a non-exhaustive `assert_never` is caught by `type-assertion-failure`, which is **not** one of
  the five Tier-C rules and is not ignored anywhere — plan 23 §9 requires exactly that — so it
  fires on every file under `bencher/`, strict-listed or not. Without the reason on the page, the
  next reader re-derives the same wrong conclusion from the same plausible sentence.
- **Trims R9 §2 to its code fix.** `composable_container_video.py:158-161` still ends
  `match render_cfg.compose_method` with `case _: raise RuntimeError`; the `assert_never` arm
  still happens, but the "+ strict-list" half is unnecessary for the same reason — the arm takes
  effect the moment it is written.

Docs-only. No code, config or gate behaviour changes.

## Verification

The claim that strict-listing is irrelevant to `assert_never` was **measured, not read**: an
incomplete `match` was seeded at a path under `bencher/` that appears in no override block, and
the repo's own unmodified pixi task argv (`ty check --respect-ignore-files --python
"$CONDA_PREFIX" .`) was run from the repo root. It reported:

```
error[type-assertion-failure]: Argument does not have asserted type `Never`
  --> bencher/_wf_probe_an.py:10:13
```

The probe file was removed; the tree was clean before this branch was cut.

An earlier version of that probe ran from `/tmp`, where no `pyproject.toml` governs, and so
proved nothing about the gate. That is plan 23 §10 P12b item 10's trap — *a probe run under
anything other than the checked-in config proves nothing about the checked-in config* — and it
is why the result above is stated with the argv and the working directory spelled out.

Supporting counts, measured on `5da6f213` with the pinned ty 0.0.66 (the commit is cited in the
plan text per `plans/README.md` ground rule 7):

| | |
|---|---|
| Python files under `bencher/` | 387 |
| Files with ≥1 Tier-C diagnostic | 72 |
| Files already Tier-C clean | 315 |
| Files currently strict-listed | 17 |

§3's four files: `plotting/plot_filter.py` **0**, `plugins/bench_data.py` **0**, `utils.py` 3,
`results/bench_result_base.py` 15. So the interim regression protection §3 would really have
bought covers two more of 315 already-clean files — a selection that encodes nothing but which
files the item happened to name.

Re-checked after merging `origin/main` (now v1.118.0): the strict-list and the `ty==0.0.66` pin
are untouched since the measurement commit, so these figures still hold.

## Test plan

- [x] `prek run --from-ref origin/main --to-ref HEAD` — all hooks pass
- [x] Merged `origin/main` cleanly; no code paths touched, so the suite is unaffected

## Context

Decided in [Does plan 26 R9 section 3's strict-list work still happen?](https://github.com/blooop/bencher/issues/1062),
a decision ticket on the [ty adoption map](https://github.com/blooop/bencher/issues/1056).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update plan 26 post-merge remediation notes to reflect corrected understanding of assert_never behavior and its relationship to strict-listing, and to mark part of the plan as superseded by a newer global Tier-C ratchet plan.

Documentation:
- Revise R9 section 2 to focus solely on adding an assert_never match arm without requiring strict-listing for its effect.
- Mark R9 section 3 strict-list additions as superseded by plan 28 and document why the original rationale about decorative assert_never usages was incorrect, including the measured behavior and related decision tickets.