### PR TITLE
feat: grammar foundation — Channel vocabulary, Compose node, capability table (#1108)

### DIFF
--- a/bencher/grammar/__init__.py
+++ b/bencher/grammar/__init__.py
@@ -1,0 +1,44 @@
+"""bencher.grammar — the typed core of A6's grammar of N-D data.
+
+Re-exports only; no logic (plan 25 D1). Import direction is one-way: rendering code may
+import this package; nothing here imports `bencher.results`, `bencher.plugins`, or any
+rendering library — enforced by `test/test_grammar.py`.
+"""
+
+from bencher.grammar.capability import (
+    RERUN_CAPABILITIES,
+    SUBSTITUTION_CHAIN,
+    Approx,
+    BackendCapabilities,
+    Capability,
+    Direct,
+    EvalMode,
+    Lowering,
+    Native,
+    NoLowering,
+    Substituted,
+    Unsupported,
+    substitute,
+)
+from bencher.grammar.channels import GRAMMAR_VERSION, Channel
+from bencher.grammar.compose import Compose, compose
+
+__all__ = [
+    "GRAMMAR_VERSION",
+    "RERUN_CAPABILITIES",
+    "SUBSTITUTION_CHAIN",
+    "Approx",
+    "BackendCapabilities",
+    "Capability",
+    "Channel",
+    "Compose",
+    "Direct",
+    "EvalMode",
+    "Lowering",
+    "Native",
+    "NoLowering",
+    "Substituted",
+    "Unsupported",
+    "compose",
+    "substitute",
+]

--- a/bencher/grammar/capability.py
+++ b/bencher/grammar/capability.py
@@ -1,0 +1,166 @@
+"""Backend capability tables and planner-owned fallback — A6 Law 3.
+
+Each backend exports a static table: per channel, one of `Native | Approx |
+Unsupported` (the arm *is* Law 3's fidelity ``native | approx | none`` — no separate
+tag to drift out of sync). Fallback belongs to the planner side via one documented
+substitution chain; backends are dumb translators and never degrade on their own
+(Law 3 rejects backend-owned degradation as re-scattering the knowledge).
+
+With no planner yet, the embryo is `substitute()`: a pure, table-driven function the
+phase-3 planner absorbs unchanged (plan 25 amendment). The **rerun** table seeds it
+because rerun is the backend the current route builds; the panel table joins in
+phase 3, when `marks.py` absorbs the table type per plan 25 D1.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import assert_never
+
+from strenum import StrEnum
+
+from bencher.grammar.channels import Channel
+
+
+class EvalMode(StrEnum):
+    """How a `Compose` along a channel evaluates on this backend — A6 Law 4.
+
+    ``view`` is a live backend view; ``materialize`` is a blob cell (webm, merged rrd,
+    parquet; content-addressed per Law 1). A backend/medium property carried by the
+    capability entry, never by the `Compose` node.
+    """
+
+    VIEW = "view"
+    MATERIALIZE = "materialize"
+
+
+@dataclass(frozen=True)
+class Native:
+    """Full-fidelity lowering."""
+
+    mode: EvalMode
+
+
+@dataclass(frozen=True)
+class Approx:
+    """Lowers with a visible degradation, stated so `explain()` (phase 3) can show it."""
+
+    mode: EvalMode
+    how: str
+
+
+@dataclass(frozen=True)
+class Unsupported:
+    """No lowering: the substitution chain is the only route."""
+
+    why: str
+
+
+Capability = Native | Approx | Unsupported
+
+
+@dataclass(frozen=True)
+class BackendCapabilities:
+    """One backend's static table, total over the vocabulary by construction: a missing
+    channel is a constructor error, not a `KeyError` at plan time."""
+
+    backend: str
+    channels: Mapping[Channel, Capability]
+
+    def __post_init__(self) -> None:
+        missing = set(Channel) - set(self.channels)
+        if missing:
+            names = ", ".join(sorted(c.name for c in missing))
+            raise ValueError(f"capability table for {self.backend!r} misses channels: {names}")
+
+
+# The documented substitution chain (Law 3) — exactly the substitutions A6 states:
+# Time → Tabs (Law 3's example), Overlay → FacetCol (Law 5's shared-frame fallback),
+# Spread → Overlay (§3's declared rerun gap). Extending this mapping is a grammar
+# change: document the ruling first.
+SUBSTITUTION_CHAIN: dict[Channel, Channel] = {
+    Channel.TIME: Channel.TABS,
+    Channel.OVERLAY: Channel.FACET_COL,
+    Channel.SPREAD: Channel.OVERLAY,
+}
+
+
+@dataclass(frozen=True)
+class Direct:
+    """The requested channel lowers as-is."""
+
+    channel: Channel
+    capability: Native | Approx
+
+
+@dataclass(frozen=True)
+class Substituted:
+    """The requested channel lowers via the chain. `via` is the full walk — requested
+    channel first, landing channel last, length >= 2 — recorded so a plan can surface
+    it in `explain()` (Law 3: substitutions are visible, never silent)."""
+
+    channel: Channel
+    via: tuple[Channel, ...]
+    capability: Native | Approx
+
+
+@dataclass(frozen=True)
+class NoLowering:
+    """The chain ran out before reaching a supported channel."""
+
+    requested: Channel
+    reason: str
+
+
+Lowering = Direct | Substituted | NoLowering
+
+
+def substitute(table: BackendCapabilities, requested: Channel) -> Lowering:
+    """Resolve `requested` against one backend's table, walking the documented chain on
+    `Unsupported`. Total: every (table, channel) pair returns one of the three arms."""
+    walked: list[Channel] = [requested]
+    current = requested
+    reasons: list[str] = []
+    while True:
+        cap = table.channels[current]
+        match cap:
+            case Native() | Approx():
+                if current is requested:
+                    return Direct(channel=current, capability=cap)
+                return Substituted(channel=current, via=tuple(walked), capability=cap)
+            case Unsupported(why=why):
+                reasons.append(f"{current}: {why}")
+                nxt = SUBSTITUTION_CHAIN.get(current)
+                if nxt is None or nxt in walked:
+                    return NoLowering(requested=requested, reason="; ".join(reasons))
+                walked.append(nxt)
+                current = nxt
+            case _ as unreachable:
+                assert_never(unreachable)
+
+
+# Seed table: rerun — A6 §3's parity table made typed, refined by the measured
+# lowering-gaps dossier (issue #1110). Everything rerun shows is a live view; the
+# materialize mode arrives with the video backend (Law 10 phase 4b).
+RERUN_CAPABILITIES = BackendCapabilities(
+    backend="rerun",
+    channels={
+        # SeriesLines / points on a timeline (§3: native).
+        Channel.X: Native(mode=EvalMode.VIEW),
+        Channel.Y: Native(mode=EvalMode.VIEW),
+        # Heatmap/volume lower to rr.Tensor views (§3: native/approx) — a sliceable
+        # tensor, not a 3D surface mark.
+        Channel.Z: Approx(mode=EvalMode.VIEW, how="lowers to rr.Tensor views; no 3D surface mark"),
+        # Sibling entity paths in a shared view (§3: native).
+        Channel.OVERLAY: Native(mode=EvalMode.VIEW),
+        # rrb.Vertical / Horizontal / Tabs containers (§3: native).
+        Channel.FACET_ROW: Native(mode=EvalMode.VIEW),
+        Channel.FACET_COL: Native(mode=EvalMode.VIEW),
+        Channel.TABS: Native(mode=EvalMode.VIEW),
+        # A named timeline per Time dim (§3: native).
+        Channel.TIME: Native(mode=EvalMode.VIEW),
+        # §3's declared gap: no native mean±std band view.
+        Channel.SPREAD: Unsupported(why="no native band view (A6 §3 declared gap)"),
+    },
+)

--- a/bencher/grammar/channels.py
+++ b/bencher/grammar/channels.py
@@ -1,0 +1,36 @@
+"""The closed dimension-assignment vocabulary — A6 Law 5.
+
+`Channel` is the complete set of ways a dataset dimension can be assigned to report
+structure. It is deliberately closed: anything that is not a dimension assignment is
+mark styling, and marks are the open, plugin-registered side of the grammar.
+
+Rejected candidates, settled by owner ruling (A6 Law 5): `Color` (the plotting-backend
+styling parameter of `Overlay`, not a channel), `Style`/`Dash` (a second overlay dim),
+`Animation` (distinct from `Time`), `EntityPath` (a rerun lowering detail).
+"""
+
+from strenum import StrEnum
+
+# Versions the vocabulary itself: plans embed it, and any change to the member set
+# bumps it (A6 Law 5). Assignment *policy* is versioned separately (POLICY_VERSION,
+# arriving with the phase-3 planner).
+GRAMMAR_VERSION = "1"
+
+
+class Channel(StrEnum):
+    """Closed dimension-assignment vocabulary — A6 Law 5. Adding a member requires a
+    GRAMMAR_VERSION bump and an owner-reviewed grammar change.
+
+    Values are explicit lowercase strings, never ``auto()``: they become Law 8's kwarg
+    names in phase 5 and golden-file content before that, so each value is a contract.
+    """
+
+    X = "x"
+    Y = "y"
+    Z = "z"
+    OVERLAY = "overlay"
+    FACET_ROW = "facet_row"
+    FACET_COL = "facet_col"
+    TABS = "tabs"
+    TIME = "time"
+    SPREAD = "spread"

--- a/bencher/grammar/compose.py
+++ b/bencher/grammar/compose.py
@@ -1,0 +1,43 @@
+"""The one composition algebra — A6 Law 4.
+
+A `Compose` node is items plus a layout channel. It replaces the four-way-ambiguous
+`ComposeType.{right,down,sequence,overlay}` encoding (`sequence` means Tabs in
+panel/rerun but temporal concatenation in video) with the same channel vocabulary that
+assigns sweep dimensions, so report structure and within-plot structure are one algebra.
+
+Two producers exist in the design; only one exists here. The **user** builds `Compose`
+directly — ``compose([a, b, c], along="facet_col")`` — over any ad-hoc collection. The
+**planner** producer (items from slicing a sweep dim) arrives with A6 phase 3.
+
+How a `Compose` evaluates — ``view`` (a live backend view) or ``materialize`` (a blob
+cell) — is a property of the backend capability table (`capability.py`), never a field
+on the node itself (Law 4).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from bencher.grammar.channels import Channel
+
+
+@dataclass(frozen=True)
+class Compose:
+    """Items laid out along one channel.
+
+    Items are opaque to the grammar — renditions, report items, or nested `Compose`
+    nodes; the grammar never imports a rendering type (the direction-of-import rule).
+    """
+
+    items: tuple[object, ...]
+    along: Channel
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise ValueError("Compose of zero items has no meaning; give at least one item")
+
+
+def compose(items: Iterable[object], along: Channel | str) -> Compose:
+    """User-facing producer: ``compose([a, b, c], along="facet_col")``."""
+    return Compose(items=tuple(items), along=Channel(along))

--- a/plans/25-grammar-phase-2-channel-plan.md
+++ b/plans/25-grammar-phase-2-channel-plan.md
@@ -1077,3 +1077,45 @@ deviations by this plan.
 - **A6 phases 3–5:** phase 3's plan doc should be written only after P4 here lands,
   against the final divergence ledger — the ledger is phase 3's review contract, the
   same way plan 23 §8 gated this plan on the P4 registry.
+
+---
+
+## Amendment — rerun-first reorder (2026-08-06)
+
+Owner rulings on [#1108](https://github.com/blooop/bencher/issues/1108), sequenced by
+the phase-order ruling on [#1111](https://github.com/blooop/bencher/issues/1111),
+resequence this plan; they do not rewrite it. Recorded here so this plan and A6 cannot
+describe different worlds.
+
+- **A6 Law 10's phase 4 splits**: 4a (the rerun backend) executes *ahead* of phases
+  2–3, driven by the rerun map
+  ([#1103](https://github.com/blooop/bencher/issues/1103)); 4b (video) stays where
+  Law 10 put it. Phases 2 → 3 → 4b → 5 keep their relative order, and the per-phase
+  acceptance gate (before/after regenerated gallery docs per PR) is unchanged. (#1111)
+- **Landed ahead of P1, on branch `task/grammar-foundation-1108`**: D1's package
+  skeleton, D2 verbatim (`channels.py`: `GRAMMAR_VERSION`, the nine-member `Channel`),
+  a **`Compose` node this plan never specified** (`compose.py` — Law 4: items + one
+  layout channel; how it evaluates, `view` vs `materialize`, is a capability-table
+  property, never a node field; user producer only, the planner producer arrives with
+  phase 3), and a **Law 3 embryo** (`capability.py`: per-channel
+  `Native | Approx | Unsupported` — the arm *is* the fidelity — the documented
+  substitution chain `Time→Tabs`, `Overlay→FacetCol`, `Spread→Overlay`, a total
+  `substitute()`, and the **rerun** table as seed, inverting this plan's panel-first
+  scoping; the panel table joins in phase 3).
+- **D1's isolation rule is amended.** The DoD grep "nothing under `bencher/results/`
+  or `bencher/plugins/` imports `bencher.grammar`" assumed a shadow-mode planner whose
+  only consumers sit in `test/`. With a real rerun consumer the rule becomes
+  **direction-of-import**: renderers may import grammar; grammar imports no rendering
+  module and no `param` — enforced by `test/test_grammar.py::TestImportDirection`, not
+  by grep. D1's other clauses (fixed module ownership, one-way intra-package order,
+  strict-`ty` ratchet from birth, `assert_never` on every match) apply unchanged and
+  are already enforced on the landed modules.
+- **What survives, per the #1108 rulings**: P1 survives whole — it *is* the vocabulary
+  landed above. P2's type layer survives as the landed records need it; the full
+  serialization layer waits for plans that need serializing. **P3 and P4 defer to
+  phase 3 — deferred 100%, avoided 0%** (#1111): if phase 3 executes, the shadow
+  harness, divergence ledger, and golden corpus are still built in full, and phase 3
+  receives Laws-3/4/5 types already exercised by a real backend, with no golden-churn
+  exposure (no goldens exist yet to churn).
+- **Absorption path when phase 3 lands D1's remaining modules**: `marks.py` absorbs
+  the capability-table type, `planner.py` absorbs `substitute()`; `compose.py` stays.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,6 +360,12 @@ include = [
     # The other eleven it touched did not, and their counts are recorded in plan 23
     # section 10 so the R9 follow-up can pick them up rather than re-measure.
     "bencher/plugins/registry.py",
+    # The grammar package lands strict from birth (plan 25 D1's ratchet rule, via the
+    # #1108 rulings): every module joins in the PR that creates it.
+    "bencher/grammar/__init__.py",
+    "bencher/grammar/channels.py",
+    "bencher/grammar/compose.py",
+    "bencher/grammar/capability.py",
     "bencher/results/manim_cartesian/cartesian_product_scene.py",
     "bencher/example/meta/generate_meta_plot_types.py",
     "bencher/example/meta/generate_meta_bool_plot_types.py",

--- a/test/test_grammar.py
+++ b/test/test_grammar.py
@@ -1,0 +1,203 @@
+"""Tests for bencher.grammar — the Laws 3/4/5 foundation (issue #1108's rulings).
+
+Three contracts are pinned here: the closed channel vocabulary (Law 5), the `Compose`
+node (Law 4), and the capability-table/substitution embryo (Law 3) — plus the
+direction-of-import rule that replaces plan 25 D1's isolation grep.
+"""
+
+import ast
+import dataclasses
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from bencher.grammar import (
+    GRAMMAR_VERSION,
+    RERUN_CAPABILITIES,
+    Approx,
+    BackendCapabilities,
+    Channel,
+    Compose,
+    Direct,
+    EvalMode,
+    Native,
+    NoLowering,
+    Substituted,
+    Unsupported,
+    compose,
+    substitute,
+)
+from bencher.grammar import capability as capability_module
+
+GRAMMAR_DIR = Path(__file__).parent.parent / "bencher" / "grammar"
+
+
+class TestChannelVocabulary:
+    def test_member_set_is_pinned(self):
+        """Law 5: exactly nine members with these exact values. Adding, removing, or
+        renaming one must land here as a visible, reviewed diff plus a GRAMMAR_VERSION
+        bump — the values are Law 8's future kwarg names, so each is a contract."""
+        assert {m.name: m.value for m in Channel} == {
+            "X": "x",
+            "Y": "y",
+            "Z": "z",
+            "OVERLAY": "overlay",
+            "FACET_ROW": "facet_row",
+            "FACET_COL": "facet_col",
+            "TABS": "tabs",
+            "TIME": "time",
+            "SPREAD": "spread",
+        }
+
+    def test_rejected_candidates_are_absent(self):
+        """Color/Style/Dash/Animation/EntityPath are settled owner rejections (Law 5)."""
+        values = {m.value for m in Channel}
+        assert values.isdisjoint({"color", "style", "dash", "animation", "entity_path"})
+
+    def test_grammar_version(self):
+        assert GRAMMAR_VERSION == "1"
+
+
+class TestCompose:
+    def test_zero_items_is_unrepresentable(self):
+        with pytest.raises(ValueError, match="zero items"):
+            Compose(items=(), along=Channel.TABS)
+
+    def test_factory_accepts_channel_value_strings(self):
+        node = compose(["a", "b"], along="facet_col")
+        assert node == Compose(items=("a", "b"), along=Channel.FACET_COL)
+
+    def test_factory_rejects_non_channel_strings(self):
+        with pytest.raises(ValueError):
+            compose(["a"], along="sequence")  # ComposeType's vocabulary, not the grammar's
+
+    def test_nodes_nest(self):
+        inner = compose(["a", "b"], along=Channel.OVERLAY)
+        outer = compose([inner, "c"], along=Channel.FACET_ROW)
+        assert outer.items[0] is inner
+
+    def test_node_is_frozen(self):
+        node = compose(["a"], along=Channel.TABS)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            node.along = Channel.X
+
+
+class TestCapabilityTable:
+    def test_partial_table_is_unrepresentable(self):
+        """Totality by construction: forgetting to classify a channel is a constructor
+        error naming the gap, not a KeyError at plan time."""
+        with pytest.raises(ValueError, match="SPREAD"):
+            BackendCapabilities(
+                backend="partial",
+                channels={
+                    c: Native(mode=EvalMode.VIEW) for c in Channel if c is not Channel.SPREAD
+                },
+            )
+
+    def test_rerun_seed_is_total(self):
+        assert set(RERUN_CAPABILITIES.channels) == set(Channel)
+
+
+def _all_unsupported_except(supported: dict[Channel, Native | Approx]) -> BackendCapabilities:
+    channels: dict[Channel, Native | Approx | Unsupported] = {
+        c: Unsupported(why=f"{c} not lowerable") for c in Channel
+    }
+    channels.update(supported)
+    return BackendCapabilities(backend="synthetic", channels=channels)
+
+
+class TestSubstitute:
+    def test_supported_channel_lowers_directly(self):
+        outcome = substitute(RERUN_CAPABILITIES, Channel.TIME)
+        assert outcome == Direct(channel=Channel.TIME, capability=Native(mode=EvalMode.VIEW))
+
+    def test_declared_gap_walks_the_chain(self):
+        """A6 §3's declared rerun gap: Spread → Overlay, with the walk recorded."""
+        outcome = substitute(RERUN_CAPABILITIES, Channel.SPREAD)
+        assert isinstance(outcome, Substituted)
+        assert outcome.channel is Channel.OVERLAY
+        assert outcome.via == (Channel.SPREAD, Channel.OVERLAY)
+
+    def test_exhausted_chain_reports_every_refusal(self):
+        """Spread → Overlay → FacetCol all unsupported and FacetCol has no successor:
+        the outcome names each refusal instead of raising or silently dropping."""
+        table = _all_unsupported_except({Channel.X: Native(mode=EvalMode.VIEW)})
+        outcome = substitute(table, Channel.SPREAD)
+        assert isinstance(outcome, NoLowering)
+        assert outcome.requested is Channel.SPREAD
+        for c in (Channel.SPREAD, Channel.OVERLAY, Channel.FACET_COL):
+            assert str(c) in outcome.reason
+
+    def test_chain_cycle_terminates(self, monkeypatch):
+        monkeypatch.setitem(capability_module.SUBSTITUTION_CHAIN, Channel.FACET_COL, Channel.SPREAD)
+        table = _all_unsupported_except({})
+        outcome = substitute(table, Channel.SPREAD)
+        assert isinstance(outcome, NoLowering)
+
+
+class TestImportDirection:
+    """#1108 ruling 4: renderers may import grammar; grammar imports no rendering
+    module — the direction-of-import rule that replaces plan 25 D1's isolation grep."""
+
+    # Module prefixes the grammar package must never import: bencher's rendering/report
+    # layers and every rendering library. Extending grammar never loosens this list.
+    FORBIDDEN_PREFIXES = (
+        "bencher.results",
+        "bencher.plugins",
+        "bencher.bench_report",
+        "bencher.render",
+        "panel",
+        "holoviews",
+        "hvplot",
+        "plotly",
+        "bokeh",
+        "matplotlib",
+        "rerun",
+        "xarray",
+        "param",
+    )
+
+    # Plan 25 D1's one-way intra-package order: channels.py imports nothing from the
+    # package; every other module may import only what is listed here.
+    INTRA_PACKAGE_ALLOWED: ClassVar[dict[str, set[str]]] = {
+        "__init__": {
+            "bencher.grammar.channels",
+            "bencher.grammar.compose",
+            "bencher.grammar.capability",
+        },
+        "channels": set(),
+        "compose": {"bencher.grammar.channels"},
+        "capability": {"bencher.grammar.channels"},
+    }
+
+    @staticmethod
+    def _imported_modules(path: Path) -> set[str]:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        found: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                found.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                found.add(node.module)
+        return found
+
+    def test_grammar_imports_no_rendering_module(self):
+        for path in sorted(GRAMMAR_DIR.glob("*.py")):
+            for module in self._imported_modules(path):
+                assert not module.startswith(self.FORBIDDEN_PREFIXES), (
+                    f"{path.name} imports {module}; grammar must stay import-free of "
+                    "rendering modules (#1108 ruling 4)"
+                )
+
+    def test_intra_package_imports_are_one_way(self):
+        for path in sorted(GRAMMAR_DIR.glob("*.py")):
+            allowed = self.INTRA_PACKAGE_ALLOWED[path.stem]
+            internal = {m for m in self._imported_modules(path) if m.startswith("bencher.grammar")}
+            assert internal <= allowed, (
+                f"{path.name} imports {sorted(internal - allowed)}; plan 25 D1's "
+                "dependency order is strictly one-way"
+            )
+
+    def test_every_grammar_module_is_covered(self):
+        assert {p.stem for p in GRAMMAR_DIR.glob("*.py")} == set(self.INTRA_PACKAGE_ALLOWED)


### PR DESCRIPTION
Implements the foundation decided in #1108 (five owner-confirmed rulings), sequenced by #1111's Law 10 phase-4a reorder: the typed core of A6 Laws 3/4/5, landed ahead of the phase-2/3 planner, with the rerun backend as first consumer.

## What lands

- **`bencher/grammar/channels.py`** — `GRAMMAR_VERSION = "1"` and the closed nine-member `Channel` vocabulary (Law 5), plan 25 D2 verbatim: explicit lowercase values (they become Law 8's kwarg names), member set pinned by test so any change is a visible reviewed act.
- **`bencher/grammar/compose.py`** — the `Compose` node (Law 4): items + one layout channel, replacing `ComposeType`'s four-way-ambiguous encoding. User producer only (`compose([a, b, c], along="facet_col")`); the planner producer arrives with phase 3. How a `Compose` evaluates (`view` vs `materialize`) is a capability-table property, never a node field.
- **`bencher/grammar/capability.py`** — the Law 3 embryo: per-channel `Native | Approx | Unsupported` (the arm *is* the fidelity), tables total-by-construction, the documented substitution chain (`Time→Tabs`, `Overlay→FacetCol`, `Spread→Overlay`), a total `substitute()` returning `Direct | Substituted | NoLowering`, and the **rerun** seed table typed from A6 §3's parity rows — inverting plan 25's panel-first scoping per ruling 3.
- **`test/test_grammar.py`** — 17 tests: the vocabulary pin, `Compose` construction, table totality, all three `substitute()` outcomes plus cycle termination, and the **direction-of-import rule** (renderers may import grammar; grammar imports no rendering module and no `param`) that replaces plan 25 D1's isolation grep per ruling 4.
- **`pyproject.toml`** — all four modules join the strict `ty` ratchet in the PR that creates them (plan 25 D1's rule).
- **`plans/25-grammar-phase-2-channel-plan.md`** — the Amendment section recording the reorder, the amended isolation rule, what survives (P1 whole, P2's type layer) and what defers (P3/P4 → phase 3), and the absorption path when `plan.py`/`marks.py`/`planner.py` land.

## What deliberately does not land

No consumer is rewired yet — panel's legacy recursion is untouched (owner-set route), and the single rerun recursion that consumes `Channel`/`Compose` is #1109, now unblocked. No persisted state is touched (no `CACHE_VERSION` implications, per #1111 §3).

Gates: `pixi run ci` green locally (2907 passed / 24 skipped), lint 10/10, `ty` clean with the new modules on the strict list.

Closes nothing by merge; #1108 is already resolved and closed — this PR is the artifact its resolution names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce the initial typed grammar foundation package for A6 Laws 3/4/5, centered on channels, composition, and backend capability tables, and hook it into the project’s strict typing and planning documentation.

New Features:
- Add a closed Channel vocabulary with versioned grammar identifier for dimension assignment in reports.
- Introduce a Compose node and user-facing factory for expressing layout along grammar channels, including support for nested compositions.
- Define backend capability tables with native/approx/unsupported fidelity, a documented substitution chain, and a seeded rerun capability table.
- Expose the grammar primitives and capability utilities via a new bencher.grammar package for consumption by rendering backends.

Enhancements:
- Extend the grammar phase-2 plan document with an amendment describing the rerun-first phase reorder, updated isolation rule, and absorption path for future planner modules.

Build:
- Register the new grammar package modules in the strict typing configuration so they are type-checked from inception.

Tests:
- Add a dedicated grammar test suite that pins the channel vocabulary, validates Compose behavior, enforces capability-table totality and substitution outcomes, and checks import-direction and intra-package dependency rules for the grammar modules.