### PR TITLE
fix: give every pane type an over_time layout, not just the named ones

### DIFF
--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -1004,14 +1004,8 @@ class BenchResultBase:
                     # renderer asking that for one value raises. A pane type
                     # without a bespoke over_time layout must still get a correct
                     # one, including one added after this line was written.
-                    #
-                    # For ResultDataSet specifically, path-backed cells (plan 22)
-                    # make historical payloads loadable from any run, so every time
-                    # point renders like the other blob types. Legacy index cells
-                    # are only trusted at the final time index — dataset_list
-                    # belongs to the final run, so an in-range historical index
-                    # would silently render the *current* payload under a
-                    # historical label; those render a labelled placeholder.
+                    # Per-type concerns (ResultDataSet's legacy index cells) belong
+                    # to the layout, not to this branch — see the method's docstring.
                     return self._pane_over_time_samples(
                         dataset, result_var, plot_callback, **kwargs
                     )

--- a/bencher/results/bench_result_base.py
+++ b/bencher/results/bench_result_base.py
@@ -40,6 +40,7 @@ from bencher.utils import (
 from bencher.variables.inputs import with_subsampling_divisions
 from bencher.variables.parametrised_sweep import ParametrizedSweep
 from bencher.variables.results import (
+    PANEL_TYPES,
     OptDir,
     ResultBool,
     ResultDataSet,
@@ -994,16 +995,30 @@ class BenchResultBase:
                     return self._pane_over_time_grid(dataset, result_var)
                 if isinstance(result_var, (ResultVideo, ResultImage)):
                     return self._pane_over_time_slider(dataset, result_var)
-                if isinstance(result_var, ResultDataSet):
-                    # Path-backed cells (plan 22) make historical payloads loadable
-                    # from any run, so every time point renders like the other blob
-                    # types.  Legacy index cells are only trusted at the final time
-                    # index — dataset_list belongs to the final run, so an in-range
-                    # historical index would silently render the *current* payload
-                    # under a historical label; those render a labelled placeholder.
-                    return self._pane_over_time_dataset(
+                if isinstance(result_var, PANEL_TYPES):
+                    # Every *other* pane type renders one labelled pane per time
+                    # point.  Catching the whole family rather than listing members
+                    # is the point: for these, the fall-through below is not a
+                    # different layout, it is a crash — it hands `plot_callback` a
+                    # dataset that still carries over_time, and a per-sample
+                    # renderer asking that for one value raises. A pane type
+                    # without a bespoke over_time layout must still get a correct
+                    # one, including one added after this line was written.
+                    #
+                    # For ResultDataSet specifically, path-backed cells (plan 22)
+                    # make historical payloads loadable from any run, so every time
+                    # point renders like the other blob types. Legacy index cells
+                    # are only trusted at the final time index — dataset_list
+                    # belongs to the final run, so an in-range historical index
+                    # would silently render the *current* payload under a
+                    # historical label; those render a labelled placeholder.
+                    return self._pane_over_time_samples(
                         dataset, result_var, plot_callback, **kwargs
                     )
+                # Numeric callbacks (line, bar, heatmap) are the ones that *must*
+                # keep the whole over_time dimension: they build the slider
+                # themselves via hvplot groupby / hv.HoloMap, and pre-selecting a
+                # time point here would flatten the series they exist to show.
             return plot_callback(dataset=dataset, result_var=result_var, **kwargs)
 
         return outer_container.render()
@@ -1139,19 +1154,28 @@ class BenchResultBase:
             return pn.pane.Markdown("*No rerun data available*")
         return pn.Row(*items)
 
-    def _pane_over_time_dataset(
+    def _pane_over_time_samples(
         self,
         dataset: xr.Dataset,
         result_var,
         plot_callback: Callable,
         **kwargs,
     ) -> pn.Row | None:
-        """Render ``ResultDataSet`` over_time as a grid of labelled per-time panes.
+        """Render a pane-typed result over_time as a row of labelled per-time panes.
 
-        Path-backed cells are meaningful in any process, so history points render
-        instead of being cut down to the latest event (the pre-plan-22
-        ``isel(over_time=-1)`` workaround).  A time point whose cell is missing
-        (either generation's sentinel) is skipped.  A legacy index cell is only
+        The general over_time layout for pane types, and the only one that reduces
+        the dimension before the per-sample renderer sees it: it selects one time
+        index at a time, so ``plot_callback`` is handed the single value its
+        contract is written for. ``ResultRerun`` and ``ResultVideo``/
+        ``ResultImage`` opt out into layouts of their own; every other pane type
+        arrives here, including any added later.
+
+        A time point whose value is missing is skipped, so a variable that a
+        historical run did not record leaves a gap rather than a broken pane.
+
+        For ``ResultDataSet``, path-backed cells are meaningful in any process, so
+        history points render instead of being cut down to the latest event (the
+        pre-plan-22 ``isel(over_time=-1)`` workaround). A legacy index cell is only
         trusted at the *final* time index: ``dataset_list`` holds the final run's
         payloads alone, so a pre-plan history with in-range indices at every time
         point would otherwise render the current payload under historical labels.

--- a/plans/25-grammar-phase-2-channel-plan.md
+++ b/plans/25-grammar-phase-2-channel-plan.md
@@ -152,9 +152,9 @@ budget for them. **Only the first postdates the A6 commit** (`cead5fff`,
 distinction, so this plan claims "A6 did not enumerate them", never "the surface grew":
 
 - **A tenth member of the over-time-grid family, genuinely post-A6:**
-  `_pane_over_time_samples` (`bench_result_base.py`), added
+  `_pane_over_time_samples` (`bench_result_base.py:1151`), added
   2026-07-31 (`48b64798`) by plan 22 D4 for blob-backed `ResultDataSet` history —
-  dispatched from `_to_panes_da`. Phase 1 created it as
+  dispatched from `_to_panes_da` at `:998-1011`. Phase 1 created it as
   `_pane_over_time_dataset`; it was since renamed and made the *default* over_time
   layout for every pane type that does not opt into one of its own, so it is no
   longer a `ResultDataSet` specialisation.

--- a/plans/25-grammar-phase-2-channel-plan.md
+++ b/plans/25-grammar-phase-2-channel-plan.md
@@ -152,9 +152,12 @@ budget for them. **Only the first postdates the A6 commit** (`cead5fff`,
 distinction, so this plan claims "A6 did not enumerate them", never "the surface grew":
 
 - **A tenth member of the over-time-grid family, genuinely post-A6:**
-  `_pane_over_time_dataset` (`bench_result_base.py:1105-1151`), added
+  `_pane_over_time_samples` (`bench_result_base.py`), added
   2026-07-31 (`48b64798`) by plan 22 D4 for blob-backed `ResultDataSet` history —
-  dispatched from `_to_panes_da` at `:960-969`. Phase 1 created it.
+  dispatched from `_to_panes_da`. Phase 1 created it as
+  `_pane_over_time_dataset`; it was since renamed and made the *default* over_time
+  layout for every pane type that does not opt into one of its own, so it is no
+  longer a `ResultDataSet` specialisation.
 - **The `TabularSpec` family** (`holoview_results/tabular_spec.py:167`, `.build` at
   `:202`) with four xy result classes (`xy_scatter_result.py:56-74` builds `hv.Points`;
   siblings `xy_curve_result.py`, `xy_hexbin_result.py`, `xy_histogram_result.py`) —
@@ -306,7 +309,7 @@ clarifications. None of the seven affects A6's reasoning.
    must plan around live hmaps (D3).
 6. A6's "nine pathways" and "three dialects" are correct for what they count. Three
    further pathways sit outside the list of nine (§2.2) and one selection ladder sits
-   beside the three shape dialects (§2.3) — but only `_pane_over_time_dataset` postdates
+   beside the three shape dialects (§2.3) — but only `_pane_over_time_samples` postdates
    A6, and the ladder predates it by months. "A6 did not enumerate them" is the true
    claim; "the surface grew" and "A6's count predates it" are not, and are withdrawn.
 7. Law 5's entry-point group name is **right** (`plugins/registry.py:14`

--- a/test/test_over_time_pane_contract.py
+++ b/test/test_over_time_pane_contract.py
@@ -84,16 +84,16 @@ def _over_time_dataset(var_name: str, values) -> xr.Dataset:
     )
 
 
-def _render(result_var, values) -> _Spy:
+def _render(result_var, values) -> tuple[_Spy, object]:
     spy = _Spy()
     dataset = _over_time_dataset(result_var.name, values)
-    spy._to_panes_da(  # pylint: disable=protected-access
+    rendered = spy._to_panes_da(  # pylint: disable=protected-access
         dataset,
         plot_callback=spy.callback,
         target_dimension=0,
         result_var=result_var,
     )
-    return spy
+    return spy, rendered
 
 
 @pytest.mark.parametrize("result_type", PANEL_TYPES, ids=lambda t: t.__name__)
@@ -103,12 +103,19 @@ def test_pane_types_never_see_an_unreduced_over_time(result_type):
     result_var.name = "v"
     # Strings for every type: the spy replaces the renderer that would interpret
     # them, so what matters is the dataset's shape, not what the cells mean.
-    spy = _render(result_var, ["a", "b"])
+    spy, rendered = _render(result_var, ["a", "b"])
 
     if issubclass(result_type, _SELF_RESOLVING):
         assert not spy.seen, (
             f"{result_type.__name__} resolves its own values, so plot_callback "
             "should not be called; it now is, and this test no longer checks it"
+        )
+        # "never called the spy" is also true of a branch that returned nothing,
+        # so pin that these types reached a layout rather than falling off the
+        # dispatch — otherwise this parametrisation checks nothing at all.
+        assert rendered is not None, (
+            f"{result_type.__name__} took no over_time layout: it neither called "
+            "the per-sample renderer nor produced a viewable of its own"
         )
         return
 
@@ -132,7 +139,7 @@ def test_pane_types_render_every_time_point(result_type):
         pytest.skip(f"{result_type.__name__} has a layout of its own with its own test")
     result_var = result_type()
     result_var.name = "v"
-    spy = _render(result_var, ["a", "b"])
+    spy, _ = _render(result_var, ["a", "b"])
     assert len(spy.seen) == _TIME_POINTS, (
         f"{result_type.__name__} rendered {len(spy.seen)} of {_TIME_POINTS} time "
         "points; a report that drops history silently is the failure mode the "

--- a/test/test_over_time_pane_contract.py
+++ b/test/test_over_time_pane_contract.py
@@ -1,0 +1,193 @@
+"""Contract: over_time is reduced before a per-sample renderer ever sees it.
+
+The defect class this exists to catch, stated once: ``_to_panes_da`` decides what
+to do with a result var when the dataset carries more than one ``over_time`` point,
+and it decided that by naming types. Naming types means a type nobody named falls
+through to ``plot_callback`` with the ``over_time`` dimension still attached — and
+``plot_callback`` is a *per-sample* renderer, so it asks a two-element array for one
+value and raises ``ValueError: can only convert an array of size 1 to a Python
+scalar``. ``ResultString`` fell through that way for as long as the branch existed.
+
+Two properties make it expensive rather than merely wrong, and both argue for a
+contract test over one more per-type case:
+
+* ``PaneResult.to_panes`` renders every pane-typed var in a single loop and
+  ``BenchResult.to_auto`` catches per *plugin*, so one un-dispatched type deletes
+  every image, video, rerun viewer and dataset scatter in the report with it.
+* Nothing fails. The report is written, incomplete, and the process exits 0.
+
+So this module asserts the *invariant* over every member of ``PANEL_TYPES``, rather
+than testing the types that happen to exist today. A pane type added later is
+covered the moment it joins the tuple; if it needs a bespoke layout it must add one,
+and if it does not it inherits the per-time-point default. Either way the invariant
+below is what says so.
+
+The mirror-image assertion is here too, because it is the mistake this fix nearly
+made: numeric callbacks (line, bar, heatmap) *require* the whole dimension, since
+they build their own slider via hvplot groupby / ``hv.HoloMap``. Pre-selecting a
+time point for them would flatten the series they exist to draw. So the rule is not
+"always reduce" — it is "reduce for pane types, never for the rest", and both halves
+need pinning or the next fix trades one silent-wrong for the other.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import panel as pn
+import pytest
+import xarray as xr
+
+from bencher.results.bench_result_base import BenchResultBase
+from bencher.variables.results import (
+    PANEL_TYPES,
+    ResultFloat,
+    ResultImage,
+    ResultRerun,
+    ResultString,
+    ResultVideo,
+)
+
+_TIME_POINTS = 2
+
+# Types that own an over_time layout of their own and resolve values themselves
+# rather than through plot_callback, so a spy sees no calls at all from them. They
+# satisfy the invariant trivially; listing them keeps "never called" from reading as
+# a test that silently checked nothing.
+_SELF_RESOLVING = (ResultRerun, ResultVideo, ResultImage)
+
+
+class _Spy(BenchResultBase):
+    """A result base that records every dataset handed to the per-sample renderer.
+
+    Subclassed rather than mocked so the real ``_to_panes_da`` runs: the dispatch
+    under test is exactly the code being bypassed if this were a fake.
+    """
+
+    # pylint: disable=super-init-not-called
+    def __init__(self, over_time: bool = True) -> None:
+        self.bench_cfg = type("_Cfg", (), {"over_time": over_time})()
+        self.object_index = []
+        self.seen: list[xr.Dataset] = []
+
+    def callback(self, dataset: xr.Dataset, result_var, **_kwargs):
+        self.seen.append(dataset)
+        return pn.pane.Markdown(f"{result_var.name}")
+
+
+def _over_time_dataset(var_name: str, values) -> xr.Dataset:
+    """A dataset holding *var_name* at ``_TIME_POINTS`` time points and nothing else."""
+    times = pd.to_datetime(["2000-01-01T00:00:00", "2000-01-01T00:00:01"])
+    return xr.Dataset(
+        {var_name: (("over_time",), np.asarray(values, dtype=object))},
+        coords={"over_time": times},
+    )
+
+
+def _render(result_var, values) -> _Spy:
+    spy = _Spy()
+    dataset = _over_time_dataset(result_var.name, values)
+    spy._to_panes_da(  # pylint: disable=protected-access
+        dataset,
+        plot_callback=spy.callback,
+        target_dimension=0,
+        result_var=result_var,
+    )
+    return spy
+
+
+@pytest.mark.parametrize("result_type", PANEL_TYPES, ids=lambda t: t.__name__)
+def test_pane_types_never_see_an_unreduced_over_time(result_type):
+    """No pane type may reach the per-sample renderer with over_time unreduced."""
+    result_var = result_type()
+    result_var.name = "v"
+    # Strings for every type: the spy replaces the renderer that would interpret
+    # them, so what matters is the dataset's shape, not what the cells mean.
+    spy = _render(result_var, ["a", "b"])
+
+    if issubclass(result_type, _SELF_RESOLVING):
+        assert not spy.seen, (
+            f"{result_type.__name__} resolves its own values, so plot_callback "
+            "should not be called; it now is, and this test no longer checks it"
+        )
+        return
+
+    assert spy.seen, (
+        f"{result_type.__name__} rendered nothing at all — it neither reduced "
+        "over_time nor delegated to a layout of its own"
+    )
+    unreduced = [ds.sizes.get("over_time") for ds in spy.seen if ds.sizes.get("over_time", 1) > 1]
+    assert not unreduced, (
+        f"{result_type.__name__} reached the per-sample renderer with over_time "
+        f"still at {unreduced} — that call raises 'can only convert an array of "
+        "size 1 to a Python scalar', and the failure takes every other pane in the "
+        "report with it"
+    )
+
+
+@pytest.mark.parametrize("result_type", PANEL_TYPES, ids=lambda t: t.__name__)
+def test_pane_types_render_every_time_point(result_type):
+    """Each retained event gets its own pane, so history is not silently dropped."""
+    if issubclass(result_type, _SELF_RESOLVING):
+        pytest.skip(f"{result_type.__name__} has a layout of its own with its own test")
+    result_var = result_type()
+    result_var.name = "v"
+    spy = _render(result_var, ["a", "b"])
+    assert len(spy.seen) == _TIME_POINTS, (
+        f"{result_type.__name__} rendered {len(spy.seen)} of {_TIME_POINTS} time "
+        "points; a report that drops history silently is the failure mode the "
+        "per-event layout replaced"
+    )
+
+
+def test_numeric_types_keep_the_whole_over_time_dimension():
+    """The other half of the rule: numeric callbacks build their own slider.
+
+    A fix that reduced over_time for everything would pass every assertion above
+    and quietly flatten every line and bar plot in every over_time report.
+    """
+    result_var = ResultFloat()
+    result_var.name = "v"
+    spy = _Spy()
+    dataset = xr.Dataset(
+        {"v": (("over_time",), np.asarray([1.0, 2.0]))},
+        coords={"over_time": pd.to_datetime(["2000-01-01", "2000-01-02"])},
+    )
+    spy._to_panes_da(  # pylint: disable=protected-access
+        dataset,
+        plot_callback=spy.callback,
+        target_dimension=0,
+        result_var=result_var,
+    )
+    assert [ds.sizes.get("over_time") for ds in spy.seen] == [_TIME_POINTS], (
+        "a numeric result var must be handed the whole over_time dimension; "
+        "hvplot groupby / hv.HoloMap is what turns it into a slider"
+    )
+
+
+def test_single_time_point_is_unchanged_for_pane_types():
+    """One event is not history, so it takes the plain single-sample path.
+
+    Pins the boundary the dispatch keys on. Without this, a change that treated
+    ``over_time`` as present whenever the coordinate exists would wrap every
+    ordinary one-run report in a one-cell per-event grid and no other test here
+    would notice.
+    """
+    result_var = ResultString()
+    result_var.name = "v"
+    spy = _Spy()
+    dataset = xr.Dataset(
+        {"v": (("over_time",), np.asarray(["a"], dtype=object))},
+        coords={"over_time": pd.to_datetime(["2000-01-01"])},
+    )
+    spy._to_panes_da(  # pylint: disable=protected-access
+        dataset,
+        plot_callback=spy.callback,
+        target_dimension=0,
+        result_var=result_var,
+    )
+    # One call, and over_time is gone as a *dimension* — the pane recursion sliced
+    # it away, which is what leaves a single value for the renderer. It survives as
+    # a scalar coordinate, so assert on dims rather than on the coord's presence.
+    assert len(spy.seen) == 1
+    assert "over_time" not in spy.seen[0].sizes

--- a/test/test_over_time_pane_dispatch.py
+++ b/test/test_over_time_pane_dispatch.py
@@ -17,6 +17,7 @@ code.
 import warnings
 from datetime import datetime, timedelta
 
+import holoviews as hv
 import pandas as pd
 import panel as pn
 import pytest
@@ -64,7 +65,31 @@ class StringOnlySweep(bn.ParametrizedSweep):
         self.note = f"run-{self.run_id}"
 
 
-def _run_over_time(worker, result_vars, runs=_RUNS):
+class SweptScalarSweep(bn.ParametrizedSweep):
+    """The same history with an ordinary swept input, for the numeric half.
+
+    Separate from the sweeps above rather than folded into them, because the two
+    shapes exercise different things and swapping one for the other silently costs
+    coverage.  With no input vars a pane type at over_time > 1 *raises*, which is
+    what the tests above pin.  Add an input var and the very same defect stops
+    raising: ``phase`` survives the pane recursion as a scalar coordinate, so
+    ``zero_dim_da_to_val`` takes its ``expand_dims`` branch instead of ``.item()``
+    and returns the whole two-element array, which renders as one ``Str(ndarray)``
+    pane holding both time points and labelled with neither.  Silent-wrong, not
+    loud-wrong.  Only the content assertions catch it in that shape.
+    """
+
+    phase = bn.IntSweep(default=0, bounds=[0, 1], doc="one ordinary swept input")
+
+    score = bn.ResultFloat(units="pt", doc="a plain scalar, which keeps its series")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.score = float(self.run_id + self.phase)
+
+
+def _run_over_time(worker, result_vars, runs=_RUNS, input_vars=()):
     """Sample *worker* once per run against one history, as a CI report does."""
     run_cfg = bn.BenchRunCfg()
     run_cfg.over_time = True
@@ -78,7 +103,7 @@ def _run_over_time(worker, result_vars, runs=_RUNS):
         run_cfg.clear_history = run == 0
         result = bench.plot_sweep(
             "over_time_panes",
-            input_vars=[],
+            input_vars=list(input_vars),
             result_vars=result_vars,
             run_cfg=run_cfg,
             time_src=_BASE_TIME + timedelta(seconds=run),
@@ -91,6 +116,13 @@ def _mixed(tmp_path, monkeypatch):
     """A two-run history of a string beside a dataset, from a scratch cache dir."""
     monkeypatch.chdir(tmp_path)
     return _run_over_time(StringAndDataSetSweep(), ["note", "table", "score"])
+
+
+@pytest.fixture(name="swept")
+def _swept(tmp_path, monkeypatch):
+    """A two-run history of a scalar over a swept input — see ``SweptScalarSweep``."""
+    monkeypatch.chdir(tmp_path)
+    return _run_over_time(SweptScalarSweep(), ["score"], input_vars=["phase"])
 
 
 def _markdown_text(viewable) -> list[str]:
@@ -133,7 +165,10 @@ def test_auto_report_reports_no_pane_render_failure(mixed):
     # Scoped to the panes plugin rather than to any failure: a sweep with no input
     # vars also trips hvplot's numeric path ("no valid index for a 0-dimensional
     # object"), which is a separate defect and would make this test fail for the
-    # wrong reason.
+    # wrong reason.  Widening the scope by giving the fixture an input var is not
+    # the trade it looks like — see ``SweptScalarSweep``: with an input var the
+    # pane defect stops raising at all, so this assertion would gain a plugin and
+    # lose its subject.
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         auto = mixed.to_auto()
@@ -146,7 +181,32 @@ def test_auto_report_reports_no_pane_render_failure(mixed):
     assert not [t for t in _markdown_text(auto) if "panes" in t and "failed to render" in t]
 
 
-def test_scalar_keeps_its_over_time_series(mixed):
+def _holomaps(viewable) -> list:
+    """Every HoloMap in a rendered panel object."""
+    return [
+        pane.object
+        for pane in viewable.select(pn.pane.HoloViews)
+        if isinstance(pane.object, hv.HoloMap)
+    ]
+
+
+def test_scalar_keeps_its_over_time_series(swept):
     # Rendering panes per event must not cost the scalars their series — that
     # series is what regression detection reads.
-    assert mixed.to_dataset()["score"].sizes["over_time"] == _RUNS
+    #
+    # Asserted on the *rendered* curve, not on to_dataset(): the dataset is built
+    # before any dispatch decision, so a version of this that read to_dataset()
+    # alone would pass no matter what _to_panes_da did with the dimension, and so
+    # could not guard the half of the rule it names.
+    score = next(rv for rv in swept.get_results_var_list() if rv.name == "score")
+    curve = swept.to_curve(result_var=score)
+    assert curve is not None
+
+    hmaps = _holomaps(curve)
+    assert hmaps, f"a numeric var over_time must render an hv.HoloMap: {curve!r}"
+    # over_time reaches the plot as a HoloMap *key dimension* with one key per
+    # run: that is the slider hvplot builds from the whole dimension, and it is
+    # exactly what pre-selecting a time point in _to_panes_da would flatten away.
+    hmap = hmaps[0]
+    assert "over_time" in [d.name for d in hmap.kdims], hmap.kdims
+    assert len(hmap.keys()) == _RUNS, hmap.keys()

--- a/test/test_over_time_pane_dispatch.py
+++ b/test/test_over_time_pane_dispatch.py
@@ -1,0 +1,152 @@
+"""Every pane type gets a correct over_time layout, not just the ones named.
+
+``_to_panes_da`` gives ``ResultRerun`` a grid and ``ResultVideo``/``ResultImage`` a
+slider. Before ``_pane_over_time_samples`` became the default, anything else fell
+through to the per-sample renderer with the ``over_time`` dimension still on the
+dataset, and asking that for one value raised ``ValueError: can only convert an
+array of size 1 to a Python scalar``.
+
+The blast radius is what makes it worth a test: ``PaneResult.to_panes`` renders
+every pane-typed result var in one loop, and ``BenchResult.to_auto`` catches per
+*plugin*, not per variable. So one un-dispatched string deleted the images, videos,
+rerun viewers and dataset scatters of the whole report along with itself — and,
+before the render-failure surfacing landed, did it with no warning and a zero exit
+code.
+"""
+
+import warnings
+from datetime import datetime, timedelta
+
+import pandas as pd
+import panel as pn
+import pytest
+
+import bencher as bn
+from bencher.results.pane_result import PaneResult
+from bencher.results.render_failure import RenderFailedWarning
+
+_RUNS = 2
+_BASE_TIME = datetime(2000, 1, 1)
+
+
+def _frame(run: int) -> pd.DataFrame:
+    return pd.DataFrame({"idx": [0, 1], "value": [float(run), float(run) + 1.0]})
+
+
+def _table_container(df: pd.DataFrame) -> pn.pane.Markdown:
+    """Stand-in for a real plot: takes the payload alone, returns something viewable."""
+    return pn.pane.Markdown(f"rows={len(df)} sum={df['value'].sum():g}")
+
+
+class StringAndDataSetSweep(bn.ParametrizedSweep):
+    """A string beside a dataset, which is the shape that lost both panes."""
+
+    note = bn.ResultString(doc="text the benchmark produced")
+    table = bn.ResultDataSet(container=_table_container, doc="payload")
+    score = bn.ResultFloat(units="pt", doc="a plain scalar, which keeps its series")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.note = f"run-{self.run_id}"
+        self.table = bn.ResultDataSet(_frame(self.run_id))
+        self.score = float(self.run_id)
+
+
+class StringOnlySweep(bn.ParametrizedSweep):
+    """A string with no pane-typed sibling, so nothing can mask its own failure."""
+
+    note = bn.ResultString(doc="text the benchmark produced")
+
+    run_id = 0
+
+    def benchmark(self):
+        self.note = f"run-{self.run_id}"
+
+
+def _run_over_time(worker, result_vars, runs=_RUNS):
+    """Sample *worker* once per run against one history, as a CI report does."""
+    run_cfg = bn.BenchRunCfg()
+    run_cfg.over_time = True
+    run_cfg.repeats = 1
+    run_cfg.auto_plot = False
+    bench = worker.to_bench(run_cfg)
+    result = None
+    for run in range(runs):
+        worker.run_id = run
+        run_cfg.clear_cache = True
+        run_cfg.clear_history = run == 0
+        result = bench.plot_sweep(
+            "over_time_panes",
+            input_vars=[],
+            result_vars=result_vars,
+            run_cfg=run_cfg,
+            time_src=_BASE_TIME + timedelta(seconds=run),
+        )
+    return result
+
+
+@pytest.fixture(name="mixed")
+def _mixed(tmp_path, monkeypatch):
+    """A two-run history of a string beside a dataset, from a scratch cache dir."""
+    monkeypatch.chdir(tmp_path)
+    return _run_over_time(StringAndDataSetSweep(), ["note", "table", "score"])
+
+
+def _markdown_text(viewable) -> list[str]:
+    return [str(pane.object) for pane in viewable.select(pn.pane.Markdown)]
+
+
+def test_string_over_time_renders_instead_of_raising(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = _run_over_time(StringOnlySweep(), ["note"])
+    assert result.to_dataset().sizes["over_time"] == _RUNS
+    # The regression: this call raised, so there is no weaker assertion to make.
+    panes = PaneResult.to_panes(result)
+    assert panes is not None
+
+
+def test_one_pane_per_time_point_labelled_with_its_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = _run_over_time(StringOnlySweep(), ["note"])
+    text = _markdown_text(PaneResult.to_panes(result))
+    # Each event contributes its own value, so a stale or repeated pane shows up
+    # here rather than as a plausible-looking report.
+    for run in range(_RUNS):
+        assert any(f"run-{run}" in line for line in text), text
+
+
+def test_string_does_not_delete_its_sibling_panes(mixed):
+    # The actual damage: one raising var dropped every other pane-typed var with
+    # it, because to_auto catches per plugin rather than per variable.
+    text = _markdown_text(PaneResult.to_panes(mixed))
+    assert any("rows=2" in line for line in text), text
+    for run in range(_RUNS):
+        assert any(f"run-{run}" in line for line in text), text
+
+
+def test_auto_report_reports_no_pane_render_failure(mixed):
+    # to_auto turns a plugin exception into a visible pane and a warning rather
+    # than a failure, so a report can be incomplete while the job stays green.
+    # Assert neither mark, since neither would fail this test on its own.
+    #
+    # Scoped to the panes plugin rather than to any failure: a sweep with no input
+    # vars also trips hvplot's numeric path ("no valid index for a 0-dimensional
+    # object"), which is a separate defect and would make this test fail for the
+    # wrong reason.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        auto = mixed.to_auto()
+    failures = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, RenderFailedWarning) and "panes" in str(w.message)
+    ]
+    assert not failures, failures
+    assert not [t for t in _markdown_text(auto) if "panes" in t and "failed to render" in t]
+
+
+def test_scalar_keeps_its_over_time_series(mixed):
+    # Rendering panes per event must not cost the scalars their series — that
+    # series is what regression detection reads.
+    assert mixed.to_dataset()["score"].sizes["over_time"] == _RUNS


### PR DESCRIPTION
## The bug

`_to_panes_da` decides what to do with a result var once the dataset carries more
than one `over_time` point, and it decided that by **naming types**:

```python
if isinstance(result_var, ResultRerun):            return self._pane_over_time_grid(...)
if isinstance(result_var, (ResultVideo, ResultImage)): return self._pane_over_time_slider(...)
if isinstance(result_var, ResultDataSet):          return self._pane_over_time_dataset(...)
return plot_callback(dataset=dataset, result_var=result_var, **kwargs)   # <-- over_time still on it
```

Naming types means a type nobody named reaches that last line with the `over_time`
dimension still attached — and `plot_callback` is a **per-sample** renderer, so it
asks a multi-element array for one value:

```
ValueError: can only convert an array of size 1 to a Python scalar
```

`ResultString`, `ResultPath`, `ResultContainer` and `ResultReference` have all
fallen through that way for as long as the branch has existed. Only the string case
was reported; the contract test below found the other three.

## Why it was expensive rather than merely wrong

- `PaneResult.to_panes` renders **every** pane-typed var in one loop, and
  `BenchResult.to_auto` catches per *plugin*. So one un-dispatched string deletes
  every image, video, rerun viewer and dataset scatter in the report along with
  itself.
- Nothing fails. The report is written, incomplete, and the process exits 0.

Downstream, this cost a robotics pose-repeatability benchmark its measurement
scatter *and* its `.rrd` recording on every published run that had history, across
months of reports, because the bench plotted one `ResultString` beside them. The
`⚠️ Plot plugin 'panes' failed to render` pane added in 1.118.0 is what finally made
it visible — the raise itself long predates it.

## The fix

Dispatch on the `PANEL_TYPES` family instead of on individual members, so a pane
type with no bespoke layout inherits the per-time-point one — including a type added
after this line is written. `_pane_over_time_dataset` becomes
`_pane_over_time_samples`; its mechanics were always type-agnostic and only the
docstring said `ResultDataSet`.

**The other half matters as much.** Numeric callbacks (line, bar, heatmap) *require*
the whole dimension, because they build the slider themselves via hvplot groupby /
`hv.HoloMap`; reducing it for them flattens the series they exist to draw. An
earlier draft of this fix routed *every* var through the per-event path and broke
exactly that — `test_over_time_repeats` caught it. The rule is "reduce for pane
types, never for the rest", and both halves are now pinned.

## Catching the class, not the instance

`test/test_over_time_pane_contract.py` asserts the invariant — *no pane type reaches
the per-sample renderer with `over_time` unreduced* — parametrised over every member
of `PANEL_TYPES`, plus the mirror assertion for numeric vars and the
single-time-point boundary. It tests the family rather than today's members, so a
new pane type is covered the moment it joins the tuple.

Run against the old dispatch it fails on all four broken types:

```
FAILED test_over_time_pane_contract.py::test_pane_types_never_see_an_unreduced_over_time[ResultPath]
FAILED test_over_time_pane_contract.py::test_pane_types_never_see_an_unreduced_over_time[ResultString]
FAILED test_over_time_pane_contract.py::test_pane_types_never_see_an_unreduced_over_time[ResultContainer]
FAILED test_over_time_pane_contract.py::test_pane_types_never_see_an_unreduced_over_time[ResultReference]
(+ the 4 matching render-every-time-point cases)
```

`test/test_over_time_pane_dispatch.py` covers the same ground end to end — a real
two-run history through `plot_sweep`, `to_panes` and `to_auto`, including that a
string no longer deletes its sibling panes. All four of its behavioural tests fail
against the old dispatch with the reported `ValueError`.

## Checks

`pixi run ci` green: **2856 passed, 24 skipped**.

## Notes for review

- Per plans ground rule 7: `plans/25` cited `_pane_over_time_dataset` as "a tenth
  member of the over-time-grid family ... for blob-backed `ResultDataSet` history".
  That characterisation no longer holds now that it is the generic default, so both
  references are updated in place rather than left to go stale silently.
- **Separate defect noticed, not fixed here:** a sweep with **no input vars** trips
  hvplot's numeric path with `ValueError: no valid index for a 0-dimensional object`,
  which `to_auto` swallows the same way. `test_auto_report_reports_no_pane_render_failure`
  is scoped to the panes plugin so it does not fail for that unrelated reason. Worth
  its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure all pane result types receive a correct over_time layout and add tests to pin the dispatch behaviour.

Bug Fixes:
- Prevent pane types like strings, paths, containers and references from falling through to the per-sample renderer with an unreduced over_time dimension, which previously raised a ValueError and silently dropped all panes in the report.

Enhancements:
- Generalise the over_time layout to apply to the full PANEL_TYPES family via a renamed _pane_over_time_samples helper, while preserving special layouts for rerun and media results.
- Clarify documentation in the channel plan to reflect the generic role of the over_time samples layout instead of treating it as a ResultDataSet specialisation.

Tests:
- Introduce contract tests that assert pane types always see reduced over_time data, numeric types retain the full over_time dimension, and single-event reports follow the plain path.
- Add end-to-end dispatch tests covering over_time behaviour for strings, datasets and scalars, including that pane failures no longer delete sibling panes and that auto reports surface no pane render failures.