### PR TITLE
release: v1.119.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.119.0] - 2026-08-05
+
 ### Fixed
+- **A report with history no longer loses every pane when one result type has no
+  `over_time` layout.** `_to_panes_da` chose an `over_time > 1` layout by naming types
+  (rerun, video, image, dataset), so a pane type nobody named fell through to
+  `plot_callback` — a per-sample renderer — with the time dimension still attached, raising
+  `ValueError: can only convert an array of size 1 to a Python scalar`. `ResultString`,
+  `ResultPath`, `ResultContainer` and `ResultReference` all fell through that way. Because
+  `PaneResult.to_panes` renders every pane var in one loop and `to_auto` catches per plugin,
+  one un-dispatched string deleted every image, video, rerun viewer and dataset plot in the
+  report along with itself — and the run still exited 0, so the report was silently
+  incomplete. Dispatch is now on the `PANEL_TYPES` family, so a pane type without a bespoke
+  layout inherits the per-time-point one, including types added later. Numeric callbacks
+  (line, bar, heatmap) keep the whole dimension, as they build their own slider via hvplot
+  `groupby` / `hv.HoloMap`.
 - **A `ResultDataSet` history no longer loses every event but the newest when its cache
   dir moves.** A cell stored the blob's absolute path, resolved against the working
   directory at collect time, so a cache dir tarred on one machine and restored at another

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "holobench"
-version = "1.118.0"
+version = "1.119.0"
 
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A package for benchmarking the performance of arbitrary functions"


### PR DESCRIPTION
Cuts the `[Unreleased]` section to **1.119.0** and bumps `pyproject.toml`. No code changes — `docs/conf.py` reads the version from package metadata, so `pyproject.toml` is the only place it lives.

## What's in this release

**Fixed — `over_time` pane dispatch (#1080).** `_to_panes_da` chose an `over_time > 1` layout by naming types, so any pane type nobody named fell through to `plot_callback` with the time dimension still attached (`ValueError: can only convert an array of size 1 to a Python scalar`). `ResultString`, `ResultPath`, `ResultContainer` and `ResultReference` all did. Since `PaneResult.to_panes` renders every pane var in one loop and `to_auto` catches per plugin, one un-dispatched string deleted every image, video, rerun viewer and dataset plot in the report — and the run still exited 0. Dispatch is now on the `PANEL_TYPES` family, so future pane types are covered too.

**Fixed — `ResultDataSet` history across a moved cache dir (#1081).** Cells stored the blob's absolute path, so a cache dir restored at a different path (CI round-trip, copy between checkouts, downloaded tarball) rendered one plot and N-1 "could not be loaded" placeholders. Cells now store the blob *name*, resolved against the active cache dir, with the collect-time dir recorded as a fallback so the `bencher <result.pkl> <out_dir>` collect/render split still resolves from a fresh process.

**Changed.** `blob_store` formats come from one table (`_BLOB_FORMATS`) instead of being restated in four places.

No cache version bump: `resolve_blob` accepts either cell generation, so existing 1.118.0 caches keep rendering and get the fix retroactively.

## Note

PR #1080's fix had no CHANGELOG entry, so this PR adds it as part of the cut — otherwise a user-facing fix would have shipped unlisted.

## Verification

`pixi run format`, `pixi run lint` (ruff + ty + pylint 10.00/10) all clean locally. Full suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Cut a 1.119.0 release by updating the changelog and project version to include recent fixes.

Bug Fixes:
- Document that over_time pane dispatch now covers all pane types via the PANEL_TYPES family, preventing silent loss of report panes when an unnamed result type is present.
- Document that ResultDataSet histories remain intact when cache directories are moved by storing blob names instead of absolute paths.

Build:
- Bump project version in pyproject.toml from 1.118.0 to 1.119.0.

Documentation:
- Add a 1.119.0 section to the changelog describing recent fixes to pane dispatch and ResultDataSet cache handling.